### PR TITLE
feat(dsh-ssh): add press feedback to sidebar entry row

### DIFF
--- a/packages/dsh-ssh/src/client/panel/panel.module.css
+++ b/packages/dsh-ssh/src/client/panel/panel.module.css
@@ -50,6 +50,11 @@ html[data-dsh-ssh-active]:not([data-dsh-taskboard-active]) [data-pane='conversat
   cursor: pointer;
   font-size: 13px;
   white-space: nowrap;
+  transition: transform 120ms ease;
+}
+
+.entry:active {
+  transform: translateY(1px);
 }
 
 .entry:hover {


### PR DESCRIPTION
## Summary

The SSH sidebar entry has no press feedback: clicking it produces no visual
acknowledgement, which makes it feel unresponsive next to the task-board entry.
The task board's entry shifts 1px on `:active` with a 120ms `transform`
transition — a small "press" confirmation. This change brings the SSH entry to
parity with that behaviour.

## Changes

- `transition: transform 120ms ease` on `.entry`
- `.entry:active { transform: translateY(1px) }`

## Scope

- CSS-only, single file: `packages/dsh-ssh/src/client/panel/panel.module.css`
- No logic changes, no new dependencies.

## Verification

- Applied the same two rules to the built bundle locally; the entry now
  animates on press and matches the task-board feel.
