### PR TITLE
docs: warn about pnpm minimumReleaseAge silently installing old versions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -193,6 +193,8 @@ dsh plugin --profile web add @linxin666/dsh-web-ui-all
 
 Restart `dsh web` and all plugin entries appear in the sidebar. Skins only? Install `@linxin666/dsh-skins`.
 
+> **Ended up with an old version?** pnpm 11+ gates brand-new releases (~10 days) via the `minimumReleaseAge` setting and silently installs an older version instead of the latest (e.g. `0.1.6` instead of `0.1.10`). Old skin-center versions lack the "bundled-carrier skin entry" fix, so applying a skin then restarting dies with `ERR_MODULE_NOT_FOUND .../dsh-client-ui-skin-<id>/index.js`. Fix: set `minimumReleaseAge: 0` in the profile's `pnpm-workspace.yaml` (or add `@linxin666/*` to `minimumReleaseAgeExclude`), then run `dsh plugin --profile web update @linxin666/dsh-web-ui-all` to reach the latest. See [issue #71](https://github.com/zhu1090093659/dsh-web-ui/issues/71).
+
 ### Install from the GitHub Repository (Development)
 
 The packages are already on npm; installing from this repository is only for development (requires Node.js >= 22 and pnpm):

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ dsh plugin --profile web add @linxin666/dsh-web-ui-all
 
 装完重启 `dsh web`，侧边栏就有全部插件入口。只要皮肤就装 `@linxin666/dsh-skins`。
 
+> **装到了旧版本？** pnpm 11+ 的发布年龄门禁（`minimumReleaseAge`）会把新发布（约 10 天内）的版本静默隔离，导致按上面命令实际装到旧版（如 `0.1.6` 而非 `0.1.10`）。旧版皮肤中心缺少 "carrier 内建皮肤可解析入口" 的修复，应用皮肤后重启会以 `ERR_MODULE_NOT_FOUND .../dsh-client-ui-skin-<id>/index.js` 崩溃。解决办法：在 profile 的 `pnpm-workspace.yaml` 设置 `minimumReleaseAge: 0`（或把 `@linxin666/*` 加进 `minimumReleaseAgeExclude`），再执行 `dsh plugin --profile web update @linxin666/dsh-web-ui-all` 升级到最新版。详见 [issue #71](https://github.com/zhu1090093659/dsh-web-ui/issues/71)。
+
 ### 从 GitHub 仓库安装（开发调试）
 
 插件包已在 npm 发布，仓库安装仅供开发调试（需要 Node.js >= 22 与 pnpm）：


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；
> 提交信息用 Conventional Commits（`type(scope): subject`），禁止 emoji。
> 本仓库接受修复、增强与优化类 PR（bug 修复、现有功能的增强、性能 / 体验优化、维护与文档修正）；新皮肤始终欢迎。全新特性 / 新功能的 PR 暂不接受，请先提 Issue 讨论。
## 摘要（Summary）

在 `README.md` / `README.en.md` 的「从 npm 安装」小节补充一条排障提示：pnpm 11+ 的 `minimumReleaseAge` 门禁会静默安装旧版本（如 `0.1.6` 而非 `0.1.10`），旧版皮肤中心应用皮肤后重启会因 `ERR_MODULE_NOT_FOUND .../dsh-client-ui-skin-<id>/index.js` 崩溃；给出 `minimumReleaseAge: 0` 或 `minimumReleaseAgeExclude` 的解决办法。

## 涉及包（Affected Packages）

- [x] 其他（请说明）——仅修改仓库根 `README.md` / `README.en.md` 文档，未改动任何包代码。

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [x] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```sh
git fetch origin && git rebase origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

Claude（Anthropic）

使用的编码 Agent 工具：

Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

<!-- 可选。若本 PR 贡献的是插件或皮肤，可在项目 README 末尾「来源与版权」的版权表中追加一行声明你自己的版权（包 / 来源 / 版权三列，格式参考表中现有行）；不声明则维持现有版权归属。 -->

## 社区插件索引登记（Community Plugin Index）

<!-- 可选。若你贡献的是第三方插件且希望被 dsh-web-ui 的「社区插件」卡片索引（设置 > 插件配置 > Web UI 插件），按 docs/plugins.md 的说明在 packages/dsh-web-ui-settings/community.json 登记，并运行 node scripts/community-index 重新生成注册表。 -->

## 本地验证（Local Validation）

执行的命令：

```sh
pnpm docs:check
```

结果摘要：

通过：中英 README 已在「从 npm 安装」小节同步新增 release-age 排障提示，双语内容一致，文档规范校验通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（仅文档改动，无用户可见功能变更）
