### PR TITLE
fix(remote-web-ui): 修复手机配对后丢失工作区深链

### DIFF
--- a/packages/dsh-remote-web-ui/src/client/deep-link.ts
+++ b/packages/dsh-remote-web-ui/src/client/deep-link.ts
@@ -74,7 +74,7 @@ export function runPairBootFlow(ctx: Context, search: string, page: PageSurface 
   }
 }
 
-/** Accept the token, then reload (the workspace param survives the reload). */
+/** Accept the token, then enter the matching desktop/mobile surface. */
 async function runAccept(token: string, page: PageSurface): Promise<void> {
   let ok = false
   try {
@@ -91,9 +91,15 @@ async function runAccept(token: string, page: PageSurface): Promise<void> {
   page.replaceState(`${url.pathname}${url.search}${url.hash}`)
   if (ok) {
     // Phones land on the standalone simplified surface (the full desktop UI
-    // is not built for small screens); desktops stay on the full UI.
-    if (isMobileSurface()) page.navigate('/m')
-    else page.reload()
+    // is not built for small screens). Keep the workspace target so the
+    // mobile surface can open the intended workspace instead of losing the
+    // QR context at this navigation boundary.
+    if (isMobileSurface()) {
+      url.pathname = '/m'
+      page.navigate(`${url.pathname}${url.search}${url.hash}`)
+    } else {
+      page.reload()
+    }
   }
 }
 

--- a/packages/dsh-remote-web-ui/src/mobile/views/App.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/App.tsx
@@ -42,6 +42,12 @@ export interface RenderMessage {
   toolSummary?: string
 }
 
+/** Read the optional workspace target carried from the pairing QR flow. */
+export function mobileWorkspaceTarget(search: string): string | undefined {
+  const value = new URLSearchParams(search).get('workspace')
+  return value === null || value === '' ? undefined : value
+}
+
 /** Map a list row to the surface model; the title comes from projections when present. */
 export function toSessionView(item: {
   sessionId: string
@@ -83,6 +89,9 @@ export function formatTime(epochMs: number): string {
  */
 export function App() {
   const [route, setRoute] = useState<Route>({ kind: 'workspaces' })
+  const [initialWorkspaceId, setInitialWorkspaceId] = useState<string | undefined>(
+    () => mobileWorkspaceTarget(window.location.search),
+  )
   const muxRef = useRef<MuxClient | undefined>(undefined)
 
   // The mux stream lives for the page lifetime: session events keep the
@@ -113,10 +122,20 @@ export function App() {
     setRoute({ kind: 'chat', session, workspace })
   }, [])
 
+  const openWorkspace = useCallback((workspace: WorkspaceRow) => {
+    if (initialWorkspaceId !== undefined) {
+      const url = new URL(window.location.href)
+      url.searchParams.delete('workspace')
+      window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+      setInitialWorkspaceId(undefined)
+    }
+    setRoute({ kind: 'sessions', workspace })
+  }, [initialWorkspaceId])
+
   return (
     <div className="mobile">
       {route.kind === 'workspaces'
-        ? <WorkspaceRoster onPick={(workspace) => { setRoute({ kind: 'sessions', workspace }) }} />
+        ? <WorkspaceRoster initialWorkspaceId={initialWorkspaceId} onPick={openWorkspace} />
         : route.kind === 'sessions'
           ? (
             <SessionListView

--- a/packages/dsh-remote-web-ui/src/mobile/views/WorkspaceView.test.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/WorkspaceView.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+/** Mobile workspace landing: roster rendering and QR deep-link selection. */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { WorkspaceView as WorkspaceRow } from '@deepseek-ai/dsh-host-apiproxy/api/workspace'
+import { mobileWorkspaceTarget } from './App.tsx'
+import { WorkspaceView } from './WorkspaceView.tsx'
+
+vi.mock('../api.ts', () => ({
+  listWorkspaces: vi.fn(),
+}))
+import { listWorkspaces } from '../api.ts'
+
+const listWorkspacesMock = vi.mocked(listWorkspaces)
+const workspaces: WorkspaceRow[] = [
+  {
+    workspaceId: 'ws-1' as never,
+    path: '/tmp/first',
+    title: 'First',
+    sessionIds: [] as never,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    workspaceId: 'ws-2' as never,
+    path: '/tmp/second',
+    title: 'Second',
+    sessionIds: [] as never,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+]
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('mobile workspace deep link', () => {
+  it('reads a non-empty workspace target from the query', () => {
+    expect(mobileWorkspaceTarget('?workspace=ws-2')).toBe('ws-2')
+    expect(mobileWorkspaceTarget('?workspace=')).toBeUndefined()
+    expect(mobileWorkspaceTarget('')).toBeUndefined()
+  })
+
+  it('opens the targeted workspace as soon as the roster loads', async () => {
+    listWorkspacesMock.mockResolvedValue(workspaces)
+    const onPick = vi.fn()
+
+    render(<WorkspaceView initialWorkspaceId="ws-2" onPick={onPick} />)
+
+    await waitFor(() => expect(onPick).toHaveBeenCalledWith(workspaces[1]))
+    expect(onPick).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the roster when the target no longer exists', async () => {
+    listWorkspacesMock.mockResolvedValue(workspaces)
+    const onPick = vi.fn()
+
+    render(<WorkspaceView initialWorkspaceId="missing" onPick={onPick} />)
+
+    expect(await screen.findByText('First')).toBeTruthy()
+    expect(await screen.findByText('Second')).toBeTruthy()
+    expect(onPick).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dsh-remote-web-ui/src/mobile/views/WorkspaceView.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/WorkspaceView.tsx
@@ -13,6 +13,8 @@ import { ThemeToggle } from '../theme-toggle.tsx'
 
 /** Props for the workspace roster. */
 export interface WorkspaceViewProps {
+  /** Workspace carried by the pairing link; opened after the roster loads. */
+  initialWorkspaceId?: string
   /** Open one workspace's session list. */
   onPick(workspace: WorkspaceRow): void
 }
@@ -22,7 +24,7 @@ export interface WorkspaceViewProps {
  * @param props - the pick action.
  * @returns the roster.
  */
-export function WorkspaceView({ onPick }: WorkspaceViewProps) {
+export function WorkspaceView({ initialWorkspaceId, onPick }: WorkspaceViewProps) {
   const [items, setItems] = useState<WorkspaceRow[] | undefined>(undefined)
   const [error, setError] = useState<string | undefined>(undefined)
 
@@ -31,6 +33,13 @@ export function WorkspaceView({ onPick }: WorkspaceViewProps) {
     void listWorkspaces().then(
       (rows) => {
         if (cancelled) return
+        const target = initialWorkspaceId === undefined
+          ? undefined
+          : rows.find(workspace => workspace.workspaceId === initialWorkspaceId)
+        if (target !== undefined) {
+          onPick(target)
+          return
+        }
         setItems(rows)
       },
       (reason: unknown) => {
@@ -39,7 +48,7 @@ export function WorkspaceView({ onPick }: WorkspaceViewProps) {
       },
     )
     return () => { cancelled = true }
-  }, [])
+  }, [initialWorkspaceId, onPick])
 
   if (error !== undefined) {
     return (

--- a/packages/dsh-remote-web-ui/tests/deep-link.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/deep-link.spec.ts
@@ -75,6 +75,19 @@ describe('runPairBootFlow', () => {
     expect(replaceState).toHaveBeenCalledWith('/')
   })
 
+  it('preserves the workspace target when routing an accepted phone to /m', async () => {
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Android 16; Mobile)' })
+    const { page, navigate, replaceState } = fakePage('?pair=tok-1&workspace=ws-7')
+    const fetch = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    vi.stubGlobal('fetch', fetch)
+    const ctx = { get: () => undefined }
+
+    runPairBootFlow(ctx as never, '?pair=tok-1&workspace=ws-7', page)
+
+    await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith('/m?workspace=ws-7'))
+    expect(replaceState).toHaveBeenCalledWith('/?workspace=ws-7')
+  })
+
   it('marks the failure instead of reloading when the token is refused', async () => {
     const { page, reload } = fakePage('?pair=tok-1')
     const fetch = vi.fn(async () => new Response(JSON.stringify({ ok: false, code: 'used' }), { status: 409 }))


### PR DESCRIPTION
## 摘要（Summary）

手机扫描带 `workspace` 参数的远程配对二维码并完成配对后，页面原本会直接跳转到 `/m`，导致工作区深链丢失，用户仍需手动选择工作区。

本 PR 在进入移动端页面时保留工作区参数，并在工作区列表加载完成后自动打开目标工作区；如果目标已不存在，则安全回退到正常的工作区列表。

根因是配对成功后的移动端导航硬编码为 `/m`，没有继续携带移除 `pair` 参数后剩余的查询参数，同时移动端入口也没有消费 `workspace` 参数。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream --prune
```

提交前确认 `upstream/main` 为 `a36f60f`，当前分支基于该提交，ahead/behind 为 `0/0`（不含本 PR 提交）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5.6 Sol

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）；本 PR 未新增包目录。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
pnpm --filter @linxin666/dsh-remote-web-ui build
git diff --check
```

结果摘要：

- 14 个测试文件、108 项测试全部通过。
- TypeScript 类型检查通过。
- host、client、mobile 三个 bundle 构建通过。
- `git diff --check` 通过。
- 测试期间仅出现官方 SDK 发布物缺少 source map 的既有警告，不影响测试结果。

## 用户可见变更证据（Local Feature Evidence）

证据：本次修复没有新增界面。自动化回归测试覆盖了配对成功后保留 `/m?workspace=ws-7`，以及移动端自动打开目标工作区、目标不存在时回退到工作区列表的行为。
