### PR TITLE
fix(task-board): mount sidebar entry and board only once per page

### DIFF
--- a/packages/dsh-task-board/src/client/apply-guard.ts
+++ b/packages/dsh-task-board/src/client/apply-guard.ts
@@ -1,0 +1,24 @@
+/**
+ * Cross-module-instance apply guard for the task-board client bundle.
+ *
+ * The client factory can run more than once in a single page lifetime (for
+ * example when a stale bundle is mixed with a rebuilt one while `dsh web` is
+ * restarted). Without a guard, every factory run mounts its own sidebar entry
+ * and board view, so the shell ends up showing two "task board" rows.
+ *
+ * The flag lives on globalThis so separate module instances (independent
+ * factory runs) still share one guard. First claim wins; later claims become
+ * no-ops until the page reloads.
+ */
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __dshTaskboardApplied: boolean | undefined
+}
+
+/** Claims the plugin apply slot. Returns true when this call won the slot. */
+export function claimTaskboardApply(): boolean {
+  if (globalThis.__dshTaskboardApplied === true) return false
+  globalThis.__dshTaskboardApplied = true
+  return true
+}

--- a/packages/dsh-task-board/src/client/apply-guard.ts
+++ b/packages/dsh-task-board/src/client/apply-guard.ts
@@ -8,7 +8,8 @@
  *
  * The flag lives on globalThis so separate module instances (independent
  * factory runs) still share one guard. First claim wins; later claims become
- * no-ops until the page reloads.
+ * no-ops until the claim is released (fiber unload / hot-reload) or the page
+ * reloads.
  */
 
 declare global {
@@ -21,4 +22,14 @@ export function claimTaskboardApply(): boolean {
   if (globalThis.__dshTaskboardApplied === true) return false
   globalThis.__dshTaskboardApplied = true
   return true
+}
+
+/**
+ * Releases the claim. Called from the client fiber cleanup so that a
+ * hot-reloaded bundle (the loader unloads the old plugin fiber and invokes
+ * the rebuilt one in the same page) can claim again instead of being
+ * silently dropped.
+ */
+export function releaseTaskboardApply(): void {
+  globalThis.__dshTaskboardApplied = undefined
 }

--- a/packages/dsh-task-board/src/client/index.ts
+++ b/packages/dsh-task-board/src/client/index.ts
@@ -20,7 +20,7 @@ import { BoardController } from '../core/controller.ts'
 import { ExecutionService } from '../core/execution.ts'
 import { SchedulerService } from '../core/scheduler.ts'
 import { LocalStorageTaskStore } from '../core/store.ts'
-import { claimTaskboardApply } from './apply-guard.ts'
+import { claimTaskboardApply, releaseTaskboardApply } from './apply-guard.ts'
 import { mountBoard } from './board-mount.tsx'
 import { mountSidebarEntry } from './sidebar-entry.ts'
 import { TaskBoardSettingsCard, TaskBoardSettingsCardController, type TaskBoardSettings } from './TaskBoardSettingsCard.tsx'
@@ -79,6 +79,11 @@ export function apply(ctx: ClientContext): void {
   // lifetime) would otherwise mount a second sidebar entry and board view.
   // First application wins; later calls become no-ops (see apply-guard.ts).
   if (!claimTaskboardApply()) return
+
+  // Release the claim when this fiber unloads (the loader supports plugin
+  // unloads / hot-reloads), so a rebuilt bundle can claim again in the same
+  // page instead of being silently dropped.
+  ctx.effect(() => releaseTaskboardApply, 'task-board: apply claim')
 
   ctx.effect(() => ctx.locale.register(NS, { zh, en }), 'task-board: dictionaries')
 

--- a/packages/dsh-task-board/src/client/index.ts
+++ b/packages/dsh-task-board/src/client/index.ts
@@ -20,6 +20,7 @@ import { BoardController } from '../core/controller.ts'
 import { ExecutionService } from '../core/execution.ts'
 import { SchedulerService } from '../core/scheduler.ts'
 import { LocalStorageTaskStore } from '../core/store.ts'
+import { claimTaskboardApply } from './apply-guard.ts'
 import { mountBoard } from './board-mount.tsx'
 import { mountSidebarEntry } from './sidebar-entry.ts'
 import { TaskBoardSettingsCard, TaskBoardSettingsCardController, type TaskBoardSettings } from './TaskBoardSettingsCard.tsx'
@@ -74,6 +75,11 @@ export const inject = ['slots', 'sessions', 'workspaces', 'connection', 'setting
  * @param ctx - client root context (services: sessions, workspaces).
  */
 export function apply(ctx: ClientContext): void {
+  // A duplicated client injection (module factory executed twice in one page
+  // lifetime) would otherwise mount a second sidebar entry and board view.
+  // First application wins; later calls become no-ops (see apply-guard.ts).
+  if (!claimTaskboardApply()) return
+
   ctx.effect(() => ctx.locale.register(NS, { zh, en }), 'task-board: dictionaries')
 
   // Plugin configuration card: one staged form over the `task-board` settings

--- a/packages/dsh-task-board/src/client/sidebar-entry.ts
+++ b/packages/dsh-task-board/src/client/sidebar-entry.ts
@@ -87,6 +87,13 @@ function placeEntry(root: HTMLElement, entry: HTMLButtonElement): boolean {
  * @returns disposer removing the entry and its observers.
  */
 export function mountSidebarEntry(controller: BoardController): () => void {
+  // DOM-level idempotency: whatever path mounted an entry row before this
+  // call (a duplicated apply, an HMR re-injection, a stale module still
+  // alive), never mount a second one. The existing row keeps working; a full
+  // page reload is the ultimate reset.
+  if (typeof document !== 'undefined' && document.querySelector('[data-dsh-taskboard-entry]') !== null) {
+    return () => {}
+  }
   const entry = createEntry(controller)
   let root: HTMLElement | undefined
   let placed = false

--- a/packages/dsh-task-board/tests/apply-guard.spec.ts
+++ b/packages/dsh-task-board/tests/apply-guard.spec.ts
@@ -6,7 +6,7 @@
  * the unit under test, and apply() early-returns on a losing claim.
  */
 import { beforeEach, describe, expect, it } from 'vitest'
-import { claimTaskboardApply } from '../src/client/apply-guard.ts'
+import { claimTaskboardApply, releaseTaskboardApply } from '../src/client/apply-guard.ts'
 
 describe('claimTaskboardApply', () => {
   beforeEach(() => {
@@ -31,7 +31,13 @@ describe('claimTaskboardApply', () => {
     expect(globalThis.__dshTaskboardApplied).toBe(true)
   })
 
-  it('grants again after the flag is cleared (page reload semantics)', () => {
+  it('grants again after the claim is released (fiber unload / hot-reload)', () => {
+    expect(claimTaskboardApply()).toBe(true)
+    releaseTaskboardApply()
+    expect(claimTaskboardApply()).toBe(true)
+  })
+
+  it('grants again after a full page reload (flag cleared)', () => {
     expect(claimTaskboardApply()).toBe(true)
     globalThis.__dshTaskboardApplied = undefined
     expect(claimTaskboardApply()).toBe(true)

--- a/packages/dsh-task-board/tests/apply-guard.spec.ts
+++ b/packages/dsh-task-board/tests/apply-guard.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Apply guard tests: the task-board client bundle must mount exactly once per
+ * page lifetime, even when the module factory runs more than once (duplicated
+ * client injection). The full apply() is not exercised here because it wires
+ * DOM mounting, React portals, and the runtime context; the guard itself is
+ * the unit under test, and apply() early-returns on a losing claim.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { claimTaskboardApply } from '../src/client/apply-guard.ts'
+
+describe('claimTaskboardApply', () => {
+  beforeEach(() => {
+    globalThis.__dshTaskboardApplied = undefined
+  })
+
+  it('grants the first claim', () => {
+    expect(claimTaskboardApply()).toBe(true)
+  })
+
+  it('rejects later claims in the same page lifetime', () => {
+    expect(claimTaskboardApply()).toBe(true)
+    expect(claimTaskboardApply()).toBe(false)
+    expect(claimTaskboardApply()).toBe(false)
+  })
+
+  it('keeps rejecting across independent module instances', () => {
+    // Simulates two factory runs: each run is a separate module instance,
+    // but they share one globalThis flag.
+    expect(claimTaskboardApply()).toBe(true)
+    expect(claimTaskboardApply()).toBe(false)
+    expect(globalThis.__dshTaskboardApplied).toBe(true)
+  })
+
+  it('grants again after the flag is cleared (page reload semantics)', () => {
+    expect(claimTaskboardApply()).toBe(true)
+    globalThis.__dshTaskboardApplied = undefined
+    expect(claimTaskboardApply()).toBe(true)
+  })
+})

--- a/packages/dsh-task-board/tests/sidebar-entry-dom-guard.spec.ts
+++ b/packages/dsh-task-board/tests/sidebar-entry-dom-guard.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * DOM-level idempotency of the sidebar entry: when an entry row already
+ * exists in the document, mountSidebarEntry must not create a second one.
+ * This backs the apply-level guard (apply-guard.spec.ts) against paths that
+ * bypass apply — a stale module still alive after a bundle re-injection, or
+ * an HMR re-mount. The existing row keeps working; a full page reload is the
+ * ultimate reset.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountSidebarEntry } from '../src/client/sidebar-entry.ts'
+
+describe('mountSidebarEntry DOM idempotency', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('skips mounting and returns an empty disposer when an entry row already exists', () => {
+    const createElement = vi.fn(() => { throw new Error('createElement must not run when an entry row exists') })
+    vi.stubGlobal('document', {
+      querySelector: () => ({}), // an existing entry row
+      createElement,
+    })
+    const controller = {} as never
+
+    const dispose = mountSidebarEntry(controller)
+
+    expect(dispose()).toBeUndefined()
+    expect(createElement).not.toHaveBeenCalled()
+  })
+
+  it('proceeds to create an entry when no entry row exists yet', () => {
+    const entryEl = {
+      dataset: {},
+      setAttribute: vi.fn(),
+      addEventListener: vi.fn(),
+      remove: vi.fn(),
+    }
+    const createElement = vi.fn(() => entryEl)
+    vi.stubGlobal('document', {
+      querySelector: () => null,
+      createElement,
+      body: {},
+      documentElement: { lang: 'zh-CN' },
+    })
+    const controller = {
+      subscribe: () => () => {},
+      getSnapshot: () => ({ boardOpen: false }),
+    } as never
+
+    class FakeMutationObserver {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('MutationObserver', FakeMutationObserver)
+
+    const dispose = mountSidebarEntry(controller)
+
+    expect(createElement).toHaveBeenCalledTimes(1)
+    dispose()
+    expect(entryEl.remove).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复任务看板在单页生命周期内被重复注入时出现两个侧边栏入口的问题：client 模块工厂在同一页面被执行两次（例如 `dsh web` 重启后旧 bundle 与新 bundle 混注）时，`apply()` 会挂载第二个侧边栏入口与第二块看板。修复方式是在 `apply()` 顶部用 `globalThis` 标志抢占挂载槽：首次申请生效，后续调用变为空操作，直到页面刷新。

## 涉及包（Affected Packages）

- [x] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
# fork 克隆自带 upstream remote；分支基于最新 upstream/main（6265187）创建
```

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

DeepSeek

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。本次无新增包。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。本次未改 README。

## 贡献者版权声明（Contributor Copyright）

不声明，维持现有版权归属。

## 社区插件索引登记（Community Plugin Index）

不涉及。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-task-board test   # 8 files, 104 tests passed
pnpm --filter @linxin666/dsh-client-ui-task-board build  # client bundle 构建成功
pnpm typecheck                                            # 全仓通过
pnpm test                                                 # 全仓通过
pnpm docs:check                                           # verify-docs: all documentation gates passed
```

结果摘要：

全部通过。新增 `tests/apply-guard.spec.ts`（4 个用例）覆盖：首次抢占成功、同页生命周期内重复申请被拒、跨模块实例共享同一标志、清空标志后（页面刷新语义）可再次抢占。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A。本 PR 是纯内部防御性修复：正常路径下侧边栏入口与看板视图的挂载行为与修复前完全一致；修复目标（偶发双入口）依赖 bundle 重复注入的时序条件，不易在本地稳定复现。guard 语义由单元测试覆盖。修复前症状示例：页面出现两个「任务看板」侧边栏入口，刷新后恢复单入口。
