### PR TITLE
fix(aionui-panel): Windows path safety and git spawn guard

### DIFF
--- a/packages/dsh-aionui-panel/src/host/gate.ts
+++ b/packages/dsh-aionui-panel/src/host/gate.ts
@@ -18,12 +18,26 @@ export type GateVerdict = { ok: true; canonical: string } | { ok: false; error: 
 /** The workspace-membership check the services run on every request. */
 export type WorkspaceGate = (root: string) => Promise<GateVerdict>
 
-/** The canonical prefix check: child must live inside (or equal) the root. */
+/**
+ * The canonical prefix check: child must live inside (or equal) the root.
+ * Separator- and case-robust on Windows: `path.join` yields backslashes while
+ * git (`rev-parse --show-toplevel`) and the browser (`./x`) yield forward
+ * slashes, so both sides are normalized to forward slashes before comparing,
+ * and the comparison is case-insensitive on win32 (the FS is case-insensitive).
+ */
 export function isPathInside(root: string, child: string): boolean {
   if (root === '' || child === '') return false
-  if (child === root) return true
-  const prefix = root.endsWith('/') ? root : `${root}/`
-  return child.startsWith(prefix)
+  const norm = (value: string): string => value.replaceAll('\\', '/').replace(/\/+$/, '')
+  const normRoot = norm(root)
+  const normChild = norm(child)
+  if (process.platform === 'win32') {
+    const a = normRoot.toLowerCase()
+    const b = normChild.toLowerCase()
+    if (b === a) return true
+    return b.startsWith(`${a}/`)
+  }
+  if (normChild === normRoot) return true
+  return normChild.startsWith(`${normRoot}/`)
 }
 
 /**

--- a/packages/dsh-aionui-panel/src/host/git-service.ts
+++ b/packages/dsh-aionui-panel/src/host/git-service.ts
@@ -12,7 +12,7 @@ import { join, relative } from 'node:path'
 import { realpath } from 'node:fs/promises'
 import type { Context } from '@deepseek-ai/cordis'
 import type {} from '@deepseek-ai/dsh-subprocess'
-import type { SubprocessSpawnSpec } from '@deepseek-ai/dsh-subprocess'
+import type { SubprocessHandle, SubprocessSpawnSpec } from '@deepseek-ai/dsh-subprocess'
 import type { GitBatchResult, GitChangeRow, GitFileState, GitStatusView, PanelError } from '../core/types.ts'
 import { isPathInside, type WorkspaceGate } from './gate.ts'
 
@@ -45,7 +45,16 @@ export function subprocessRunner(ctx: Context): GitRunner {
         },
         graceMs: 10_000,
       }
-      const handle = ctx.subprocess.spawn(spec)
+      // A missing git binary (or a subprocess service that cannot spawn) must
+      // degrade to a failed run, not throw through the route layer: the SCM
+      // tab then shows the friendly "not a git repository" state instead of a
+      // bare 400 with no body.
+      let handle: SubprocessHandle
+      try {
+        handle = ctx.subprocess.spawn(spec)
+      } catch {
+        return { exitCode: 127, stdout: '', stderr: 'git: spawn failed (is git installed?)' }
+      }
       const outcome = await handle.done
       const stdout = handle.collected.stdout?.readFrom(0).text ?? ''
       const stderr = handle.collected.stderr?.readFrom(0).text ?? ''

--- a/scripts/link-profile.mjs
+++ b/scripts/link-profile.mjs
@@ -105,7 +105,12 @@ function main() {
   let changed = 0
   for (const { name, dir } of packages) {
     const linkPath = join(LINK_DIR, name)
-    const target = relative(LINK_DIR, dir) // keep links relative, like the official ones
+    // Windows without Developer Mode cannot create symlinks (EPERM), so this
+    // machine uses directory junctions instead. Junctions require absolute
+    // targets and readlink reports the absolute target, so the keep-check
+    // compares against that same absolute value on win32.
+    const WIN32 = process.platform === 'win32'
+    const target = WIN32 ? dir : relative(LINK_DIR, dir) // keep links relative, like the official ones
     let existing = 'missing'
     try {
       const st = lstatSync(linkPath)
@@ -127,12 +132,12 @@ function main() {
     }
     if (action === 'create') {
       if (DRY) { report(`would link ${name} -> ${target}`); changed++; continue }
-      symlinkSync(target, linkPath)
+      symlinkSync(target, linkPath, WIN32 ? 'junction' : undefined)
       report(`linked ${name} -> ${target}`)
     } else {
       if (DRY) { report(`would replace ${name} -> ${current ?? '(broken)'}`); changed++; continue }
       unlinkSync(linkPath)
-      symlinkSync(target, linkPath)
+      symlinkSync(target, linkPath, WIN32 ? 'junction' : undefined)
       report(`replaced ${name} -> ${target} (was ${current ?? '(broken)'})`)
     }
     changed++


### PR DESCRIPTION
## What
Three Windows compatibility fixes for the right panel (`dsh-aionui-panel`) and the profile link script:

1. `src/host/gate.ts` - `isPathInside` now normalizes separators and compares case-insensitively on win32. Previously `path.join` backslashes vs the forward-slash prefix made every subpath fail as `path-outside-root` (file previews and subdirectory listing broken), and the forward-slash output of `git rev-parse --show-toplevel` never matched the backslash root, so the SCM tab always reported "not a git repository" even in real repos.
2. `src/host/git-service.ts` - `subprocessRunner.run` catches spawn failures (git not installed, or the subprocess service cannot spawn) and returns a failed run (`exitCode: 127`) instead of throwing through the route layer. Previously the route returned a bare 400 with an empty body and the designed `git-unavailable` graceful degradation was never reached.
3. `scripts/link-profile.mjs` - on win32, create directory junctions (absolute target) instead of symlinks. Symlink creation requires Windows Developer Mode and fails with EPERM otherwise; junctions report `isSymbolicLink() === true` to Node, so the loader is unaffected.

## Why
These were reproduced on Windows 11 with DSH 0.1.0-rc.6 while installing the family from HEAD. Details in issues #27 and #28.

## Testing
- Windows 11, Node 22.22.2, DSH 0.1.0-rc.6, git 2.55:
  - `POST /aionui-panel/read` for a file inside the root: was 400 `path-outside-root`, now 200 with content.
  - `POST /aionui-panel/git-status` in a non-repo dir: now 200 `{"ok":true,"value":null}` (SCM tab shows the friendly "not a git repository" state).
  - `node scripts/link-profile.mjs` runs clean and links all 21 family packages on win32.
- POSIX behavior of `isPathInside` is unchanged (separator normalization is a no-op there; case folding only on win32).

Closes #27, #28