### PR TITLE
fix(remote-web-ui): keep paired phone online while idle on the mobile channel

### DIFF
--- a/packages/dsh-remote-web-ui/src/mobile-api.ts
+++ b/packages/dsh-remote-web-ui/src/mobile-api.ts
@@ -103,10 +103,23 @@ export function makeMobileApiRoutes(deps: MobileApiDeps): WebRoute[] {
   const { service, apiProxy, mobileEnterToSend } = deps
   const eventsHeartbeatMs = deps.eventsHeartbeatMs ?? DEFAULT_EVENTS_HEARTBEAT_MS
 
+  /**
+   * Refresh the paired device's presence and report whether it is live.
+   * The mobile surface (unlike the desktop Web UI) has no `/api/pair/heartbeat`
+   * sender, so any activity on the mobile channel — a gated RPC, or the live
+   * SSE stream staying open — must count as presence. Without this, an
+   * idle-but-connected phone ages past `offlineAfterMs` and the desktop panel
+   * wrongly reports it as disconnected.
+   */
+  const touchDeviceFor = (req: IncomingMessage): boolean => {
+    const deviceId = readCookie(req.headers.cookie, service.config.cookieName)
+    if (deviceId === undefined) return false
+    return service.touchDevice(deviceId)
+  }
+
   /** The phone gate: a live paired-device cookie, or nothing else proceeds. */
   const gateOk = (req: IncomingMessage): boolean => {
-    const deviceId = readCookie(req.headers.cookie, service.config.cookieName)
-    return deviceId !== undefined && service.hasDevice(deviceId)
+    return touchDeviceFor(req)
   }
 
   const writeJson = (res: ServerResponse, status: number, body: unknown): void => {
@@ -190,6 +203,10 @@ export function makeMobileApiRoutes(deps: MobileApiDeps): WebRoute[] {
     let closed = false
     const heartbeat = setInterval(() => {
       if (closed) return
+      // An open SSE stream proves the phone is still live even while the agent
+      // idles (no RPC traffic), so refresh presence alongside the transport
+      // keepalive — otherwise an idle phone drifts to "disconnected".
+      touchDeviceFor(req)
       try {
         res.write(': ping\n\n')
       } catch {

--- a/packages/dsh-remote-web-ui/tests/mobile-api.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/mobile-api.spec.ts
@@ -5,7 +5,7 @@
  * a dead "加载中…" mobile surface.
  */
 import { createServer, request as httpRequest } from 'node:http'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { AddressInfo } from 'node:net'
 import type { WebRoute } from '@deepseek-ai/dsh-host-webserver'
 import type { ApiProxy } from '@deepseek-ai/dsh-host-apiproxy'
@@ -22,6 +22,7 @@ const cookieName = 'dsh_pair'
 const service = {
   config: { cookieName },
   hasDevice: () => true,
+  touchDevice: () => true,
 } as never
 
 /** The resolved mobile composer preference (tests flip it per case). */
@@ -76,6 +77,24 @@ async function call(port: number, method: string): Promise<{ status: number; bod
     const req = httpRequest({
       host: '127.0.0.1', port, path: `/m/api/${method}`, method: 'POST',
       headers: { 'content-type': 'application/json', cookie: `${cookieName}=device-1`, 'content-length': Buffer.byteLength(body) },
+    }, (response) => {
+      const chunks: Buffer[] = []
+      response.on('data', (chunk) => { chunks.push(chunk as Buffer) })
+      response.on('end', () => {
+        resolve({ status: response.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') })
+      })
+    })
+    req.on('error', reject)
+    req.end(body)
+  })
+}
+
+async function callNoCookie(port: number, method: string): Promise<{ status: number; body: string }> {
+  return await new Promise((resolve, reject) => {
+    const body = JSON.stringify({ type: 'client-request', rpcId: 'probe-1', method, payload: {} })
+    const req = httpRequest({
+      host: '127.0.0.1', port, path: `/m/api/${method}`, method: 'POST',
+      headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) },
     }, (response) => {
       const chunks: Buffer[] = []
       response.on('data', (chunk) => { chunks.push(chunk as Buffer) })
@@ -190,5 +209,104 @@ describe('mobile api envelope', () => {
 
     req.destroy()
     await new Promise<void>(resolve => server.close(() => resolve()))
+  })
+
+  it('refreshes device presence on every gated unary request', async () => {
+    // The mobile surface has no /api/pair/heartbeat sender, so any gated RPC
+    // must count as presence (touchDevice) — otherwise an idle phone ages past
+    // offlineAfterMs and the desktop panel reports it as disconnected while it
+    // is still actively connected.
+    const touchDevice = vi.fn(() => true)
+    const spyService = { config: { cookieName }, hasDevice: () => true, touchDevice } as never
+    const server = await serve(makeMobileApiRoutes({ service: spyService, apiProxy, mobileEnterToSend }))
+    try {
+      const { status } = await call(server.port, 'session.list')
+      expect(status).toBe(200)
+      expect(touchDevice).toHaveBeenCalledWith('device-1')
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('refreshes device presence on every SSE keep-alive while the stream stays open', async () => {
+    // The core scenario: an idle phone keeps its SSE stream open but sends no
+    // RPC traffic. The keep-alive interval must keep calling touchDevice so the
+    // device never ages past offlineAfterMs — without this the desktop panel
+    // reports "disconnected" while the phone is still connected.
+    const touchDevice = vi.fn(() => true)
+    const spyService = { config: { cookieName }, hasDevice: () => true, touchDevice } as never
+    const blockingProxy = {
+      ...apiProxy,
+      events: { mux: () => (async function* () { while (true) { await new Promise(() => {}) } })() },
+    } as unknown as ApiProxy
+    const routes = makeMobileApiRoutes({ service: spyService, apiProxy: blockingProxy, mobileEnterToSend, eventsHeartbeatMs: 20 })
+    const server = createServer((request, response) => {
+      const pathname = new URL(request.url ?? '/', 'http://x').pathname
+      const exact = routes.find(r => r.kind === 'exact' && r.path === pathname)
+      const route = exact ?? routes.find(r => r.kind === 'prefix' && pathname.startsWith(r.path))
+      if (route === undefined) {
+        response.writeHead(404)
+        response.end()
+        return
+      }
+      void route.handler(request, response)
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address() as AddressInfo
+
+    let resolveDone: (() => void) | undefined
+    const done = new Promise<void>(resolve => { resolveDone = resolve })
+    const req = httpRequest({
+      host: '127.0.0.1', port: address.port, path: '/m/api/events.mux', method: 'GET',
+      headers: { cookie: 'dsh_pair=device-1' },
+    }, () => {})
+    req.on('error', () => { resolveDone?.() })
+    req.end()
+
+    // Wait until the keep-alive interval has fired enough times (>= 2 touches).
+    const deadline = Date.now() + 2000
+    while (touchDevice.mock.calls.length < 2 && Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, 10))
+    }
+    resolveDone?.()
+
+    expect(touchDevice.mock.calls.length).toBeGreaterThanOrEqual(2)
+    // Each keep-alive refreshes presence for the paired device cookie.
+    for (const callArgs of touchDevice.mock.calls) {
+      expect(callArgs[0]).toBe('device-1')
+    }
+
+    req.destroy()
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  })
+
+  it('vetoes when touchDevice returns false despite a present cookie', async () => {
+    // hasDevice may be true while touchDevice is false (e.g. the service was
+    // stopped). The gate must still refuse and must not leak the request.
+    const touchDevice = vi.fn(() => false)
+    const spyService = { config: { cookieName }, hasDevice: () => true, touchDevice } as never
+    const server = await serve(makeMobileApiRoutes({ service: spyService, apiProxy, mobileEnterToSend }))
+    try {
+      const { status } = await call(server.port, 'session.list')
+      expect(status).toBe(403)
+      expect(touchDevice).toHaveBeenCalledWith('device-1')
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('does not refresh presence when the device cookie is absent', async () => {
+    const touchDevice = vi.fn(() => true)
+    const spyService = { config: { cookieName }, hasDevice: () => false, touchDevice } as never
+    const server = await serve(makeMobileApiRoutes({ service: spyService, apiProxy, mobileEnterToSend }))
+    try {
+      // A request without the pairing cookie must be vetoed and must not
+      // touchDevice (there is no device id to refresh).
+      const { status } = await callNoCookie(server.port, 'session.list')
+      expect(status).toBe(403)
+      expect(touchDevice).not.toHaveBeenCalled()
+    } finally {
+      await server.close()
+    }
   })
 })


### PR DESCRIPTION
# PR 说明：修复移动端设备空闲时被误判为「离线」

> 仓库：`zhu1090093659/dsh-web-ui`
> 分支基于最新 `main`
> 类型：**Bug 修复**（符合「本仓库只接受修复型 PR」的要求）

---

## 摘要（Summary）

修复 `dsh-remote-web-ui` 的一个 bug：手机移动端页面**没有独立的 `/api/pair/heartbeat` 心跳发送器**，且移动端数据通道（`/m/api/*`）的门控 `gateOk` 只调用 `hasDevice`（仅校验配对存在、**不刷新 `lastSeenAt`**），导致已配对且正常使用的手机在空闲超过 `offlineAfterMs`（默认 25 秒）后，被桌面端面板错误显示为「离线/断开」。

修复：让移动端通道上的任何有效活动（受门控的 RPC 请求、以及保持打开的 SSE 流）都调用 `service.touchDevice(deviceId)` 刷新存在性，与 `api/gate` 网关卡、桌面端心跳的语义保持一致。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
# 已完成：拉取上游并 rebase 到最新 main（解决 mobile-api 两文件的 eventsHeartbeatMs seam 冲突）
git fetch upstream main
git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek（deepseek-v4-pro，经 DeepSeek Harness 驱动）

使用的编码 Agent 工具：

DeepSeek Harness（DSH Web GUI）

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 未新增包目录（本次仅改动既有包 `dsh-remote-web-ui` 内文件）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 未改动任何 README，故无需维护中英三件套（`pnpm docs:check` 不涉及本包文档变更）。

## 贡献者版权声明（Contributor Copyright）

（可选，不声明则维持现有版权归属 `Apache-2.0 (zhu1090093659)`。）

## 社区插件索引登记（Community Plugin Index）

（不适用，本次为修复既有插件，非新增第三方插件。）

## 本地验证（Local Validation）

执行的命令：

```bash
# 1. 安装依赖（全仓）
cd dsh-web-ui
pnpm install

# 2. 仅构建受影响包（install 的 prepare 阶段已构建；如需手动重建）
cd packages/dsh-remote-web-ui
pnpm build

# 3. 类型检查（通过，无输出即成功）
pnpm typecheck

# 4. 包级单元测试
pnpm test
```

结果摘要：

- `pnpm typecheck`：**通过**（`tsc -b --pretty false` 无错误输出）。
- `pnpm test`：`tests/mobile-api.spec.ts` **7 个测试全部通过**（含本次新增/保留的 4 个：
  `refreshes device presence on every gated unary request`、
  `does not refresh presence when the device cookie is absent`、
  `refreshes device presence on every SSE keep-alive while the stream stays open`、
  `vetoes when touchDevice returns false despite a present cookie`）。
  SSE 空闲保活用例通过 main 的 `eventsHeartbeatMs` seam 用小间隔（20ms）断言
  流保持打开期间 `touchDevice` 被持续调用 ≥ 2 次。
  其余测试文件通过；仅 `tests/update.spec.ts > runUpdate > kills and
  reports timeout` 在 Windows 上失败（`child.killed` 平台断言差异），
  **与本次改动无关**，为仓库在 Windows 上的既有 flaky 测试（Linux CI 不触发）。

## 用户可见变更证据（Local Feature Evidence）

验证步骤（真实设备）：

1. 覆盖构建产物到本地 profile 的 `@linxin666/dsh-remote-web-ui`，重启 `dsh web`；
2. 桌面端「移动端远程控制」刷新二维码，手机扫码配对（走 cloudflared 公网隧道）；
3. 在手机端发送一条消息，收到正常回复后，故意停顿超过 25 秒不进行任何操作；
4. 回到桌面端配对面板，设备状态**保持「在线/已连接」**（修复前会误判为「离线」）。

证据：

（提交时请在此粘贴截图/录屏：一张是手机端空闲状态的界面，一张是桌面端配对面板显示「已连接 N」且停留超过 25 秒后的状态。）

---

## 根因与修复细节（供 reviewer 参考）

**根因链**：

1. 移动端页面走独立的精简 bundle（`src/mobile/`，构建为 `lib/mobile.js`），
   其中**没有任何 `/api/pair/heartbeat` 心跳发送逻辑**（心跳仅在桌面 Web UI 的
   `src/client/index.ts` 中，且仅当 `connection.isLoopback` 为 false 时启动）；
2. 移动端数据通道 `src/mobile-api.ts` 的 `gateOk` 只调用 `service.hasDevice(deviceId)`
   （**只判断配对存在，不刷新 `lastSeenAt`**），而 `api/gate` 网关卡
   `makeGateListener` 才会调用 `touchDevice`；
3. 移动端 RPC 走自己的 `/m/api/*` 前缀，**不经过** `api/gate` 网关卡；
4. 结果：`lastSeenAt` 只在配对成功时（`pairing.ts` 里 `accept` 写 `lastSeenAt: now`）
   被设置一次，此后永不刷新，25 秒（`offlineAfterMs` 默认值）后必判「离线」。

**修复**（最小改动，语义与 `api/gate` 一致）：

- 新增 `touchDeviceFor(req)`：从 cookie 读 `deviceId` 并调用
  `service.touchDevice(deviceId)`（`touchDevice` 会刷新 `lastSeenAt` 并触发
  `notify()`，快照仅在「在线↔离线」边界变化时才真正 emit，无性能抖动）；
- `gateOk` 改为委托 `touchDeviceFor`，使每个受门控的移动端 RPC 请求都刷新存在性；
- SSE 长连接（`handleEvents`）的每 15 秒 keepalive 定时器里也调用
  `touchDeviceFor(req)`，使「agent 空闲但 SSE 仍连接」的手机保持在线。

**安全语义**：`touchDevice` 的返回值布尔语义与 `hasDevice` 等价（对 unknown 或
已 `stop()` 的设备均返回 false），`gateOk` 仍会 veto 未配对/已撤销设备；本改动
仅额外刷新 `lastSeenAt`，不放松任何访问控制。

**测试**：新增 4 个单元测试覆盖「带 cookie 的请求会 touchDevice」「无 cookie 的
请求被 veto 且不 touchDevice」「SSE 空闲保活期间持续 touchDevice（≥2 次）」
「cookie 有效但 touchDevice 返回 false 时 403 不放行」；并给既有 stub 补充
`touchDevice` 方法以保持类型与运行时一致。SSE 保活测试复用 main 的
`eventsHeartbeatMs` seam（不硬编码 15s），避免破坏 main 已有的 25ms keepalive 测试。

