### PR TITLE
test(skins): 闭合交易终端皮肤审查建议 — 腾讯短格式拒收断言 + README 数据读取范围

### DIFF
--- a/packages/skins/trading/README.i18n.yaml
+++ b/packages/skins/trading/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 19ebbaae9eaee70385f98b3f90cfe05f933488aa
-README.zh.md: 8ff2c7a5eabfaa496020f012668847aefccf06cb
+README.md: 5227db9c51b34da0c731c045886562041835bb9b
+README.zh.md: 20b2fad0343d6a12f3cce00a9be72ec0c53ead58

--- a/packages/skins/trading/README.md
+++ b/packages/skins/trading/README.md
@@ -76,6 +76,15 @@ package) to return to the default look.
   `@deepseek-ai/dsh-client-connection` handle when available; without a
   connection it shows `--`.
 
+### Data read scope
+
+The skin's data surface is strictly read-only (the same precedent as the ths
+skin): it consumes quote feeds (fun-ticker proxy / longbridge snapshot /
+public endpoints) and the `workspace.list` RPC for the workspace-count cell —
+via `ctx.get('connection')` when the connection handle is available. It never
+writes settings, never calls a model endpoint, and never emits cordis events;
+every read fails safe to `--` cells.
+
 ## Model Experience
 
 None. The skin mutates only the browser DOM and reads quote feeds; nothing

--- a/packages/skins/trading/README.zh.md
+++ b/packages/skins/trading/README.zh.md
@@ -44,6 +44,13 @@ pnpm 打印的包键加入相应 profile 的 `pnpm-workspace.yaml` 的 `allowBui
 - 工作区计数格通过 `@deepseek-ai/dsh-client-connection` 句柄读 `workspace.list` RPC；
   无连接时显示 `--`。
 
+### 数据读取范围
+
+皮肤的数据面严格只读（与 ths 皮肤同一先例）：只消费行情源（fun-ticker 代理 /
+长桥快照 / 公共端点）与 `workspace.list` RPC（工作区计数格，经
+`ctx.get('connection')` 在有连接句柄时读取）。不写任何设置、不调用模型端点、
+不发 cordis 事件；所有读取失败均安全降级为 `--` 单元格。
+
 ## 模型体验
 
 无。皮肤只改浏览器 DOM 并读取行情源，不触及模型请求。

--- a/packages/skins/trading/tests/quotes.spec.ts
+++ b/packages/skins/trading/tests/quotes.spec.ts
@@ -63,6 +63,13 @@ describe('parseTencentRow', () => {
     expect(parseTencentRow('1~名称~代码~abc~0~0~0')).toBeNull()
     expect(parseTencentRow('short')).toBeNull()
   })
+
+  it('rejects the truncated US short payload (real sample shape)', () => {
+    // qt.gtimg.cn also serves a short `name|price|...` shape; it is not the
+    // full ~-split payload the parser needs (8 fields < the 35-field floor),
+    // so it must be rejected — never half-parsed into a phantom quote.
+    expect(parseTencentRow(US_STOCK)).toBeNull()
+  })
 })
 
 describe('trendOf (红涨绿跌)', () => {


### PR DESCRIPTION
## 摘要（Summary）

PR #13（交易终端皮肤）合入后，维护者留下两条非阻塞后续建议，本 PR 逐一落实：

1. `tests/quotes.spec.ts` 补一条「腾讯短格式被拒 → null」断言：`US_STOCK` 短格式样例（8 个字段）此前只定义未覆盖，现在闭合——截断的 qt.gtimg.cn 载荷绝不会被半解析成幽灵行情；
2. `README.md` / `README.zh.md` 的 Requirements 新增「Data read scope / 数据读取范围」小节：明确皮肤数据面严格只读（行情源 + 经 `ctx.get('connection')` 的 `workspace.list` RPC，与 ths 先例一致），不写设置、不调用模型端点、不发 cordis 事件。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`（仅 `packages/skins/trading`）

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 包内构建只使用 `shared/tsdown.client.ts`（本 PR 无构建改动）。
- [x] 未引入任何 emoji（含 Emoji_Presentation 字符）。
- [x] 改包 README 已同步维护中英三件套，并用 `pnpm docs:write-pair` 重录配对。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-skin-trading test
tsc -p tsconfig.vitest.json --noEmit
pnpm docs:check
```

结果摘要：

25/25 通过（含维护者合入后的 refresh-scheduler 用例）；tsc 通过；docs:check 全部门禁通过；改动仅限 tests + README（+ i18n 配对记录），无 lib / 注册表 / gallery 产物变化