### PR TITLE
fix(git-graph): selector-context 槽位未声明时回退到 composer dock，恢复分支切换按钮（#77）

### DIFF
--- a/packages/dsh-git-graph/src/client/index.ts
+++ b/packages/dsh-git-graph/src/client/index.ts
@@ -1,21 +1,26 @@
 /**
- * Git-graph surface plugin, browser half: the git branch selector chip in
- * the input selector row's context hole (`conversation.input.selector
- * .context`, a session-maybe list slot declared and rendered by the shipped
- * ui-conversation shell), docked right beside the official workspace
- * selector above the input card. All git facts arrive through the host
- * /git routes (this package's own host half); the inject face carries the
+ * Git-graph surface plugin, browser half: the git branch selector chip,
+ * mounted with declaration awareness — the preferred seat is the input
+ * selector row's context hole (`conversation.input.selector.context`, a
+ * session-maybe list slot declared and rendered by ui-conversation shells
+ * after rc.6, right beside the official workspace selector above the input
+ * card); when the running shell never declares that hole (the shipped rc.6
+ * shell, whose published npm SDK also dropped its type), the chip falls
+ * back to the composer dock band (`conversation.input.dock`, the 0.1.9
+ * seat). A late preferred-seat declaration migrates the chip onto it and
+ * unmounts the fallback entry. All git facts arrive through the host /git
+ * routes (this package's own host half); the inject face carries the
  * business verbs, the components stay pure props.
  *
- * The context hole is session-maybe: the chip stays mounted from cold start
- * through the active phase and hides itself when its data source is absent
- * (no session cwd, or not a git repository) — no workspace selector lives
- * here, the official selector chip docked above the input card owns that
- * surface. An earlier revision (acbcf80) moved the chip to
- * `conversation.input.dock` on the wrong premise that the selector-context
- * hole was undeclared; the running shell declares it, so the chip registers
- * here to sit in the same row as the workspace chip. The published npm SDK
- * (rc.6) dropped the hole's type, so it is spelled locally below.
+ * Both seats hide the chip when its data source is absent (no session cwd,
+ * or not a git repository); the selector-context seat additionally keeps
+ * the chip mounted in the hero phase. An earlier revision (acbcf80) moved
+ * the chip to `conversation.input.dock`; 0be6546 moved it back to the
+ * selector-context hole on the premise that the running shell declares it —
+ * false for rc.6, so the chip vanished there. The fallback below restores
+ * the chip on every shell while keeping the preferred seat for shells that
+ * declare it. The published npm SDK (rc.6) dropped the hole's type, so it
+ * is spelled locally below.
  * @module dsh-git-graph/client
  */
 
@@ -157,17 +162,54 @@ export function apply(ctx: ClientContext): void {
       }
     }
 
-    // Declaration-aware: the chip registers only when the shell declares the
-    // selector-context hole. A bare register() would throw on shells that
-    // dropped the hole (SDK SlotCore.register rejects undeclared slots), so
-    // route through inject like the pet / remote-web-ui entries.
-    scope.slots.inject('conversation.input.selector.context', () =>
-      scope.slots.register({
-        name: 'conversation.input.selector.context',
+    // Declaration-aware mount with a dock fallback: the preferred seat is the
+    // selector-row context hole (declared by shells after rc.6; session-maybe,
+    // beside the workspace chip). The shipped rc.6 shell never declares it —
+    // slots.inject would wait forever — so when `spec()` reports it absent,
+    // register the chip on the composer dock band instead (the 0.1.9 seat).
+    // If the preferred seat is declared later (shell boots after this plugin),
+    // the pending inject fires, unmounts the fallback entry, and migrates the
+    // chip onto the preferred seat. register() throws on undeclared slots, so
+    // the fallback register is additionally guarded by its own spec probe.
+    const PREFERRED = 'conversation.input.selector.context'
+    const FALLBACK = 'conversation.input.dock'
+    let mountedAt: 'preferred' | 'fallback' | null = null
+    let unmountFallback: (() => void) | null = null
+
+    scope.slots.inject(PREFERRED, () => {
+      unmountFallback?.()
+      unmountFallback = null
+      const dispose = scope.slots.register({
+        name: PREFERRED,
         id: 'git-graph',
         order: 100,
         locale: NS,
         inject: injected,
-      }, BranchChip))
+      }, BranchChip)
+      mountedAt = 'preferred'
+      return () => {
+        if (mountedAt === 'preferred') {
+          mountedAt = null
+          dispose()
+        }
+      }
+    })
+
+    if (mountedAt === null && scope.slots.spec(PREFERRED) === undefined && scope.slots.spec(FALLBACK) !== undefined) {
+      const dispose = scope.slots.register({
+        name: FALLBACK,
+        id: 'git-graph',
+        order: 100,
+        locale: NS,
+        inject: injected,
+      }, BranchChip)
+      unmountFallback = () => {
+        if (mountedAt === 'fallback') {
+          mountedAt = null
+          dispose()
+        }
+      }
+      mountedAt = 'fallback'
+    }
   })
 }

--- a/packages/dsh-git-graph/tests/client-apply.spec.tsx
+++ b/packages/dsh-git-graph/tests/client-apply.spec.tsx
@@ -1,38 +1,53 @@
 // @vitest-environment jsdom
 /**
  * Client apply() registration tests: the browser half registers the branch
- * chip on the input selector row's context hole
- * (`conversation.input.selector.context`, session-maybe), NOT the composer
- * dock band — the hole the shipped ui-conversation shell renders right beside
- * the official workspace selector. This guards the acbcf80 regression where
- * the chip was moved to `conversation.input.dock` on the wrong premise that
- * the selector-context hole was undeclared.
+ * chip with declaration awareness — on the input selector row's context hole
+ * (`conversation.input.selector.context`, session-maybe) when the shell
+ * declares it (shells after rc.6, beside the official workspace selector),
+ * and on the composer dock band (`conversation.input.dock`) when the shell
+ * never declares the preferred hole (the shipped rc.6 shell — the 0be6546
+ * regression this guards). The inject wait is the registration-safe signal
+ * for the preferred seat: a late declaration migrates the chip onto it.
  */
 import { describe, expect, it, vi } from 'vitest'
 import { apply } from '../src/client/index.ts'
 import { BranchChip } from '../src/client/chips/BranchChip.tsx'
 
+/** Scripted slots face: inject runs or parks the wait, spec answers declaration state. */
+function bench(preferredSpec: unknown, parkInject: boolean) {
+  const register = vi.fn(() => () => undefined)
+  const slotInject = vi.fn((_name: string, callback: () => () => void) => {
+    if (!parkInject) callback()
+    return () => undefined
+  })
+  // The fallback seat is always declared; only the preferred hole varies.
+  const spec = vi.fn((key: string) =>
+    key === 'conversation.input.selector.context' ? preferredSpec : { kind: 'list', scope: 'session' })
+
+  const scope = {
+    slots: { inject: slotInject, register, spec },
+    conversation: {},
+    sessions: { list: { getSnapshot: () => ({ byId: {} }) } },
+  }
+  const ctx = {
+    effect: vi.fn((fn: () => void) => { fn(); return () => {} }),
+    locale: { register: vi.fn() },
+    inject: vi.fn((_services: unknown, callback: (s: typeof scope) => void) => { callback(scope) }),
+  }
+
+  apply(ctx as never)
+  return { register, slotInject, spec }
+}
+
 describe('client apply()', () => {
-  it('registers the branch chip on the selector-context hole (session-maybe)', () => {
-    const register = vi.fn(() => () => undefined)
-    const slotInject = vi.fn((_name: string, callback: () => () => void) => callback())
-
-    const scope = {
-      slots: { inject: slotInject, register },
-      conversation: {},
-      sessions: { list: { getSnapshot: () => ({ byId: {} }) } },
-    }
-    const ctx = {
-      effect: vi.fn((fn: () => void) => { fn(); return () => {} }),
-      locale: { register: vi.fn() },
-      inject: vi.fn((_services: unknown, callback: (s: typeof scope) => void) => { callback(scope) }),
-    }
-
-    apply(ctx as never)
+  it('registers the branch chip on the selector-context hole when declared', () => {
+    const { register, slotInject } = bench(
+      { kind: 'list', scope: 'session-maybe' },
+      /* parkInject */ false,
+    )
 
     // The registration waits on the conversation/sessions seam, then on the
     // selector-context declaration before registering the chip component.
-    expect(ctx.inject).toHaveBeenCalledWith(['slots', 'conversation', 'sessions'], expect.any(Function))
     expect(slotInject).toHaveBeenCalledWith('conversation.input.selector.context', expect.any(Function))
     expect(register).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -47,5 +62,26 @@ describe('client apply()', () => {
       expect.anything(),
     )
   })
-})
 
+  it('falls back to the composer dock band when the selector-context hole is undeclared (rc.6)', () => {
+    const { register, slotInject, spec } = bench(undefined, /* parkInject */ true)
+
+    // rc.6 never declares the preferred hole: the inject wait parks, the
+    // spec probe reports absent, and the chip registers on the dock band
+    // (the 0.1.9 seat) instead of vanishing.
+    expect(slotInject).toHaveBeenCalledWith('conversation.input.selector.context', expect.any(Function))
+    expect(spec).toHaveBeenCalledWith('conversation.input.selector.context')
+    expect(register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'conversation.input.dock',
+        id: 'git-graph',
+        order: 100,
+      }),
+      BranchChip,
+    )
+    expect(register).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'conversation.input.selector.context' }),
+      expect.anything(),
+    )
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 #77：0.1.10 回归——提交 0be6546 把 git 分支切换按钮（branch chip）从 `conversation.input.dock` 移回 `conversation.input.selector.context`，但 rc.6 的 `dsh-client-ui-conversation` **运行时没有声明该槽位**（Inspect 实测：槽位树只有 `input.dock` 等，无 `selector.context`），`slots.inject` 永远等不到声明，chip 不挂载、按钮消失。

本 PR 改为**声明感知 + 回退**挂载：

- shell 声明 `conversation.input.selector.context`（rc.6 之后的 shell，位置在输入选择行、workspace 选择器旁边）→ 照旧挂首选槽位，行为不变；
- 未声明（rc.6，即 0be6546 回归场景）→ 回退到 `conversation.input.dock`（0.1.9 的座位，输入框上方独立一行），chip 恢复显示；
- 首选槽位**晚声明**（shell 晚于本插件启动）→ 挂起的 inject 触发，自动卸载回退条目并迁移到首选槽位；
- 回退注册前用 `slots.spec()` 探测双槽位，避免 `register()` 对未声明槽位抛错。

## 涉及包（Affected Packages）

- [x] Git 图谱 `packages/dsh-git-graph`
- [ ] 任务看板 `packages/dsh-task-board`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

（rebase 到 `7fc1d1c`，与最新 main 无冲突）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

DeepSeek

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-git-graph build
pnpm --filter @linxin666/dsh-client-ui-git-graph test
```

结果摘要：

- `tsc -b && tsdown` 构建成功；
- vitest 46/46 通过（含新增的「selector-context 未声明 → 回退 dock」场景测试）；
- 源码改动仅 `src/client/index.ts`（挂载逻辑）+ `tests/client-apply.spec.tsx`（两个场景），`BranchChip` 组件零改动（两个槽位的 `PropsRuntime` 结构兼容）。

## 用户可见变更证据（Local Feature Evidence）

证据：rc.6 + 本分支产物实测，进入 git 仓库工作区会话（D:\work，master 分支），branch chip 恢复显示于输入框上方，点击后分支菜单（搜索分支 / 创建并检出新分支 / Git 图谱）正常工作：

![chip](https://cfbed.629090.xyz/file/screenshot-140744.png)

（图为用户实机高分屏截图：输入框上方展开的分支菜单显示 master 选项与创建/Git 图谱入口；修复前该按钮在 rc.6 上完全不渲染。）

## 补充说明

- 修复利用官方类型化 API `slots.inject`（已声明时同步执行 / 未声明时挂起等待）+ `slots.spec`（声明探测），未 hack SlotCore 私有字段；
- 已通过运行时 `slots` 槽位树（Inspect）确认 rc.6 无 `conversation.input.selector.context`，与 #77 报告者的分析一致；
- 0be6546 提交说明「运行中的 shell (rc.2) 声明并渲染了 selector.context」与 rc.6 实际不符——回退逻辑保证两个 shell 世代都可用。
