### PR TITLE
fix(aionui-panel): git 未安装时停止 2 秒刷屏的 git-missing 轮询（#82）

### DIFF
--- a/packages/dsh-aionui-panel/src/core/types.ts
+++ b/packages/dsh-aionui-panel/src/core/types.ts
@@ -26,6 +26,7 @@ export type PanelErrorCode =
   | 'write-failed'
   | 'search-failed'
   | 'git-unavailable'
+  | 'git-missing'
   | 'git-failed'
   | 'internal'
 

--- a/packages/dsh-aionui-panel/src/host/git-service.ts
+++ b/packages/dsh-aionui-panel/src/host/git-service.ts
@@ -149,6 +149,15 @@ export function parseStatusView(root: string, branch: string, output: string): G
 /** The not-a-repository verdict for status reads. */
 const NO_REPO: PanelError = { code: 'git-unavailable', message: 'not a git repository' }
 
+/** The git binary is missing (the spawn seam degraded) — the SCM surface is unavailable. */
+const GIT_MISSING: PanelError = { code: 'git-missing', message: 'git is not installed' }
+
+/** True when a run outcome is the spawn seam's own degradation markers. */
+function isSpawnFailure(result: GitRunResult): boolean {
+  return result.exitCode === 127
+    && (result.stderr.startsWith('git: spawn failed') || result.stderr.startsWith('git: run failed'))
+}
+
 /**
  * Workspace-scoped git operations. Every method passes the gate, resolves the
  * repository root, and rejects non-repositories with a stable error.
@@ -168,7 +177,12 @@ export class GitService {
     const gated = await this.gate(root)
     if (!gated.ok) return { ok: false, error: gated.error }
     const result = await this.run(['rev-parse', '--show-toplevel'], gated.canonical)
-    if (result.exitCode !== 0) return { ok: false, error: NO_REPO }
+    if (result.exitCode !== 0) {
+      // A missing git binary must be distinguishable from "not a repository":
+      // the former makes the whole SCM surface unavailable (routes stop
+      // polling on it), the latter is an ordinary quiet state.
+      return { ok: false, error: isSpawnFailure(result) ? GIT_MISSING : NO_REPO }
+    }
     const repo = result.stdout.trim()
     if (repo === '' || !isPathInside(repo, gated.canonical)) return { ok: false, error: NO_REPO }
     return { ok: true, root: gated.canonical, repo }

--- a/packages/dsh-aionui-panel/src/host/routes.ts
+++ b/packages/dsh-aionui-panel/src/host/routes.ts
@@ -98,16 +98,26 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
   }
 
   let polling = false
+  // git 缺失时置位：pollGit 直接跳过，避免每 2 秒一次 spawn ENOENT 刷屏。
+  // 判定来自 git.status 的 git-missing（git-service 对 spawn 失败的标记），
+  // 首次命中记一条日志后不再轮询，直到插件重载。
+  let gitUnavailable = false
   const pollGit = async (): Promise<void> => {
     // Guard against overlapping polls: a slow git status on a large repo must
     // not stack another run on the next 2s tick.
-    if (polling) return
+    if (gitUnavailable || polling) return
     polling = true
     try {
       await Promise.all([...subscribers].map(async (subscriber) => {
         try {
           const status = await git.status(subscriber.root)
-          if (status === null || typeof status === 'object' && 'code' in status) return
+          if (status === null || typeof status === 'object' && 'code' in status) {
+            if (status !== null && status.code === 'git-missing') {
+              gitUnavailable = true
+              ctx.logger.warn(`dsh-aionui-panel: git is not installed; SCM polling stopped (${subscriber.root})`)
+            }
+            return
+          }
           const key = `${status.branch}|${JSON.stringify(status.staged)}|${JSON.stringify(status.unstaged)}|${JSON.stringify(status.untracked)}`
           if (key === subscriber.lastGit) return
           subscriber.lastGit = key

--- a/packages/dsh-aionui-panel/tests/git-service.spec.ts
+++ b/packages/dsh-aionui-panel/tests/git-service.spec.ts
@@ -161,6 +161,43 @@ describe('GitService.diff', () => {
   })
 })
 
+describe('GitService.status git availability', () => {
+  it('reports git-missing when the binary is absent (spawn degradation markers)', async () => {
+    const runner: GitRunner = {
+      async run() {
+        return { exitCode: 127, stdout: '', stderr: 'git: spawn failed: spawn git ENOENT' }
+      },
+    }
+    const service = new GitService(runner, gate, vi.fn(async () => ({ ok: true as const })))
+    const result = await service.status(ROOT)
+    expect(result).toEqual({ code: 'git-missing', message: 'git is not installed' })
+  })
+
+  it('reports git-missing on run-degradation markers too', async () => {
+    const runner: GitRunner = {
+      async run() {
+        return { exitCode: 127, stdout: '', stderr: 'git: run failed: killed' }
+      },
+    }
+    const service = new GitService(runner, gate, vi.fn(async () => ({ ok: true as const })))
+    const result = await service.status(ROOT)
+    expect(result).toEqual({ code: 'git-missing', message: 'git is not installed' })
+  })
+
+  it('stays null (not a repository) when git runs but rev-parse fails', async () => {
+    const runner: GitRunner = {
+      async run() {
+        // A present git binary answers a non-repo with exit 128 and its own
+        // stderr — not the spawn seam's 127 degradation markers.
+        return { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository' }
+      },
+    }
+    const service = new GitService(runner, gate, vi.fn(async () => ({ ok: true as const })))
+    const result = await service.status(ROOT)
+    expect(result).toBeNull()
+  })
+})
+
 describe('subprocessRunner spawn degradation', () => {
   const collected = {
     stdout: { readFrom: (offset: number) => ({ text: 'ok' }) },

--- a/packages/dsh-aionui-panel/tests/poll-git.spec.ts
+++ b/packages/dsh-aionui-panel/tests/poll-git.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Poll-loop degradation test: with git missing (git.status resolves
+ * git-missing), the SSE poll loop logs ONCE, marks git unavailable, and
+ * stops calling git.status on subsequent ticks — the 2s log-spam regression
+ * from issue #82 must not come back.
+ */
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import { registerPanelRoutes } from '../src/host/routes.ts'
+import type { FsService } from '../src/host/fs-service.ts'
+import type { GitService } from '../src/host/git-service.ts'
+
+const ROOT = '/w'
+
+/** A ctx whose logger.warn is recorded; webServer.register captures handlers. */
+function fakeCtx() {
+  const warn = vi.fn()
+  const registrations: Array<{ kind: string; path: string; handler: (req: unknown, res: unknown) => Promise<void> }> = []
+  const ctx = {
+    logger: { warn },
+    webServer: {
+      register: (row: { kind: string; path: string; handler: (req: unknown, res: unknown) => Promise<void> }) => {
+        registrations.push(row)
+        return () => {}
+      },
+    },
+    effect: (fn: () => void) => { fn(); return () => {} },
+  }
+  return { ctx, registrations, warn }
+}
+
+/** A fake SSE exchange: writable response + close trigger. */
+function fakeStream() {
+  const res = new EventEmitter() as EventEmitter & { writeHead: ReturnType<typeof vi.fn>; write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+  res.writeHead = vi.fn()
+  res.write = vi.fn()
+  res.end = vi.fn()
+  return res
+}
+
+describe('poll loop with missing git (issue #82)', () => {
+  it('logs once and stops polling after the first git-missing verdict', { timeout: 15_000 }, async () => {
+    const { ctx, registrations, warn } = fakeCtx()
+    const status = vi.fn(async () => ({ code: 'git-missing', message: 'git is not installed' }))
+    const fs: Pick<FsService, 'verify' | 'watch'> = {
+      verify: vi.fn(async () => ({ ok: true as const, canonical: ROOT })),
+      watch: vi.fn(() => () => {}),
+    }
+    const git = { status } as unknown as GitService
+    registerPanelRoutes(ctx as never, fs as never, git)
+
+    const sse = registrations.find((item) => item.kind === 'exact' && item.path === '/aionui-panel/events')
+    expect(sse).toBeDefined()
+    const res = fakeStream()
+    const req = new EventEmitter() as EventEmitter & { url?: string }
+    req.url = `/aionui-panel/events?root=${encodeURIComponent(ROOT)}`
+    await sse!.handler(req as never, res as never)
+
+    // First poll tick: one git.status call, one warning, then the loop parks.
+    await new Promise((resolve) => setTimeout(resolve, 2_300))
+    expect(status).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toContain('git is not installed')
+
+    // Two more ticks: the loop must not touch the subprocess seam again.
+    await new Promise((resolve) => setTimeout(resolve, 4_300))
+    expect(status).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    // Cleanup: close the stream so the timers are cleared.
+    req.emit('close')
+  })
+
+  it('keeps polling when git is present but the root is not a repository', async () => {
+    const { ctx, registrations, warn } = fakeCtx()
+    const status = vi.fn(async () => null)
+    const fs: Pick<FsService, 'verify' | 'watch'> = {
+      verify: vi.fn(async () => ({ ok: true as const, canonical: ROOT })),
+      watch: vi.fn(() => () => {}),
+    }
+    const git = { status } as unknown as GitService
+    registerPanelRoutes(ctx as never, fs as never, git)
+
+    const sse = registrations.find((item) => item.kind === 'exact' && item.path === '/aionui-panel/events')!
+    const res = fakeStream()
+    const req = new EventEmitter() as EventEmitter & { url?: string }
+    req.url = `/aionui-panel/events?root=${encodeURIComponent(ROOT)}`
+    await sse.handler(req as never, res as never)
+
+    // Non-repository is an ordinary state: polling continues each tick.
+    await new Promise((resolve) => setTimeout(resolve, 2_300))
+    await new Promise((resolve) => setTimeout(resolve, 2_300))
+    expect(status).toHaveBeenCalledTimes(2)
+    expect(warn).not.toHaveBeenCalled()
+
+    req.emit('close')
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 #82：机器未安装 git 时，`/aionui-panel/events` SSE 的 git 轮询（`GIT_POLL_MS = 2s`）每次 `git.status()` 都因 `spawn git ENOENT` 失败，`subprocessRunner` 的 catch 每次打一条 `console.error('[dsh-aionui-panel] git run failed: ...')`——每 2 秒一条、永不停止，淹没终端真实日志。

修复（host 端，最小改动）：

1. **git-service.ts**：把「git 二进制缺失」与「目录不是 git 仓库」区分开——`subprocessRunner` 降级时返回 `exitCode 127 + stderr 标记（git: spawn/run failed）`，`repo()` 据此返回新错误码 `git-missing`（而非统一的 `git-unavailable`）。git 存在但目录非仓库（rev-parse 非零，如 exit 128）仍返回 `git-unavailable`（routes 里映射为 null 的安静状态，轮询继续）。
2. **routes.ts**：`pollGit` 首次收到 `git-missing` 时打**一条** `logger.warn`，置 `gitUnavailable` 位后**跳过后续所有轮询 tick**（不再碰 subprocess seam），直到插件重载。
3. **core/types.ts**：`PanelErrorCode` 增加 `'git-missing'`。

行为对比：

- 未装 git：修复前每 2s 一条 `git run failed` 刷屏；修复后首次探测一条 `git is not installed; SCM polling stopped` 警告后静默，SCM 面板收到 `git-missing`（可自行展示「未安装 git」提示，属 client 侧后续增强）。
- 已装 git（非仓库目录）：行为不变，轮询继续（该状态安静，无日志）。

## 涉及包（Affected Packages）

- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 任务看板 `packages/dsh-task-board`
- [x] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

（基于 `7fc1d1c`，与最新 main 无冲突）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

DeepSeek

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel exec tsc -b tsconfig.host.json --pretty false
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
```

结果摘要：

- host 半区 `tsc -b tsconfig.host.json` 通过（本 PR 只触碰 host 端：routes / git-service / core types）；
- vitest 120/120 通过，新增 5 个测试：
  - `git-service.spec.ts`：spawn 降级标记 → `status()` 返回 `git-missing`；git 存在但非仓库 → 仍返回 null（不误伤）；
  - `tests/poll-git.spec.ts`（新）：模拟 SSE 订阅 + 真实 2s 轮询节奏——首次 `git-missing` 后 `git.status` 只被调用 1 次、`logger.warn` 只 1 次，后续 tick 不再触碰 subprocess seam；对照场景（git 存在、目录非仓库）轮询继续每 2s 一次。

⚠️ 已知限制（非本 PR 引入）：**该包全量 `pnpm build` 目前在 main 上无法通过**——PR #57（`100b4c2`）的 client 端引用了 rc.6 官方 SDK 中不存在的 `@deepseek-ai/dsh-client-ui-conversation/client` 导出与 `ctx.conversation`/`conversation.input.dock` 槽位（TS2307/2339/2344），与 SDK 升级或 #57 的返工关联，建议单独处理。本 PR 的 host 端独立编译与全部测试均通过，未触碰 client 端。

## 用户可见变更证据（Local Feature Evidence）

未附截图（该缺陷是终端日志行为，不涉及 UI 渲染）。验证以 `tests/poll-git.spec.ts` 为准：在订阅存活的 6.6 秒窗口内（3 个轮询 tick），`git.status` 与警告日志均只出现一次。

## 补充说明

- `subprocessRunner` 的 `console.error`（L57/L70）保留：修复后轮询不再触发它；用户手动操作 SCM 时的单次失败仍输出（每次操作一条，非循环），stderr 亦带回调用方供诊断。
- client 端「未安装 git」的 SCM 面板提示不在本 PR 范围（可基于新的 `git-missing` 错误码在后续 PR 实现）。
