### PR TITLE
fix(liangshen): copy preset trees without fs.cpSync to survive CJK paths on Windows

### DIFF
--- a/packages/dsh-liangshen/src/sync.test.ts
+++ b/packages/dsh-liangshen/src/sync.test.ts
@@ -52,6 +52,23 @@ describe('syncPresetTrees', () => {
     } finally { f.dispose() }
   })
 
+  it('copies a preset whose source path contains non-ASCII characters', () => {
+    const f = fixture()
+    try {
+      // Regression test for nodejs/node#54476: on Node 22 for Windows,
+      // fs.cpSync({ recursive: true }) aborts the process (0xC0000409) when
+      // the source path contains CJK characters, e.g. a CJK home directory.
+      // sync.ts must not use fs.cpSync; a CJK user profile must still boot.
+      const chinese = join(f.source, '梁神')
+      mkdirSync(chinese, { recursive: true })
+      writeFileSync(join(chinese, 'agent.cordis.yml'), VALID_AGENT_YAML)
+      writeFileSync(join(chinese, 'preset.yml'), 'name: 梁神模式\n')
+      const result = syncPresetTrees(f.source, f.target)
+      expect(result.synced).toContain('梁神')
+      expect(readFileSync(join(f.target, '梁神', 'agent.cordis.yml'), 'utf8')).toBe(VALID_AGENT_YAML)
+    } finally { f.dispose() }
+  })
+
   it('retires a previously bundled preset directory removed from the source', () => {
     const f = fixture()
     try {

--- a/packages/dsh-liangshen/src/sync.ts
+++ b/packages/dsh-liangshen/src/sync.ts
@@ -15,7 +15,7 @@
  * can observe (and surface) a broken preset rather than silently shipping it.
  */
 
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, utimesSync } from 'node:fs'
 import { basename, dirname, join, relative } from 'node:path'
 import { validateAgentCordis } from './schema.ts'
 
@@ -99,6 +99,33 @@ function validatePresetAgentFile(presetDir: string): string[] {
   return validateAgentCordis(readFileSync(agent, 'utf8'))
 }
 
+/**
+ * Copy the whole tree under `sourceDir` into `targetDir`, creating the target
+ * directory as needed. Intentionally not `fs.cpSync` (recursive): on Node 22
+ * for Windows, `fs.cpSync` with `recursive: true` crashes the process with a
+ * fatal error (STATUS_STACK_BUFFER_OVERRUN / 0xC0000409, no JS exception is
+ * thrown) whenever the source path contains non-ASCII characters such as a
+ * CJK home directory (nodejs/node#54476, regression from nodejs/node#53614).
+ * Since `engines` supports Node ^22.19.0, this must work on Node 22, so the
+ * copy is done with the same per-entry primitives the rest of the module
+ * already uses. Source mtimes are preserved to keep the `preserveTimestamps`
+ * contract of the previous `cpSync` call.
+ */
+function copyTreeSync(sourceDir: string, targetDir: string): void {
+  mkdirSync(targetDir, { recursive: true })
+  for (const entry of readdirSync(sourceDir)) {
+    const source = join(sourceDir, entry)
+    const target = join(targetDir, entry)
+    const stat = statSync(source)
+    if (stat.isDirectory()) {
+      copyTreeSync(source, target)
+    } else {
+      copyFileSync(source, target)
+      utimesSync(target, stat.atime, stat.mtime)
+    }
+  }
+}
+
 /** Copy `sourceRoot/<id>` into `targetRoot/<id>`, idempotently. */
 export function syncOnePreset(sourceDir: string, targetDir: string): 'synced' | 'current' {
   const sourceFiles = filesUnder(sourceDir)
@@ -108,7 +135,7 @@ export function syncOnePreset(sourceDir: string, targetDir: string): 'synced' | 
     rmSync(targetDir, { recursive: true, force: true })
   }
   if (!existsSync(targetDir)) {
-    cpSync(sourceDir, targetDir, { recursive: true, preserveTimestamps: true })
+    copyTreeSync(sourceDir, targetDir)
     pruneExtras(targetDir, sourceSet)
     return 'synced'
   }
@@ -131,10 +158,10 @@ export function syncOnePreset(sourceDir: string, targetDir: string): 'synced' | 
   }
   if (!dirty) return 'current'
 
-  // Drop target-only entries first so file/dir type clashes never reach cpSync,
-  // then copy and prune again per the post-copy contract.
+  // Drop target-only entries first so file/dir type clashes never reach the
+  // copy, then copy and prune again per the post-copy contract.
   pruneExtras(targetDir, sourceSet)
-  cpSync(sourceDir, targetDir, { recursive: true, preserveTimestamps: true })
+  copyTreeSync(sourceDir, targetDir)
   pruneExtras(targetDir, sourceSet)
   return 'synced'
 }


### PR DESCRIPTION
## 摘要（Summary）

修复 dsh-liangshen 在 **Node 22 + Windows + 非 ASCII（CJK）用户目录** 下启动即崩溃（进程无输出直接退出，`STATUS_STACK_BUFFER_OVERRUN` / `0xC0000409`）的问题。

**根因**：`src/sync.ts` 使用 `fs.cpSync(source, target, { recursive: true, preserveTimestamps: true })` 同步预设树。Node 22 在 Windows 上该 API 遇到含非 ASCII 字符的**源路径**（例如 CJK 用户名 `C:\Users\紫枫\...`）时会在原生层 fail-fast 崩溃进程，不抛任何 JS 异常（nodejs/node#54476，由 nodejs/node#53614 引入的回归）。本包 `engines` 声明支持 `^22.19.0`，但 README 验证环境为 Node 24（该回归已修复），导致 Node 22 用户一升级就被崩溃。

**修复**：新增 `copyTreeSync()`（`mkdirSync` + 逐项 `copyFileSync` + `utimesSync` 保持时间戳语义），替换两处 `cpSync` 调用。这些逐项原语正是本模块其余部分（`filesUnder`/`sameFile`/`pruneExtras`）已经在用的，对 Node 22 Windows + CJK 路径安全。新增回归测试（CJK 目录名预设）。

## 涉及包（Affected Packages）

- [x] dsh-liangshen（`packages/dsh-liangshen`）

## PR 类型（PR Type）

- [ ] 增加新的用户功能或行为
- [x] Bug 修复
- [ ] 改文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## 本地验证（Local Validation）

执行的命令：`pnpm install && pnpm test && pnpm typecheck`（在 `packages/dsh-liangshen`）
结果摘要：5 个测试文件 / 60 个测试全部通过（含新增 CJK 路径回归测试）；`tsc --noEmit` 无错误。

## 复现（Reproduction）

Node 22.22.0 + Windows 11，用户名含 CJK：

```sh
node -e "const fs=require('fs'); fs.cpSync('C:/Users/紫枫/some-dir','C:/dest',{recursive:true})"
# -> 进程直接崩溃，exit code -1073740791 (0xC0000409)，无任何输出
```

修复后 `dsh web` 在 CJK 用户名环境下正常启动。

参考：nodejs/node#54476（同场景崩溃报告）；nodejs/node#53614（引入回归）。
