### PR TITLE
fix(task-board): 适配 DSH 0.1.0-rc.6 AppFrame 布局（[data-pane=conversation] 已失效）

### DIFF
--- a/packages/dsh-task-board/README.md
+++ b/packages/dsh-task-board/README.md
@@ -11,7 +11,8 @@
 
 ## 功能
 
-- **侧边栏入口**：`[data-pane="sidebar"]` 列内、新会话按钮下方注入「任务看板」入口行
+- **侧边栏入口**：侧边栏列（`[class*="sidebarCol"]`，DSH 0.1.0-rc.6 AppFrame 布局）内、
+  新会话按钮下方注入「任务看板」入口行
   （宽栏显示图标+文字，折叠 rail 显示纯图标，随 DSH 皮肤 token 自适应）。
 - **多列看板**：待规划 / 待办 / 进行中 / 已完成 / 已失败 五列；卡片显示标题、描述、
   状态、更新时间、执行次数；顶部支持搜索过滤、新建任务、返回对话。
@@ -63,7 +64,8 @@ scripts/dsh-task-board.js                          # 一键挂载/卸载/状态 
   skin 先例的 **DOM 注入**，并用 MutationObserver 自愈（React 重渲染波及该节点时
   同帧内重新插入，无闪烁）。
 - **中间列无法通过槽位替换**：`conversation` 槽位是 single 且已被 ui-conversation
-  占用。看板视图以 DOM 方式挂在 `[data-pane="conversation"]` 列内（React 不管的
+  占用。看板视图以 DOM 方式挂在中间列（`[class*="centerCol"]`，rc.6 起为 AppFrame
+  布局；旧版为 `[data-pane="conversation"]`）内（React 不管的
   尾部子节点），通过 `<html data-dsh-taskboard-active>` 属性切换显隐，底下的对话
   子树保持挂载有状态。
 - **持久化用浏览器 localStorage**：客户端插件跑在浏览器里，DSH 没有浏览器可写的

--- a/packages/dsh-task-board/src/client/board-mount.tsx
+++ b/packages/dsh-task-board/src/client/board-mount.tsx
@@ -3,8 +3,10 @@
  *
  * The `conversation` slot is single-occupant (ui-conversation) and external
  * plugins cannot declare slots, so the board takes over the center column at
- * the DOM level: a container is appended inside the `[data-pane="conversation"]`
- * grid item (an extra trailing child React never manages), and a stylesheet
+ * the DOM level: a container is appended inside the center column
+ * (`[class*="centerCol"]`, the dsh 0.1.0-rc.6 AppFrame layout; previously
+ * `[data-pane="conversation"]` on older shells) as an extra trailing child
+ * React never manages, and a stylesheet
  * rule hides the conversation content while the board is active. Toggling is
  * a data attribute on <html> — no React involvement, so the conversation
  * subtree underneath stays mounted and stateful.
@@ -17,7 +19,7 @@ import css from './board.module.css'
 /** The injected board container (kept in the DOM, hidden when inactive). */
 export const BOARD_VIEW_SELECTOR = '[data-dsh-taskboard-view]'
 
-const CONVERSATION_COLUMN_SELECTOR = '[data-pane="conversation"]'
+const CONVERSATION_COLUMN_SELECTOR = '[class*="centerCol"]'
 const ACTIVE_ATTR = 'data-dsh-taskboard-active'
 /** The sibling panel's activation attribute (ssh), removed when this panel opens. */
 const OTHER_ACTIVE_ATTR = 'data-dsh-ssh-active'

--- a/packages/dsh-task-board/src/client/board.module.css
+++ b/packages/dsh-task-board/src/client/board.module.css
@@ -6,7 +6,7 @@
 
 /* --- center-column takeover (global rules, attribute-scoped) ----------------- */
 
-[data-pane='conversation'] {
+[class*='centerCol'] {
   position: relative;
 }
 
@@ -32,7 +32,7 @@ html[data-dsh-taskboard-active]:not([data-dsh-ssh-active]) [data-dsh-taskboard-v
    `display: contents`, and inline styles beat a plain stylesheet rule. Without
    it the composer (input card) stays visible at the bottom and paints over the
    board modals' footer, hiding the run/delete buttons (issue #76). */
-html[data-dsh-taskboard-active]:not([data-dsh-ssh-active]) [data-pane='conversation'] > :not([data-dsh-taskboard-view]) {
+html[data-dsh-taskboard-active]:not([data-dsh-ssh-active]) [class*='centerCol'] > :not([data-dsh-taskboard-view]) {
   display: none !important;
 }
 


### PR DESCRIPTION
## 摘要（Summary）

修复 dsh-task-board 在 DSH 0.1.0-rc.6 上点击侧边栏「任务看板」入口无反应的问题：rc.6 将 Web shell 重构为 AppFrame 布局（`[data-dsh-frame]` + `sidebarCol/centerCol/detailsCol` css-module 类名），旧版 `data-pane` 属性已删除，插件的中心列选择器 `[data-pane="conversation"]` 永远匹配不到，看板容器永不创建。将选择器改为 `[class*="centerCol"]`（与侧边栏入口已有的 `[class*="sidebarCol"]` 前缀匹配风格一致）。

## 涉及包（Affected Packages）

- [x] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

（分支基于 `main` @ `a82665f`，创建于提交前最后一次 fetch）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

DeepSeek V4

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
# 改动为纯选择器替换（无依赖 / 构建逻辑变更），未运行 pnpm build
# 1. 运行时 bundle 对比（DSH 0.1.0-rc.6 实际 serve 的产物）：
#    curl /plugins/@deepseek-ai/dsh-client-ui-layout/client.js 与 dsh-client-ui-conversation/client.js
#    -> 确认 rc.6 中心列类名为 .pI_x6G_centerCol，全 bundle 无 data-pane 属性
# 2. 本地 profile 应用同款补丁（3 处相同替换）后：
#    curl /plugins/@linxin666/dsh-client-ui-task-board/client.js
#    -> 无 [data-pane=conversation] 残留，[class*=centerCol] 生效
```

结果摘要：

- 运行时确认：rc.6 中心列 DOM 为 `[class*="centerCol"]` 可匹配的 css-module 类名，旧 `data-pane` 属性在 shell 中已不存在（layout / conversation / sidebar 三个 bundle 逐一验证）
- 本地同款补丁应用后运行时 bundle 无旧选择器残留
- 未进行真实 GUI 点击验证（提交时无 rc.6 实例在手）；建议维护者在 rc.6 上安装后 **Ctrl+F5 硬刷新**复验

## 用户可见变更证据（Local Feature Evidence）

N/A —— 本次为 Bug 修复（修复前看板完全不可见，无"修复前"界面可截图）；修复后界面验证见上「本地验证」。若维护者需要，可在 rc.6 复验时补充截图。

## 备注

`packages/dsh-ssh` 存在同款 `data-pane` 依赖（`mount.tsx` / `panel.module.css` / `sidebar-entry.ts`），rc.6 上可能同样失效，建议一并排查（本 PR 不扩大范围）。
