### PR TITLE
test(skin-center): guard resolvePaths().patchPath before useSkin writes

### DIFF
--- a/packages/skins/skin-center/tests/skin-switch.spec.ts
+++ b/packages/skins/skin-center/tests/skin-switch.spec.ts
@@ -292,6 +292,11 @@ describe('harness home resolution (issue #120: DSH_HOME)', () => {
     const dshHome = mkdtempSync(join(tmpdir(), 'skin-switch-use-dsh-home-'))
     try {
       withEnv({ DSH_HOME: dshHome }, () => {
+        // patchPath guard before useSkin: a resolvePaths regression must fail
+        // here instead of letting useSkin write into the real ~/.dsh.
+        const paths = resolvePaths()
+        expect(paths.patchPath).toBe(join(dshHome, 'cordis.patch.yml'))
+        expect(paths.patchPath).not.toBe(join(homedir(), '.dsh', 'cordis.patch.yml'))
         useSkin('official', {})
         expect(existsSync(join(dshHome, 'cordis.patch.yml'))).toBe(true)
         expect(currentSkin(undefined, {})).toBe('none')
@@ -424,6 +429,11 @@ describe('useSkin / currentSkin against a throwaway HOME', () => {
       qq98: { ...qq98, dir: fakeDir },
     }
     writeFileSync(patchPath(h), '')
+    // patchPath guard before useSkin: the throwaway home owns the write
+    // target, never the real ~/.dsh.
+    const paths = resolvePaths(h)
+    expect(paths.patchPath).toBe(patchPath(h))
+    expect(paths.patchPath).not.toBe(join(homedir(), '.dsh', 'cordis.patch.yml'))
     const message = useSkin('qq98', { home: h, registry: fakeRegistry })
     const after = readFileSync(patchPath(h), 'utf8')
     expect(after).toContain('- insert:')


### PR DESCRIPTION
## 摘要（Summary）

按维护者在 #154 的建议补一条守卫：在两个 useSkin 端到端用例里，调用 useSkin 之前先断言 `resolvePaths().patchPath` 指向注入的临时 HOME / $DSH_HOME，而不是真实的 `homedir()/.dsh/cordis.patch.yml`。这样一旦 resolvePaths 的 harness-home 解析回归（重新硬编码 `~/.dsh`），测试会在任何写入发生前失败，不会把 cordis.patch.yml 误写进真实 `~/.dsh`。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream && git checkout -b test/skin-center-patchpath-guard upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek（deepseek-v4-pro）

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改 README）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter "@linxin666/dsh-client-ui-skin-center" test
pnpm typecheck
```

结果摘要：

skin-center 包测试 71 个用例：70 通过，1 失败——失败为 Windows 预存问题（0600 权限位用例，`statSync(patch).mode & 0o777` 在 Windows 上得到 0o666；CI 为 Linux 不受影响），与本改动无关。pnpm typecheck 全仓通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（纯测试增量，无用户可见行为变更）。
