### PR TITLE
fix: 皮肤中心与 dsh-ssh 的 schemastery 改为运行时依赖（修复 #70）

### DIFF
--- a/packages/dsh-ssh/package.json
+++ b/packages/dsh-ssh/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "schemastery": "^3.18.0",
     "ssh2": "^1.17.0",
     "ws": "^8.18.0"
   },
@@ -88,7 +89,6 @@
     "lightningcss": "1.32.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "schemastery": "^3.18.0",
     "tsdown": "0.22.2",
     "typescript": "~5.7.2",
     "vitest": "^3.0.0"

--- a/packages/skins/skin-center/package.json
+++ b/packages/skins/skin-center/package.json
@@ -30,6 +30,9 @@
     "test": "vitest run"
   },
   "license": "BSD-3-Clause",
+  "dependencies": {
+    "schemastery": "^3.18.0"
+  },
   "peerDependencies": {
     "react": "^18.2.0"
   },
@@ -46,8 +49,7 @@
     "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
-    "schemastery": "^3.18.0"
+    "@deepseek-ai/dsh-settings": "^0.1.0-rc.6"
   },
   "files": [
     "lib",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      schemastery:
+        specifier: ^3.18.0
+        version: 3.18.0
       ssh2:
         specifier: ^1.17.0
         version: 1.17.0
@@ -501,9 +504,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      schemastery:
-        specifier: ^3.18.0
-        version: 3.18.0
       tsdown:
         specifier: 0.22.2
         version: 0.22.2(typescript@5.7.3)
@@ -744,6 +744,10 @@ importers:
         version: 4.1.10(@types/node@22.20.1)(esbuild@0.28.2)(jsdom@29.1.1)
 
   packages/skins/skin-center:
+    dependencies:
+      schemastery:
+        specifier: ^3.18.0
+        version: 3.18.0
     devDependencies:
       '@deepseek-ai/cordis':
         specifier: ^4.0.1
@@ -778,9 +782,6 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.3.1
-      schemastery:
-        specifier: ^3.18.0
-        version: 3.18.0
       tsdown:
         specifier: ^0.22.2
         version: 0.22.2(typescript@6.0.3)


### PR DESCRIPTION
## 摘要（Summary）
修复 #70：@linxin666/dsh-client-ui-skin-center 与 @linxin666/dsh-ssh 在运行时 import schemastery（用于构建配置 schema），但 schemastery 只声明在 devDependencies，导致安装后 dsh web 启动崩溃（ERR_MODULE_NOT_FOUND）。将其移入 dependencies，与同仓库 dsh-pet / dsh-live-stats / dsh-remote-web-ui / dsh-task-board 的既有惯例一致。

## 方案说明（Alternative Considered）
官方 dsh 生态（@deepseek-ai/*）的惯例是 import @deepseek-ai/schemastery（fork，与 schemastery 同一 3.18.x 代码线）。本 PR 选择原版 schemastery 移入 dependencies：与本仓库 4 个既有包保持一致、diff 最小；若维护者更倾向官方 fork 写法，可改为 import @deepseek-ai/schemastery + 对应 dependencies 声明，一行改动即可切换。

## 涉及包（Affected Packages）
- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [x] 其他（请说明）：`packages/dsh-ssh`（同病一并修复）

## PR 类型（PR Type）
- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）
- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：git fetch origin && git checkout main && git reset --hard origin/main

## AI 编码披露（AI Coding Disclosure）
- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek
使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）
- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）
执行的命令：
```bash
pnpm install --lockfile-only
pnpm install --frozen-lockfile --ignore-scripts
pnpm --filter @linxin666/dsh-client-ui-skin-center build
pnpm --filter @linxin666/dsh-ssh build
```
结果摘要：
本地构建通过：skin-center 与 dsh-ssh 均 build 成功（exit 0）；frozen-lockfile 安装通过（403 packages）；JSON 校验合法；diff 无 emoji。等效修法此前已在真实 dsh 环境实测（本地补丁：schemastery 别名指向 @deepseek-ai/schemastery@3.18.1，dsh web 正常启动）。

## 用户可见变更证据（Local Feature Evidence）
证据：N/A（Bug 修复，未勾选"面向用户的功能或行为变更"，按仓库规则无需证据）

Fixes #70
