### PR TITLE
fix(skins): readable tooltip background on light-background skins

### DIFF
--- a/packages/skins/blue-fantasy/src/client/blue-fantasy.module.css
+++ b/packages/skins/blue-fantasy/src/client/blue-fantasy.module.css
@@ -274,7 +274,7 @@ body[data-dsh-blue-fantasy] {
   --dsw-alias-state-warn-secondary: #d9a94f;
   --dsw-alias-state-warn-tertiary: #f7ecd8;
   --dsw-alias-toast-bg: #3c4e92;
-  --dsw-alias-tooltip-bg: #ffffe1;
+  --dsw-alias-tooltip-bg: #12264d;
   --dsw-specific-bubble-highlight: #c3cfee;
   --dsw-specific-bubble: #dce3f7;
   --dsw-specific-input-major: rgba(255, 255, 255, 0.6);
@@ -366,7 +366,7 @@ body[data-dsh-blue-fantasy][data-ds-dark-theme] {
   --dsw-alias-state-warn-secondary: #d9a94f;
   --dsw-alias-state-warn-tertiary: #4a3515;
   --dsw-alias-toast-bg: #33417a;
-  --dsw-alias-tooltip-bg: #ffffe1;
+  --dsw-alias-tooltip-bg: #12264d;
   --dsw-specific-bubble-highlight: #33417a;
   --dsw-specific-bubble: #2c3765;
   --dsw-specific-input-major: rgba(26, 34, 56, 0.65);

--- a/packages/skins/dragon-heir/src/client/dragon-heir.module.css
+++ b/packages/skins/dragon-heir/src/client/dragon-heir.module.css
@@ -368,7 +368,7 @@ body[data-dsh-dragon-heir][data-ds-dark-theme] {
   --dsw-alias-state-warn-secondary: #d9a94f;
   --dsw-alias-state-warn-tertiary: #4a3515;
   --dsw-alias-toast-bg: #96702a;
-  --dsw-alias-tooltip-bg: #eef1f6;
+  --dsw-alias-tooltip-bg: #262319;
   --dsw-specific-bubble-highlight: #35415e;
   --dsw-specific-bubble: #2a344c;
   --dsw-specific-input-major: rgba(21, 27, 41, 0.65);

--- a/packages/skins/miku/src/client/miku.module.css
+++ b/packages/skins/miku/src/client/miku.module.css
@@ -299,7 +299,7 @@ body[data-dsh-miku] {
   --dsw-alias-state-warn-secondary: #e5b94f;
   --dsw-alias-state-warn-tertiary: #fdf3dd;
   --dsw-alias-toast-bg: #1e6fd9;
-  --dsw-alias-tooltip-bg: #ffffff;
+  --dsw-alias-tooltip-bg: #213856;
   --dsw-specific-bubble-highlight: #cfe3ff;
   --dsw-specific-bubble: #e4f0ff;
   --dsw-specific-input-major: #fff;

--- a/packages/skins/qq98/src/client/qq98.module.css
+++ b/packages/skins/qq98/src/client/qq98.module.css
@@ -291,7 +291,7 @@ body[data-dsh-retro] {
   --dsw-alias-state-warn-tertiary: #f8ecd9;
   --dsw-alias-toast-bg: #1e63b8;
   /* QQ-era tooltips were the classic yellow note. */
-  --dsw-alias-tooltip-bg: #ffffe1;
+  --dsw-alias-tooltip-bg: #2b3648;
   --dsw-specific-bubble-highlight: #b6d6f4;
   --dsw-specific-bubble: #dcecfb;
   --dsw-specific-input-major: #fff;
@@ -384,7 +384,7 @@ body[data-dsh-retro][data-ds-dark-theme] {
   --dsw-alias-state-warn-tertiary: #3a2d14;
   --dsw-alias-toast-bg: #224064;
   /* QQ-era tooltips were the classic yellow note. */
-  --dsw-alias-tooltip-bg: #ffffe1;
+  --dsw-alias-tooltip-bg: #2b3648;
   --dsw-specific-bubble-highlight: #2b4f7d;
   --dsw-specific-bubble: #1e3a5e;
   --dsw-specific-input-major: #15233a;

--- a/packages/skins/whale-song/src/client/whale-song.module.css
+++ b/packages/skins/whale-song/src/client/whale-song.module.css
@@ -275,7 +275,7 @@ body[data-dsh-whale-song] {
   --dsw-alias-state-warn-secondary: #e3c070;
   --dsw-alias-state-warn-tertiary: #f7efdc;
   --dsw-alias-toast-bg: #1a3a7a;
-  --dsw-alias-tooltip-bg: #ffffe1;
+  --dsw-alias-tooltip-bg: #0a1e4a;
   --dsw-specific-bubble-highlight: #c4dbf1;
   --dsw-specific-bubble: #d9e9f5;
   --dsw-specific-input-major: rgba(255, 255, 255, 0.6);
@@ -367,7 +367,7 @@ body[data-dsh-whale-song][data-ds-dark-theme] {
   --dsw-alias-state-warn-secondary: #d9b45b;
   --dsw-alias-state-warn-tertiary: #6b5420;
   --dsw-alias-toast-bg: #1c3460;
-  --dsw-alias-tooltip-bg: #ffffe1;
+  --dsw-alias-tooltip-bg: #0a1e4a;
   --dsw-specific-bubble-highlight: #213a68;
   --dsw-specific-bubble: #1c3460;
   --dsw-specific-input-major: rgba(18, 36, 76, 0.65);


### PR DESCRIPTION
## 问题

tooltip 组件（`[role=tooltip]`）的文字色是**静态浅色 token**（`--dsw-static-neutral-bluish-00`，恒为白色系），背景走 `--dsw-alias-tooltip-bg` 变量。基础主题默认背景为深色（bluish-750/850），白字可读。

以下皮肤把 `--dsw-alias-tooltip-bg` 覆盖成了浅色，导致**白字糊浅底、完全不可读**：

| 皮肤 | 亮色 | 暗色 |
|---|---|---|
| whale-song | `#ffffe1` ❌ | `#ffffe1` ❌ |
| blue-fantasy | `#ffffe1` ❌ | `#ffffe1` ❌ |
| qq98 | `#ffffe1` ❌ | `#ffffe1` ❌ |
| miku | `#ffffff` ❌ | `#213856` ✅ |
| dragon-heir | `#262319` ✅ | `#eef1f6` ❌ |

复现：在任一受影响皮肤下，悬停对话统计行（如「80 轮 · 621 步 | LLM … | 输入 …」）的 tooltip 即白字米黄底。

## 修复

把上述浅色 tooltip 背景改为各皮肤自己的深色调（与暗色面板一致），白字恢复可读：

- whale-song → `#0a1e4a`
- blue-fantasy → `#12264d`
- qq98 → `#2b3648`
- miku 亮色 → `#213856`
- dragon-heir 暗色 → `#262319`

xp / ths / trading / minecraft 已是深色背景，未改动。影响面仅 tooltip 背景色，皮肤其他外观不变。