### PR TITLE
fix(remote-web-ui): 修复移动端打开会话期间实时事件被丢弃的竞态

### DIFF
--- a/packages/dsh-remote-web-ui/src/mobile/views/ChatView.test.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/ChatView.test.tsx
@@ -187,6 +187,40 @@ describe('ChatView message folds', () => {
   })
 })
 
+describe('ChatView initial-load race', () => {
+  /** Minimal mux stand-in: captures the ChatView's frame listener for hand-off. */
+  class FakeMux {
+    listeners = new Set<(frame: unknown) => void>()
+    onFrame(listener: (frame: unknown) => void): () => void {
+      this.listeners.add(listener)
+      return () => { this.listeners.delete(listener) }
+    }
+    emit(frame: unknown): void {
+      for (const listener of this.listeners) listener(frame)
+    }
+  }
+
+  it('keeps live events that arrive while the tail page is still loading', async () => {
+    let resolveHistory: (page: HistoryPage) => void = () => {}
+    loadHistoryMock.mockReturnValue(new Promise<HistoryPage>((resolve) => { resolveHistory = resolve }))
+    const mux = new FakeMux()
+    render(<ChatView session={session} mux={mux as never} onBack={() => {}} />)
+
+    // A live turn starts before the snapshot resolves: chunk, tool call, final.
+    await act(async () => {
+      mux.emit({ type: 'session/event', sessionId: 's-1', event: makeEntry('assistant/chunk', { turn: 1, step: 0, chunk: { type: 'text-delta', text: '正在' } }, 6).event })
+      mux.emit({ type: 'session/event', sessionId: 's-1', event: makeEntry('tool/call', { turn: 1, step: 0, callId: 'c9', name: 'bash', arguments: '{"cmd":"ls"}' }, 7).event })
+      mux.emit({ type: 'session/event', sessionId: 's-1', event: makeEntry('assistant/message', { turn: 1, step: 0, message: { id: 'a-9', role: 'assistant', content: [{ type: 'text', text: '实时新消息' }] } }, 8).event })
+    })
+    // The snapshot predates those events; resolving it must not drop them.
+    await act(async () => { resolveHistory(historyPage(turnEvents())) })
+
+    expect(await screen.findByText('实时新消息')).toBeTruthy()
+    // The history turn's tool disclosure plus the live one both render.
+    expect((await screen.findAllByRole('button', { name: /工具/ })).length).toBe(2)
+  })
+})
+
 describe('ChatView model sheet', () => {
   it('labels the toolbar chip with the current model and selects a new one', async () => {
     loadHistoryMock.mockResolvedValue(historyPage(turnEvents()))

--- a/packages/dsh-remote-web-ui/src/mobile/views/ChatView.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/ChatView.tsx
@@ -101,6 +101,16 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
   const [sending, setSending] = useState(false)
   const scrollRef = useRef<HTMLDivElement | undefined>(undefined)
   const pendingRef = useRef(false)
+  /**
+   * True while the initial tail page is in flight. Live events arriving in
+   * that window go to {@link liveBufferRef} instead of the message list: the
+   * tail load replaces the list wholesale, so a directly folded event would
+   * flash once, be discarded by the snapshot, and then be skipped forever by
+   * the seq watermark.
+   */
+  const tailLoadingRef = useRef(true)
+  /** Live session events buffered while the initial tail page loads. */
+  const liveBufferRef = useRef<WireEvent[]>([])
 
   /** The session's permission select (absent = capability not composed). */
   const [permissions, setPermissions] = useState<PermissionSelectValue | undefined>(undefined)
@@ -112,13 +122,20 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
   // Tail page on open (content loads only when the session is opened).
   useEffect(() => {
     let cancelled = false
+    tailLoadingRef.current = true
+    liveBufferRef.current = []
     setLoading(true)
     setError(undefined)
     setMessages([])
     void loadHistory(session.sessionId).then(
       (page) => {
         if (cancelled) return
-        setMessages(foldEvents(page.events.map(eventOf)))
+        // Buffered live events re-fold on top of the snapshot; the watermark
+        // drops any the snapshot already includes, so nothing is lost or doubled.
+        const buffered = liveBufferRef.current
+        liveBufferRef.current = []
+        tailLoadingRef.current = false
+        setMessages(foldEvents(buffered, foldEvents(page.events.map(eventOf))))
         setHasOlder(page.hasMore)
         setLoading(false)
         // The history-tail projection baseline seeds the permission picker.
@@ -129,6 +146,11 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
       },
       (reason: unknown) => {
         if (cancelled) return
+        // Load failed: flush the buffer so the live stream still renders.
+        const buffered = liveBufferRef.current
+        liveBufferRef.current = []
+        tailLoadingRef.current = false
+        if (buffered.length > 0) setMessages(foldEvents(buffered))
         setError(errorText(reason))
         setLoading(false)
       },
@@ -150,7 +172,12 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
     return mux.onFrame((frame: MuxFrame) => {
       if (frame.type === 'session/event') {
         if (frame.sessionId !== session.sessionId) return
-        setMessages(previous => foldEvents([frame.event as WireEvent], previous))
+        const event = frame.event as WireEvent
+        if (tailLoadingRef.current) {
+          liveBufferRef.current.push(event)
+          return
+        }
+        setMessages(previous => foldEvents([event], previous))
         return
       }
       // Live projection pushes keep the permission picker current.


### PR DESCRIPTION
## 摘要（Summary）

修复移动端打开会话期间到达的实时事件被永久丢弃的竞态：历史尾页加载中时到达的 live 事件先被折叠渲染，快照返回后整个列表被覆盖替换，而这些事件的 seq 已低于新水位线，之后被折叠器跳过——手机上表现为工具调用闪一下就消失，刷新前不再出现。现在加载期间缓冲 live 事件，快照返回后叠加折叠（水位线保证幂等，不丢不重）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

git fetch origin && git checkout -b fix/mobile-live-event-race origin/main

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：Kimi

使用的编码 Agent 工具：Kimi Code CLI

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-remote-web-ui
node_modules/.bin/vitest run src/mobile
node_modules/.bin/tsc -b
node_modules/.bin/tsdown
```

结果摘要：

新增回归测试「keeps live events that arrive while the tail page is still loading」（快照返回前到达的 chunk/tool/call/final 在快照解析后仍完整渲染）。41 个 mobile 测试全部通过；typecheck 与构建通过。已在真机（iPhone 经 Cloudflare Tunnel 访问）验证：修复前工具调用闪现即消失，修复后打开进行中的会话不再丢卡片。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（竞态类 Bug 修复，行为证据为回归测试 + 真机验证描述）。
