### PR TITLE
fix(skin-center): honor $DSH_HOME in the in-process skin switch

### DIFF
--- a/packages/skins/skin-center/src/skin-switch.ts
+++ b/packages/skins/skin-center/src/skin-switch.ts
@@ -4,10 +4,11 @@
  * `dsh-skin` binary on PATH (the bug zhu1090093659/dsh-web-ui#5: "dsh-skin
  * CLI not found on PATH").
  *
- * `use` owns the `dsh-skin managed` section of `~/.dsh/cordis.patch.yml`
- * (atomic rewrite, hot-reloaded by the DSH config watcher within seconds,
- * no restart) and the profile node_modules symlink that makes the selected
- * skin resolvable from the web profile. `current` reads the active back.
+ * `use` owns the `dsh-skin managed` section of the harness home's
+ * cordis.patch.yml (`$DSH_HOME` when set, else `~/.dsh` — atomic rewrite,
+ * hot-reloaded by the DSH config watcher within seconds, no restart) and the
+ * profile node_modules symlink that makes the selected skin resolvable from
+ * the web profile. `current` reads the active back.
  *
  * The behaviour/text is a 1:1 port of scripts/dsh-skin (`use`/`current`;
  * workspace assets live in packages/skins/<id>). The skin registry is
@@ -334,23 +335,39 @@ export function currentActive(patch: string, registry: Record<string, SkinSwitch
 
 /** Layout of the DSH home + profile the CLI switches against. */
 export interface SkinSwitchPaths {
-  /** ~/.dsh/cordis.patch.yml */
+  /** <harness home>/cordis.patch.yml ($DSH_HOME, else <home>/.dsh) */
   patchPath: string
-  /** ~/.dsh/profiles/<profile>/node_modules */
+  /** <harness home>/profiles/<profile>/node_modules */
   profileModulesDir: string
 }
 
 /**
- * Resolve the DSH paths under a HOME. home/profile are injectable so tests
- * can point at a throwaway HOME (mirrors scripts/dsh-skin.test.mjs).
+ * Resolve the DSH paths the switch operates on. The harness home is $DSH_HOME
+ * when set (the dsh launcher may point it anywhere, e.g. D:\AppDataMigration\dsh),
+ * else the historical <home>/.dsh layout — mirroring scripts/dsh-skin and the
+ * harness's own resolveDshHome precedence. home/profile stay injectable so
+ * tests can point at a throwaway HOME (mirrors scripts/dsh-skin.test.mjs).
  * @param home - home dir (defaults to the process HOME).
  * @param profile - profile name (defaults to DSH_SKIN_PROFILE or 'web').
  */
 export function resolvePaths(home: string = homedir(), profile: string = DEFAULT_PROFILE): SkinSwitchPaths {
+  const harnessHome = dshHomeFromEnv() ?? joinPath(home, '.dsh')
   return {
-    patchPath: joinPath(home, '.dsh', 'cordis.patch.yml'),
-    profileModulesDir: joinPath(home, '.dsh', 'profiles', profile, 'node_modules'),
+    patchPath: joinPath(harnessHome, 'cordis.patch.yml'),
+    profileModulesDir: joinPath(harnessHome, 'profiles', profile, 'node_modules'),
   }
+}
+
+/**
+ * $DSH_HOME when set and non-empty, else undefined. A harness running under a
+ * custom DSH_HOME keeps its boot patch at $DSH_HOME/cordis.patch.yml and its
+ * profiles under $DSH_HOME/profiles; writing those to ~/.dsh instead makes the
+ * config watcher (which watches the real harness home) never see the switch —
+ * the skin applies "successfully" but the running server never mounts it.
+ */
+function dshHomeFromEnv(): string | undefined {
+  const fromEnv = process.env.DSH_HOME
+  return typeof fromEnv === 'string' && fromEnv.trim() !== '' ? fromEnv : undefined
 }
 
 // --- fs side effects ---

--- a/packages/skins/skin-center/tests/skin-switch.spec.ts
+++ b/packages/skins/skin-center/tests/skin-switch.spec.ts
@@ -11,7 +11,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readlinkSync, rmSy
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { afterAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Spy on symlinkSync only (everything else stays real) so the win32 junction
 // fallback branch of ensureSymlink can be exercised on non-Windows machines.
@@ -39,7 +39,15 @@ import {
 /** A throwaway HOME with an empty .dsh dir; removed after all tests. */
 let home: string
 afterAll(() => {
+  delete process.env.DSH_HOME
   if (home !== undefined) rmSync(home, { recursive: true, force: true })
+})
+
+// Keep every test hermetic: a DSH_HOME set on the dev machine must not
+// redirect the throwaway-HOME assertions. The dedicated $DSH_HOME tests
+// below set the variable explicitly and restore it in their own finally.
+beforeEach(() => {
+  delete process.env.DSH_HOME
 })
 
 function fakeHome(): string {
@@ -124,10 +132,12 @@ describe('pure patch helpers', () => {
     expect(rendered).not.toContain(`- id: ${registry.qq98.id}\n  disabled: true`)
   })
 
-  it('renderManaged(wired skin) needs no insert row', () => {
+  it('renderManaged keeps an insert row for every skin (none is bundle-wired in the npm aggregate layout)', () => {
     const registry = miniRegistry()
     const rendered = renderManaged('xp', registry)
-    expect(rendered).not.toContain('- insert:')
+    expect(rendered).toContain('- insert:')
+    expect(rendered).toContain(`- id: ${registry.xp.id}`)
+    expect(rendered).not.toContain(`- id: ${registry.xp.id}\n  disabled: true`)
   })
 
   it('stripManaged removes only the managed section', () => {
@@ -289,6 +299,44 @@ describe('useSkin / currentSkin against a throwaway HOME', () => {
     } finally {
       Object.defineProperty(process, 'platform', platformDesc)
       mock.mockReset()
+    }
+  })
+})
+
+describe('custom $DSH_HOME (harness home env, mirrors scripts/dsh-skin)', () => {
+  it('resolvePaths targets $DSH_HOME instead of <home>/.dsh', () => {
+    const h = fakeHome()
+    const custom = join(h, 'custom-dsh-home')
+    process.env.DSH_HOME = custom
+    try {
+      const paths = resolvePaths(h)
+      expect(paths.patchPath).toBe(join(custom, 'cordis.patch.yml'))
+      expect(paths.profileModulesDir).toBe(join(custom, 'profiles', 'web', 'node_modules'))
+    } finally {
+      delete process.env.DSH_HOME
+    }
+  })
+
+  it('useSkin/currentSkin write and read the patch under $DSH_HOME, leaving <home>/.dsh untouched', () => {
+    const h = fakeHome()
+    const custom = join(h, 'custom-dsh-home')
+    const registry = loadRegistry()
+    const qq98 = registry.qq98
+    const fakeDir = join(h, 'code', 'dsh-web-ui', 'packages', 'skins', 'qq98')
+    makeSkinPackage(fakeDir, qq98)
+    const fakeRegistry: Record<string, SkinSwitchEntry> = {
+      ...registry,
+      qq98: { ...qq98, dir: fakeDir },
+    }
+    process.env.DSH_HOME = custom
+    try {
+      useSkin('qq98', { registry: fakeRegistry })
+      expect(readFileSync(join(custom, 'cordis.patch.yml'), 'utf8')).toContain('- insert:')
+      expect(currentSkin(undefined, { registry: fakeRegistry })).toBe('qq98')
+      // The historical <home>/.dsh layout must stay untouched.
+      expect(existsSync(join(h, '.dsh', 'cordis.patch.yml'))).toBe(false)
+    } finally {
+      delete process.env.DSH_HOME
     }
   })
 })


### PR DESCRIPTION
## Problem

The in-process port of `dsh-skin use` (packages/skins/skin-center/src/skin-switch.ts) resolves the boot patch and profile node_modules under `<home>/.dsh`, while the CLI (`scripts/dsh-skin`) and the harness itself resolve the harness home as `$DSH_HOME` first, falling back to `~/.dsh`.

When the dsh launcher runs with a custom `$DSH_HOME` (e.g. `D:\AppDataMigration\dsh`), the skin center therefore:

1. writes the `dsh-skin managed` section of the boot patch to `~/.dsh/cordis.patch.yml` — a file the running server never watches (the config watcher targets `$DSH_HOME/cordis.patch.yml`),
2. links the selected skin package into `~/.dsh/profiles/web/node_modules` — not the active profile's modules dir.

Result: applying a skin reports `ok` ("skin switched to ..."), the patch is hot-reloaded nowhere, and the boot graph never mounts the skin — the UI never changes, and `/api/skin-center/state` disagrees with the running server.

## Fix

Align `resolvePaths` with the CLI and with the harness's own `resolveDshHome` precedence:

- use `$DSH_HOME` when set and non-empty as the harness home,
- else fall back to the historical `<home>/.dsh` layout.

The `home`/`profile` parameters stay injectable for tests. The test suite now clears `DSH_HOME` before every test so a dev machine with the variable set cannot redirect the throwaway-HOME assertions, and two new tests cover the custom-`$DSH_HOME` layout end to end (patch written/read under `$DSH_HOME`, `<home>/.dsh` untouched).

Also fixed a stale test: `renderManaged('xp')` no longer expects a bundle-wired skin — xp ships like every other skin in the npm aggregate layout (see the registry derivation test) and carries its own insert row when applied.

## Verification

- `vitest run` in packages/skins/skin-center: 48/48 tests pass (previously 1 failing test on main).
- Manual end-to-end on Windows with `$DSH_HOME=D:\AppDataMigration\dsh`: skin switch now writes the real harness home patch, the config watcher hot-applies it, and the boot graph mounts the selected skin after a page refresh.