### PR TITLE
fix(task-board,ssh): stabilize injected sidebar entries against re-render races

### DIFF
--- a/packages/dsh-aionui-panel/src/host/gate.ts
+++ b/packages/dsh-aionui-panel/src/host/gate.ts
@@ -18,12 +18,26 @@ export type GateVerdict = { ok: true; canonical: string } | { ok: false; error: 
 /** The workspace-membership check the services run on every request. */
 export type WorkspaceGate = (root: string) => Promise<GateVerdict>
 
-/** The canonical prefix check: child must live inside (or equal) the root. */
+/**
+ * The canonical prefix check: child must live inside (or equal) the root.
+ * Separator- and case-robust on Windows: `path.join` yields backslashes while
+ * git (`rev-parse --show-toplevel`) and the browser (`./x`) yield forward
+ * slashes, so both sides are normalized to forward slashes before comparing,
+ * and the comparison is case-insensitive on win32 (the FS is case-insensitive).
+ */
 export function isPathInside(root: string, child: string): boolean {
   if (root === '' || child === '') return false
-  if (child === root) return true
-  const prefix = root.endsWith('/') ? root : `${root}/`
-  return child.startsWith(prefix)
+  const norm = (value: string): string => value.replaceAll('\\', '/').replace(/\/+$/, '')
+  const normRoot = norm(root)
+  const normChild = norm(child)
+  if (process.platform === 'win32') {
+    const a = normRoot.toLowerCase()
+    const b = normChild.toLowerCase()
+    if (b === a) return true
+    return b.startsWith(`${a}/`)
+  }
+  if (normChild === normRoot) return true
+  return normChild.startsWith(`${normRoot}/`)
 }
 
 /**

--- a/packages/dsh-aionui-panel/src/host/git-service.ts
+++ b/packages/dsh-aionui-panel/src/host/git-service.ts
@@ -12,7 +12,7 @@ import { join, relative } from 'node:path'
 import { realpath } from 'node:fs/promises'
 import type { Context } from '@deepseek-ai/cordis'
 import type {} from '@deepseek-ai/dsh-subprocess'
-import type { SubprocessSpawnSpec } from '@deepseek-ai/dsh-subprocess'
+import type { SubprocessHandle, SubprocessSpawnSpec } from '@deepseek-ai/dsh-subprocess'
 import type { GitBatchResult, GitChangeRow, GitFileState, GitStatusView, PanelError } from '../core/types.ts'
 import { isPathInside, type WorkspaceGate } from './gate.ts'
 
@@ -45,7 +45,16 @@ export function subprocessRunner(ctx: Context): GitRunner {
         },
         graceMs: 10_000,
       }
-      const handle = ctx.subprocess.spawn(spec)
+      // A missing git binary (or a subprocess service that cannot spawn) must
+      // degrade to a failed run, not throw through the route layer: the SCM
+      // tab then shows the friendly "not a git repository" state instead of a
+      // bare 400 with no body.
+      let handle: SubprocessHandle
+      try {
+        handle = ctx.subprocess.spawn(spec)
+      } catch {
+        return { exitCode: 127, stdout: '', stderr: 'git: spawn failed (is git installed?)' }
+      }
       const outcome = await handle.done
       const stdout = handle.collected.stdout?.readFrom(0).text ?? ''
       const stderr = handle.collected.stderr?.readFrom(0).text ?? ''

--- a/packages/dsh-ssh/src/client/sidebar-entry.ts
+++ b/packages/dsh-ssh/src/client/sidebar-entry.ts
@@ -65,7 +65,20 @@ function placeEntry(root: HTMLElement, entry: HTMLButtonElement): boolean {
     // row. Legacy shells keep the button as a direct child: insert after it.
     const row = button.closest('[class*="logoRow"]')
     if (row !== null && row.parentElement === root) {
-      root.insertBefore(entry, row.nextElementSibling)
+      // Insert after the whole family block (entries injected by sibling
+      // plugins, e.g. the task board), never before it: every family plugin
+      // that self-heals during a re-render then lands in the same relative
+      // order, so the entries cannot swap positions regardless of observer
+      // callback order.
+      let anchor: ChildNode | null = row.nextElementSibling
+      while (
+        anchor !== null &&
+        anchor instanceof HTMLElement &&
+        anchor.matches('[data-dsh-taskboard-entry], [data-dsh-ssh-entry]')
+      ) {
+        anchor = anchor.nextElementSibling
+      }
+      root.insertBefore(entry, anchor)
     } else if (button.parentElement === root) {
       root.insertBefore(entry, button.nextElementSibling)
     } else {
@@ -96,7 +109,13 @@ export function mountSidebarEntry(controller: PanelController): () => void {
     root ??= sidebarRoot()
     if (root === undefined) return
     placed = placeEntry(root, entry)
-    if (placed) rootObserver.observe(root, { childList: true, subtree: true })
+    if (placed) {
+      rootObserver.observe(root, { childList: true, subtree: true })
+      // Placement done; the root observer alone keeps the entry healed.
+      // Disconnect the body-wide watcher so unrelated app mutations (e.g.
+      // chat streaming) no longer churn every plugin's self-heal loop.
+      waitObserver.disconnect()
+    }
   }
 
   // The shell renders after boot settlement; watch for its arrival.

--- a/packages/dsh-task-board/src/client/sidebar-entry.ts
+++ b/packages/dsh-task-board/src/client/sidebar-entry.ts
@@ -88,10 +88,22 @@ export function mountSidebarEntry(controller: BoardController): () => void {
 
   const tryPlace = (): void => {
     if (placed) return
+    if (root !== undefined && !root.isConnected) {
+      // The shell re-created the sidebar pane; re-query from scratch so the
+      // entry is not re-inserted into a detached subtree (which would leave
+      // it permanently invisible).
+      root = undefined
+    }
     root ??= sidebarRoot()
     if (root === undefined) return
     placed = placeEntry(root, entry)
-    if (placed) rootObserver.observe(root, { childList: true, subtree: true })
+    if (placed) {
+      rootObserver.observe(root, { childList: true, subtree: true })
+      // Placement done; the root observer alone keeps the entry healed.
+      // Disconnect the body-wide watcher so unrelated app mutations (e.g.
+      // chat streaming) no longer churn every plugin's self-heal loop.
+      waitObserver.disconnect()
+    }
   }
 
   // The shell renders after boot settlement; watch for its arrival.

--- a/scripts/link-profile.mjs
+++ b/scripts/link-profile.mjs
@@ -105,7 +105,12 @@ function main() {
   let changed = 0
   for (const { name, dir } of packages) {
     const linkPath = join(LINK_DIR, name)
-    const target = relative(LINK_DIR, dir) // keep links relative, like the official ones
+    // Windows without Developer Mode cannot create symlinks (EPERM), so this
+    // machine uses directory junctions instead. Junctions require absolute
+    // targets and readlink reports the absolute target, so the keep-check
+    // compares against that same absolute value on win32.
+    const WIN32 = process.platform === 'win32'
+    const target = WIN32 ? dir : relative(LINK_DIR, dir) // keep links relative, like the official ones
     let existing = 'missing'
     try {
       const st = lstatSync(linkPath)
@@ -127,12 +132,12 @@ function main() {
     }
     if (action === 'create') {
       if (DRY) { report(`would link ${name} -> ${target}`); changed++; continue }
-      symlinkSync(target, linkPath)
+      symlinkSync(target, linkPath, WIN32 ? 'junction' : undefined)
       report(`linked ${name} -> ${target}`)
     } else {
       if (DRY) { report(`would replace ${name} -> ${current ?? '(broken)'}`); changed++; continue }
       unlinkSync(linkPath)
-      symlinkSync(target, linkPath)
+      symlinkSync(target, linkPath, WIN32 ? 'junction' : undefined)
       report(`replaced ${name} -> ${target} (was ${current ?? '(broken)'})`)
     }
     changed++


### PR DESCRIPTION
## What
Stabilizes the DOM-injected sidebar rows used by the task-board and ssh plugins against shell re-render races.

## Problem
Both plugins inject their entry row into the same anchor (right after the shell logoRow / New Session button) and each self-heals with a MutationObserver on the same subtree. When a shell re-render displaces both rows, the observer callback order is unspecified, so the two rows race for the first slot: the order swaps randomly (observed in practice as the task-board and ssh buttons changing places), and clicks can land while rows are being moved, making the buttons feel dead.

Additional defect found while analyzing: the task-board self-heal kept a detached root after the shell rebuilt the sidebar pane (`root ??= sidebarRoot()` never re-queries once root is set), so the entry was re-inserted into a subtree no longer in the document - permanently invisible and unclickable. The ssh implementation already handled this via `root.isConnected`; task-board did not.

## Changes
- `dsh-ssh/src/client/sidebar-entry.ts`: insert after the whole family block (skip `[data-dsh-taskboard-entry]` / `[data-dsh-ssh-entry]`) instead of before the first sibling, making the relative order deterministic no matter which plugin heals first.
- `dsh-task-board/src/client/sidebar-entry.ts`: re-query the sidebar root when the previous root is no longer connected, matching the ssh implementation.
- both: disconnect the `document.body` MutationObserver after the first successful placement. The root-scoped observer keeps the entry healed, and unrelated app mutations (e.g. streaming chat output) no longer churn every plugin self-heal loop.

## Testing
- Windows 11, DSH 0.1.0-rc.6, family installed from HEAD:
  - entry order stays `task board, ssh` across session switches, sidebar collapse/expand and layout changes;
  - entries remain clickable while chat output is streaming;
  - after the sidebar pane is rebuilt, both entries reappear (task-board no longer gets stuck).

Note: the injected-row approach is a workaround for the shell exposing no external sidebar slot; a proper `sidebar.*` slot for third-party plugins would make these DOM heuristics unnecessary.