### PR TITLE
fix: 修复全家桶插件在当前 dsh web shell 上的挂载（兼容 shim + 挂载修复）

### DIFF
--- a/packages/dsh-git-graph/package.json
+++ b/packages/dsh-git-graph/package.json
@@ -39,8 +39,7 @@
       "inject": [
         "@deepseek-ai/dsh-client-locale",
         "@deepseek-ai/dsh-client-runtime",
-        "@deepseek-ai/dsh-client-ui-conversation",
-        "@deepseek-ai/dsh-client-ui-slots"
+        "@deepseek-ai/dsh-client-ui-conversation"
       ],
       "platform": "web"
     }

--- a/packages/dsh-git-graph/src/client/DockBranchChip.tsx
+++ b/packages/dsh-git-graph/src/client/DockBranchChip.tsx
@@ -1,0 +1,26 @@
+/**
+ * Dock-band fallback seat for the git branch chip.
+ *
+ * Current dsh web shells declare `conversation.input.dock` (the composer dock
+ * band, a list slot) instead of the legacy `conversation.input.selector.context`
+ * hole this plugin was written against. The dock band's owner props carry
+ * `sessionId` but not the legacy seat's `subscribeChanges` channel; session
+ * switches still re-key the chip through the `sessionId` prop, so the fallback
+ * is a pure props re-cast.
+ */
+import type { PropsLocale, PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
+import type {} from '@deepseek-ai/dsh-client-ui-conversation/client'
+import { BranchChip, type BranchChipProps } from './chips/BranchChip.tsx'
+import type { GitGraphInjected } from './index.ts'
+
+/** Composed props of the dock-band fallback seat. */
+export type DockBranchChipProps = PropsRuntime<'conversation.input.dock'> & GitGraphInjected & PropsLocale<'git-graph'>
+
+/**
+ * Render the branch chip from the composer dock band.
+ * @param props - composed slot props (dock band seat).
+ * @returns the branch chip element tree.
+ */
+export function DockBranchChip(props: DockBranchChipProps) {
+  return <BranchChip {...(props as unknown as BranchChipProps)} />
+}

--- a/packages/dsh-git-graph/src/client/index.ts
+++ b/packages/dsh-git-graph/src/client/index.ts
@@ -24,6 +24,7 @@ import type {
 } from '../core/types.ts'
 import { GitApi, subscribeChanges } from './api.ts'
 import { BranchChip } from './chips/BranchChip.tsx'
+import { DockBranchChip } from './DockBranchChip.tsx'
 import { en, zh, type GitGraphKey } from './locales.ts'
 
 export type { GitGraphKey } from './locales.ts'
@@ -80,56 +81,70 @@ export function apply(ctx: ClientContext): void {
     const cwdOf = (sessionId: SessionId | undefined): string | undefined =>
       sessionId === undefined ? undefined : sessions.list.getSnapshot().byId[sessionId]?.cwd
 
+    /** The injected face shared by every seat this chip registers into. */
+    const injected = (): GitGraphInjected => {
+      /** Resolve the workspace root for one git call. */
+      const pathOf = (sessionId: SessionId | undefined): { ok: true; path: string } | { ok: false; error: GitError } => {
+        const cwd = cwdOf(sessionId)
+        if (cwd === undefined || cwd === '') return { ok: false, error: NO_WORKSPACE }
+        return { ok: true, path: cwd }
+      }
+      return {
+        repoStatus: async (sessionId) => {
+          const resolved = pathOf(sessionId)
+          if (!resolved.ok) return null
+          const result = await git.status(resolved.path)
+          return result.ok ? result.value : null
+        },
+        branches: async (sessionId) => {
+          const resolved = pathOf(sessionId)
+          if (!resolved.ok) return null
+          const result = await git.branches(resolved.path)
+          return result.ok ? result.value : null
+        },
+        switchBranch: async (sessionId, branch) => {
+          const resolved = pathOf(sessionId)
+          if (!resolved.ok) return { ok: false, error: resolved.error }
+          const result = await git.switchBranch(resolved.path, branch)
+          return result.ok ? { ok: true, branch: result.value.branch } : result
+        },
+        createBranch: async (sessionId, name) => {
+          const resolved = pathOf(sessionId)
+          if (!resolved.ok) return { ok: false, error: resolved.error }
+          const result = await git.createBranch(resolved.path, name)
+          return result.ok ? { ok: true, branch: result.value.branch } : result
+        },
+        graph: async (sessionId, limit) => {
+          const resolved = pathOf(sessionId)
+          if (!resolved.ok) return null
+          const result = await git.graph(resolved.path, limit)
+          return result.ok ? result.value : null
+        },
+        subscribeChanges: (sessionId, onChange) => {
+          const resolved = pathOf(sessionId)
+          if (!resolved.ok) return () => {}
+          return subscribeChanges(resolved.path, onChange)
+        },
+      }
+    }
+
     scope.effect(() => scope.slots.register({
       name: 'conversation.input.selector.context',
       id: 'git-graph',
       order: 100,
       locale: NS,
-      inject: (): GitGraphInjected => {
-        /** Resolve the workspace root for one git call. */
-        const pathOf = (sessionId: SessionId | undefined): { ok: true; path: string } | { ok: false; error: GitError } => {
-          const cwd = cwdOf(sessionId)
-          if (cwd === undefined || cwd === '') return { ok: false, error: NO_WORKSPACE }
-          return { ok: true, path: cwd }
-        }
-        return {
-          repoStatus: async (sessionId) => {
-            const resolved = pathOf(sessionId)
-            if (!resolved.ok) return null
-            const result = await git.status(resolved.path)
-            return result.ok ? result.value : null
-          },
-          branches: async (sessionId) => {
-            const resolved = pathOf(sessionId)
-            if (!resolved.ok) return null
-            const result = await git.branches(resolved.path)
-            return result.ok ? result.value : null
-          },
-          switchBranch: async (sessionId, branch) => {
-            const resolved = pathOf(sessionId)
-            if (!resolved.ok) return { ok: false, error: resolved.error }
-            const result = await git.switchBranch(resolved.path, branch)
-            return result.ok ? { ok: true, branch: result.value.branch } : result
-          },
-          createBranch: async (sessionId, name) => {
-            const resolved = pathOf(sessionId)
-            if (!resolved.ok) return { ok: false, error: resolved.error }
-            const result = await git.createBranch(resolved.path, name)
-            return result.ok ? { ok: true, branch: result.value.branch } : result
-          },
-          graph: async (sessionId, limit) => {
-            const resolved = pathOf(sessionId)
-            if (!resolved.ok) return null
-            const result = await git.graph(resolved.path, limit)
-            return result.ok ? result.value : null
-          },
-          subscribeChanges: (sessionId, onChange) => {
-            const resolved = pathOf(sessionId)
-            if (!resolved.ok) return () => {}
-            return subscribeChanges(resolved.path, onChange)
-          },
-        }
-      },
+      inject: injected,
     }, BranchChip), 'dsh-git-graph: branch chip registration')
+
+    // Current shells declare the composer dock band instead of the legacy
+    // selector context hole; register the same chip there too. Both injects
+    // are declaration-aware, so only the one the shell declares ever fires.
+    scope.effect(() => scope.slots.register({
+      name: 'conversation.input.dock',
+      id: 'git-graph',
+      order: 100,
+      locale: NS,
+      inject: injected,
+    }, DockBranchChip), 'dsh-git-graph: dock fallback registration')
   })
 }

--- a/packages/dsh-pet/package.json
+++ b/packages/dsh-pet/package.json
@@ -50,7 +50,6 @@
         "@deepseek-ai/dsh-client-runtime",
         "@deepseek-ai/dsh-client-connection",
         "@deepseek-ai/dsh-client-ui-settings",
-        "@deepseek-ai/dsh-client-ui-slots",
         "@deepseek-ai/dsh-client-ui-conversation"
       ],
       "platform": "web"

--- a/packages/dsh-pet/src/client/DockPetDockEntry.tsx
+++ b/packages/dsh-pet/src/client/DockPetDockEntry.tsx
@@ -1,0 +1,27 @@
+/**
+ * Dock-band fallback seat for the pet.
+ *
+ * Current dsh web shells declare `conversation.input.dock` (the composer dock
+ * band, a list slot) instead of the legacy `conversation.input.selector.context`
+ * hole this plugin was written against. The dock band renders only for an
+ * active session, so on shells that carry it the pet follows the session seat
+ * — an acceptable degradation until the upstream shell restores the context
+ * hole. The underlying entry ignores owner props (it reads only injected
+ * actions and the locale), so this wrapper is a pure props re-cast.
+ */
+import type { PropsLocale, PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
+import type {} from '@deepseek-ai/dsh-client-ui-conversation/client'
+import { PetDockEntry, type PetDockEntryProps, type PetInjected } from './PetDockEntry.tsx'
+import { NS } from './locales.ts'
+
+/** Composed props of the dock-band fallback seat. */
+export type DockPetDockEntryProps = PropsRuntime<'conversation.input.dock'> & PetInjected & PropsLocale<typeof NS>
+
+/**
+ * Render the pet dock from the composer dock band.
+ * @param props - composed slot props (dock band seat).
+ * @returns the dock entry element tree.
+ */
+export function DockPetDockEntry(props: DockPetDockEntryProps) {
+  return <PetDockEntry {...(props as unknown as PetDockEntryProps)} />
+}

--- a/packages/dsh-pet/src/client/index.ts
+++ b/packages/dsh-pet/src/client/index.ts
@@ -22,6 +22,7 @@ import type { PetInteractResult, PetStateView } from '../service.ts'
 import type { PetInteraction } from '../affinity.ts'
 import { createPetStore, type PetStoreInstance } from './pet-store.ts'
 import { PetDockEntry, type PetInjected } from './PetDockEntry.tsx'
+import { DockPetDockEntry } from './DockPetDockEntry.tsx'
 import { PetSettingsCard, PetSettingsCardController, type PetSettings } from './PetSettingsCard.tsx'
 import { NS, en, zh } from './locales.ts'
 
@@ -246,8 +247,22 @@ export function apply(ctx: ClientContext): void {
           locale: NS,
         }, PetDockEntry))
 
+      // Current shells declare the composer dock band instead of the legacy
+      // selector context hole; register the same entry there too. Both
+      // injects are declaration-aware, so only the one the shell declares
+      // ever fires — the dock never renders twice.
+      const disposeDockFallback = ctx.slots.inject('conversation.input.dock', () =>
+        ctx.slots.register({
+          name: 'conversation.input.dock',
+          id: 'pet',
+          order: 110,
+          inject: injected,
+          locale: NS,
+        }, DockPetDockEntry))
+
       disposeUi = () => {
         disposeDock()
+        disposeDockFallback()
         disposePoll()
         disposeUi = undefined
       }

--- a/packages/dsh-remote-web-ui/src/client/FooterRemoteEntry.tsx
+++ b/packages/dsh-remote-web-ui/src/client/FooterRemoteEntry.tsx
@@ -1,0 +1,31 @@
+/**
+ * Sidebar footer-seat wrapper for the remote-control entry.
+ *
+ * Current dsh web shells declare `sidebar.footer.action` (the seat beside the
+ * settings trigger) instead of the legacy `sidebar.remote` seat this plugin
+ * was written against. The footer seat supplies `{ wide }` but not the
+ * `useWorkspaces` projection hook, so this wrapper substitutes a
+ * workspace-agnostic selector: pairing without a deep-linked workspace is
+ * fully supported by the host `/api/pair` routes.
+ */
+import type { PropsLocale } from '@deepseek-ai/dsh-client-ui-slots'
+import { RemoteEntry } from './RemoteEntry.tsx'
+
+/** Entry props: the footer seat's column state + the standard locale seat. */
+export type FooterRemoteEntryProps = PropsLocale<'remote'> & { wide: boolean }
+
+/**
+ * Render the remote-control trigger + pairing panel from the footer seat.
+ * @param props - composed slot props (footer seat subset).
+ * @returns the entry element tree.
+ */
+export function FooterRemoteEntry(props: FooterRemoteEntryProps) {
+  return (
+    <RemoteEntry
+      wide={props.wide}
+      useWorkspaces={() => undefined as never}
+      useSessions={() => undefined as never}
+      t={props.t}
+    />
+  )
+}

--- a/packages/dsh-remote-web-ui/src/client/index.ts
+++ b/packages/dsh-remote-web-ui/src/client/index.ts
@@ -17,6 +17,7 @@ import type {} from '@deepseek-ai/dsh-client-locale/client'
 import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
 import type {} from '@deepseek-ai/dsh-client-ui-sidebar/client'
 import type { ConnectionHandle } from '@deepseek-ai/dsh-client-connection/client'
+import { FooterRemoteEntry } from './FooterRemoteEntry.tsx'
 import { RemoteEntry } from './RemoteEntry.tsx'
 import { PairFailedNotice } from './PairFailedNotice.tsx'
 import { RemoteSettingsCard, RemoteSettingsCardController, type RemoteSettings } from './RemoteSettingsCard.tsx'
@@ -103,6 +104,28 @@ export function apply(ctx: ClientContext): void {
     const syncEntry = (): void => {
       if (enabled() && disposeEntry === undefined) {
         disposeEntry = ctx.slots.register({ name: 'sidebar.remote', locale: NS }, RemoteEntry)
+      } else if (!enabled() && disposeEntry !== undefined) {
+        disposeEntry()
+        disposeEntry = undefined
+      }
+    }
+    const unsubscribe = settingsScope.subscribe(syncEntry)
+    syncEntry()
+    return () => {
+      unsubscribe()
+      disposeEntry?.()
+    }
+  })
+
+  // Current shells declare `sidebar.footer.action` instead of the legacy
+  // `sidebar.remote` seat; this fallback registers the same entry there when
+  // the legacy seat never arrives (declaration-aware: only one of the two
+  // injects ever fires, so the trigger can never render twice).
+  ctx.slots.inject('sidebar.footer.action', () => {
+    let disposeEntry: (() => void) | undefined
+    const syncEntry = (): void => {
+      if (enabled() && disposeEntry === undefined) {
+        disposeEntry = ctx.slots.register({ name: 'sidebar.footer.action', id: 'remote-web-ui', locale: NS }, FooterRemoteEntry)
       } else if (!enabled() && disposeEntry !== undefined) {
         disposeEntry()
         disposeEntry = undefined

--- a/packages/dsh-remote-web-ui/tests/remote-entry.spec.tsx
+++ b/packages/dsh-remote-web-ui/tests/remote-entry.spec.tsx
@@ -210,7 +210,7 @@ describe('apply registration', () => {
       },
     }
     apply(ctx as never)
-    expect(injected).toEqual(['sidebar.remote', 'web-ui.plugin.item'])
+    expect(injected).toEqual(['sidebar.remote', 'sidebar.footer.action', 'web-ui.plugin.item'])
   })
 
   it('waits for the settings snapshot before mounting the sidebar entry and runtime', async () => {
@@ -256,6 +256,6 @@ describe('apply registration', () => {
 
     snapshot = { status: 'ready' as const, writable: true, value: { enabled: true } }
     notify()
-    expect(registered).toEqual(['web-ui.plugin.item', 'sidebar.remote'])
+    expect(registered).toEqual(['web-ui.plugin.item', 'sidebar.remote', 'sidebar.footer.action'])
   })
 })

--- a/packages/dsh-ssh/src/client/sidebar-entry.ts
+++ b/packages/dsh-ssh/src/client/sidebar-entry.ts
@@ -19,21 +19,24 @@ import css from './panel/panel.module.css'
 /** Stable data attribute identifying the injected entry row. */
 export const ENTRY_SELECTOR = '[data-dsh-ssh-entry]'
 
-/** The sidebar column is the grid item AppFrame renders with this pane marker. */
-const SIDEBAR_COLUMN_SELECTOR = '[data-pane="sidebar"]'
-
 /** Inline icon (matches the shell's 16px nav-icon look): a terminal prompt glyph. */
 const ICON = '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="2.5" width="12" height="11" rx="1.5"/><path d="M4.5 5.5l2.5 2.5-2.5 2.5"/><path d="M8.5 10.5h3"/></svg>'
 
 /** Find the sidebar shell root element, or undefined while not yet mounted. */
 function sidebarRoot(): HTMLElement | undefined {
-  const column = document.querySelector<HTMLElement>(SIDEBAR_COLUMN_SELECTOR)
-  const root = column?.firstElementChild as HTMLElement | undefined
-  return root ?? undefined
+  const column = document.querySelector<HTMLElement>('[data-pane="sidebar"], [class*="sidebarCol"]')
+  if (column === null) return undefined
+  // Current shells wrap the sidebar UI: column > wrapper > root(logoRow owner).
+  // Prefer the element that owns the logo row — the real sidebar UI root —
+  // and fall back to the column's first child for legacy shells.
+  const logoOwner = column.querySelector<HTMLElement>('[class*="logoRow"]')?.parentElement
+  return logoOwner ?? (column.firstElementChild as HTMLElement | undefined)
 }
 
-/** The New Session button: the shell's only direct-child button of the root. */
+/** The New Session button: nested in the logo row on current shells, a direct child on legacy shells. */
 function newSessionButton(root: HTMLElement): HTMLButtonElement | undefined {
+  const nested = root.querySelector<HTMLButtonElement>('button[class*="newSession"]')
+  if (nested !== null) return nested
   for (const child of root.children) {
     if (child.tagName === 'BUTTON') return child as HTMLButtonElement
   }
@@ -53,14 +56,21 @@ function createEntry(controller: PanelController): HTMLButtonElement {
   return entry
 }
 
-/** Re-insert the entry after the New Session button (before the browser region). */
+/** Re-insert the entry after the New Session row (before the browser region). */
 function placeEntry(root: HTMLElement, entry: HTMLButtonElement): boolean {
   const button = newSessionButton(root)
   if (button === undefined) return false
   if (entry.parentElement !== root) {
-    // Insert after the button: React never manages this node, and the shell
-    // keeps its own child order intact around it.
-    root.insertBefore(entry, button.nextElementSibling)
+    // Current shells nest the button inside the logo row: insert after that
+    // row. Legacy shells keep the button as a direct child: insert after it.
+    const row = button.closest('[class*="logoRow"]')
+    if (row !== null && row.parentElement === root) {
+      root.insertBefore(entry, row.nextElementSibling)
+    } else if (button.parentElement === root) {
+      root.insertBefore(entry, button.nextElementSibling)
+    } else {
+      root.appendChild(entry)
+    }
   }
   return true
 }

--- a/packages/dsh-task-board/src/client/sidebar-entry.ts
+++ b/packages/dsh-task-board/src/client/sidebar-entry.ts
@@ -20,21 +20,24 @@ import css from './board.module.css'
 /** Stable data attribute identifying the injected entry row. */
 export const ENTRY_SELECTOR = '[data-dsh-taskboard-entry]'
 
-/** The sidebar column is the grid item AppFrame renders with this pane marker. */
-const SIDEBAR_COLUMN_SELECTOR = '[data-pane="sidebar"]'
-
 /** Inline icon (matches the shell's 16px nav-icon look). */
 const ICON = `<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="2.5" width="12" height="11" rx="1.5"/><path d="M2 6.5h12M6.5 6.5v7"/></svg>`
 
 /** Find the sidebar shell root element, or undefined while not yet mounted. */
 function sidebarRoot(): HTMLElement | undefined {
-  const column = document.querySelector<HTMLElement>(SIDEBAR_COLUMN_SELECTOR)
-  const root = column?.firstElementChild as HTMLElement | undefined
-  return root ?? undefined
+  const column = document.querySelector<HTMLElement>('[data-pane="sidebar"], [class*="sidebarCol"]')
+  if (column === null) return undefined
+  // Current shells wrap the sidebar UI: column > wrapper > root(logoRow owner).
+  // Prefer the element that owns the logo row — the real sidebar UI root —
+  // and fall back to the column's first child for legacy shells.
+  const logoOwner = column.querySelector<HTMLElement>('[class*="logoRow"]')?.parentElement
+  return logoOwner ?? (column.firstElementChild as HTMLElement | undefined)
 }
 
-/** The New Session button: the shell's only direct-child button of the root. */
+/** The New Session button: nested in the logo row on current shells, a direct child on legacy shells. */
 function newSessionButton(root: HTMLElement): HTMLButtonElement | undefined {
+  const nested = root.querySelector<HTMLButtonElement>('button[class*="newSession"]')
+  if (nested !== null) return nested
   for (const child of root.children) {
     if (child.tagName === 'BUTTON') return child as HTMLButtonElement
   }
@@ -53,14 +56,21 @@ function createEntry(controller: BoardController): HTMLButtonElement {
   return entry
 }
 
-/** Re-insert the entry after the New Session button (before the browser region). */
+/** Re-insert the entry after the New Session row (before the browser region). */
 function placeEntry(root: HTMLElement, entry: HTMLButtonElement): boolean {
   const button = newSessionButton(root)
   if (button === undefined) return false
   if (entry.parentElement !== root) {
-    // Insert after the button: React never manages this node, and the shell
-    // keeps its own child order intact around it.
-    root.insertBefore(entry, button.nextElementSibling)
+    // Current shells nest the button inside the logo row: insert after that
+    // row. Legacy shells keep the button as a direct child: insert after it.
+    const row = button.closest('[class*="logoRow"]')
+    if (row !== null && row.parentElement === root) {
+      root.insertBefore(entry, row.nextElementSibling)
+    } else if (button.parentElement === root) {
+      root.insertBefore(entry, button.nextElementSibling)
+    } else {
+      root.appendChild(entry)
+    }
   }
   return true
 }

--- a/packages/dsh-web-ui-all/aggregate.yml
+++ b/packages/dsh-web-ui-all/aggregate.yml
@@ -1,4 +1,4 @@
-﻿# 聚合包清单：patchFrom 的包其 cordis.patch.yml insert 行会被汇总进本包 patch
+# 聚合包清单：patchFrom 的包其 cordis.patch.yml insert 行会被汇总进本包 patch
 # deps 的包进 package.json dependencies（workspace:*）
 # dsh-skins 的 patch 行只有 ui-skin-center，汇总后自然展开
 patchFrom:

--- a/packages/dsh-web-ui-all/aggregate.yml
+++ b/packages/dsh-web-ui-all/aggregate.yml
@@ -1,7 +1,8 @@
-# 聚合包清单：patchFrom 的包其 cordis.patch.yml insert 行会被汇总进本包 patch
+﻿# 聚合包清单：patchFrom 的包其 cordis.patch.yml insert 行会被汇总进本包 patch
 # deps 的包进 package.json dependencies（workspace:*）
 # dsh-skins 的 patch 行只有 ui-skin-center，汇总后自然展开
 patchFrom:
+  - ../dsh-web-ui-compat
   - ../dsh-aionui-panel
   - ../dsh-task-board
   - ../dsh-git-graph
@@ -12,6 +13,7 @@ patchFrom:
   - ../dsh-web-ui-settings
   - ../dsh-skins
 deps:
+  - ../dsh-web-ui-compat
   - ../dsh-aionui-panel
   - ../dsh-task-board
   - ../dsh-git-graph

--- a/packages/dsh-web-ui-all/cordis.patch.yml
+++ b/packages/dsh-web-ui-all/cordis.patch.yml
@@ -2,6 +2,11 @@
 # This file is derived from the aggregate.yml manifest in this package;
 # edit aggregate.yml and rerun `node scripts/aggregate.mjs`.
 
+# from ../dsh-web-ui-compat
+- insert:
+    - id: ui-web-ui-compat
+      name: '@linxin666/dsh-web-ui-compat'
+
 # from ../dsh-aionui-panel
 - insert:
     - id: ui-dsh-aionui-panel

--- a/packages/dsh-web-ui-all/package.json
+++ b/packages/dsh-web-ui-all/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
+    "@linxin666/dsh-web-ui-compat": "workspace:*",
     "@linxin666/dsh-client-ui-aionui-panel": "workspace:*",
     "@linxin666/dsh-client-ui-task-board": "workspace:*",
     "@linxin666/dsh-client-ui-git-graph": "workspace:*",

--- a/packages/dsh-web-ui-compat/cordis.patch.yml
+++ b/packages/dsh-web-ui-compat/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: ui-web-ui-compat
+      name: '@linxin666/dsh-web-ui-compat'

--- a/packages/dsh-web-ui-compat/package.json
+++ b/packages/dsh-web-ui-compat/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@linxin666/dsh-web-ui-compat",
+  "description": "Compatibility shim for the dsh-web-ui plugin family on current dsh web shells: stamps the legacy data-pane / data-dsh-frame hooks that the family plugins' DOM mounts and skins expect onto the shell's current grid columns",
+  "version": "0.1.2",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib/**/*.js",
+    "cordis.patch.yml"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zhu1090093659/dsh-web-ui.git",
+    "directory": "packages/dsh-web-ui-compat"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    },
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepare": "tsdown",
+    "watch": "tsdown --watch"
+  },
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "tsdown": "^0.22.2",
+    "@deepseek-ai/cordis": "^4.0.1"
+  }
+}

--- a/packages/dsh-web-ui-compat/src/client/index.ts
+++ b/packages/dsh-web-ui-compat/src/client/index.ts
@@ -1,0 +1,61 @@
+/**
+ * dsh-web-ui compat shim, browser half.
+ *
+ * The current dsh web shell renders its grid columns without the legacy
+ * `data-pane` / `data-dsh-frame` hooks (the columns carry css-module class
+ * names such as `*_sidebarCol` / `*_centerCol` / `*_detailsCol`). The
+ * dsh-web-ui family plugins (task-board, ssh, aionui-panel, several skins)
+ * mount at the DOM level through those legacy selectors, so without them the
+ * plugins stay silent even though they load.
+ *
+ * This shim stamps the expected attributes onto the real shell elements and
+ * re-applies them on any DOM mutation (React re-renders that re-create the
+ * columns), which restores every DOM-mounting plugin and the skins' column
+ * selectors in one place. It only ever WRITES attributes; it never removes
+ * nodes and never disturbs React's reconciliation.
+ */
+import type { Context } from '@deepseek-ai/cordis'
+
+/** Column shims: element selector → attribute to stamp. */
+const COLUMN_SHIMS: ReadonlyArray<readonly [selector: string, attribute: string]> = [
+  ['[class*="sidebarCol"]', 'data-pane="sidebar"'],
+  ['[class*="centerCol"]', 'data-pane="conversation"'],
+  ['[class*="detailsCol"]', 'data-pane="details"'],
+]
+
+/** Stamp one attribute of the form `name="value"` onto an element, if found. */
+function stamp(el: Element | null, attribute: string): void {
+  if (el === null) return
+  const eq = attribute.indexOf('=')
+  const name = attribute.slice(0, eq)
+  const value = attribute.slice(eq + 1).replace(/^"|"$/g, '')
+  el.setAttribute(name, value)
+}
+
+/** One pass over the current DOM. */
+function applyShims(): void {
+  for (const [selector, attribute] of COLUMN_SHIMS) {
+    stamp(document.querySelector(selector), attribute)
+  }
+  // The frame is the grid item that parents the sidebar column.
+  stamp(document.querySelector('[class*="sidebarCol"]')?.parentElement ?? null, 'data-dsh-frame=""')
+}
+
+/** Required services: none — the shim must run before any DOM mount waits. */
+export const inject = [] as const
+
+/**
+ * Register the shim for the page lifetime.
+ * @param ctx - client root context.
+ */
+export function apply(ctx: Context): void {
+  ctx.effect(() => {
+    applyShims()
+    // The shell renders after boot settlement and React can re-create the
+    // columns on re-render; re-stamp on any DOM mutation. Idempotent: writes
+    // only the same attribute values, so this never fights React.
+    const observer = new MutationObserver(applyShims)
+    observer.observe(document.body, { childList: true, subtree: true })
+    return () => { observer.disconnect() }
+  })
+}

--- a/packages/dsh-web-ui-compat/src/index.ts
+++ b/packages/dsh-web-ui-compat/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Host half of the dsh-web-ui compat shim: no host behavior. The browser half
+ * (./client) stamps the legacy DOM hooks the family plugins expect.
+ */
+import type { Context } from '@deepseek-ai/cordis'
+
+/** Required services: none. */
+export const inject = [] as const
+
+/** Host plugin body: nothing to do. */
+export function apply(_ctx: Context): void {}

--- a/packages/dsh-web-ui-compat/tsdown.config.ts
+++ b/packages/dsh-web-ui-compat/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { clientBundle } from '../../shared/tsdown.client.ts'
+
+export default clientBundle('@linxin666/dsh-web-ui-compat', ['src/index.ts'])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,6 +616,18 @@ importers:
       '@linxin666/dsh-ssh':
         specifier: workspace:*
         version: link:../dsh-ssh
+      '@linxin666/dsh-web-ui-compat':
+        specifier: workspace:*
+        version: link:../dsh-web-ui-compat
+
+  packages/dsh-web-ui-compat:
+    devDependencies:
+      '@deepseek-ai/cordis':
+        specifier: ^4.0.1
+        version: 4.0.1
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(typescript@6.0.3)
 
   packages/dsh-web-ui-settings:
     devDependencies:


### PR DESCRIPTION
## 概述

全家桶插件在当前 dsh web shell 上安装正常，但多个成员挂载失败：侧边栏没有「任务看板」「SSH」入口，鲸鱼娘宠物和 Git 分支选择器不渲染，设置里「Web UI 插件」组展开只有「皮肤中心」。本 PR 让所有成员都能在当前 shell 上正常挂载，同时保留旧 shell 的回退路径。

根因（与 [#7](https://github.com/zhu1090093659/dsh-web-ui/issues/7) 一致）：

### 1. 新增兼容 shim 包：`@linxin666/dsh-web-ui-compat`
当前 shell 的网格列**不再渲染** `data-pane="sidebar|conversation|details"` / `data-dsh-frame` 属性（列只带 css-module 类名，如 `*_sidebarCol` / `*_centerCol`），导致所有 DOM 级挂载的插件和皮肤静默失败。shim 在运行时把这些属性补到真实的 shell 元素上，并在 DOM 变化时自动重打——一处修复任务看板、SSH、右侧面板以及 xp/qq98/ths/minecraft 皮肤的全部选择器。已作为 `dsh-web-ui-all` 聚合包的第一个成员接入，保证 shim 先于其它插件生效。

### 2. task-board / ssh 侧边栏入口位置
当前 shell 的侧边栏结构多了一层包装（`列 > 无类名包装层 > 根`），且「新建会话」按钮嵌套在 logoRow 里，导致注入的入口被追加到侧边栏最底部（屏幕外）。现在通过 `logoRow` 的所有者定位真实根节点，并把入口插到 logoRow 之后；旧 shell 的路径保留。

### 3. pet / git-graph
- 从两个包的 `dsh.client.inject` 中移除 `@deepseek-ai/dsh-client-ui-slots`——该包在当前 SDK 上**没有客户端半区**，引用它会让两个插件永远处于等待状态（静默不加载）。
- 增加 dock 带回退：当旧版 `conversation.input.selector.context` 槽位未被声明时，两个插件改挂到 `conversation.input.dock`（作曲家 dock 带）。注入是声明感知的，两个槽位只会渲染一个，不会重复。dock 带只在有活动会话时渲染——这是当前 shell 的固有限制，属于可接受的降级。

### 4. remote-web-ui
当前 shell 声明的是 `sidebar.footer.action` 而不是旧版 `sidebar.remote` 槽位，导致手机配对图标从未渲染。新增 footer 槽位回退（工作区无关的包装组件；不带工作区深链的配对由宿主路由支持）。

## 验证

Windows 11 + 当前 dsh web shell（`dsh web`，端口 3080）：`pnpm -r build` + `dsh plugin --profile web add link:.../packages/dsh-web-ui-all` + 重启后，侧边栏出现任务看板和 SSH 入口，宠物和 Git 分支选择器出现在作曲家 dock 带，右侧面板正常附着，手机远程触发按钮渲染在侧边栏底部，设置组的五张插件卡片全部显示。

## 未覆盖部分（需要 dsh 上游支持，见 #7）

各插件设置卡片在 harness 暴露其设置命名空间之前会渲染空白：API 代理只服务固定的 `WEB_SETTINGS_NAMESPACES` 白名单，对插件命名空间（`task-board`、`dsh-ssh`、`pet`、`live-stats`、`remote-web-ui`）一律返回 `settings-not-exposed`。harness 源码注释中已把「插件通过 `settings.register()` 自行暴露配置」标记为待办工作，建议在 dsh 侧跟进。

> 说明：本 PR 已在 `@linxin666` scope 改名（v0.1.2）之后 rebase 到最新 main；此前的 `scripts/dsh-skin` Windows 支持提交已移除，因为皮肤中心已改为进程内应用皮肤（#7 的补充问题已在上游修复）。
