### PR TITLE
fix(skins): keep tooltip readable on light palettes

### DIFF
--- a/packages/skins/blue-fantasy/src/client/blue-fantasy.module.css
+++ b/packages/skins/blue-fantasy/src/client/blue-fantasy.module.css
@@ -274,7 +274,7 @@ body[data-dsh-blue-fantasy] {
   --dsw-alias-state-warn-secondary: #d9a94f;
   --dsw-alias-state-warn-tertiary: #f7ecd8;
   --dsw-alias-toast-bg: #3c4e92;
-  --dsw-alias-tooltip-bg: #ffffe1;
+  --dsw-alias-tooltip-bg: #3c4e92;
   --dsw-specific-bubble-highlight: #c3cfee;
   --dsw-specific-bubble: #dce3f7;
   --dsw-specific-input-major: rgba(255, 255, 255, 0.6);

--- a/packages/skins/miku/src/client/miku.module.css
+++ b/packages/skins/miku/src/client/miku.module.css
@@ -299,7 +299,7 @@ body[data-dsh-miku] {
   --dsw-alias-state-warn-secondary: #e5b94f;
   --dsw-alias-state-warn-tertiary: #fdf3dd;
   --dsw-alias-toast-bg: #1e6fd9;
-  --dsw-alias-tooltip-bg: #ffffff;
+  --dsw-alias-tooltip-bg: #1e6fd9;
   --dsw-specific-bubble-highlight: #cfe3ff;
   --dsw-specific-bubble: #e4f0ff;
   --dsw-specific-input-major: #fff;
@@ -391,7 +391,7 @@ body[data-dsh-miku][data-ds-dark-theme] {
   --dsw-alias-state-warn-secondary: #e5b94f;
   --dsw-alias-state-warn-tertiary: #3a3015;
   --dsw-alias-toast-bg: #1c3468;
-  --dsw-alias-tooltip-bg: #213856;
+  --dsw-alias-tooltip-bg: #eef7f5;
   --dsw-specific-bubble-highlight: #22407a;
   --dsw-specific-bubble: #162a52;
   --dsw-specific-input-major: #12244a;

--- a/packages/skins/qq98/src/client/qq98.module.css
+++ b/packages/skins/qq98/src/client/qq98.module.css
@@ -290,8 +290,10 @@ body[data-dsh-retro] {
   --dsw-alias-state-warn-secondary: #d69a3a;
   --dsw-alias-state-warn-tertiary: #f8ecd9;
   --dsw-alias-toast-bg: #1e63b8;
-  /* QQ-era tooltips were the classic yellow note. */
-  --dsw-alias-tooltip-bg: #ffffe1;
+  /* QQ-era tooltips were the classic yellow note; the light palette must
+     keep it readable under the white tooltip text DSH forces, so use the
+     deep QQ gold here (the pale yellow note survives in dark mode). */
+  --dsw-alias-tooltip-bg: #966300;
   --dsw-specific-bubble-highlight: #b6d6f4;
   --dsw-specific-bubble: #dcecfb;
   --dsw-specific-input-major: #fff;

--- a/packages/skins/whale-song/src/client/whale-song.module.css
+++ b/packages/skins/whale-song/src/client/whale-song.module.css
@@ -275,7 +275,7 @@ body[data-dsh-whale-song] {
   --dsw-alias-state-warn-secondary: #e3c070;
   --dsw-alias-state-warn-tertiary: #f7efdc;
   --dsw-alias-toast-bg: #1a3a7a;
-  --dsw-alias-tooltip-bg: #ffffe1;
+  --dsw-alias-tooltip-bg: #1a3a7a;
   --dsw-specific-bubble-highlight: #c4dbf1;
   --dsw-specific-bubble: #d9e9f5;
   --dsw-specific-input-major: rgba(255, 255, 255, 0.6);


### PR DESCRIPTION
## 摘要（Summary）

DSH 的 Tooltip 组件文字颜色固定为白色（`--dsw-static-neutral-bluish-00`），因此浅色主题下若 tooltip 背景为浅色，会出现「白字配浅底」、几乎不可读。本次修复 4 套皮肤在浅色主题下的 `--dsw-alias-tooltip-bg`；深色主题不受影响（深色下皮肤把文字 token 映射为深色，浅底深字本就可读）。

| 皮肤 | 浅色主题（修复前 → 后） | 深色主题 |
|---|---|---|
| whale-song 鲸吟 | `#ffffe1` → `#1a3a7a`（与其 toast 深蓝一致） | 不变（可读） |
| blue-fantasy 蓝幻 | `#ffffe1` → `#3c4e92`（与其 toast 深蓝一致） | 不变（可读） |
| qq98 | `#ffffe1` → `#966300`（深 QQ 金，保留「经典黄条」意向且白字可读；浅黄条在深色主题保留） | 不变（可读） |
| miku | `#ffffff` → `#1e6fd9`（与其 toast 蓝一致） | `#213856` → `#eef7f5`（原为深底配深字不可读，改为近白薄荷底配深字） |

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 是 — 本 PR 由 AI 编码助手（deepseek-v4-flash，经 DSH 桌面端）在用户确认下生成与提交，改动为 4 个皮肤 CSS 文件的颜色 token，用户已在本地实际验证修复效果。

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [ ] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本次未新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改动 README）

## 贡献者版权声明（Contributor Copyright）

本次为对现有皮肤的 Bug 修复，不追加版权声明。

## 社区插件索引登记（Community Plugin Index）

不适用：本次非新增第三方插件，未登记社区索引。

## 本地验证（Local Validation）

执行的命令：

```bash
git diff --stat packages/skins/   # 纯 CSS 颜色 token 改动，无 TS / 构建逻辑变更，未改动包 README
```

结果摘要：

4 个皮肤 CSS 文件，8 处新增 / 6 处删除。用户环境（macOS + DSH 桌面端，浅色主题 + whale-song 皮肤）实际悬停验证：tooltip 由黄底白字变为深蓝底白字，清晰可读；其余 3 套皮肤（blue-fantasy / qq98 / miku）同问题已一并修复，切换皮肤后生效。

## 用户可见变更证据（Local Feature Evidence）

本 PR 为 Bug 修复（非新增面向用户的功能或行为变更），按仓库规则不要求证据；修复效果已在「本地验证」中描述并经用户实际确认。
