### PR TITLE
fix(dsh-git-graph): float the branch chip above the composer via the overlay anchor

### DIFF
--- a/packages/dsh-git-graph/README.md
+++ b/packages/dsh-git-graph/README.md
@@ -1,6 +1,6 @@
 # dsh-git-graph
 
-外部 dsh Web GUI 插件：**git 分支选择器**与**Git 图谱**面板，挂在官方输入选择器行的 context 洞（`conversation.input.selector.context`，session-maybe list 槽位）里，与官方工作区选择胶囊并排、紧贴输入卡上方。git 能力在 host 进程真实执行（磁盘工作树 `git switch`），UI 在浏览器 React；工作区选择完全交给官方入口（产品决策：自研选择器下线，不保留双入口）。
+外部 dsh Web GUI 插件：**git 分支选择器**与**Git 图谱**面板，挂在官方 composer 浮动 overlay 锚点（`conversation.input.overlay`，session 作用域 list 槽位）里，悬浮在输入卡顶部上方、与输入文本左对齐（与斜杠命令菜单同一锚点）。git 能力在 host 进程真实执行（磁盘工作树 `git switch`），UI 在浏览器 React；工作区选择完全交给官方入口（产品决策：自研选择器下线，不保留双入口）。
 
 行为对齐 ZCode 的 `GitBranchSwitcher`：可搜索弹层、当前项打勾、「创建并检出新分支… / Git 图谱」底部操作、切换守卫（未解决冲突 / 进行中操作 / 目标分支被其他 worktree 检出）与可读报错。
 
@@ -28,7 +28,7 @@ git 安装（无 sibling checkout 的消费者机器）走 `prepare` 脚本：`t
 
 ## 激活
 
-本包是 dsh profile bundle（`package.json` 声明 `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`）。激活后，下次启动 `dsh web`（或对应 profile）时，bundle patch 的 insert 行把 `ui-git-graph`（host half：git 服务 + `/git/*` 路由）与浏览器 half（dsh.client 声明）一起装进 Web 组合；页面刷新即可在输入框上方的 composer dock 带看到分支胶囊。
+本包是 dsh profile bundle（`package.json` 声明 `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`）。激活后，下次启动 `dsh web`（或对应 profile）时，bundle patch 的 insert 行把 `ui-git-graph`（host half：git 服务 + `/git/*` 路由）与浏览器 half（dsh.client 声明）一起装进 Web 组合；页面刷新即可在输入卡上方看到悬浮的分支胶囊。
 
 ### 通用安装（任何机器）
 
@@ -70,7 +70,7 @@ dsh plugin --profile web remove @linxin666/dsh-client-ui-git-graph
 - 边界与加载链调研、关键决策见 [docs/ADR-001-plugin-boundary.md](docs/ADR-001-plugin-boundary.md)。
 - host half 的 `/git/*` 只接受已注册 workspace 的路径（realpath 校验），浏览器无法对任意目录执行 git。
 - 切换语义是工作区级：`git switch --no-guess <branch>` 作用于 repoRoot 磁盘树，影响该工作区所有会话；项目切换 = 激活目标工作区并打开其（复用或新建的）空白会话，不给既有会话换 cwd。
-- 挂载 seam：`conversation.input.selector.context`（官方声明的 session-maybe list 槽位）——输入选择器行的 context 洞，与官方工作区胶囊并排；hero（空白会话）与 active 会话相位都有分支胶囊；无会话 cwd 或非 git 工作区时分支 chip 自行隐藏。
+- 挂载 seam：`conversation.input.overlay`（官方声明的 session 作用域 list 槽位）——composer 浮动 overlay 锚点，chip 悬浮在输入卡顶部上方；active 会话相位有分支胶囊，hero（空白会话）不再挂载（session 作用域权衡）；无会话 cwd 或非 git 工作区时分支 chip 自行隐藏。
 - 工作区选择不在此插件内：官方工作区胶囊（`conversation.input.selector.workspace`）是唯一入口，本插件只提供 git 分支上下文。
 - 分支状态刷新：挂载/弹层打开/切换成功后拉取 + host SSE（`/git/events`，订阅期间每 2s 轮询 workspace 状态）推送外部变更 + window focus 刷新。
 

--- a/packages/dsh-git-graph/docs/ADR-001-plugin-boundary.md
+++ b/packages/dsh-git-graph/docs/ADR-001-plugin-boundary.md
@@ -2,7 +2,7 @@
 
 状态：已实现。日期：2026-08-09。
 
-> 修正（2026-08）：分支 chip 挂载槽位为官方声明的 `conversation.input.selector.context`（list、session-maybe 作用域），与官方工作区选择胶囊并排。此前 acbcf80 曾把 chip 迁到 `conversation.input.dock`，理由是「selector-context 洞在 rc.6 从未声明」——该前提不成立：随发行 shell 的 apply.ts 同时声明了 selector-context（session-maybe）与 dock（session），selector-context 才是分支 chip 的正确席位，现已回迁。hero（空白会话）与 active 会话相位都挂载；见 README 挂载 seam。
+> 修正（2026-08）：分支 chip 最终挂载槽位为 `conversation.input.overlay`（list、session 作用域）——composer 浮动 overlay 锚点，chip 悬浮在输入卡顶部上方、与输入文本左对齐（与斜杠命令菜单同一锚点）。历史：最初设计在 `conversation.input.selector.context`（任意已发布 shell 都未声明的洞，chip 从不挂载）；acbcf80 迁到 `conversation.input.dock`（输入卡上方的整行堆叠）；0be6546 又误以为 rc.2 声明了 selector-context 而回迁（实测仍不挂载）；PR 曾尝试 `input.left`（工具行，与 access mode / model 并排，不符合「悬浮在输入框上方」的预期）。`input.overlay` 是已声明、且把 chip 悬浮在输入框上方的正确席位。见 README 挂载 seam。
 
 ## 背景
 

--- a/packages/dsh-git-graph/package.json
+++ b/packages/dsh-git-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linxin666/dsh-client-ui-git-graph",
-  "description": "External dsh web GUI plugin: a git branch selector + Git graph in the conversation header's context hole (beside the official workspace selector), with real host-side git operations (switch/create) and guards, as a dsh profile bundle",
+  "description": "External dsh web GUI plugin: a git branch selector + Git graph floating above the composer card (conversation.input.overlay), with real host-side git operations (switch/create) and guards, as a dsh profile bundle",
   "version": "0.1.10",
   "type": "module",
   "packageManager": "pnpm@11.7.0",

--- a/packages/dsh-git-graph/src/client/chips/BranchChip.tsx
+++ b/packages/dsh-git-graph/src/client/chips/BranchChip.tsx
@@ -1,9 +1,9 @@
 /**
- * The input selector context entry: the git branch selector chip, mounted
- * in the selector row's context hole (`conversation.input.selector.context`)
- * right beside the official workspace selector, docked above the input card.
- * The session-maybe seat keeps the chip mounted in every phase — hero (blank
- * session) included — and the chip hides itself only when its data source
+ * The floating overlay entry: the git branch selector chip, mounted in the
+ * composer's floating overlay anchor (`conversation.input.overlay`, a
+ * session-scoped list slot) and floating above the composer card's top edge,
+ * left-aligned with the input text. The seat is session-scoped, so the chip
+ * mounts once a session is active and hides itself only when its data source
  * is absent (no session cwd, or not a git repository).
  * @module dsh-git-graph/client/chips/BranchChip
  */
@@ -19,15 +19,15 @@ import { CreateBranchDialog } from './CreateBranchDialog.tsx'
 import { GraphDialog } from '../graph/GraphDialog.tsx'
 import css from './context.module.css'
 
-/** Full props of the branch chip: the context hole's runtime share + the git-graph inject face + the locale seat. */
+/** Full props of the branch chip: the overlay anchor's runtime share (empty owner) + the git-graph inject face + the locale seat. */
 export type BranchChipProps =
-  PropsRuntime<'conversation.input.selector.context'>
+  PropsRuntime<'conversation.input.overlay'>
   & GitGraphInjected
   & PropsLocale<'git-graph'>
 
 /**
  * The git branch selector chip.
- * @param props - the composed context-hole entry props.
+ * @param props - the composed overlay entry props.
  */
 export function BranchChip(props: BranchChipProps) {
   /** Repository state: undefined = loading, null = not a repository, else the snapshot. */

--- a/packages/dsh-git-graph/src/client/chips/context.module.css
+++ b/packages/dsh-git-graph/src/client/chips/context.module.css
@@ -1,8 +1,13 @@
-/* Branch selector chip in the conversation header context hole.
+/* Branch selector chip floating above the composer card's top edge.
    Tokens only — no literal colors. */
 
 .anchor {
-  position: relative;
+  position: absolute;
+  /* Float 4px above the composer card's top edge, left-aligned with the
+     input text — the same anchor the slash-command menu rides. */
+  bottom: calc(100% + 4px);
+  left: 0;
+  z-index: 60;
 }
 
 .chip {
@@ -67,8 +72,8 @@
 
 .popover {
   position: absolute;
-  /* The selector row sits above the input card: the popover opens UPWARD,
-     capped at the same 360px as the workspace picker menu beside it. */
+  /* The chip floats above the input card, so the popover opens UPWARD from
+     the chip, capped at the same 360px as the composer menus. */
   bottom: calc(100% + 4px);
   left: 0;
   z-index: 40;

--- a/packages/dsh-git-graph/src/client/index.ts
+++ b/packages/dsh-git-graph/src/client/index.ts
@@ -1,29 +1,27 @@
 /**
  * Git-graph surface plugin, browser half: the git branch selector chip in
- * the input selector row's context hole (`conversation.input.selector
- * .context`, a session-maybe list slot declared and rendered by the shipped
- * ui-conversation shell), docked right beside the official workspace
- * selector above the input card. All git facts arrive through the host
- * /git routes (this package's own host half); the inject face carries the
- * business verbs, the components stay pure props.
+ * the composer's floating overlay anchor (`conversation.input.overlay`, a
+ * session-scoped list slot the shipped ui-conversation shell renders inside
+ * the card's overlay anchor). The chip floats above the composer card's top
+ * edge, left-aligned with the input text — the same anchor the slash-command
+ * MenuView uses. All git facts arrive through the host /git routes (this
+ * package's own host half); the inject face carries the business verbs, the
+ * components stay pure props.
  *
- * The context hole is session-maybe: the chip stays mounted from cold start
- * through the active phase and hides itself when its data source is absent
- * (no session cwd, or not a git repository) — no workspace selector lives
- * here, the official selector chip docked above the input card owns that
- * surface. An earlier revision (acbcf80) moved the chip to
- * `conversation.input.dock` on the wrong premise that the selector-context
- * hole was undeclared; the running shell declares it, so the chip registers
- * here to sit in the same row as the workspace chip. The published npm SDK
- * (rc.6) dropped the hole's type, so it is spelled locally below.
+ * The seat is session-scoped: the chip mounts once a session is active and
+ * hides itself when its data source is absent (no session cwd, or not a git
+ * repository). Earlier revisions tried `conversation.input.dock` (a full-width
+ * line in the flow above the card), `conversation.input.selector.context`
+ * (a hole no published shell declares, so the chip never mounted) and
+ * `conversation.input.left` (the tool row beside access mode / model);
+ * `input.overlay` is the declared seat that floats the chip above the box.
  * @module dsh-git-graph/client
  */
 
 import type { ClientContext, SessionId } from '@deepseek-ai/dsh-client-runtime/client'
 import type {} from '@deepseek-ai/dsh-client-locale/client'
-// Type-only: pulls the ui-conversation SlotMap merge (the conversation
-// slots); the selector-context hole is spelled locally below because the
-// published npm SDK (rc.6) dropped it while the running shell still renders it.
+// Type-only: pulls the ui-conversation SlotMap merge (the input overlay
+// entry) and, transitively, ui-input-trigger's overlay slot declaration.
 import type {} from '@deepseek-ai/dsh-client-ui-conversation/client'
 import type {} from '@deepseek-ai/dsh-client-ui-slots'
 import type {
@@ -44,31 +42,24 @@ declare module '@deepseek-ai/dsh-client-ui-slots' {
 
   interface SlotMap {
     /**
-     * The input selector context-chip hole: feature chips rendered right
-     * after the workspace selector (the git branch selector's seat).
-     * Session-maybe: entries stay mounted without a session and hide
-     * themselves when their data source is absent.
-     *
-     * Declared and rendered by the running dsh web shell
-     * (ui-conversation's InputSelectorRow); the published npm SDK (rc.6)
-     * dropped this hole, so it is spelled locally to keep the chip's
-     * registration type-checked without depending on the sibling SDK surface.
+     * The composer's floating overlay anchor (the InputBar's overlayAnchor):
+     * list entries render inside the card's overlay anchor and float above
+     * the composer top edge (bottom: 100% + gap). The runtime declaration
+     * (children table) ships in ui-conversation's apply.ts; the type is
+     * spelled here because it merges from ui-input-trigger, which this
+     * package does not depend on — the same pattern the shell itself uses.
      */
-    'conversation.input.selector.context': {
+    'conversation.input.overlay': {
       kind: 'list'
-      scope: 'session-maybe'
-      owner: InputSelectorContextOwnerProps
+      scope: 'session'
     }
   }
 }
 
-/** Owner share of the input selector context-chip hole (empty by contract). */
-export interface InputSelectorContextOwnerProps {}
-
 /** Dictionary namespace owned by this plugin. */
 const NS = 'git-graph'
 
-/** Required services: slots for the selector-context entry, sessions for the cwd lookup, locale for the copy. */
+/** Required services: slots for the input overlay entry, sessions for the cwd lookup, locale for the copy. */
 export const inject = ['slots', 'sessions', 'connection', 'locale']
 
 /** Injected business face of the branch chip: git verbs, keyed by the current session id. */
@@ -91,7 +82,7 @@ export interface GitGraphInjected {
 const NO_WORKSPACE: GitError = { code: 'workspace-unknown', message: 'session has no workspace' }
 
 /**
- * Client plugin body: the selector-context entry with its git verbs.
+ * Client plugin body: the composer tool-row entry with its git verbs.
  * @param ctx - client root context.
  */
 export function apply(ctx: ClientContext): void {
@@ -99,10 +90,9 @@ export function apply(ctx: ClientContext): void {
 
   const git = new GitApi()
 
-  // Conditional mount: 'conversation.input.selector.context' is declared by
-  // the shipped ui-conversation entry (the InputSelectorRow context hole);
-  // the conversation service being up is the registration-safe signal (the
-  // GoalDock/QueueDock seam).
+  // Conditional mount: 'conversation.input.left' is declared by the shipped
+  // ui-conversation shell (the composer card's tool row). The conversation
+  // service being up is the registration-safe signal.
   ctx.inject(['slots', 'conversation', 'sessions'], (scope: ClientContext) => {
     const sessions = scope.sessions
 
@@ -158,12 +148,12 @@ export function apply(ctx: ClientContext): void {
     }
 
     // Declaration-aware: the chip registers only when the shell declares the
-    // selector-context hole. A bare register() would throw on shells that
-    // dropped the hole (SDK SlotCore.register rejects undeclared slots), so
-    // route through inject like the pet / remote-web-ui entries.
-    scope.slots.inject('conversation.input.selector.context', () =>
+    // overlay slot. A bare register() would throw on shells that dropped the
+    // slot (SDK SlotCore.register rejects undeclared slots), so route through
+    // inject like the pet / remote-web-ui entries.
+    scope.slots.inject('conversation.input.overlay', () =>
       scope.slots.register({
-        name: 'conversation.input.selector.context',
+        name: 'conversation.input.overlay',
         id: 'git-graph',
         order: 100,
         locale: NS,

--- a/packages/dsh-git-graph/tests/client-apply.spec.tsx
+++ b/packages/dsh-git-graph/tests/client-apply.spec.tsx
@@ -1,19 +1,20 @@
 // @vitest-environment jsdom
 /**
  * Client apply() registration tests: the browser half registers the branch
- * chip on the input selector row's context hole
- * (`conversation.input.selector.context`, session-maybe), NOT the composer
- * dock band — the hole the shipped ui-conversation shell renders right beside
- * the official workspace selector. This guards the acbcf80 regression where
- * the chip was moved to `conversation.input.dock` on the wrong premise that
- * the selector-context hole was undeclared.
+ * chip on the composer's floating overlay anchor
+ * (`conversation.input.overlay`, session-scoped), NOT the composer dock band
+ * above the card nor the tool row. This guards the regressions where the chip
+ * was moved to `conversation.input.dock` (a line of its own in the flow above
+ * the card), to `conversation.input.selector.context` (a hole no published
+ * shell declares, so the chip never mounted) and to `conversation.input.left`
+ * (the tool row beside access mode / model).
  */
 import { describe, expect, it, vi } from 'vitest'
 import { apply } from '../src/client/index.ts'
 import { BranchChip } from '../src/client/chips/BranchChip.tsx'
 
 describe('client apply()', () => {
-  it('registers the branch chip on the selector-context hole (session-maybe)', () => {
+  it('registers the branch chip on the floating overlay anchor (session-scoped)', () => {
     const register = vi.fn(() => () => undefined)
     const slotInject = vi.fn((_name: string, callback: () => () => void) => callback())
 
@@ -31,12 +32,12 @@ describe('client apply()', () => {
     apply(ctx as never)
 
     // The registration waits on the conversation/sessions seam, then on the
-    // selector-context declaration before registering the chip component.
+    // overlay declaration before registering the chip component.
     expect(ctx.inject).toHaveBeenCalledWith(['slots', 'conversation', 'sessions'], expect.any(Function))
-    expect(slotInject).toHaveBeenCalledWith('conversation.input.selector.context', expect.any(Function))
+    expect(slotInject).toHaveBeenCalledWith('conversation.input.overlay', expect.any(Function))
     expect(register).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: 'conversation.input.selector.context',
+        name: 'conversation.input.overlay',
         id: 'git-graph',
         order: 100,
       }),
@@ -46,6 +47,13 @@ describe('client apply()', () => {
       expect.objectContaining({ name: 'conversation.input.dock' }),
       expect.anything(),
     )
+    expect(register).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'conversation.input.left' }),
+      expect.anything(),
+    )
+    expect(register).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'conversation.input.selector.context' }),
+      expect.anything(),
+    )
   })
 })
-

--- a/packages/dsh-git-graph/tests/client.spec.tsx
+++ b/packages/dsh-git-graph/tests/client.spec.tsx
@@ -1,12 +1,11 @@
 // @vitest-environment jsdom
 /**
- * Branch-chip behavior tests: the input selector context entry renders the
- * branch chip from the session baseline, non-repository workspaces (and
- * sessions without a cwd) hide it, blank (hero) sessions keep it mounted,
- * the popover searches/filters and marks the current branch, the footer
- * flows fire the right verbs, switch rejections surface readable copy, and
- * the create/graph dialogs behave (validation, duplicate copy, lane
- * rendering).
+ * Branch-chip behavior tests: the floating overlay entry renders the branch
+ * chip from the session baseline, non-repository workspaces (and sessions
+ * without a cwd) hide it, blank (hero) sessions keep it mounted, the popover
+ * searches/filters and marks the current branch, the footer flows fire the
+ * right verbs, switch rejections surface readable copy, and the create/graph
+ * dialogs behave (validation, duplicate copy, lane rendering).
  */
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -94,9 +93,9 @@ function bench(options: BenchOptions = {}) {
 
   const props: BranchChipProps = {
     sessionId,
-    // The selector-context hole has an empty owner share: the chip derives
-    // its state from the standard session-maybe kit + the inject face, never
-    // from the conversation snapshot or live input state.
+    // The overlay anchor has an empty owner share: the chip derives its state
+    // from the standard session kit + the inject face, never from the
+    // conversation snapshot or live input state.
     useSession: (() => undefined) as never,
     useSessions: ((selector: (state: { byId: Record<string, { cwd?: string; blank?: boolean }> }) => unknown) =>
       selector({ byId: { [sessionId]: { cwd, blank: options.blank === true } } })) as never,
@@ -117,7 +116,7 @@ describe('BranchChip', () => {
     expect(branchChip.textContent).toContain('main')
   })
 
-  it('keeps the branch chip in a blank (hero) session — the selector row stays docked', async () => {
+  it('keeps the branch chip in a blank (hero) session — the overlay seat stays mounted', async () => {
     bench({ blank: true })
     const branchChip = await screen.findByRole('button', { name: '分支' })
     expect(branchChip.textContent).toContain('main')


### PR DESCRIPTION
## 摘要（Summary）

把 `dsh-git-graph` 的分支胶囊挂到 `conversation.input.overlay`（composer 的浮动 overlay 锚点），让它**悬浮在输入框上方**、与输入文本左对齐（和斜杠命令菜单同一锚点），而不是落在工具行 / 输入卡上方的整行。

## 涉及包（Affected Packages）

- [x] Git 图谱 `packages/dsh-git-graph`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

（本分支已 rebase 到 `a36f60f`，并为单个提交）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本次无新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm -C packages/dsh-git-graph run build     # tsc -b && tsdown
pnpm -C packages/dsh-git-graph exec vitest run --pool=threads
```

结果摘要：

- `pnpm run build`：通过（`tsc -b` + tsdown 打包）
- `vitest run --pool=threads`：**4 个测试文件、45 个用例全部通过**

## 挂载位置结论与证据

`conversation.input.overlay` 是「悬浮在输入框上方」的正确席位（InputBar 的 `overlayAnchor`，MenuView 斜杠菜单同款锚点）。此前几版都不对：

- `conversation.input.dock`：输入卡**上方的一整行**（占位、把卡片往下推），不是悬浮。
- `conversation.input.selector.context`：**任何已发布 shell（rc.2/rc.6）都未声明**（源码 `deepseek-ai/deepseek-harness` 与 npm 产物中 `selector.context` 均为 0 处、`InputSelectorRow` 组件名 0 处），chip 挂上去 `inject` 永久等待、从不挂载。
- `conversation.input.left`：工具行（紧挨 access mode / model），不符合「悬浮在输入框上方」的预期。

`input.overlay` 的 SlotMap 类型来自 ui-input-trigger，本包不依赖它，故在 `index.ts` 里按 shell 自身的写法本地拼写该槽位（`kind: 'list'; scope: 'session'`），运行时声明本就随 ui-conversation 的 apply.ts 下发。

## 用户可见变更证据（Local Feature Evidence）

本地 `dsh web --port 3199` + Playwright（`--channel=chrome`）实测：

- chip 出现在 `div.uV2eYG_overlayAnchor` 内，祖先链为 `button._0tixmW_chip > div._0tixmW_anchor > div[data-slot=conversation.input.overlay] > div.uV2eYG_overlayAnchor > div.uV2eYG_card[data-composer-card]`
- chip `top=393 < card top=421`，`floatsAboveCard: true` —— 即**悬浮在输入卡上方**、与输入文本左对齐