### PR TITLE
fix(skins): drop stale bundleWired flag on xp so apply inserts its row

### DIFF
--- a/gallery/manifest.js
+++ b/gallery/manifest.js
@@ -74,7 +74,7 @@ window.SKIN_MANIFEST = {
       "package": "@linxin666/dsh-client-ui-skin-xp",
       "wiring": {
         "id": "ui-skin-xp",
-        "bundleWired": true
+        "bundleWired": false
       },
       "preview": {
         "light": "packages/skins/xp/preview/light.png",

--- a/packages/dsh-skins/skins/xp/skin.json
+++ b/packages/dsh-skins/skins/xp/skin.json
@@ -17,7 +17,7 @@
   "package": "@linxin666/dsh-client-ui-skin-xp",
   "wiring": {
     "id": "ui-skin-xp",
-    "bundleWired": true
+    "bundleWired": false
   },
   "preview": {
     "light": "packages/skins/xp/preview/light.png",

--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -190,7 +190,7 @@ function loadRegistry(skinsDir = SKINS_DIR) {
 }
 /**
 * The skins the bundle layer already wires (no insert row needed) — derived
-* from each skin.json wiring.bundleWired (the repo's static truth, e.g. xp).
+* from each skin.json wiring.bundleWired (the repo's static truth).
 *
 * TODO: the CLI also detects skins wired via the active profile's
 * dsh.profile.bundles (bundleWiredFromProfile). A skin installed from the

--- a/packages/skins/skin-center/src/skin-switch.ts
+++ b/packages/skins/skin-center/src/skin-switch.ts
@@ -241,7 +241,7 @@ export function loadRegistry(skinsDir: string = SKINS_DIR): Record<string, SkinS
 
 /**
  * The skins the bundle layer already wires (no insert row needed) — derived
- * from each skin.json wiring.bundleWired (the repo's static truth, e.g. xp).
+ * from each skin.json wiring.bundleWired (the repo's static truth).
  *
  * TODO: the CLI also detects skins wired via the active profile's
  * dsh.profile.bundles (bundleWiredFromProfile). A skin installed from the

--- a/packages/skins/skin-center/tests/skin-switch.spec.ts
+++ b/packages/skins/skin-center/tests/skin-switch.spec.ts
@@ -97,9 +97,10 @@ describe('skin registry derivation (from skin.json wiring)', () => {
       pkg: '@linxin666/dsh-client-ui-skin-blue-fantasy',
       id: 'ui-skin-blue-fantasy',
     }))
-    // xp is bundle-wired (carries no insert row) — the repo's skin.json truth.
-    expect(registry.xp.bundleWired).toBe(true)
-    expect(wiredNames(registry).has('xp')).toBe(true)
+    // No skin is bundle-wired in the npm aggregate layout — xp ships like the
+    // others and must carry its own insert row when applied.
+    expect(registry.xp.bundleWired).toBe(false)
+    expect(wiredNames(registry).has('xp')).toBe(false)
   })
 })
 

--- a/packages/skins/xp/skin.json
+++ b/packages/skins/xp/skin.json
@@ -17,7 +17,7 @@
   "package": "@linxin666/dsh-client-ui-skin-xp",
   "wiring": {
     "id": "ui-skin-xp",
-    "bundleWired": true
+    "bundleWired": false
   },
   "preview": {
     "light": "packages/skins/xp/preview/light.png",

--- a/scripts/dsh-skin
+++ b/scripts/dsh-skin
@@ -20,8 +20,7 @@
  * Switch = rewrite the managed patch section → HMR re-scans → refresh the
  * page. Only ONE skin row is ever enabled: every non-active skin gets an
  * id-target `disabled: true` row (which also neutralizes skins wired at
- * the bundle layer, e.g. ui-skin-xp), and the active skin gets its insert
- * row (xp needs none — the bundle layer already carries it).
+ * the bundle layer), and the active skin gets its insert row.
  */
 
 const fs = require('node:fs')
@@ -51,8 +50,8 @@ const SKINS = {
   trading: { pkg: '@linxin666/dsh-client-ui-skin-trading', id: 'ui-skin-trading', dir: `${REPO}/packages/skins/trading` },
   miku: { pkg: '@linxin666/dsh-client-ui-skin-miku', id: 'ui-skin-miku', dir: `${REPO}/packages/skins/miku` },
 }
-/** Skin wired at the bundle layer already (no insert row needed here). */
-const BUNDLE_WIRED = new Set(['xp'])
+/** Skins wired at the bundle layer already (no insert row needed here). Empty in the npm aggregate layout — no skin ships pre-wired; profile-installed skins are detected dynamically via bundleWiredFromProfile(). */
+const BUNDLE_WIRED = new Set()
 
 /** The profile manifest path (`$DSH_HOME/profiles/<profile>/package.json`). */
 function profileManifestPath() {


### PR DESCRIPTION
## 摘要（Summary）

npm 聚合安装下，xp 皮肤的 skin.json 仍标记 bundleWired: true（scripts/dsh-skin 也硬编码了 BUNDLE_WIRED = ['xp']），但聚合包实际没有预接线任何皮肤。于是 useSkin('xp') 跳过 xp 的 insert 行，应用 xp 后 boot 图里没有任何皮肤处于启用态，页面回落到默认外观。

修复：把 xp 的 bundleWired 改为 false（与其余 8 个皮肤一致），清空 dsh-skin 的静态 BUNDLE_WIRED 集合（profile 级安装的皮肤仍由 bundleWiredFromProfile() 动态识别），并同步更新皮肤中心测试与注释。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：
git fetch origin && git rebase origin/main

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 新增包目录以 dsh- 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：
- node scripts/dsh-skin.test.mjs（在本机沙箱中失败：spawn EPERM，属沙箱限制，非本次改动导致）
- 端到端：POST /api/skin-center/apply {"skin":"xp"}，检查 managed 段与 state

结果摘要：
- 端到端通过：应用 xp 后 ~/.dsh/cordis.patch.yml 的 managed 段正确出现 `- insert: - id: ui-skin-xp`，state 返回 active=xp；应用 blue-fantasy 同样正确。
- 单元测试因沙箱 spawn EPERM 无法在本机跑完，交由 CI 执行。

## 用户可见变更证据（Local Feature Evidence）

N/A（Bug 修复，修复 xp 应用后回落默认皮肤的问题；已在运行中的 DSH 上通过 /api/skin-center/apply 端到端验证 insert 行写入正确）。