### PR TITLE
feat(remote-web-ui): 移动端显示选项（工具调用 / 系统提示词开关）

### DIFF
--- a/packages/dsh-remote-web-ui/src/mobile/display-options.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/display-options.ts
@@ -1,0 +1,66 @@
+/**
+ * Mobile chat display options: which auxiliary rows the chat view renders.
+ * Like the theme, the choice persists in localStorage and a tiny module
+ * store (subscribe/get) keeps the options sheet and the message list in
+ * sync without threading props through the view levels.
+ */
+
+export interface MobileDisplayOptions {
+  /** Render tool-call disclosures on assistant messages (default on). */
+  readonly showTools: boolean
+  /**
+   * Render host-injected user-role messages — agent instructions, runtime
+   * snapshots, skill catalogs (default off: they drown out the conversation
+   * on a small screen).
+   */
+  readonly showSystemMessages: boolean
+}
+
+const STORAGE_KEY = 'dsh.remote.displayOptions'
+const DEFAULT_OPTIONS: MobileDisplayOptions = { showTools: true, showSystemMessages: false }
+
+let current: MobileDisplayOptions = readStored() ?? DEFAULT_OPTIONS
+const listeners = new Set<() => void>()
+
+function readStored(): MobileDisplayOptions | undefined {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return undefined
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
+    const record = parsed as Record<string, unknown>
+    return {
+      showTools: typeof record['showTools'] === 'boolean' ? record['showTools'] : DEFAULT_OPTIONS.showTools,
+      showSystemMessages: typeof record['showSystemMessages'] === 'boolean' ? record['showSystemMessages'] : DEFAULT_OPTIONS.showSystemMessages,
+    }
+  } catch {
+    // Private-mode storage failures are non-fatal; the session keeps the defaults.
+    return undefined
+  }
+}
+
+function persist(options: MobileDisplayOptions): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(options))
+  } catch {
+    // Private-mode storage failures are non-fatal; the session keeps the choice.
+  }
+}
+
+/** Current display options (defaults unless the user explicitly toggled). */
+export function getDisplayOptions(): MobileDisplayOptions {
+  return current
+}
+
+/** Subscribe to display-option changes; returns the unsubscribe function. */
+export function subscribeDisplayOptions(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => { listeners.delete(listener) }
+}
+
+/** Merge a partial update into the current options (persisted + broadcast). */
+export function setDisplayOptions(patch: Partial<MobileDisplayOptions>): void {
+  current = { ...current, ...patch }
+  persist(current)
+  for (const listener of [...listeners]) listener()
+}

--- a/packages/dsh-remote-web-ui/src/mobile/messages.test.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/messages.test.ts
@@ -219,4 +219,20 @@ describe('foldEvents', () => {
     foldEvents([makeEvent('assistant/message', assistantMessageData('a-1', 0, 0, 'world'), 1)], first)
     expect(JSON.stringify(first)).toBe(snapshot)
   })
+
+  it('marks host-injected user-role messages with their source kind', () => {
+    const events: WireEvent[] = [
+      makeEvent('user/message', userMessageData('u-1', 'hello'), 0),
+      makeEvent('user/message', {
+        id: 'sys-1',
+        role: 'user',
+        content: [{ type: 'text', text: 'workspace instructions' }],
+        source: { kind: 'agent-instructions' },
+      }, 1),
+    ]
+    const result = foldEvents(events)
+    expect(result).toHaveLength(2)
+    expect(result[0]?.sourceKind).toBeUndefined()
+    expect(result[1]).toMatchObject({ id: 'sys-1', kind: 'user', sourceKind: 'agent-instructions' })
+  })
 })

--- a/packages/dsh-remote-web-ui/src/mobile/messages.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/messages.ts
@@ -68,6 +68,12 @@ export interface RenderMessage {
   readonly toolSummary?: string
   /** Set when the owning turn ended in an error. */
   readonly failed?: boolean
+  /**
+   * `source.kind` of a user-role message injected by the host rather than
+   * typed by the user (e.g. `agent-instructions`, `plugin`, `skill-catalog`).
+   * Absent for genuine user prompts; the surface hides these by default.
+   */
+  readonly sourceKind?: string
 }
 
 /** One tool call attached to an assistant message (callId dedupes repeats). */
@@ -304,13 +310,16 @@ function applyUserMessage(state: FoldState, event: WireEvent): void {
   const data = isRecord(event.data) ? event.data : {}
   const id = pickString(data['id']) ?? syntheticId('user', event.seq)
   const text = textFromContent(data['content'])
+  const source = isRecord(data['source']) ? data['source'] : undefined
+  const sourceKind = source !== undefined ? pickString(source['kind']) : undefined
+  const injected = sourceKind !== undefined && sourceKind !== 'user' ? { sourceKind } : {}
   const existing = state.byId.get(id)
   if (existing !== undefined) {
     // Idempotent replace (replayed events update in place, never duplicate).
-    replaceMessage(state, existing, { ...existing, text, seq: event.seq, time: event.time })
+    replaceMessage(state, existing, { ...existing, text, ...injected, seq: event.seq, time: event.time })
     return
   }
-  const message: RenderMessage = { id, kind: 'user', text, seq: event.seq, time: event.time }
+  const message: RenderMessage = { id, kind: 'user', text, ...injected, seq: event.seq, time: event.time }
   state.messages.push(message)
   state.byId.set(id, message)
 }

--- a/packages/dsh-remote-web-ui/src/mobile/views/ChatView.test.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/ChatView.test.tsx
@@ -24,6 +24,7 @@ vi.mock('./App.tsx', async importOriginal => {
   }
 })
 import { models, selectModel, sendCommand } from '../api.ts'
+import { setDisplayOptions } from '../display-options.ts'
 import { loadHistory } from './App.tsx'
 
 const session: SessionView = {
@@ -184,6 +185,52 @@ describe('ChatView message folds', () => {
     await waitFor(() => {
       expect(sendCommandMock).toHaveBeenCalledWith('s-1', '/permission danger-full-access')
     })
+  })
+})
+
+describe('ChatView display options', () => {
+  beforeEach(() => {
+    // The store is module-level; reset both toggles so tests stay independent.
+    setDisplayOptions({ showTools: true, showSystemMessages: false })
+  })
+
+  it('hides host-injected messages by default and reveals them from the display sheet', async () => {
+    loadHistoryMock.mockResolvedValue(historyPage([
+      makeEntry('user/message', {
+        id: 'sys-1',
+        role: 'user',
+        source: { kind: 'agent-instructions' },
+        content: [{ type: 'text', text: '注入的工作区指令' }],
+      }, 0),
+      ...turnEvents().map((entry, index) => makeEntry(entry.event.type, entry.event.data, index + 1)),
+    ]))
+    render(<ChatView session={session} onBack={() => {}} />)
+
+    expect(await screen.findByText('改一下代码')).toBeTruthy()
+    expect(screen.queryByText('注入的工作区指令')).toBeNull()
+
+    fireEvent.click(await screen.findByRole('button', { name: /显示/ }))
+    const toggle = await screen.findByRole('button', { name: /系统提示词/ })
+    expect(toggle.getAttribute('aria-pressed')).toBe('false')
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-pressed')).toBe('true')
+    expect(await screen.findByText('注入的工作区指令')).toBeTruthy()
+  })
+
+  it('hides tool disclosures when the tools option is switched off', async () => {
+    loadHistoryMock.mockResolvedValue(historyPage(turnEvents()))
+    render(<ChatView session={session} onBack={() => {}} />)
+    expect(await screen.findByRole('button', { name: /工具/ })).toBeTruthy()
+
+    fireEvent.click(await screen.findByRole('button', { name: /显示/ }))
+    fireEvent.click(await screen.findByRole('button', { name: /工具调用/ }))
+    // Close the sheet (backdrop click) so its rows do not match the query.
+    const backdrop = document.querySelector('.sheet-backdrop')
+    expect(backdrop).not.toBeNull()
+    fireEvent.click(backdrop as Element)
+    await waitFor(() => { expect(screen.queryByRole('button', { name: /工具/ })).toBeNull() })
+    // The final assistant text still renders without the tool card.
+    expect(screen.getByText('已完成修改')).toBeTruthy()
   })
 })
 

--- a/packages/dsh-remote-web-ui/src/mobile/views/ChatView.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/ChatView.tsx
@@ -11,12 +11,13 @@
  *   permission pickers, both as bottom sheets.
  */
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from 'react'
 import type { MuxFrame } from '@deepseek-ai/dsh-host-apiproxy/api/events'
 import type { SessionModels } from '@deepseek-ai/dsh-host-apiproxy/api/sessions'
 import { loadHistory, prompt, type SessionView } from './App.tsx'
 import { errorText, formatTime, staleHostHint } from './App.tsx'
 import { models, selectModel, sendCommand } from '../api.ts'
+import { getDisplayOptions, setDisplayOptions, subscribeDisplayOptions } from '../display-options.ts'
 import { foldEvents, type RenderMessage, type ToolCallInfo, type WireEvent } from '../messages.ts'
 import { MuxClient } from '../mux.ts'
 import { ThemeToggle } from '../theme-toggle.tsx'
@@ -107,7 +108,9 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
   /** The current model selection for the toolbar chip (best-effort label). */
   const [currentModel, setCurrentModel] = useState<{ provider: string; model: string; reasoningEffort?: string } | undefined>(undefined)
   /** Which bottom sheet is open. */
-  const [sheet, setSheet] = useState<'model' | 'permission' | null>(null)
+  const [sheet, setSheet] = useState<'model' | 'permission' | 'display' | null>(null)
+  /** Chat display options (tool disclosures, host-injected messages). */
+  const displayOptions = useSyncExternalStore(subscribeDisplayOptions, getDisplayOptions)
 
   // Tail page on open (content loads only when the session is opened).
   useEffect(() => {
@@ -239,6 +242,10 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
     ? undefined
     : permissions.options.find(option => option.value === permissions.currentValue)?.name
       ?? displayName(permissions.currentValue)
+  /** Messages after the display-option filter (host-injected rows hidden by default). */
+  const visibleMessages = displayOptions.showSystemMessages
+    ? messages
+    : messages.filter(message => message.sourceKind === undefined)
 
   return (
     <div className="chat">
@@ -254,9 +261,9 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
             {loading ? '加载中…' : '加载更早的消息'}
           </button>
         )}
-        {messages.map(message => <MessageRow key={message.id} message={message} />)}
-        {loading && messages.length === 0 && <p className="chat-typing">加载中…</p>}
-        {!loading && messages.length === 0 && <p className="chat-typing">还没有消息，发一句话开始吧</p>}
+        {visibleMessages.map(message => <MessageRow key={message.id} message={message} showTools={displayOptions.showTools} />)}
+        {loading && visibleMessages.length === 0 && <p className="chat-typing">加载中…</p>}
+        {!loading && visibleMessages.length === 0 && <p className="chat-typing">还没有消息，发一句话开始吧</p>}
       </div>
       <div className="chat-tools">
         <button type="button" className="chat-chip" onClick={() => { setSheet('model') }} aria-haspopup="dialog">
@@ -271,6 +278,10 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
             <span className="chat-chip-chevron" aria-hidden>›</span>
           </button>
         )}
+        <button type="button" className="chat-chip" onClick={() => { setSheet('display') }} aria-haspopup="dialog">
+          <span className="chat-chip-label">显示</span>
+          <span className="chat-chip-chevron" aria-hidden>›</span>
+        </button>
       </div>
       <div className="chat-inputbar">
         <textarea
@@ -309,6 +320,7 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
           onClose={() => { setSheet(null) }}
         />
       )}
+      {sheet === 'display' && <DisplaySheet onClose={() => { setSheet(null) }} />}
     </div>
   )
 }
@@ -316,13 +328,13 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
 /* ── message rows ─────────────────────────────────────────────────────── */
 
 /** One rendered message row (user bubble or assistant bubble with folds). */
-function MessageRow({ message }: { message: RenderMessage }) {
+function MessageRow({ message, showTools }: { message: RenderMessage; showTools: boolean }) {
   return (
     <div className={`chat-msg chat-msg-${message.kind}${message.pending === true ? ' chat-msg-pending' : ''}${message.failed === true ? ' chat-msg-failed' : ''}`}>
       {message.kind === 'assistant' && message.reasoning !== undefined && message.reasoning !== '' && (
         <ReasoningDisclosure text={message.reasoning} pending={message.pending === true} />
       )}
-      {message.kind === 'assistant' && message.tools !== undefined && message.tools.length > 0 && (
+      {showTools && message.kind === 'assistant' && message.tools !== undefined && message.tools.length > 0 && (
         <ToolDisclosure tools={message.tools} />
       )}
       <CollapsibleText text={message.text} />
@@ -659,6 +671,44 @@ function PermissionSheet({ sessionId, value, onChanged, onClose }: {
           </button>
         )
       })}
+    </Sheet>
+  )
+}
+
+/** Display-option toggles: tool-call disclosures and host-injected messages. */
+function DisplaySheet({ onClose }: { onClose(): void }) {
+  const options = useSyncExternalStore(subscribeDisplayOptions, getDisplayOptions)
+  const rows = [
+    {
+      key: 'showTools' as const,
+      title: '工具调用',
+      description: '关闭后只保留最终回复，不再展示工具调用卡片',
+      on: options.showTools,
+    },
+    {
+      key: 'showSystemMessages' as const,
+      title: '系统提示词',
+      description: '工作区指令、技能目录等注入内容',
+      on: options.showSystemMessages,
+    },
+  ]
+  return (
+    <Sheet title="显示选项" onClose={onClose}>
+      {rows.map(row => (
+        <button
+          type="button"
+          key={row.key}
+          className={`sheet-option${row.on ? ' sheet-option-selected' : ''}`}
+          aria-pressed={row.on}
+          onClick={() => { setDisplayOptions({ [row.key]: !row.on }) }}
+        >
+          <span className="sheet-option-copy">
+            <span className="sheet-option-title">{row.title}</span>
+            <span className="sheet-option-desc">{row.description}</span>
+          </span>
+          {row.on && <span className="sheet-option-check" aria-hidden>√</span>}
+        </button>
+      ))}
     </Sheet>
   )
 }


### PR DESCRIPTION
## 摘要（Summary）

移动端聊天工具栏新增「显示」底栏面板，提供两个持久化开关（localStorage）：

- 工具调用（默认开）：关闭后只保留最终回复，不再展示工具调用卡片，适合只看结果的场景；
- 系统提示词（默认关）：工作区指令、运行时快照、技能目录等宿主注入内容以 user 角色消息下发（`source.kind` 非 `user`），折叠层现在把该 kind 带到渲染消息上，界面默认隐藏这些整屏文本。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

git fetch origin && git checkout -b feat/mobile-display-options origin/main

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：Kimi

使用的编码 Agent 工具：Kimi Code CLI

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-remote-web-ui
node_modules/.bin/vitest run src/mobile
node_modules/.bin/tsc -b
node_modules/.bin/tsdown
```

结果摘要：

新增 3 个测试（fold 层 sourceKind 标记；默认隐藏注入消息并可从面板打开；关闭工具开关后工具卡片消失且最终回复保留）。43 个 mobile 测试全部通过；typecheck 与构建通过。已在真机（iPhone）验证默认视图与开关行为。

## 用户可见变更证据（Local Feature Evidence）

证据：

显示选项面板（工具调用开、系统提示词关）：

![显示选项面板](https://raw.githubusercontent.com/Rostopher/dsh-web-ui/pr-mobile-assets/03-display-sheet.png)

关闭工具调用后的聊天视图（仅剩最终回复，工具栏可见「显示」入口）：

![关闭工具调用](https://raw.githubusercontent.com/Rostopher/dsh-web-ui/pr-mobile-assets/05-tools-off.png)

打开系统提示词开关后注入消息可见：

![显示系统提示词](https://raw.githubusercontent.com/Rostopher/dsh-web-ui/pr-mobile-assets/04-system-messages-on.png)
