### PR TITLE
fix(dsh-aionui-panel): keep drag handles off the neighbour scrollbar

### DIFF
--- a/packages/dsh-aionui-panel/src/client/layout.ts
+++ b/packages/dsh-aionui-panel/src/client/layout.ts
@@ -85,6 +85,17 @@ export function trackPx(track: string): number {
 export const EXPLORER_HANDLE_WIDTH = 12
 export const PREVIEW_HANDLE_WIDTH = 20
 
+/**
+ * How far each handle's hit zone may reach into its NEIGHBOURING column.
+ * The chat column owns its scrollbar at its very right edge — the boundary the
+ * preview handle sits on — so a full-width overlap swallows the scrollbar and
+ * makes the conversation undraggable (only the panel resize stays reachable).
+ * Keep a thin lip on the far side so the boundary stays discoverable, and put
+ * the bulk of the zone inside the panel, whose own left padding absorbs it.
+ */
+const EXPLORER_HANDLE_LIP = 2
+const PREVIEW_HANDLE_LIP = 4
+
 /** The layout controller: frame sync, handles, floating button, width math. */
 export class PanelLayoutController {
   private frame: HTMLElement | null = null
@@ -241,8 +252,10 @@ export class PanelLayoutController {
     el.style.cursor = 'col-resize'
     el.style.width = `${hitWidth}px`
     if (reverse) {
-      // The preview handle extends LEFT of the preview region's left edge.
-      el.style.marginLeft = `-${hitWidth}px`
+      // Only the thin lip may reach past the panel edge into the neighbouring
+      // column (see EXPLORER_HANDLE_LIP / PREVIEW_HANDLE_LIP): a full-width
+      // overlap would cover the neighbour's scrollbar and block its dragging.
+      el.style.marginLeft = kind === 'preview' ? `-${PREVIEW_HANDLE_LIP}px` : `-${EXPLORER_HANDLE_LIP}px`
     }
     el.addEventListener('pointerdown', (event: PointerEvent) => {
       const isExplorer = kind === 'explorer'
@@ -355,7 +368,7 @@ export class PanelLayoutController {
     if (this.explorerHandle !== null) {
       const left = Math.round(width - explorer)
       this.explorerHandle.style.left = `${left}px`
-      this.explorerHandle.style.marginLeft = `${-EXPLORER_HANDLE_WIDTH / 2}px`
+      this.explorerHandle.style.marginLeft = `-${EXPLORER_HANDLE_LIP}px`
       this.explorerHandle.style.display = explorer > 0 && state.root !== '' ? 'block' : 'none'
     }
     if (this.previewHandle !== null) {

--- a/packages/dsh-aionui-panel/src/client/styles/tokens.module.css
+++ b/packages/dsh-aionui-panel/src/client/styles/tokens.module.css
@@ -190,11 +190,15 @@
   width: 6px;
   background-color: var(--aion-brand);
 }
-/* The preview handle's line sits at its right edge (its hit zone extends
-   left); the explorer's at its left edge. */
+/* The visual line of each handle sits exactly on the panel boundary: the hit
+   zone now extends mostly into the panel (thin lip on the far side), so the
+   line is offset from the handle's own left edge by the lip width. */
+:global(.aionui-explorer-handle::after) {
+  left: 2px;
+}
 :global(.aionui-preview-handle::after) {
-  left: auto;
-  right: 0;
+  left: 4px;
+  right: auto;
   opacity: 0.3;
 }
 :global(.aionui-preview-handle:hover::after),


### PR DESCRIPTION
Fixes #103

## 问题

预览把手命中区（20px，margin-left: -20px）整个压在对话列右侧，恰好盖住对话区滚动条：用户拖动对话上下的滚动条时，实际命中的是面板拉伸把手，只能横向拉伸布局、无法滚动对话。explorer 把手同理侵入预览面板内容区的滚动条（12px 居中于边界）。

## 改动

- `layout.ts`：新增 `EXPLORER_HANDLE_LIP = 2` / `PREVIEW_HANDLE_LIP = 4`；`createHandle` 与 `applyGrid` 的 margin 由全宽侵入改为薄唇（preview: 命中区 [边界-4, 边界+16]；explorer: [边界-2, 边界+10]），面板侧多出的部分被面板 10px 左内边距吸收，不挡工具栏按钮。
- `tokens.module.css`：视觉分隔线精确保持在面板边界上（`::after` 左移唇宽：explorer `left: 2px`，preview `left: 4px`）。

## 验证

- `pnpm typecheck` 通过；
- `pnpm test` 115 个测试全部通过；
- 本地安装在 0.1.7 上的同等补丁已在真实 GUI 验证：对话滚动条可正常拖拽，面板拉伸、双击复位不受影响。
