### PR TITLE
fix(pet): include rolldown chunk in published files

### DIFF
--- a/packages/dsh-pet/package.json
+++ b/packages/dsh-pet/package.json
@@ -35,6 +35,7 @@
     "lib/index.js",
     "lib/invariant.js",
     "lib/client.js",
+    "lib/*.js",
     "lib/types/**/*.d.ts",
     "lib/types/**/*.d.ts.map",
     "src",


### PR DESCRIPTION
## Problem

The `@linxin666/dsh-pet` npm package is broken on install. The lib build splits `state.ts` into a rolldown chunk (`lib/state-IyVnKymD.js`) that `lib/index.js` imports, but the `files` whitelist in `package.json` only lists `lib/index.js`, `lib/invariant.js` and `lib/client.js` — the chunk is dropped from the tarball. Any profile that installs the package crashes at load:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../node_modules/@linxin666/dsh-pet/lib/state-IyVnKymD.js'
imported from .../node_modules/@linxin666/dsh-pet/lib/index.js
```

## Fix

Add `"lib/*.js"` to the `files` whitelist so rolldown chunk files under `lib/` are published.

Verified with `npm pack`:
- Before: 43 files, no `lib/state-*.js` → broken install
- After: 44 files, `lib/state-IyVnKymD.js` included → install works

Only `dsh-pet` is affected — the other packages' lib builds emit no chunks (checked all 8 packages with a `files` whitelist).

Note: `pnpm publish` from the repo root may be needed to republish `dsh-pet@0.1.2` so users get the fixed artifact.