### PR TITLE
fix(remote-web-ui): update with --latest and verify versions moved (#191)

### DIFF
--- a/packages/dsh-remote-web-ui/README.i18n.yaml
+++ b/packages/dsh-remote-web-ui/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 97f5f6b000e12fd89ad8723fd25306075a10df06
-README.zh.md: 30c7d55a4f31e914091318c3205d23f3b9979f60
+README.md: c1e5ea0deaca90a5a188342db0d38256f5917369
+README.zh.md: 9be2fbeb481ea23f05aa06f732234b2310c3d16a

--- a/packages/dsh-remote-web-ui/README.md
+++ b/packages/dsh-remote-web-ui/README.md
@@ -38,12 +38,16 @@ actions, and the update panel that probes and runs the update.
 - **Remote update**: the download trigger in the sidebar foot (left of the
   phone icon) opens the update panel, which probes the npm registry for the
   installed `@linxin666/dsh-*` family releases. When a newer release exists
-  the panel runs the update automatically (`pnpm update` inside the owning
-  dsh profile; when pnpm is missing it falls back to `corepack pnpm` and
-  then `npx --yes pnpm`, and on Windows the command runs through `cmd.exe`
-  so npm-installed `.cmd` shims resolve; the loopback-only
+  the panel runs the update automatically (`pnpm update --latest` inside the
+  owning dsh profile; when pnpm is missing it falls back to `corepack pnpm`
+  and then `npx --yes pnpm`, and on Windows the command runs through
+  `cmd.exe` so npm-installed `.cmd` shims resolve; the loopback-only
   `/api/update/status` + `/api/update/run` endpoints drive it) and asks for
-  a dsh web restart to pick it up. Local
+  a dsh web restart to pick it up. After a green pnpm exit the installed
+  versions are re-checked against the registry: a green exit that left every
+  version in place (e.g. the pnpm `minimumReleaseAge` gate silently skipping
+  same-day releases) is reported as a stale update with configuration
+  guidance instead of a false success. Local
   link installs (development mode) are detected and report the npm state
   without updating.
 

--- a/packages/dsh-remote-web-ui/README.zh.md
+++ b/packages/dsh-remote-web-ui/README.zh.md
@@ -13,7 +13,7 @@
 - **手机侧**：扫码将手机与一次性、限时令牌绑定，并落地到 **`/m` 独立移动端界面**——一款专为小屏设计的轻客户端（见[截图](#截图)），而不是把桌面 UI 塞进手机。链接携带 `workspace` 参数，手机落地到桌面正在查看的同一工作区。
 - **安全**：一个有效的一次性令牌（刷新会使旧链接失效；已接受的令牌不可复用；令牌会过期）。停止会撤销每一台已配对设备与当前令牌——已配对设备在下一次请求时被切断。当插件 `requirePairingForLan` 门开启（默认）时，每个非 loopback 的 `/api` 请求必须携带有效的已配对设备 cookie，因此二维码是进入暴露在局域网上的 dsh web 的唯一途径。
 - **实时状态**：桌面面板经 SSE 流实时镜像配对状态（等待 → 已连接 → 已断开）。
-- **远程更新**：侧边栏底部的下载触发按钮（手机图标左侧）打开更新面板，它探测 npm registry 上已安装的 `@linxin666/dsh-*` 全家桶版本。当存在较新版本时，面板自动执行更新（在所属 dsh profile 内 `pnpm update`；pnpm 缺失时依次回退 `corepack pnpm`、`npx --yes pnpm`，Windows 上经 `cmd.exe` 执行以解析 npm 安装的 `.cmd` shim；由仅 loopback 的 `/api/update/status` + `/api/update/run` 端点驱动）并请求重启 dsh web 以生效。本地 link 安装（开发模式）会被探测到，只报告 npm 状态而不更新。
+- **远程更新**：侧边栏底部的下载触发按钮（手机图标左侧）打开更新面板，它探测 npm registry 上已安装的 `@linxin666/dsh-*` 全家桶版本。当存在较新版本时，面板自动执行更新（在所属 dsh profile 内 `pnpm update --latest`；pnpm 缺失时依次回退 `corepack pnpm`、`npx --yes pnpm`，Windows 上经 `cmd.exe` 执行以解析 npm 安装的 `.cmd` shim；由仅 loopback 的 `/api/update/status` + `/api/update/run` 端点驱动）并请求重启 dsh web 以生效。pnpm 绿色退出后还会对照 registry 复核已装版本：绿色退出但版本纹丝不动（例如 pnpm 的 `minimumReleaseAge` 门禁静默跳过同日发布的新版本）会报告为「未更新成功」并附配置指引，而不是误报成功。本地 link 安装（开发模式）会被探测到，只报告 npm 状态而不更新。
 
 ## 截图
 

--- a/packages/dsh-remote-web-ui/src/client/UpdatePanel.tsx
+++ b/packages/dsh-remote-web-ui/src/client/UpdatePanel.tsx
@@ -198,6 +198,7 @@ function errorMessageOf(t: TranslateNS<"remote">, result: UpdateRunResult): stri
     case "not-found": return t("update.error.notFound")
     case "link": return t("update.error.link")
     case "pnpm-failed": return t("update.error.pnpmFailed", { code: String(result.exitCode ?? "?") })
+    case "stale": return t("update.error.stale")
     default: return result.error ?? t("update.error.unknown")
   }
 }

--- a/packages/dsh-remote-web-ui/src/client/UpdatePanel.tsx
+++ b/packages/dsh-remote-web-ui/src/client/UpdatePanel.tsx
@@ -199,6 +199,7 @@ function errorMessageOf(t: TranslateNS<"remote">, result: UpdateRunResult): stri
     case "link": return t("update.error.link")
     case "pnpm-failed": return t("update.error.pnpmFailed", { code: String(result.exitCode ?? "?") })
     case "stale": return t("update.error.stale")
+    case "verify-failed": return t("update.error.verifyFailed")
     default: return result.error ?? t("update.error.unknown")
   }
 }

--- a/packages/dsh-remote-web-ui/src/client/locales.ts
+++ b/packages/dsh-remote-web-ui/src/client/locales.ts
@@ -102,6 +102,7 @@ export const zh = {
   'update.error.notFound': '未找到 dsh-web-ui 聚合包安装，无法更新。',
   'update.error.link': '当前为本地开发模式（链接安装），无法自动更新。',
   'update.error.pnpmFailed': '更新执行失败（pnpm 退出码 {code}），详见下方输出。',
+  'update.error.stale': '更新命令已执行，但安装版本未变化。常见原因：pnpm 11 的 minimumReleaseAge 门禁会静默跳过发布不足 24 小时的新版本。请在 profile 目录（~/.dsh/profiles/<profile>）的 pnpm-workspace.yaml 中配置 minimumReleaseAgeExclude（例如 "@linxin666/*"）或 minimumReleaseAge: 0 后重新点击更新。',
   'update.error.unknown': '更新失败，请重试。',
 } satisfies Record<string, string>
 
@@ -213,5 +214,6 @@ export const en = {
   'update.error.notFound': 'The dsh-web-ui aggregate package is not installed; nothing to update.',
   'update.error.link': 'Local development mode (link install) — automatic update is unavailable.',
   'update.error.pnpmFailed': 'The update failed (pnpm exited with code {code}); see the output below.',
+  'update.error.stale': 'The update command ran but the installed versions did not change. Likely cause: the pnpm 11 minimumReleaseAge gate silently skips releases published less than 24 hours ago. Add minimumReleaseAgeExclude (e.g. "@linxin666/*") or set minimumReleaseAge: 0 in pnpm-workspace.yaml under the profile directory (~/.dsh/profiles/<profile>), then run the update again.',
   'update.error.unknown': 'Update failed; try again.',
 } satisfies Record<RemoteKey, string>

--- a/packages/dsh-remote-web-ui/src/client/locales.ts
+++ b/packages/dsh-remote-web-ui/src/client/locales.ts
@@ -103,6 +103,7 @@ export const zh = {
   'update.error.link': '当前为本地开发模式（链接安装），无法自动更新。',
   'update.error.pnpmFailed': '更新执行失败（pnpm 退出码 {code}），详见下方输出。',
   'update.error.stale': '更新命令已执行，但安装版本未变化。常见原因：pnpm 11 的 minimumReleaseAge 门禁会静默跳过发布不足 24 小时的新版本。请在 profile 目录（~/.dsh/profiles/<profile>）的 pnpm-workspace.yaml 中配置 minimumReleaseAgeExclude（例如 "@linxin666/*"）或 minimumReleaseAge: 0 后重新点击更新。',
+  'update.error.verifyFailed': '更新命令已执行，但无法核对安装后的版本（可能是 registry 探测失败或安装路径变化）。请查看下方输出，或稍后重试。',
   'update.error.unknown': '更新失败，请重试。',
 } satisfies Record<string, string>
 
@@ -215,5 +216,6 @@ export const en = {
   'update.error.link': 'Local development mode (link install) — automatic update is unavailable.',
   'update.error.pnpmFailed': 'The update failed (pnpm exited with code {code}); see the output below.',
   'update.error.stale': 'The update command ran but the installed versions did not change. Likely cause: the pnpm 11 minimumReleaseAge gate silently skips releases published less than 24 hours ago. Add minimumReleaseAgeExclude (e.g. "@linxin666/*") or set minimumReleaseAge: 0 in pnpm-workspace.yaml under the profile directory (~/.dsh/profiles/<profile>), then run the update again.',
+  'update.error.verifyFailed': 'The update command ran but the installed versions could not be verified afterwards (registry probe failed or the install path changed). Inspect the output below, or retry later.',
   'update.error.unknown': 'Update failed; try again.',
 } satisfies Record<RemoteKey, string>

--- a/packages/dsh-remote-web-ui/src/index.ts
+++ b/packages/dsh-remote-web-ui/src/index.ts
@@ -27,7 +27,7 @@ import {
   fetchLatestVersion,
   resolveAnchorManifest,
   resolveUpdateTarget,
-  runUpdate,
+  runUpdateVerified,
   type UpdateRunResult,
 } from './update.ts'
 import { makeUpdateRoutes } from './update-routes.ts'
@@ -238,11 +238,11 @@ export function apply(ctx: Context, config?: Config): void {
   }
   // ── remote update ────────────────────────────────────────────────────────
   // The dsh-web-ui self-update surface: probe the npm registry for family
-  // releases and run `pnpm update` in the owning profile. Resolutions anchor
-  // on the host process's own module graph, so the update always targets the
-  // profile the running web GUI was booted from. The probe path resolves once
-  // (the anchor stays the same package across updates); versions are re-read
-  // from disk per check.
+  // releases and run `pnpm update --latest` in the owning profile. Resolutions
+  // anchor on the host process's own module graph, so the update always
+  // targets the profile the running web GUI was booted from. The probe path
+  // resolves once (the anchor stays the same package across updates); versions
+  // are re-read from disk per check.
   const requireFromHost = createRequire(import.meta.url)
   const anchorManifestPath = resolveAnchorManifest(specifier => requireFromHost.resolve(specifier))
   const updateRoutes = makeUpdateRoutes({
@@ -272,7 +272,24 @@ export function apply(ctx: Context, config?: Config): void {
           errorCode: code,
         }
       }
-      return runUpdate({ profileDir: target.profileDir, packages: target.packages })
+      // Verify the versions actually moved after a green pnpm exit: the pnpm
+      // 11 minimumReleaseAge gate can silently keep the installed versions
+      // (same-day releases), which a plain exit-0 check would report as
+      // success — the user then restarts and nothing changed.
+      return runUpdateVerified({
+        run: { profileDir: target.profileDir, packages: target.packages },
+        check: {
+          anchorManifestPath,
+          resolve: specifier => {
+            try {
+              return requireFromHost.resolve(specifier)
+            } catch {
+              return undefined
+            }
+          },
+          fetchLatest: name => fetchLatestVersion(name, fetch),
+        },
+      })
     },
   })
   const routes = [

--- a/packages/dsh-remote-web-ui/src/index.ts
+++ b/packages/dsh-remote-web-ui/src/index.ts
@@ -240,17 +240,24 @@ export function apply(ctx: Context, config?: Config): void {
   // The dsh-web-ui self-update surface: probe the npm registry for family
   // releases and run `pnpm update --latest` in the owning profile. Resolutions
   // anchor on the host process's own module graph, so the update always
-  // targets the profile the running web GUI was booted from. The probe path
-  // resolves once (the anchor stays the same package across updates); versions
-  // are re-read from disk per check.
+  // targets the profile the running web GUI was booted from. The anchor path
+  // is re-resolved per operation: pnpm removes the old version's .pnpm
+  // directory on update, so a boot-time captured path would fail to read
+  // after a successful update; versions are re-read from disk per check.
   const requireFromHost = createRequire(import.meta.url)
-  const anchorManifestPath = resolveAnchorManifest(specifier => requireFromHost.resolve(specifier))
+  const resolveAnchorPath = (): string | undefined => resolveAnchorManifest(specifier => {
+    try {
+      return requireFromHost.resolve(specifier)
+    } catch {
+      return undefined
+    }
+  })
   const updateRoutes = makeUpdateRoutes({
     // Control endpoints are host-surface only: a LAN/phone origin must never
     // trigger a real install on this machine.
     fence: request => isTrustedApiRequest(request, []),
     check: () => checkUpdates({
-      anchorManifestPath,
+      anchorManifestPath: resolveAnchorPath(),
       resolve: specifier => {
         try {
           return requireFromHost.resolve(specifier)
@@ -261,7 +268,7 @@ export function apply(ctx: Context, config?: Config): void {
       fetchLatest: name => fetchLatestVersion(name, fetch),
     }),
     run: async (): Promise<UpdateRunResult> => {
-      const target = resolveUpdateTarget({ anchorManifestPath })
+      const target = resolveUpdateTarget({ anchorManifestPath: resolveAnchorPath() })
       if ('error' in target) {
         const code = target.error
         return {
@@ -279,7 +286,7 @@ export function apply(ctx: Context, config?: Config): void {
       return runUpdateVerified({
         run: { profileDir: target.profileDir, packages: target.packages },
         check: {
-          anchorManifestPath,
+          anchorManifestPath: resolveAnchorPath(),
           resolve: specifier => {
             try {
               return requireFromHost.resolve(specifier)

--- a/packages/dsh-remote-web-ui/src/update.ts
+++ b/packages/dsh-remote-web-ui/src/update.ts
@@ -184,16 +184,19 @@ export interface UpdateCheckDeps {
 
 /**
  * Resolve the anchor package's manifest path. The aggregate package is the
- * canonical entry point; this plugin's own package is the fallback.
+ * canonical entry point; this plugin's own package is the fallback. Both a
+ * throwing resolve and an undefined return mean "not installed" and move on
+ * to the next candidate.
  * @param resolve - a Node resolve implementation scoped to the host process.
  * @returns the absolute manifest path, or undefined when neither is installed.
  */
 export function resolveAnchorManifest(
-  resolve: (specifier: string) => string,
+  resolve: (specifier: string) => string | undefined,
 ): string | undefined {
   for (const name of [AGGREGATE_PACKAGE, SELF_PACKAGE]) {
     try {
-      return resolve(name + '/package.json')
+      const path = resolve(name + '/package.json')
+      if (path !== undefined) return path
     } catch {
       // Not installed — try the next candidate.
     }
@@ -361,6 +364,8 @@ export type UpdateErrorCode =
   | 'pnpm-failed'
   /** pnpm exited 0 but the installed versions did not move. */
   | 'stale'
+  /** pnpm exited 0 but the post-run version check could not verify the install. */
+  | 'verify-failed'
 
 /** Result of one update run. */
 export interface UpdateRunResult {
@@ -542,18 +547,60 @@ export interface UpdateRunVerifiedDeps {
  * Run the update, then verify the installed versions actually moved. pnpm
  * exits 0 even when it silently kept the installed versions — the pnpm 11
  * `minimumReleaseAge` gate refuses same-day releases by default — so a green
- * exit alone would report a misleading "update complete". Re-check the
- * registry comparison afterwards and surface a `stale` failure (with the
- * captured pnpm output) when nothing changed, so the panel can tell the user
+ * exit alone would report a misleading "update complete". Re-read the
+ * installed versions afterwards and surface a `stale` failure (with the
+ * captured pnpm output) when nothing moved, so the panel can tell the user
  * how to unblock the gate instead of claiming success.
+ *
+ * The stale decision anchors on the pre-run installed versions, not on the
+ * registry latest: under a lenient gate pnpm may move 0.1.12 -> 0.1.13 while
+ * latest stays 0.1.15 — that is a real update, not stale. The post-run anchor
+ * path is re-resolved rather than reused from boot time: pnpm removes the old
+ * version's .pnpm directory on update, so a boot-time captured path would
+ * fail to read and collapse a successful update into a bogus 'missing'.
+ *
+ * A green exit whose verification has nothing to compare (registry probe
+ * outage, missing anchor, non-npm mode) is reported as `verify-failed` — it
+ * must never read as success.
  * @param deps - the run and check seams.
- * @returns the run result; a `stale` failure when exit 0 left versions behind.
+ * @returns the run result; `stale` when exit 0 left every version in place,
+ * `verify-failed` when the post-run check could not verify anything.
  */
 export async function runUpdateVerified(deps: UpdateRunVerifiedDeps): Promise<UpdateRunResult> {
+  // Pre-run snapshot: the installed versions the update starts from. The
+  // stale decision compares against these, not against the registry latest.
+  const before = new Map<string, string>()
+  for (const name of deps.run.packages) {
+    before.set(name, readInstalledVersion(deps.check.resolve, name))
+  }
   const result = await runUpdate(deps.run)
   if (!result.ok) return result
-  const status = await checkUpdates(deps.check)
-  if (status.outdated) {
+  // Re-resolve the anchor after the run: pnpm removes the old version's
+  // .pnpm directory, so a boot-time captured path no longer reads. Fall back
+  // to the provided path only when nothing resolves now.
+  const anchorManifestPath = resolveAnchorManifest(deps.check.resolve) ?? deps.check.anchorManifestPath
+  const status = await checkUpdates({ ...deps.check, anchorManifestPath })
+  // A green exit with no comparable result is not a success: registry probe
+  // outage, missing anchor, or a non-npm install mode all mean the post-run
+  // check could not verify anything.
+  if (status.error !== undefined || status.mode !== 'npm') {
+    return {
+      ...result,
+      ok: false,
+      errorCode: 'verify-failed',
+      error: 'pnpm exited 0 but the post-run version check could not verify the install',
+    }
+  }
+  // stale: registry comparison completed, but no package moved from its
+  // pre-run version (e.g. the minimumReleaseAge gate kept everything in
+  // place). A partial move (lenient gate) is a real update, not stale. A
+  // package without a pre-run baseline (not part of the update list) is
+  // ignored — only the packages pnpm was told to update count as evidence.
+  const moved = status.packages.some(packageStatus => {
+    const beforeVersion = before.get(packageStatus.name)
+    return beforeVersion !== undefined && packageStatus.current !== beforeVersion
+  })
+  if (status.outdated && !moved) {
     return {
       ...result,
       ok: false,

--- a/packages/dsh-remote-web-ui/src/update.ts
+++ b/packages/dsh-remote-web-ui/src/update.ts
@@ -283,14 +283,22 @@ export async function fetchLatestVersion(
   }
 }
 
+/**
+ * Sentinel for an installed version that could not be read (missing manifest
+ * or resolve failure). It is a real-looking version so `checkUpdates` can
+ * render the affected row, but the verified-update comparison must never
+ * treat it as evidence — a read failure is not a version that "moved".
+ */
+const VERSION_UNKNOWN = '0.0.0'
+
 /** The resolved current version of one family package (probe failure tolerated). */
 function readInstalledVersion(resolve: (specifier: string) => string | undefined, name: string): string {
   try {
     const path = resolve(name + '/package.json')
     const version = path === undefined ? undefined : readManifest(path)?.version
-    return typeof version === 'string' ? version : '0.0.0'
+    return typeof version === 'string' ? version : VERSION_UNKNOWN
   } catch {
-    return '0.0.0'
+    return VERSION_UNKNOWN
   }
 }
 
@@ -561,17 +569,23 @@ export interface UpdateRunVerifiedDeps {
  *
  * A green exit whose verification has nothing to compare (registry probe
  * outage, missing anchor, non-npm mode) is reported as `verify-failed` — it
- * must never read as success.
+ * must never read as success. A green exit where no package moved but the
+ * post-run check could not prove the install is fully current (a partial
+ * probe failure hides whether a gate kept something back) is also
+ * `verify-failed`: it must not collapse into a success either.
  * @param deps - the run and check seams.
  * @returns the run result; `stale` when exit 0 left every version in place,
  * `verify-failed` when the post-run check could not verify anything.
  */
 export async function runUpdateVerified(deps: UpdateRunVerifiedDeps): Promise<UpdateRunResult> {
-  // Pre-run snapshot: the installed versions the update starts from. The
-  // stale decision compares against these, not against the registry latest.
+  // Pre-run snapshot: the installed versions the update starts from. Only
+  // successfully-read versions are recorded — a read failure (VERSION_UNKNOWN)
+  // is not a baseline and must not look like a version that "moved", or a
+  // green exit that left everything in place could be mistaken for success.
   const before = new Map<string, string>()
   for (const name of deps.run.packages) {
-    before.set(name, readInstalledVersion(deps.check.resolve, name))
+    const version = readInstalledVersion(deps.check.resolve, name)
+    if (version !== VERSION_UNKNOWN) before.set(name, version)
   }
   const result = await runUpdate(deps.run)
   if (!result.ok) return result
@@ -591,21 +605,39 @@ export async function runUpdateVerified(deps: UpdateRunVerifiedDeps): Promise<Up
       error: 'pnpm exited 0 but the post-run version check could not verify the install',
     }
   }
-  // stale: registry comparison completed, but no package moved from its
-  // pre-run version (e.g. the minimumReleaseAge gate kept everything in
-  // place). A partial move (lenient gate) is a real update, not stale. A
-  // package without a pre-run baseline (not part of the update list) is
-  // ignored — only the packages pnpm was told to update count as evidence.
+  // A package "moved" only when a known pre-run version differs from a known
+  // post-run version. A read failure on either side (VERSION_UNKNOWN) is not
+  // evidence of movement and must not turn a no-op update into a success; a
+  // package without a pre-run baseline is ignored — only the packages pnpm
+  // was told to update count as evidence.
   const moved = status.packages.some(packageStatus => {
     const beforeVersion = before.get(packageStatus.name)
-    return beforeVersion !== undefined && packageStatus.current !== beforeVersion
+    if (beforeVersion === undefined || packageStatus.current === VERSION_UNKNOWN) return false
+    return packageStatus.current !== beforeVersion
   })
-  if (status.outdated && !moved) {
+  if (moved) return result
+  // Nothing moved. A green exit is only a true no-op when the post-run check
+  // proves the install is already current: every probe succeeded and nothing
+  // is outdated. If a probe failed we cannot tell "already up to date" from
+  // "a gate silently kept it back", so report verify-failed rather than a
+  // false success.
+  if (status.outdated) {
+    // stale: the check ran, a newer release exists, and no package moved
+    // (e.g. the minimumReleaseAge gate kept everything in place).
     return {
       ...result,
       ok: false,
       errorCode: 'stale',
       error: 'pnpm exited 0 but the installed versions did not change',
+    }
+  }
+  const unverifiable = status.packages.some(packageStatus => packageStatus.latest === undefined)
+  if (unverifiable) {
+    return {
+      ...result,
+      ok: false,
+      errorCode: 'verify-failed',
+      error: 'pnpm exited 0 but the post-run version check could not verify the install',
     }
   }
   return result

--- a/packages/dsh-remote-web-ui/src/update.ts
+++ b/packages/dsh-remote-web-ui/src/update.ts
@@ -2,7 +2,7 @@
  * Remote update support for the dsh-web-ui family — host half. Detects the
  * installed aggregate package (@linxin666/dsh-web-ui-all) and its family
  * children, probes the npm registry for newer releases, and runs the actual
- * update as `pnpm update` inside the owning dsh profile directory.
+ * update as `pnpm update --latest` inside the owning dsh profile directory.
  *
  * Pure logic with injected seams (manifest reading, registry fetches, process
  * spawning) so the whole surface is unit-testable without touching disk,
@@ -359,6 +359,8 @@ export type UpdateErrorCode =
   | 'link'
   /** pnpm exited non-zero. */
   | 'pnpm-failed'
+  /** pnpm exited 0 but the installed versions did not move. */
+  | 'stale'
 
 /** Result of one update run. */
 export interface UpdateRunResult {
@@ -419,10 +421,14 @@ export function runUpdate(deps: UpdateRunDeps): Promise<UpdateRunResult> {
     }
     // Ordered fallback chain: each is tried only when the previous one is
     // missing on PATH (ENOENT on the spawn error event, never on close).
+    // `--latest` is required: dsh plugin writes exact-version specs (e.g.
+    // "0.1.12" without a range), and plain `pnpm update` treats an exact spec
+    // as pinned — it prints "Already up to date" and exits 0 without moving
+    // the installed version, so the panel would report a false success.
     const candidates: ReadonlyArray<{ command: string; args: string[] }> = [
-      { command: 'pnpm', args: ['update', ...packages] },
-      { command: 'corepack', args: ['pnpm', 'update', ...packages] },
-      { command: 'npx', args: ['--yes', 'pnpm', 'update', ...packages] },
+      { command: 'pnpm', args: ['update', '--latest', ...packages] },
+      { command: 'corepack', args: ['pnpm', 'update', '--latest', ...packages] },
+      { command: 'npx', args: ['--yes', 'pnpm', 'update', '--latest', ...packages] },
     ]
     // `output` accumulates across candidates for UI display; `currentOutput`
     // is reset per candidate and carries only that candidate's own diagnostics
@@ -522,4 +528,38 @@ export function runUpdate(deps: UpdateRunDeps): Promise<UpdateRunResult> {
     }
     runCandidate(0)
   })
+}
+
+/** Seam set for the verified update run (run + post-run status check). */
+export interface UpdateRunVerifiedDeps {
+  /** The pnpm run (profile dir + package list). */
+  run: UpdateRunDeps
+  /** The post-run status check (same seams as checkUpdates). */
+  check: UpdateCheckDeps
+}
+
+/**
+ * Run the update, then verify the installed versions actually moved. pnpm
+ * exits 0 even when it silently kept the installed versions — the pnpm 11
+ * `minimumReleaseAge` gate refuses same-day releases by default — so a green
+ * exit alone would report a misleading "update complete". Re-check the
+ * registry comparison afterwards and surface a `stale` failure (with the
+ * captured pnpm output) when nothing changed, so the panel can tell the user
+ * how to unblock the gate instead of claiming success.
+ * @param deps - the run and check seams.
+ * @returns the run result; a `stale` failure when exit 0 left versions behind.
+ */
+export async function runUpdateVerified(deps: UpdateRunVerifiedDeps): Promise<UpdateRunResult> {
+  const result = await runUpdate(deps.run)
+  if (!result.ok) return result
+  const status = await checkUpdates(deps.check)
+  if (status.outdated) {
+    return {
+      ...result,
+      ok: false,
+      errorCode: 'stale',
+      error: 'pnpm exited 0 but the installed versions did not change',
+    }
+  }
+  return result
 }

--- a/packages/dsh-remote-web-ui/tests/update.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/update.spec.ts
@@ -657,4 +657,67 @@ describe("runUpdateVerified", () => {
     expect(result.ok).toBe(false)
     expect(result.errorCode).toBe("verify-failed")
   })
+
+  it("reports stale rather than success when a package becomes unreadable and nothing moved", async () => {
+    // A green exit that re-lays node_modules can leave a family child's
+    // manifest unreadable at the post-run check. An unreadable version reads
+    // as the unknown sentinel, which is NOT evidence of movement — a no-op
+    // update must not collapse into "update complete". The anchor still being
+    // outdated is what drives the stale verdict.
+    const anchor = npmFixture("0.1.10", "0.1.10")
+    const childDir = join(fixture!, "profiles", "web", "node_modules", "@linxin666", "dsh-ssh")
+    const child = new FakeChild(0)
+    const spawnImpl = (() => child) as never
+    const promise = runUpdateVerified({
+      run: { profileDir: "/p", packages: [AGGREGATE_PACKAGE], spawnImpl },
+      check: {
+        anchorManifestPath: anchor,
+        resolve: (specifier: string) => {
+          if (specifier === "@linxin666/dsh-ssh/package.json") {
+            return join(childDir, "package.json")
+          }
+          return anchor
+        },
+        fetchLatest: async name => name === AGGREGATE_PACKAGE ? "0.1.11" : "0.1.10",
+      },
+    })
+    // pre-run snapshot reads the child fine; pnpm then (green) removes it.
+    rmSync(childDir, { recursive: true, force: true })
+    child.run(0)
+    const result = await promise
+    expect(result.ok).toBe(false)
+    expect(result.errorCode).toBe("stale")
+  })
+
+  it("reports verify-failed when nothing moved and a post-run probe failed", async () => {
+    // The panel launches the update because a package was outdated; pnpm
+    // exits 0 without moving anything, and the post-run probe for that very
+    // package now fails. status.outdated is false only because the probe has
+    // no latest to compare against, so "update complete" would be a false
+    // success — verify-failed is the honest verdict.
+    const anchor = npmFixture("0.1.10", "0.1.10")
+    const child = new FakeChild(0)
+    const spawnImpl = (() => child) as never
+    const promise = runUpdateVerified({
+      run: { profileDir: "/p", packages: [AGGREGATE_PACKAGE], spawnImpl },
+      check: {
+        anchorManifestPath: anchor,
+        resolve: (specifier: string) => {
+          if (specifier === "@linxin666/dsh-ssh/package.json") {
+            return join(fixture!, "profiles", "web", "node_modules", "@linxin666", "dsh-ssh", "package.json")
+          }
+          return anchor
+        },
+        // The anchor probe fails while the child succeeds — a partial probe
+        // failure (probeFailures < names.length), so status.error stays unset
+        // and this must route through the verify-failed branch, not success.
+        fetchLatest: async name => name === AGGREGATE_PACKAGE ? undefined : "0.1.10",
+      },
+    })
+    child.run(0)
+    const result = await promise
+    expect(result.ok).toBe(false)
+    expect(result.errorCode).toBe("verify-failed")
+    expect(result.exitCode).toBe(0)
+  })
 })

--- a/packages/dsh-remote-web-ui/tests/update.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/update.spec.ts
@@ -156,6 +156,16 @@ describe("resolveAnchorManifest", () => {
   it("returns undefined when nothing resolves", () => {
     expect(resolveAnchorManifest(() => { throw new Error("missing") })).toBeUndefined()
   })
+  it("falls back to the self package when resolve returns undefined", () => {
+    // A resolve seam may signal "not installed" with undefined instead of
+    // throwing; both must move on to the next candidate.
+    const resolve = (specifier: string) => {
+      if (specifier.startsWith(AGGREGATE_PACKAGE)) return undefined
+      if (specifier.includes("dsh-remote-web-ui")) return "/pkg/self/package.json"
+      return undefined
+    }
+    expect(resolveAnchorManifest(resolve)).toBe("/pkg/self/package.json")
+  })
 })
 
 describe("checkUpdates", () => {
@@ -342,7 +352,7 @@ describe("runUpdate", () => {
     const pnpm = new FakeChild(null)
     const corepack = new FakeChild(null)
     const npx = new FakeChild(0)
-    const { spawnImpl, order } = dispatchFake({ pnpm, corepack, npx })
+    const { spawnImpl, order, argo } = dispatchFake({ pnpm, corepack, npx })
     const promise = runUpdate({ profileDir: "/p", packages: ["a"], spawnImpl })
     pnpm.fail(error)
     corepack.fail(error)
@@ -350,6 +360,12 @@ describe("runUpdate", () => {
     npx.run(0)
     const result = await promise
     expect(order).toEqual(["pnpm", "corepack", "npx"])
+    // Every fallback candidate keeps --latest (npx prefixes --yes before pnpm).
+    expect(argo.map(entry => entry.args)).toEqual([
+      ["update", "--latest", "a"],
+      ["pnpm", "update", "--latest", "a"],
+      ["--yes", "pnpm", "update", "--latest", "a"],
+    ])
     expect(result.ok).toBe(true)
     expect(result.output).toBe("npx pnpm ok")
   })
@@ -373,7 +389,10 @@ describe("runUpdate", () => {
     vi.useFakeTimers()
     const child = new FakeChild(null)
     const spawnImpl = (() => child) as never
-    const promise = runUpdate({ profileDir: "/p", packages: ["a"], spawnImpl, timeoutMs: 1000 })
+    // Pin the POSIX SIGTERM kill path (darwin): on win32 the timeout routes
+    // through taskkill and never touches child.kill(), which would fail the
+    // assertion on Windows hosts.
+    const promise = runUpdate({ profileDir: "/p", packages: ["a"], spawnImpl, timeoutMs: 1000, platform: "darwin" })
     vi.advanceTimersByTime(1000)
     const result = await promise
     expect(child.killed).toBe(true)
@@ -548,5 +567,94 @@ describe("runUpdateVerified", () => {
     const result = await promise
     expect(result.ok).toBe(false)
     expect(result.errorCode).toBe("pnpm-failed")
+  })
+
+  it("reports verify-failed when every post-run registry probe fails", async () => {
+    // pnpm exits 0 but the verification has nothing to compare — every
+    // registry probe failed. This must not collapse into a false success.
+    const child = new FakeChild(0)
+    const spawnImpl = (() => child) as never
+    const promise = runUpdateVerified({
+      run: { profileDir: "/p", packages: [AGGREGATE_PACKAGE], spawnImpl },
+      check: fixtureCheck(async () => undefined),
+    })
+    child.run(0)
+    const result = await promise
+    expect(result.ok).toBe(false)
+    expect(result.errorCode).toBe("verify-failed")
+    expect(result.exitCode).toBe(0)
+  })
+
+  it("reports verify-failed when the post-run anchor cannot be resolved", async () => {
+    // pnpm exits 0, then the post-run check loses the anchor entirely
+    // (mode 'missing') — the boot-time captured path pointed at the old
+    // version's .pnpm directory and nothing re-resolves. Not a success.
+    const child = new FakeChild(0)
+    const spawnImpl = (() => child) as never
+    const promise = runUpdateVerified({
+      run: { profileDir: "/p", packages: [AGGREGATE_PACKAGE], spawnImpl },
+      check: { anchorManifestPath: undefined, resolve: () => undefined, fetchLatest: async () => "0.1.11" },
+    })
+    child.run(0)
+    const result = await promise
+    expect(result.ok).toBe(false)
+    expect(result.errorCode).toBe("verify-failed")
+  })
+
+  it("accepts a partial update as success when versions moved", async () => {
+    // Lenient minimumReleaseAge gate: pnpm moves 0.1.10 -> 0.1.13 while the
+    // registry latest is 0.1.15 — versions moved, so this is a real update,
+    // not a stale failure (the stale decision anchors on the pre-run
+    // versions, not on the registry latest).
+    const anchor = npmFixture("0.1.10", "0.1.10")
+    const child = new FakeChild(0)
+    const spawnImpl = (() => child) as never
+    const promise = runUpdateVerified({
+      run: { profileDir: "/p", packages: [AGGREGATE_PACKAGE], spawnImpl },
+      check: {
+        anchorManifestPath: anchor,
+        resolve: (specifier: string) => {
+          if (specifier === "@linxin666/dsh-ssh/package.json") {
+            return join(fixture!, "profiles", "web", "node_modules", "@linxin666", "dsh-ssh", "package.json")
+          }
+          return anchor
+        },
+        fetchLatest: async () => "0.1.15",
+      },
+    })
+    // pnpm actually updates the installed anchor on disk (the gate allowed a
+    // partial move to 0.1.13) before it exits 0.
+    writeManifest(join(fixture!, "profiles", "web", "node_modules", "@linxin666", "dsh-web-ui-all"), {
+      name: AGGREGATE_PACKAGE,
+      version: "0.1.13",
+      dependencies: { "@linxin666/dsh-ssh": "^0.1.10" },
+    })
+    child.run(0)
+    const result = await promise
+    expect(result.ok).toBe(true)
+    expect(result.exitCode).toBe(0)
+  })
+
+  it("reports verify-failed when a non-npm mode follows a green exit", async () => {
+    // The post-run check resolves into a link install (no profile walk) —
+    // there is no registry comparison to trust, so the run must not claim
+    // success.
+    const root = makeFixture()
+    const anchorDir = join(root, 'checkout', 'node_modules', '@linxin666', 'dsh-web-ui-all')
+    writeManifest(anchorDir, { name: AGGREGATE_PACKAGE, version: "0.1.10", dependencies: {} })
+    const child = new FakeChild(0)
+    const spawnImpl = (() => child) as never
+    const promise = runUpdateVerified({
+      run: { profileDir: "/p", packages: [AGGREGATE_PACKAGE], spawnImpl },
+      check: {
+        anchorManifestPath: join(anchorDir, "package.json"),
+        resolve: () => join(anchorDir, "package.json"),
+        fetchLatest: async () => "0.1.11",
+      },
+    })
+    child.run(0)
+    const result = await promise
+    expect(result.ok).toBe(false)
+    expect(result.errorCode).toBe("verify-failed")
   })
 })

--- a/packages/dsh-remote-web-ui/tests/update.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/update.spec.ts
@@ -17,6 +17,7 @@ import {
   resolveAnchorManifest,
   resolveUpdateTarget,
   runUpdate,
+  runUpdateVerified,
 } from "../src/update.ts"
 
 /** One temp fixture root per suite; removed after each test. */
@@ -292,7 +293,7 @@ describe("runUpdate", () => {
     }) as never
     return { spawnImpl, order, argo }
   }
-  it("spawns pnpm update with the packages and resolves on success", async () => {
+  it("spawns pnpm update --latest with the packages and resolves on success", async () => {
     let spawned: { command: string; args: string[]; cwd: string } | undefined
     const child = new FakeChild(0)
     const spawnImpl = ((command: string, args: string[], options: { cwd: string }) => {
@@ -303,7 +304,7 @@ describe("runUpdate", () => {
     child.emitOutput("Progress 1/2")
     child.run(0)
     const result = await promise
-    expect(spawned).toEqual({ command: "pnpm", args: ["update", "a", "b"], cwd: "/p" })
+    expect(spawned).toEqual({ command: "pnpm", args: ["update", "--latest", "a", "b"], cwd: "/p" })
     expect(result).toEqual({ ok: true, exitCode: 0, output: "Progress 1/2" })
   })
   it("reports pnpm-failed on a non-zero exit", async () => {
@@ -320,13 +321,20 @@ describe("runUpdate", () => {
     const pnpmError = Object.assign(new Error("spawn pnpm ENOENT"), { code: "ENOENT" })
     const pnpm = new FakeChild(null)
     const corepack = new FakeChild(0)
-    const { spawnImpl, order } = dispatchFake({ pnpm, corepack })
+    const { spawnImpl, order, argo } = dispatchFake({ pnpm, corepack })
     const promise = runUpdate({ profileDir: "/p", packages: ["a"], spawnImpl })
     pnpm.fail(pnpmError)
     corepack.emitOutput("corepack pnpm 1/2")
     corepack.run(0)
     const result = await promise
     expect(order).toEqual(["pnpm", "corepack"])
+    // Every fallback candidate must keep --latest (exact specs in the profile
+    // are otherwise treated as pinned and never move); corepack prefixes the
+    // pnpm subcommand.
+    expect(argo.map(entry => entry.args)).toEqual([
+      ["update", "--latest", "a"],
+      ["pnpm", "update", "--latest", "a"],
+    ])
     expect(result).toEqual({ ok: true, exitCode: 0, output: "corepack pnpm 1/2" })
   })
   it("falls back to npx when pnpm and corepack are missing and succeeds", async () => {
@@ -479,5 +487,66 @@ describe("runUpdate", () => {
     expect(result.ok).toBe(false)
     expect(result.errorCode).toBe("timeout")
     vi.useRealTimers()
+  })
+})
+
+describe("runUpdateVerified", () => {
+  /** The standard check seam for the npm fixture. */
+  function fixtureCheck(fetchLatest: (name: string) => Promise<string | undefined>) {
+    return {
+      anchorManifestPath: npmFixture("0.1.10", "0.1.10"),
+      resolve: (specifier: string) => {
+        if (specifier === "@linxin666/dsh-ssh/package.json") {
+          return join(fixture!, "profiles", "web", "node_modules", "@linxin666", "dsh-ssh", "package.json")
+        }
+        return join(fixture!, "profiles", "web", "node_modules", "@linxin666", "dsh-web-ui-all", "package.json")
+      },
+      fetchLatest,
+    }
+  }
+
+  it("reports stale when pnpm exits 0 but the installed versions did not move", async () => {
+    // Registry carries 0.1.11 while the installed anchor stays 0.1.10 — the
+    // pnpm 11 minimumReleaseAge gate can produce exactly this "green exit,
+    // nothing changed" outcome, and the panel must not claim success.
+    const child = new FakeChild(0)
+    const spawnImpl = (() => child) as never
+    const promise = runUpdateVerified({
+      run: { profileDir: "/p", packages: [AGGREGATE_PACKAGE], spawnImpl },
+      check: fixtureCheck(async name => name === AGGREGATE_PACKAGE ? "0.1.11" : "0.1.10"),
+    })
+    child.emitOutput("Already up to date")
+    child.run(0)
+    const result = await promise
+    expect(result.ok).toBe(false)
+    expect(result.errorCode).toBe("stale")
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toBe("Already up to date")
+    expect(result.error).toContain("did not change")
+  })
+
+  it("resolves ok when the post-run check sees every package current", async () => {
+    const child = new FakeChild(0)
+    const spawnImpl = (() => child) as never
+    const promise = runUpdateVerified({
+      run: { profileDir: "/p", packages: [AGGREGATE_PACKAGE], spawnImpl },
+      check: fixtureCheck(async () => "0.1.10"),
+    })
+    child.run(0)
+    const result = await promise
+    expect(result).toEqual({ ok: true, exitCode: 0, output: "" })
+  })
+
+  it("returns the run result unchanged when pnpm fails", async () => {
+    const child = new FakeChild(1)
+    const spawnImpl = (() => child) as never
+    const promise = runUpdateVerified({
+      run: { profileDir: "/p", packages: ["a"], spawnImpl },
+      check: { anchorManifestPath: undefined, resolve: () => undefined, fetchLatest: async () => "0.1.11" },
+    })
+    child.run(1)
+    const result = await promise
+    expect(result.ok).toBe(false)
+    expect(result.errorCode).toBe("pnpm-failed")
   })
 })


### PR DESCRIPTION
## 摘要（Summary）

修复"更新面板提示成功但重启后版本不变"：`runUpdate()` 执行的 `pnpm update`
未带 `--latest`，而 `dsh plugin add` 写入 profile 的是精确版本 spec（如
"0.1.12" 无 `^`），pnpm 将其视为已锁定，输出 "Already up to date" 且 exit 0，
更新器 `ok: code === 0` 误报成功。此外 pnpm 11 默认 `minimumReleaseAge`
（24 小时）会静默跳过同日发布的新版本，同样表现为"exit 0 但版本未变"。

改动：
1. `pnpm update --latest`（corepack / npx 回退链同步），精确 spec 也能升级；
2. 新增 `runUpdateVerified()`：pnpm exit 0 后重新核对已装版本，版本未变时
   返回 `stale` 失败，更新面板显示 minimumReleaseAge 门禁的配置指引，不再误报
   "更新完成"。

## 评审意见处理（Review Fixes）

已按 reviewer 意见修复并 rebase 到最新 main（含 qq2006 皮肤移除后的 5153e9a）：

1. **runUpdateVerified 不再把"校验失败"塌缩成成功**：新增 `verify-failed`
   errorCode（zh/en 文案同步）。`status.error`（registry 探测全失败）或
   `mode !== 'npm'`（anchor 丢失 / 链接安装）均判为独立失败，不再误报成功；
   补测试「pnpm exit 0 + fetchLatest 返回 undefined -> ok: false」及
   「post-run anchor 无法解析 -> verify-failed」。
2. **post-run 校验重新解析 anchor 路径**：boot-time 捕获的 anchorManifestPath
   指向旧版本 .pnpm 目录，pnpm 更新成功后会摘除旧目录导致 readManifest 失败
   （mode: 'missing'）。现在 check 路由与 run 的 post-check 均按当前安装
   重新解析（`resolveAnchorPath()` / `resolveAnchorManifest`）。
3. **stale 判定锚定"版本是否移动"而非 registry latest**：宽松 minimumReleaseAge
   门禁下 pnpm 可能把 0.1.12 升到 0.1.13（latest 0.1.15 被门禁挡），这是真实
   部分更新，不再误报 stale。补测试「0.1.10 -> 0.1.13（latest 0.1.15）-> ok」。
4. **rebase 最新 main**：rebase 到 5153e9a（含 qq2006 皮肤移除），在最新 head
   上重跑 typecheck / test / docs:check 全绿。
5. **非阻塞项**：npx 回退档补 --latest args 断言；顺带修复
   `resolveAnchorManifest` 对返回 undefined 的 resolve 不 fallback 到
   SELF_PACKAGE 的问题；`kills and reports timeout` 测试固定 POSIX platform
   （win32 走 taskkill 分支不调 child.kill()，原测试在 Windows 本机必挂）。
6. **第二轮评审（#192 复审修复）**：
   - **读取失败不再被当成"版本移动"**：pre-run 快照只记录成功读取的版本
     （`VERSION_UNKNOWN` 哨兵不入基线），post-run 读取失败的包也不再算
     "moved"——否则绿色退出但实际未更新时，可能因一侧读取失败被误判为
     "更新完成"。补测试「post-run 子包不可读 + 版本未动 -> stale」。
   - **部分探测失败不再误报成功**：绿色退出且无包移动时，只有 post-run
     能证明"已全部最新"（所有探测成功且无 outdated）才算 no-op 成功；
     存在探测失败的包时报 `verify-failed`，不再塌缩成"更新完成"。
     补测试「无包移动 + post-run 部分探测失败 -> verify-failed」。

## 涉及包（Affected Packages）

- [x] 远程 Web UI `packages/dsh-remote-web-ui`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream && git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek

使用的编码 Agent 工具：

DeepSeek Harness (DSH)

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（更新了 update 行为描述，三件套已同步，`pnpm docs:check` 全绿）

## 贡献者版权声明（Contributor Copyright）

N/A（不声明，维持现有版权归属）。

## 社区插件索引登记（Community Plugin Index）

N/A（非新增第三方插件）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-remote-web-ui build
pnpm typecheck
pnpm docs:check
```

结果摘要：

（最新 head d6c9598，rebase 5153e9a 之后，含第二轮评审修复）

- typecheck：通过（包级 + 全仓）。
- test：174/174 通过（含新增 verify-failed / 部分更新 / anchor 重解析 / npx
  --latest 断言 / 读取失败哨兵 / 部分探测失败等 9 组测试）。
- build：通过。
- docs:check：全部文档门禁通过（README 中英三件套已同步 update 行为描述）。
- 说明：`pnpm test:scripts` 有 3 个与本 PR 无关的既有失败（community-index
  漂移、dsh-skin 的 Windows symlink EPERM、sync-shared 的 CRLF 假阳性漂移）；
  全仓 `pnpm test` 另有 dsh-aionui-panel 的 2 个 symlink 逃逸测试在 Windows
  本机失败（stash 本 PR 改动后复测同样失败，属 Windows symlink 权限环境
  问题，POSIX CI 上不受影响）。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（命令行行为修复，无 GUI 交互面变更；通过上述单元测试与对照实验验证。
修复的用户可见效果：更新面板在版本未变化时显示明确错误与配置指引，而非
误报"更新完成"。）
