### PR TITLE
fix(task-board): raise board container and modal z-index above panel overlays

### DIFF
--- a/packages/dsh-task-board/src/client/board.module.css
+++ b/packages/dsh-task-board/src/client/board.module.css
@@ -16,7 +16,7 @@
   position: absolute;
   inset: 0;
   display: none;
-  z-index: 5;
+  z-index: 60;
 }
 
 /* The center column is single-occupant; the :not() guards keep the two
@@ -426,7 +426,7 @@ html[data-dsh-taskboard-active]:not([data-dsh-ssh-active]) [data-pane='conversat
 .modalBackdrop {
   position: fixed;
   inset: 0;
-  z-index: 40;
+  z-index: 1300;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## 摘要（Summary）

任务看板的容器与弹窗 z-index 过低：看板容器（5）低于 Git 图谱浮层，任务详情 / 新建任务 / 确认弹窗（40）低于右侧面板的悬浮把手（100）、确认框（1000）、右键菜单（1100）与 toast（1200），导致看板及其弹窗被其他 UI 浮层遮挡。将看板容器提升至 60、弹窗遮罩提升至 1300（仍低于宠物 2147483000）。

## 涉及包（Affected Packages）

- [x] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

DeepSeek

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-task-board build
```

结果摘要：

构建成功：client bundle 115.43 kB（gzip 28.27 kB），并在产物 `lib/client.js` 中确认包含 `z-index: 60` 与 `z-index: 1300`。

## 用户可见变更证据（Local Feature Evidence）

证据：

本地以 `link:` 方式挂载源码构建产物验证层级关系：任务看板在聊天区正常接管显示，弹窗遮罩层级高于右侧面板全部浮层。改动仅两行 CSS 数值，未附截图。
