### PR TITLE
docs(dsh-web-ui-all): document manual-upgrade top-level node_modules refresh

### DIFF
--- a/packages/dsh-web-ui-all/README.i18n.yaml
+++ b/packages/dsh-web-ui-all/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: a2e7686e8d06d39ed32d917934cef1d20c710b23
-README.zh.md: 044e0ff9bf3bf9cfe8048291b264b3279a33af58
+README.md: 64645a5b0465eb29bc3446260d72411796a9cbf8
+README.zh.md: 6511d224c212f6a30ca3633f660c3fd941a8b0e5

--- a/packages/dsh-web-ui-all/README.md
+++ b/packages/dsh-web-ui-all/README.md
@@ -29,6 +29,10 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-web-ui-all
 
 Restart `dsh web` for the plugins to take effect.
 
+### Manual upgrade
+
+When you upgrade by bumping the version in the profile `package.json` and running `pnpm install`, the top-level `node_modules/@linxin666/*` entries are not always refreshed: they can stay linked to the previous version's store directory until recreated. After upgrading, verify the links resolve to the new version (on Windows: `cmd /c rmdir <link>` then `cmd /c mklink /J <link> <target>`), then restart `dsh web`.
+
 ## Known limitations
 
 - Every sub-plugin activates together. For only a subset, install that sub-plugin package directly.

--- a/packages/dsh-web-ui-all/README.zh.md
+++ b/packages/dsh-web-ui-all/README.zh.md
@@ -29,6 +29,10 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-web-ui-all
 
 安装后重启 `dsh web` 使插件生效。
 
+### 手工升级
+
+在 profile 的 `package.json` 中改版本后执行 `pnpm install`，顶层 `node_modules/@linxin666/*` 条目不会总是被刷新：它们可能仍链接到旧版本的 store 目录，直到手动重建。升级后请确认这些链接已指向新版本目录（Windows 下：先 `cmd /c rmdir <链接>` 再 `cmd /c mklink /J <链接> <目标>`），然后重启 `dsh web`。
+
 ## 已知限制
 
 - 各子插件随本包一起激活；若只需要其中一部分，请直接安装对应子插件包。


### PR DESCRIPTION
## 摘要（Summary）

把此前在 #154 评论里提到的「手工升级后顶层 node_modules 不刷新」经验写进聚合包 README 的安装章节（新增「手工升级」小节，中英双语）：在 profile 的 package.json 里改版本后执行 pnpm install，顶层 `node_modules/@linxin666/*` 条目不会总是被刷新，可能仍指向旧版本 store 目录；升级后需确认链接指向新版本（Windows 下 `cmd /c rmdir <link>` + `cmd /c mklink /J <link> <target>` 重建），再重启 dsh web。

## 涉及包（Affected Packages）

- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`（仅 dsh-web-ui-all 的 README 三件套）

## PR 类型（PR Type）

- [x] 仅文档

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream && git checkout -b docs/manual-upgrade-top-level-nodemodules upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek（deepseek-v4-pro）

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm docs:write-pair
pnpm docs:check
```

结果摘要：

`pnpm docs:write-pair` 重录 dsh-web-ui-all 的 README.i18n.yaml 配对 hash；`pnpm docs:check`：all documentation gates passed（词数预算全部在限内）。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（仅文档改动）。