### PR TITLE
fix(pet,ssh): dock slot, hover panel grace, ssh-config import

### DIFF
--- a/packages/dsh-pet/src/client/WhalePet.tsx
+++ b/packages/dsh-pet/src/client/WhalePet.tsx
@@ -71,6 +71,7 @@ export function WhalePet(props: WhalePetProps): ReactPortal {
   const [nameDraft, setNameDraft] = useState('')
   const [dragPos, setDragPos] = useState<{ right: number; bottom: number } | null>(null)
   const dragRef = useRef<{ startX: number; startY: number; right: number; bottom: number } | null>(null)
+  const hideTimerRef = useRef<number | null>(null)
   const frameRef = useRef<{ track: PetAnimation | null; index: number; elapsed: number }>({
     track: null,
     index: 0,
@@ -193,6 +194,13 @@ export function WhalePet(props: WhalePetProps): ReactPortal {
   // `draggedRef` records whether the pointer actually moved, so the browser's
   // trailing click (fired after pointerup) does not pet the whale.
   const draggedRef = useRef(false)
+  const clearHideTimer = (): void => {
+    if (hideTimerRef.current !== null) {
+      window.clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = null
+    }
+  }
+
   const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>): void => {
     e.preventDefault()
     ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
@@ -226,15 +234,20 @@ export function WhalePet(props: WhalePetProps): ReactPortal {
       ref={floatRef}
       className={styles.float}
       style={{ right: pos.right, bottom: pos.bottom, zIndex: 2147483000 }}
-      onPointerEnter={() => setHovered(true)}
+      onPointerEnter={() => {
+        clearHideTimer()
+        setHovered(true)
+      }}
       onPointerLeave={(e) => {
         // The panel and bubble render OUTSIDE the container's box (absolute,
         // above the sprite), so moving onto them fires pointerleave on the
         // container. Treat a target still inside the container's DOM (the
-        // overflowed panel) as "still hovering".
+        // overflowed panel) as "still hovering"; otherwise give the pointer a
+        // short grace period to reach the panel across the gap above it.
         const next = e.relatedTarget
         if (next instanceof Node && floatRef.current?.contains(next)) return
-        setHovered(false)
+        clearHideTimer()
+        hideTimerRef.current = window.setTimeout(() => setHovered(false), 200)
       }}
     >
       <div

--- a/packages/dsh-pet/src/client/index.ts
+++ b/packages/dsh-pet/src/client/index.ts
@@ -233,13 +233,14 @@ export function apply(ctx: ClientContext): void {
         },
       })
 
-      // The input selector row mounts in EVERY conversation phase (cold
-      // start, blank-session hero, active seat) — the composer dock band
-      // only renders for an active session, which is why the pet used to
-      // vanish on the new-conversation screen.
-      const disposeDock = ctx.slots.inject('conversation.input.selector.context', () =>
+      // The legacy selector-context hole (conversation.input.selector.context)
+      // is no longer declared by newer shells (rc.6 dropped it), so the pet
+      // mounts on the composer dock band instead. The dock is session-scoped,
+      // so the pet appears once a session is active (accepted downgrade, see
+      // PR #17).
+      const disposeDock = ctx.slots.inject('conversation.input.dock', () =>
         ctx.slots.register({
-          name: 'conversation.input.selector.context',
+          name: 'conversation.input.dock',
           id: 'pet',
           order: 110,
           inject: injected,

--- a/packages/dsh-pet/src/client/pet.module.css
+++ b/packages/dsh-pet/src/client/pet.module.css
@@ -60,7 +60,7 @@
 
 .panel {
   position: absolute;
-  bottom: calc(100% + 4px);
+  bottom: 100%;
   background: rgba(15, 23, 42, 0.92);
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 10px;

--- a/packages/dsh-ssh/src/store.ts
+++ b/packages/dsh-ssh/src/store.ts
@@ -42,8 +42,8 @@ export function validateHostPayload(payload: unknown): string | undefined {
     if (auth.kind === 'key' && (typeof auth.keyPath !== 'string' || auth.keyPath.trim() === '')) {
       return 'auth.keyPath is required for key auth'
     }
-    if (auth.kind === 'password' && (typeof auth.password !== 'string' || auth.password === '')) {
-      return 'auth.password is required for password auth'
+    if (auth.kind === 'password' && auth.password !== undefined && typeof auth.password !== 'string') {
+      return 'auth.password must be a string when provided'
     }
   }
   if (p.port !== undefined && (typeof p.port !== 'number' || !Number.isInteger(p.port) || p.port < 1 || p.port > 65535)) {
@@ -58,12 +58,12 @@ export function validateHostPayload(payload: unknown): string | undefined {
   return undefined
 }
 
-/** The alias grammar (same as the scaffold rule: lowercase, digits, single hyphens). */
-const ALIAS_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/
+/** Alias grammar: letters/digits plus dots, hyphens, underscores (IP/domain aliases included). */
+const ALIAS_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
 
 /** Validate an alias for creation. */
 export function validateAlias(alias: string): string | undefined {
-  if (!ALIAS_RE.test(alias)) return 'alias must be lowercase letters, digits and single hyphens'
+  if (!ALIAS_RE.test(alias)) return 'alias must be letters, digits, dots, hyphens or underscores'
   return undefined
 }
 

--- a/packages/dsh-ssh/tests/store.test.ts
+++ b/packages/dsh-ssh/tests/store.test.ts
@@ -42,18 +42,24 @@ describe('validation', () => {
   it('accepts a valid alias', () => {
     expect(validateAlias('web-01')).toBeUndefined()
     expect(validateAlias('a')).toBeUndefined()
+    // IP / domain / uppercase aliases are accepted (imported from ~/.ssh/config)
+    expect(validateAlias('192.168.40.90')).toBeUndefined()
+    expect(validateAlias('Web_01')).toBeUndefined()
+    expect(validateAlias('c2.hpcmaster.com')).toBeUndefined()
   })
 
   it('rejects invalid aliases', () => {
-    expect(validateAlias('Web_01')).toBeDefined()
     expect(validateAlias('a b')).toBeDefined()
-    expect(validateAlias('a--b')).toBeDefined()
+    expect(validateAlias('-abc')).toBeDefined()
+    expect(validateAlias('abc!')).toBeDefined()
   })
 
   it('rejects malformed payloads', () => {
     expect(validateHostPayload({})).toBeDefined()
     expect(validateHostPayload({ host: 'h', user: 'u', auth: { kind: 'key' } })).toContain('keyPath')
-    expect(validateHostPayload({ host: 'h', user: 'u', auth: { kind: 'password' } })).toContain('password')
+    // A missing/empty password is accepted (filled later in the GUI after import)
+    expect(validateHostPayload({ host: 'h', user: 'u', auth: { kind: 'password' } })).toBeUndefined()
+    expect(validateHostPayload({ host: 'h', user: 'u', auth: { kind: 'password', password: 123 } })).toContain('password')
     expect(validateHostPayload({ host: 'h', user: 'u', auth: { kind: 'bogus' } })).toContain('kind')
   })
 })


### PR DESCRIPTION
## 摘要（Summary）

修复官方 DSH 0.1.0-rc.6 下三个缺陷（详见 #38）：

- dsh-pet：dock 槽位从不存在的 `conversation.input.selector.context` 改为官方 shell 已声明的 `conversation.input.dock`，桌宠与召唤按钮得以显示；
- dsh-pet：给悬停操作面板加 200ms 隐藏宽限并去掉面板与精灵间的 4px 间隙，按钮可稳定点击；
- dsh-ssh：放宽别名语法（允许 IP/域名/大写别名）并允许导入时无密码（密码在 GUI 后补）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [x] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [x] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

DeepSeek v4 pro

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm install
pnpm --filter @linxin666/dsh-pet --filter @linxin666/dsh-ssh build
pnpm --filter @linxin666/dsh-pet --filter @linxin666/dsh-ssh test
```

结果摘要：

- 两个包的 `build`（含 `tsc -b` 类型检查）均通过，无类型错误。
- dsh-pet 测试 28/28 通过。
- dsh-ssh 测试 53/57：本次改动涉及的别名/密码校验用例已同步更新并通过；剩余 4 个失败均为 Windows 环境既有问题（`~` 展开为绝对路径、chmod 0600 在 Windows 不生效、真实 sshd 二进制缺失），在 Linux CI 上不受影响。

## 用户可见变更证据（Local Feature Evidence）

证据：

本 PR 为 Bug 修复（未勾选"面向用户的功能或行为变更"）。修复效果已在官方 DSH 0.1.0-rc.6 实机复现并验证（桌宠显示、面板可点击、SSH 配置导入成功）；如需要可后续补充截图。

Fixes #38