### PR TITLE
fix(git-graph,aionui-panel): 分支 chip 对齐与拖拽手柄残留线

### DIFF
--- a/packages/dsh-aionui-panel/src/client/layout.ts
+++ b/packages/dsh-aionui-panel/src/client/layout.ts
@@ -237,7 +237,12 @@ export class PanelLayoutController {
     el.style.position = 'absolute'
     el.style.top = '0'
     el.style.bottom = '0'
-    el.style.zIndex = '30'
+    // The handle must float above the panel content (static flow) but stay
+    // BELOW the host shell's full-screen overlay layers (usage stats, settings,
+    // …), which use z-index 20. A value above 20 would let the handle's 2px
+    // line poke through a modal overlay. 10 clears both: above auto content,
+    // below any host overlay.
+    el.style.zIndex = '10'
     el.style.cursor = 'col-resize'
     el.style.width = `${hitWidth}px`
     if (reverse) {

--- a/packages/dsh-git-graph/src/client/chips/context.module.css
+++ b/packages/dsh-git-graph/src/client/chips/context.module.css
@@ -3,6 +3,15 @@
 
 .anchor {
   position: relative;
+  /* Align the chip with the composer card's left edge. On wide viewports the
+     input card is centered at `--dsh-composer-card-max-width`; mirror that
+     centering so the chip sits exactly over the card's left edge in every
+     phase (hero included). Keep at least 16px on narrow viewports where the
+     card fills the stack width. */
+  margin-left: max(
+    16px,
+    calc((100% - var(--dsh-composer-card-max-width)) / 2)
+  );
 }
 
 .chip {


### PR DESCRIPTION
本 PR 包含两个独立修复：

  1. fix(git-graph)：分支 chip 与输入卡左缘对齐
  2. fix(aionui-panel)：右侧面板拖拽手柄 z-index 低于宿主覆盖层

  ### 1. fix(git-graph) 分支 chip 对齐

  old（修复前）：
  <img width="2000" height="1536" alt="image" src="https://github.com/user-attachments/assets/d8c279d7-b8d4-4031-b514-41f4581d09c0" />

  new（修复后）：
  <img width="1756" height="490" alt="image" src="https://github.com/user-attachments/assets/11a672fd-7069-421a-9c79-b494606d4736" />

  The BranchChip sits in the selector context hole above the input card, but its anchor only had `position: relative`, so the chip drifted to the far
  left of the composer stack and did not line up with the input card's left edge. On wide viewports the input card is centered at
  `--dsh-composer-card-max-width`, so the chip floated past the card edge.

  Mirror the card's centering in the anchor's left margin:

    margin-left: max(16px, calc((100% - var(--dsh-composer-card-max-width)) / 2))

  so the chip left-aligned with the composer card in every phase (hero included); cards that use `conversation.input.dock` (e.g. the goal bar) keep a
  consistent 16px edge on narrow viewports.

  Verified in the live web GUI (1710px): branch chip, goal bar, and input card all share the same left edge (x=471), with no interaction changes.

  **核心改动**：`packages/dsh-git-graph/src/client/chips/context.module.css`

  ```css
  .anchor {
    position: relative;
    /* Align the chip with the composer card's left edge. On wide viewports
       the input card is centered at `--dsh-composer-card-max-width`; mirror
       that centering so the chip sits exactly over the card's left edge in
       every phase (hero included). Keep at least 16px on narrow viewports
       where the card fills the stack width. */
    margin-left: max(
      16px,
      calc((100% - var(--dsh-composer-card-max-width)) / 2)
    );
  }
```

  2. fix(aionui-panel) 右侧面板拖拽手柄残留线

  old（修复前，使用统计打开时右侧残留竖线）：
  <img width="1710" height="986" alt="image" src="https://github.com/user-attachments/assets/73fbda77-ffdc-41a7-a3d9-2e6580e74a38" />

  new（修复后，覆盖层完整盖住手柄线）：
  <img width="1644" height="1107" alt="image" src="https://github.com/user-attachments/assets/7677f518-b91b-4a7a-bc7d-09d2ac58b099" />

  The explorer/preview drag handles set an inline z-index of 30, above the host shell's full-screen overlay layers (usage stats, settings, ...) which
  stack at 20. With the right panel open, opening the usage-stats overlay left the handles' 2px divider line visible on top of the modal.

  Lower the handle z-index to 10: still above the static panel content the handles must resize, but below any host overlay so no residual line pokes
  through a modal.

  核心改动：packages/dsh-aionui-panel/src/client/layout.ts

```
     el.style.top = '0'
     el.style.bottom = '0'
  -  el.style.zIndex = '30'
  +  // The handle must float above the panel content (static flow) but stay
  +  // BELOW the host shell's full-screen overlay layers (usage stats, settings,
  +  // ...), which use z-index 20. A value above 20 would let the handle's 2px
  +  // line poke through a modal overlay. 10 clears both: above auto content,
  +  // below any host overlay.
  +  el.style.zIndex = '10'
```

  摘要（Summary）

  本次 PR 包含两个独立修复：

  1. fix(git-graph) 分支 chip 对齐：分支选择 chip（BranchChip）未与输入卡左缘对齐，改为在左边距中镜像输入卡的居中逻辑，使 chip 与输入卡左缘对齐。
  2. fix(aionui-panel) 残留线修复：右侧面板拖拽手柄 z-index 为 30，高于宿主全屏覆盖层（使用统计 / 设置）的 z-index 20；打开使用统计时，手柄的 2px
  分隔线仍浮在覆盖层之上。将手柄 z-index 降至 10，使其高于普通内容流、但低于宿主覆盖层。

  涉及包（Affected Packages）

  - [x] Git 图谱 packages/dsh-git-graph
  - [x] 右侧面板 packages/dsh-aionui-panel

  PR 类型（PR Type）

  - [x] Bug 修复

  最新代码确认（Latest Codebase Confirmation）

  - [x] 我已基于最新 main 分支开发，或在提交前已 rebase / 合并最新 main。

  AI 编码披露（AI Coding Disclosure）

  - [x] 部分 AI 辅助

  使用的 AI 模型：Claude Sonnet

  使用的编码 Agent 工具：DeepSeek Harness

  仓库规范检查（Repo Rules）

  - [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
  - [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
  - [x] 新增 / 修改文件不含任何 emoji 字符。
  - [ ] 改动包 README 时同步维护中英双语三件套并运行 pnpm docs:check。

  测试环境（Test Environment）

  - 操作系统：macOS 26.5.2（Build 25F84），Apple Silicon（arm64）
  - 运行时：Node.js v24.18.0，pnpm 11.7.0
  - 验证视口：1710 × 986 px（standard mode）

  本地验证（Local Validation）

  cd packages/dsh-git-graph && pnpm build
  cd packages/dsh-aionui-panel && pnpm build

  结果摘要：两个包构建均通过（exit 0），无 typecheck 或 css 报错。

  用户可见变更证据（Local Feature Evidence）

  1. 分支 chip 对齐

  分支 chip、进行中目标卡片、输入卡三者的左缘完全一致（x=471），chip 贴齐输入框左缘，交互不受影响。

  2. 残留线修复

  修复前：手柄 2px 竖线（z-index 30）在使用统计覆盖层（z-index 20）之上残留。修复后：z-index
  10，覆盖层完整盖住竖线；关闭统计后手柄仍可拖拽，双击复位正常。

  **标题**（同步替换为）：
  fix(git-graph,aionui-panel): 分支 chip 对齐与拖拽手柄残留线