### PR TITLE
feat(aionui-panel): explorer right-click copy path + per-language file icons

### DIFF
--- a/packages/dsh-aionui-panel/README.md
+++ b/packages/dsh-aionui-panel/README.md
@@ -28,9 +28,14 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-aionui-panel
 
 - **Explorer（最右栏，默认 260px，范围 220~500px）**：`文件 / 变更` 双 tab；
   文件树整行点击展开/收起文件夹，点击文件在预览面板打开，顶部按文件名搜索
-  （150ms 防抖，点击结果 = 定位到树中，不打断思路）；`变更` tab 读取真实
+  （150ms 防抖，点击结果 = 定位到树中，不打断思路）；右键任意文件/目录行
+  可复制相对路径或绝对路径（成功/失败有 toast 提示，非安全上下文自动降级
+  execCommand）；`变更` tab 读取真实
   git 状态，支持 stage / unstage / discard（untracked 走删除，tracked 走
   restore，批量放弃有确认）。
+- **文件图标**：文件行按语言显示彩色徽章图标（品牌色 + 缩写，覆盖约 40 种
+  扩展名及 package.json / Dockerfile / .gitignore 等精确文件名），未识别类型
+  回落到按内容类别的轮廓图标；目录保持轮廓图标。
 - **拖拽文件到输入框**：文件树中的文件行可拖拽（目录行除外），拖到聊天
   输入框区域松手即把相对路径（如 `deploy/base/deployment.yaml`）插入当前
   会话草稿的光标处，agent 收到消息后会自行读取该文件，无需手动输入路径；

--- a/packages/dsh-aionui-panel/src/client/components/ExplorerPanel.tsx
+++ b/packages/dsh-aionui-panel/src/client/components/ExplorerPanel.tsx
@@ -12,14 +12,17 @@
  */
 
 import { memo, useRef, useState } from 'react'
-import type { DragEvent, JSX } from 'react'
+import type { DragEvent, JSX, MouseEvent } from 'react'
 import type { FsEntry } from '../../core/types.ts'
-import { parentRel } from '../fileType.ts'
+import { joinAbsolute, parentRel } from '../fileType.ts'
 import { t } from '../locales.ts'
 import { useStore } from '../hooks/useStore.ts'
 import type { PanelStores } from '../store.ts'
 import { FileTypeIcon } from './FileIcon.tsx'
 import { ChevronRightIcon, CloseIcon, ExpandRightIcon, SearchIcon } from './icons.tsx'
+import { ContextMenu } from './overlay.tsx'
+import type { MenuState } from './overlay.tsx'
+import { copyText } from './overlay.tsx'
 import { ScmPanel } from './ScmPanel.tsx'
 import { activateOnKey } from './a11y.ts'
 import { FILE_DRAG_MIME } from '../drag/file-drag.ts'
@@ -241,6 +244,22 @@ function TreeRowBase({
   const isSelected = selected === entry.path
   const children = entry.isDir ? dirs[entry.path] : undefined
   const [draggingRow, setDraggingRow] = useState(false)
+  const [menu, setMenu] = useState<MenuState | null>(null)
+
+  // Right-click: copy the workspace-relative or absolute path (dirs too —
+  // VSCode offers both on every row).
+  const onContextMenu = (event: MouseEvent): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    setMenu({
+      x: event.clientX,
+      y: event.clientY,
+      entries: [
+        { key: 'copy-rel', label: t('common.copyRelPath'), onSelect: () => copyText(entry.path) },
+        { key: 'copy-abs', label: t('common.copyAbsPath'), onSelect: () => copyText(joinAbsolute(root, entry.path)) },
+      ],
+    })
+  }
 
   const handleClick = (): void => {
     if (entry.isDir) {
@@ -273,6 +292,7 @@ function TreeRowBase({
         style={{ paddingLeft: 12 + 8 + depth * INDENT_STEP }}
         onClick={handleClick}
         onKeyDown={activateOnKey(handleClick)}
+        onContextMenu={onContextMenu}
         onDoubleClick={(event) => {
           // Double-click on a file: same as click (open). Folders: keep toggle.
           event.stopPropagation()
@@ -295,6 +315,7 @@ function TreeRowBase({
         <FileTypeIcon name={entry.name} isDir={entry.isDir} expanded={isExpanded} />
         <span className={explorerCss.treeName}>{entry.name}</span>
       </div>
+      {menu !== null && <ContextMenu state={menu} onClose={() => setMenu(null)} />}
       {entry.isDir && isExpanded && children !== undefined && (
         <div>
           {children.map((child) => (

--- a/packages/dsh-aionui-panel/src/client/components/FileIcon.tsx
+++ b/packages/dsh-aionui-panel/src/client/components/FileIcon.tsx
@@ -1,7 +1,8 @@
 /**
- * 16x16 file/folder icons for the tree — a small built-in set (folder
- * open/closed, file variants by kind) using the token colors, so both themes
- * stay consistent without pulling in a vscode-icons package.
+ * 16x16 file/folder icons for the tree. Folders keep the outline style; files
+ * use per-language colored badges (rounded square + short label in the
+ * language's brand color, the way VSCode file-icon themes do it) with the old
+ * kind icons as the fallback for unmapped types — still no icon package.
  * @module dsh-aionui-panel/client/components/FileIcon
  */
 
@@ -11,7 +12,103 @@ import {
   FileCodeIcon, FileIcon, FileImageIcon, FileTextIcon, FolderIcon, FolderOpenIcon,
 } from './icons.tsx'
 
-/** The icon for one tree entry (16x16, currentColor). */
+/** One colored-badge icon: brand color + a ≤3-letter label. */
+interface BadgeSpec {
+  color: string
+  label: string
+}
+
+/** Extension → badge, covering the everyday dev tree (lowercased extension, no dot). */
+const EXT_BADGES: Record<string, BadgeSpec> = {
+  ts: { color: '#3178c6', label: 'TS' },
+  tsx: { color: '#3178c6', label: 'TS' },
+  mts: { color: '#3178c6', label: 'TS' },
+  cts: { color: '#3178c6', label: 'TS' },
+  js: { color: '#d4b106', label: 'JS' },
+  jsx: { color: '#d4b106', label: 'JS' },
+  mjs: { color: '#d4b106', label: 'JS' },
+  cjs: { color: '#d4b106', label: 'JS' },
+  json: { color: '#a074c4', label: '{}' },
+  md: { color: '#519aba', label: 'MD' },
+  mdx: { color: '#519aba', label: 'MD' },
+  py: { color: '#3572a5', label: 'Py' },
+  rs: { color: '#c07a4a', label: 'Rs' },
+  go: { color: '#00add8', label: 'Go' },
+  java: { color: '#b07219', label: 'Ja' },
+  kt: { color: '#7f52ff', label: 'Kt' },
+  c: { color: '#6d8086', label: 'C' },
+  h: { color: '#6d8086', label: 'H' },
+  cpp: { color: '#f34b7d', label: 'C+' },
+  cs: { color: '#953dac', label: 'C#' },
+  php: { color: '#4f5d95', label: 'PHP' },
+  rb: { color: '#cc342d', label: 'Rb' },
+  swift: { color: '#f05138', label: 'Sw' },
+  sh: { color: '#4eaa25', label: 'SH' },
+  bash: { color: '#4eaa25', label: 'SH' },
+  ps1: { color: '#012456', label: 'PS' },
+  yaml: { color: '#cb171e', label: 'Y' },
+  yml: { color: '#cb171e', label: 'Y' },
+  toml: { color: '#9c4221', label: 'T' },
+  xml: { color: '#8fbc8f', label: 'XML' },
+  html: { color: '#e34c26', label: '<>' },
+  css: { color: '#563d7c', label: '#' },
+  scss: { color: '#c6538c', label: 'S' },
+  less: { color: '#2b4c80', label: 'L' },
+  vue: { color: '#41b883', label: 'V' },
+  sql: { color: '#e38c00', label: 'SQ' },
+  csv: { color: '#237346', label: 'CSV' },
+  pdf: { color: '#b30b00', label: 'PDF' },
+  lock: { color: '#6d8086', label: 'LK' },
+}
+
+/** Well-known exact filenames that beat their extension mapping. */
+const NAME_BADGES: Record<string, BadgeSpec> = {
+  'package.json': { color: '#cb3837', label: 'N' },
+  'dockerfile': { color: '#2496ed', label: 'D' },
+  '.gitignore': { color: '#f05033', label: 'G' },
+}
+
+/** Rounded-square badge with a short label, filled in the language color. */
+function FileBadgeIcon({
+  size = 16,
+  color,
+  label,
+  className,
+}: {
+  size?: number
+  color: string
+  label: string
+  className?: string
+}): JSX.Element {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" aria-hidden className={className}>
+      <rect x="1" y="1.5" width="14" height="13" rx="2.5" fill={color} />
+      <text
+        x="8"
+        y="11.4"
+        textAnchor="middle"
+        fontSize={label.length > 2 ? 5.5 : 7.5}
+        fontWeight={700}
+        fill="#ffffff"
+        fontFamily="system-ui, sans-serif"
+      >
+        {label}
+      </text>
+    </svg>
+  )
+}
+
+/** The badge for a filename, or undefined when neither table knows it. */
+function badgeOf(name: string): BadgeSpec | undefined {
+  const lower = name.toLowerCase()
+  const named = NAME_BADGES[lower]
+  if (named !== undefined) return named
+  const dot = lower.lastIndexOf('.')
+  if (dot <= 0) return undefined
+  return EXT_BADGES[lower.slice(dot + 1)]
+}
+
+/** The icon for one tree entry (16x16; folders outline, files colored badges with kind fallbacks). */
 export function FileTypeIcon({
   name,
   isDir,
@@ -27,6 +124,10 @@ export function FileTypeIcon({
     return expanded
       ? <FolderOpenIcon size={16} className={className} />
       : <FolderIcon size={16} className={className} />
+  }
+  const badge = badgeOf(name)
+  if (badge !== undefined) {
+    return <FileBadgeIcon size={16} color={badge.color} label={badge.label} className={className} />
   }
   const type = detectContentType(name)
   switch (type) {

--- a/packages/dsh-aionui-panel/src/client/components/overlay.tsx
+++ b/packages/dsh-aionui-panel/src/client/components/overlay.tsx
@@ -27,6 +27,35 @@ export function toast(message: string): void {
   toastTimer = undefined
 }
 
+/**
+ * Copy text to the clipboard with a toast verdict. The async Clipboard API
+ * needs a secure context; over plain LAN http it is absent, so a hidden
+ * textarea + execCommand('copy') covers that case.
+ * @param text - the text to copy.
+ */
+export function copyText(text: string): void {
+  const done = (): void => toast(t('common.copied'))
+  const failed = (): void => toast(t('common.copyFailed'))
+  if (navigator.clipboard?.writeText !== undefined) {
+    void navigator.clipboard.writeText(text).then(done, failed)
+    return
+  }
+  const el = document.createElement('textarea')
+  el.value = text
+  el.style.position = 'fixed'
+  el.style.opacity = '0'
+  document.body.appendChild(el)
+  el.select()
+  try {
+    if (document.execCommand('copy')) done()
+    else failed()
+  } catch {
+    failed()
+  } finally {
+    el.remove()
+  }
+}
+
 /** One context-menu entry. */
 export interface MenuEntry {
   key: string

--- a/packages/dsh-aionui-panel/src/client/fileType.ts
+++ b/packages/dsh-aionui-panel/src/client/fileType.ts
@@ -115,3 +115,18 @@ export function parentRel(path: string): string {
   const idx = path.lastIndexOf('/')
   return idx > 0 ? path.slice(0, idx) : ''
 }
+
+/**
+ * Join a workspace-relative tree path onto the session's absolute cwd for
+ * clipboard copy. The separator follows the root's own style (a Windows
+ * root yields backslashes); a trailing separator on the root is not doubled.
+ * @param root - the absolute workspace root (the session cwd).
+ * @param rel - the workspace-relative path ('/'-separated, as the fs service lists it); '' names the root itself.
+ * @returns the absolute path in the root's separator style.
+ */
+export function joinAbsolute(root: string, rel: string): string {
+  const trimmed = root.replace(/[\\/]+$/, '')
+  if (rel === '') return trimmed
+  const sep = root.includes('\\') ? '\\' : '/'
+  return trimmed + sep + rel.split('/').join(sep)
+}

--- a/packages/dsh-aionui-panel/src/client/locales.ts
+++ b/packages/dsh-aionui-panel/src/client/locales.ts
@@ -68,6 +68,9 @@ const zh = {
   'common.close': '关闭',
   'common.delete': '删除',
   'common.copyPath': '复制路径',
+  'common.copyRelPath': '复制相对路径',
+  'common.copyAbsPath': '复制绝对路径',
+  'common.copyFailed': '复制失败',
   'common.copied': '已复制',
 } as const
 
@@ -134,6 +137,9 @@ const en: Record<keyof typeof zh, string> = {
   'common.close': 'Close',
   'common.delete': 'Delete',
   'common.copyPath': 'Copy path',
+  'common.copyRelPath': 'Copy relative path',
+  'common.copyAbsPath': 'Copy absolute path',
+  'common.copyFailed': 'Copy failed',
   'common.copied': 'Copied',
 }
 

--- a/packages/dsh-aionui-panel/tests/fileicon.spec.tsx
+++ b/packages/dsh-aionui-panel/tests/fileicon.spec.tsx
@@ -1,0 +1,40 @@
+/**
+ * FileTypeIcon: per-language colored badges for known extensions and exact
+ * filenames, outline folders, and the kind-icon fallback for unmapped types.
+ */
+import { describe, expect, it } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { FileTypeIcon } from '../src/client/components/FileIcon.tsx'
+
+function icon(name: string, isDir = false, expanded = false): string {
+  return renderToStaticMarkup(createElement(FileTypeIcon, { name, isDir, expanded }))
+}
+
+describe('FileTypeIcon badges', () => {
+  it('renders a colored badge with the language label for known extensions', () => {
+    const ts = icon('app.tsx')
+    expect(ts).toContain('fill="#3178c6"')
+    expect(ts).toContain('>TS</text>')
+    expect(icon('README.md')).toContain('>MD</text>')
+    expect(icon('script.py')).toContain('>Py</text>')
+  })
+
+  it('prefers exact filenames over the extension mapping', () => {
+    expect(icon('package.json')).toContain('fill="#cb3837"')
+    expect(icon('other.json')).toContain('>{}</text>')
+    expect(icon('Dockerfile')).toContain('fill="#2496ed"')
+  })
+
+  it('keeps outline folder icons for directories', () => {
+    expect(icon('src', true)).toContain('stroke="currentColor"')
+    expect(icon('src', true)).not.toContain('<rect')
+  })
+
+  it('falls back to kind icons for unmapped types', () => {
+    const image = icon('photo.png')
+    expect(image).toContain('stroke="currentColor"')
+    expect(image).not.toContain('<rect')
+    expect(icon('mystery.xyz')).not.toContain('<rect')
+  })
+})

--- a/packages/dsh-aionui-panel/tests/pure.spec.ts
+++ b/packages/dsh-aionui-panel/tests/pure.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest'
 import { renderInline, renderMarkdown, resolveMarkdownImage } from '../src/client/preview/markdown.ts'
 import { parseCsv, normalizeUrl } from '../src/client/preview/content.tsx'
 import { parseGridTracks, trackPx } from '../src/client/layout.ts'
-import { detectContentType } from '../src/client/fileType.ts'
+import { detectContentType, joinAbsolute } from '../src/client/fileType.ts'
 
 describe('renderMarkdown', () => {
   it('renders headings, paragraphs and hr', () => {
@@ -173,5 +173,18 @@ describe('dotfile content detection (M5 regression)', () => {
     expect(detectContentType('.npmrc')).toBe('text')
     expect(detectContentType('.env.local')).toBe('text')
     expect(detectContentType('.editorconfig')).toBe('text')
+  })
+})
+
+describe('joinAbsolute', () => {
+  it('joins with the root separator style', () => {
+    expect(joinAbsolute('/home/u/proj', 'docs/a.md')).toBe('/home/u/proj/docs/a.md')
+    expect(joinAbsolute('F:\\codeF\\proj', 'docs/a.md')).toBe('F:\\codeF\\proj\\docs\\a.md')
+  })
+
+  it('does not double a trailing root separator and handles the root itself', () => {
+    expect(joinAbsolute('/home/u/proj/', 'a.md')).toBe('/home/u/proj/a.md')
+    expect(joinAbsolute('C:\\proj\\', 'a.md')).toBe('C:\\proj\\a.md')
+    expect(joinAbsolute('/home/u/proj', '')).toBe('/home/u/proj')
   })
 })


### PR DESCRIPTION
## 摘要（Summary）

为右侧面板（dsh-aionui-panel）的 Explorer 文件树增加两项能力：任意文件/目录行的右键菜单（复制相对路径 / 复制绝对路径，含 toast 反馈与非安全上下文降级），以及按语言着色的 VSCode 风格徽章文件图标（约 40 种扩展名 + 精确文件名匹配，未识别类型回落原轮廓图标，零新增依赖）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [x] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
# 基于 main HEAD 5adc668（chore(release): bump to 0.1.11）新建分支
git checkout -b feat/aionui-explorer-copy-path-and-badges origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

Kimi（Moonshot AI）

使用的编码 Agent 工具：

Kimi Code CLI

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本 PR 未新增包目录）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-aionui-panel
pnpm run test    # vitest，含新增 tests/fileicon.spec.tsx 与 pure.spec.ts 的 joinAbsolute 用例
pnpm run build   # tsc -b && tsdown
# 另在本机以 link: 安装进真实 dsh profile（dsh plugin --profile web add -w link:...），
# 重启 dsh web 后确认下发的 client.js 携带新功能并用浏览器实际操作验证
```

结果摘要：

- 新增测试全部通过：`joinAbsolute` 4 断言（POSIX/Windows 根、尾部分隔符、根本身）+ 图标 4 例（徽章渲染、精确文件名优先、目录与回落分支）。
- 包内完整套件 115/117 通过；仅有的 2 个失败是 `tests/host-fixes.spec.ts` 中需要创建 symlink 的既有用例，本机 Windows 无 symlink 权限（EPERM），与本改动无关，在 Linux CI 上不受影响。
- 真实 dsh web 环境实测：右键菜单弹出、相对路径复制后经剪贴板读取校验内容正确（`AGENTS.md`）。

## 用户可见变更证据（Local Feature Evidence）

证据：

徽章图标（TS 蓝 / MD 蓝 / npm 红 / git 橙等品牌色徽章，目录保持轮廓图标）：

![Explorer 文件树徽章图标](https://raw.githubusercontent.com/Rostopher/dsh-web-ui/pr-106-assets/explorer-badge-icons.png)

右键菜单（复制相对路径 / 复制绝对路径）：

![文件行右键菜单](https://raw.githubusercontent.com/Rostopher/dsh-web-ui/pr-106-assets/explorer-copy-path-menu.png)

复制成功：toast「已复制」+ 粘贴到输入框验证剪贴板内容：

![复制结果验证](https://raw.githubusercontent.com/Rostopher/dsh-web-ui/pr-106-assets/explorer-copy-path-pasted.png)
