### PR TITLE
fix(aionui-panel): wire pdf preview through the raw stream route (#239)

### DIFF
--- a/packages/dsh-aionui-panel/src/client/fileType.ts
+++ b/packages/dsh-aionui-panel/src/client/fileType.ts
@@ -115,3 +115,15 @@ export function parentRel(path: string): string {
   const idx = path.lastIndexOf('/')
   return idx > 0 ? path.slice(0, idx) : ''
 }
+
+/**
+ * The streaming URL a pdf tab renders: the host raw route serves the bytes
+ * with mime application/pdf, so the preview iframe loads them directly — no
+ * base64 round-trip and no read-size cap. The nonce defeats browser caching
+ * when the tab is refreshed after the file changed on disk.
+ *
+ * Contributed by EricWang1358 (#239).
+ */
+export function pdfPreviewUrl(root: string, path: string, nonce: number): string {
+  return `/aionui-panel/raw?root=${encodeURIComponent(root)}&path=${encodeURIComponent(path)}&v=${nonce}`
+}

--- a/packages/dsh-aionui-panel/src/client/preview/PreviewToolbar.tsx
+++ b/packages/dsh-aionui-panel/src/client/preview/PreviewToolbar.tsx
@@ -38,7 +38,10 @@ export function refreshStateFor(
 export function downloadTab(tab: { title: string; content: string | null; contentType: PreviewContentType }): void {
   if (tab.content === null) return
   const isDataUrl = tab.content.startsWith('data:')
-  const href = isDataUrl
+  // Pdf tabs hold a same-origin raw-route URL: anchor it directly (the
+  // download attribute forces a save), no blob copy needed.
+  const isRouteUrl = tab.content.startsWith('/aionui-panel/raw')
+  const href = isDataUrl || isRouteUrl
     ? tab.content
     : URL.createObjectURL(new Blob([tab.content], { type: 'text/plain;charset=utf-8' }))
   const anchor = document.createElement('a')
@@ -48,7 +51,7 @@ export function downloadTab(tab: { title: string; content: string | null; conten
   document.body.appendChild(anchor)
   anchor.click()
   anchor.remove()
-  if (!isDataUrl) setTimeout(() => URL.revokeObjectURL(href), 10_000)
+  if (!isDataUrl && !isRouteUrl) setTimeout(() => URL.revokeObjectURL(href), 10_000)
 }
 
 /** The toolbar. */

--- a/packages/dsh-aionui-panel/src/client/preview/content.tsx
+++ b/packages/dsh-aionui-panel/src/client/preview/content.tsx
@@ -365,12 +365,14 @@ function ImageViewer({ src, meta }: { src: string; meta: string }): JSX.Element 
   )
 }
 
-/** PDF viewer (blob iframe). */
+/** PDF viewer: streamed route URL (iframe src) or a legacy data URL (blob). */
 function PdfViewer({ dataUrl, title }: { dataUrl: string; title: string }): JSX.Element {
   const [url, setUrl] = useState<string | null>(null)
   useEffect(() => {
     if (!dataUrl.startsWith('data:')) {
-      setUrl(null)
+      // Same-origin /aionui-panel/raw URL: the iframe loads the stream
+      // directly (mime application/pdf, no size cap, no base64 copy).
+      setUrl(dataUrl === '' ? null : dataUrl)
       return
     }
     const blob = dataUrlToBlob(dataUrl)

--- a/packages/dsh-aionui-panel/src/client/store.ts
+++ b/packages/dsh-aionui-panel/src/client/store.ts
@@ -12,7 +12,7 @@
 
 import type { FileRead, FsEntry, GitStatusView, PreviewContentType, SearchHit } from '../core/types.ts'
 import type { PanelApi } from './api.ts'
-import { detectContentType, isTextType, tabIdOf } from './fileType.ts'
+import { detectContentType, isTextType, pdfPreviewUrl, tabIdOf } from './fileType.ts'
 import {
   createDebounced, evictPreviewScopes, readJson, readStoredNumber, writeJson, writeStoredNumber,
 } from './persist.ts'
@@ -763,6 +763,20 @@ export function createPreviewStore(api: PanelApi): PreviewStore {
       ...prev,
       tabs: prev.tabs.map((item) => (item.id === id ? { ...item, loading: true, error: null } : item)),
     }))
+    // Pdf tabs never fetch through /read: the raw route streams the bytes
+    // straight into the preview iframe, so the tab content is the route URL.
+    if (tab.contentType === 'pdf') {
+      handle.update((prev) => {
+        if (prev.root !== root) return prev
+        return {
+          ...prev,
+          tabs: prev.tabs.map((item) => (item.id === id
+            ? { ...item, loading: false, content: pdfPreviewUrl(root, item.path, Date.now()), updated: false }
+            : item)),
+        }
+      })
+      return
+    }
     const asImage = tab.contentType === 'image'
     const result = tab.diff !== undefined
       ? await api.gitDiff(root, tab.path, tab.diff.staged)
@@ -1014,6 +1028,17 @@ export function createPreviewStore(api: PanelApi): PreviewStore {
           tabs: prev.tabs.map((item) =>
             item.id === id ? { ...item, reloadNonce: (item.reloadNonce ?? 0) + 1 } : item,
           ),
+        }))
+        return
+      }
+      if (tab.contentType === 'pdf') {
+        // Streamed tab: re-point the iframe at the raw route with a fresh
+        // nonce so the browser re-fetches the bytes (no /read round-trip).
+        handle.update((prev) => ({
+          ...prev,
+          tabs: prev.tabs.map((item) => (item.id === id
+            ? { ...item, content: pdfPreviewUrl(state.root, item.path, Date.now()), updated: false, error: null }
+            : item)),
         }))
         return
       }

--- a/packages/dsh-aionui-panel/src/host/fs-service.ts
+++ b/packages/dsh-aionui-panel/src/host/fs-service.ts
@@ -163,16 +163,19 @@ export function probeImageSize(data: Buffer): { width: number; height: number } 
   return undefined
 }
 
-/** Derive the mime type for an image read from the extension, then the content. */
+/** Derive the mime type for a raw read from the extension, then the content. */
+// pdf mappings (extension + %PDF magic) contributed by EricWang1358 (#239).
 function imageMime(rel: string, data: Buffer): string {
   const ext = rel.split('.').pop()?.toLowerCase() ?? ''
   const byExt: Record<string, string> = {
     png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
     webp: 'image/webp', svg: 'image/svg+xml', ico: 'image/x-icon', avif: 'image/avif', bmp: 'image/bmp',
+    pdf: 'application/pdf',
   }
   if (byExt[ext]) return byExt[ext]
   if (data.length >= 3 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e) return 'image/png'
   if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8) return 'image/jpeg'
+  if (data.length >= 4 && data[0] === 0x25 && data[1] === 0x50 && data[2] === 0x44 && data[3] === 0x46) return 'application/pdf'
   return 'application/octet-stream'
 }
 

--- a/packages/dsh-aionui-panel/src/host/fs-service.ts
+++ b/packages/dsh-aionui-panel/src/host/fs-service.ts
@@ -9,7 +9,7 @@
  * @module dsh-aionui-panel/host/fs-service
  */
 
-import { readdir, readFile, realpath, stat, writeFile, rm, mkdir } from 'node:fs/promises'
+import { open, readdir, readFile, realpath, stat, writeFile, rm, mkdir } from 'node:fs/promises'
 import { watch as watchPath, type Dirent, type FSWatcher } from 'node:fs'
 import { join, dirname } from 'node:path'
 import type { DirListing, FileRead, FsEntry, PanelError, SearchHit, SearchView } from '../core/types.ts'
@@ -179,6 +179,21 @@ function imageMime(rel: string, data: Buffer): string {
   return 'application/octet-stream'
 }
 
+/** Read the first 4 magic bytes of a file (empty buffer when unreadable). */
+async function readMagicBytes(abs: string): Promise<Buffer> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined
+  try {
+    handle = await open(abs, 'r')
+    const buf = Buffer.alloc(4)
+    const { bytesRead } = await handle.read(buf, 0, 4, 0)
+    return buf.subarray(0, bytesRead)
+  } catch {
+    return Buffer.alloc(0)
+  } finally {
+    if (handle !== undefined) await handle.close().catch(() => {})
+  }
+}
+
 /**
  * Filesystem service: gated listing/read/write/search/delete plus a change
  * watcher. All relative paths are resolved against the gated root.
@@ -270,17 +285,18 @@ export class FsService {
   }
 
   /**
-   * Read one file's raw bytes (the markdown image route): gated, traversal-
-   * guarded, and .git-refusing. The bytes are streamed by the HTTP layer with
-   * the derived mime so `<img>` tags can load workspace files directly.
+   * Resolve one file for raw streaming (the markdown image / pdf preview
+   * route): gated, traversal-guarded, and .git-refusing. Returns the absolute
+   * path with the derived mime and size — the HTTP layer streams the bytes
+   * itself (createReadStream + Range), so even large files never sit in host
+   * memory. Mime magic detection reads only the first few bytes.
    */
-  async readRaw(root: string, rel: string): Promise<{ data: Buffer; mime: string; size: number } | PanelError> {
+  async readRaw(root: string, rel: string): Promise<{ abs: string; mime: string; size: number } | PanelError> {
     const gated = await this.gate(root)
     if (!gated.ok) return gated.error
     if (isGitPath(rel)) return { code: 'path-outside-root', message: 'refusing to read .git' }
     const resolved = await resolveInsideRoot(gated.canonical, rel)
     if (!resolved.ok) return resolved.error
-    let data: Buffer
     let info: Awaited<ReturnType<typeof stat>>
     try {
       info = await stat(resolved.abs)
@@ -288,12 +304,7 @@ export class FsService {
       return { code: 'not-found', message: `cannot read ${rel}` }
     }
     if (info.isDirectory()) return { code: 'is-directory', message: `${rel} is a directory` }
-    try {
-      data = await readFile(resolved.abs)
-    } catch {
-      return { code: 'not-found', message: `cannot read ${rel}` }
-    }
-    return { data, mime: imageMime(rel, data), size: data.length }
+    return { abs: resolved.abs, mime: imageMime(rel, await readMagicBytes(resolved.abs)), size: info.size }
   }
 
   /** Write text content back, refusing when the file moved on disk (mtime conflict). */

--- a/packages/dsh-aionui-panel/src/host/routes.ts
+++ b/packages/dsh-aionui-panel/src/host/routes.ts
@@ -7,6 +7,8 @@
  */
 
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { createReadStream } from 'node:fs'
+import { pipeline } from 'node:stream/promises'
 import type { Context } from '@deepseek-ai/cordis'
 import type {} from '@deepseek-ai/dsh-host-webserver'
 import type { PanelEnvelope, PanelError } from '../core/types.ts'
@@ -37,6 +39,32 @@ interface Subscriber {
 const GIT_POLL_MS = 30_000
 /** SSE keep-alive comment interval (proxies drop idle connections). */
 const HEARTBEAT_MS = 15_000
+
+/**
+ * Parse a single-range `bytes=start-end` header against the file size.
+ * Returns null when no range was requested, 'invalid' for malformed or
+ * unsatisfiable ranges (the caller answers 416), or the clamped start/end
+ * (inclusive). Multi-range requests are treated as invalid — the panel only
+ * ever serves single ranges. Suffix ranges (`bytes=-N`) select the last N
+ * bytes. Range support added after human review on #242 (pdf seeking).
+ */
+export function parseRangeHeader(
+  header: string | undefined,
+  size: number,
+): { start: number; end: number } | 'invalid' | null {
+  if (header === undefined) return null
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim())
+  if (match === null || (match[1] === '' && match[2] === '')) return 'invalid'
+  if (match[1] === '') {
+    const suffix = Number(match[2])
+    if (suffix <= 0 || size === 0) return 'invalid'
+    return { start: Math.max(0, size - suffix), end: size - 1 }
+  }
+  const start = Number(match[1])
+  const end = match[2] === '' ? size - 1 : Math.min(Number(match[2]), size - 1)
+  if (size === 0 || start > end || start >= size) return 'invalid'
+  return { start, end }
+}
 
 /**
  * Deadline for one git-status subprocess inside pollGit. Not an execution
@@ -227,12 +255,15 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
   }
 
   /**
-   * GET /aionui-panel/raw: stream one workspace file (markdown image srcs).
-   * Gated like every other operation; the bytes go out with the derived mime
-   * so an `<img>` can load them. No validators are negotiated, so the browser
-   * revalidates every time — a re-edited image never shows stale bytes.
+   * GET /aionui-panel/raw: stream one workspace file (markdown image srcs,
+   * pdf preview). Gated like every other operation; FsService.readRaw only
+   * resolves and stats the path, the bytes are piped straight from disk with
+   * the derived mime — the whole file never sits in host memory. Single byte
+   * ranges are honored (206/416) so the browser pdf viewer can seek large
+   * files. No validators are negotiated, so the browser revalidates every
+   * time — a re-edited file never shows stale bytes.
    */
-  const serveRaw = async (url: URL, res: ServerResponse): Promise<void> => {
+  const serveRaw = async (req: IncomingMessage, url: URL, res: ServerResponse): Promise<void> => {
     const root = url.searchParams.get('root')
     const path = url.searchParams.get('path')
     if (root === null || root === '' || path === null || path === '') {
@@ -240,18 +271,38 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
       return
     }
     const result = await fs.readRaw(root, path)
-    if (!('data' in result)) {
+    if (!('abs' in result)) {
       const status = result.code === 'path-outside-root' || result.code === 'is-directory' ? 403 : 404
       json(res, FAIL(result), status)
       return
     }
-    res.writeHead(200, {
+    const range = parseRangeHeader(req.headers.range, result.size)
+    if (range === 'invalid') {
+      res.writeHead(416, { 'content-range': `bytes */${result.size}` })
+      res.end()
+      return
+    }
+    const headers: Record<string, string | number> = {
       'content-type': result.mime,
-      'content-length': result.size,
       'cache-control': 'no-cache',
       'x-content-type-options': 'nosniff',
-    })
-    res.end(result.data)
+      'accept-ranges': 'bytes',
+    }
+    if (range === null) {
+      headers['content-length'] = result.size
+      res.writeHead(200, headers)
+    } else {
+      headers['content-range'] = `bytes ${range.start}-${range.end}/${result.size}`
+      headers['content-length'] = range.end - range.start + 1
+      res.writeHead(206, headers)
+    }
+    try {
+      await pipeline(createReadStream(result.abs, range === null ? undefined : { start: range.start, end: range.end }), res)
+    } catch {
+      // Client aborted mid-stream or the file vanished after stat: the
+      // response is already committed, so just tear it down.
+      res.destroy()
+    }
   }
 
   const handler = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
@@ -264,7 +315,7 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
     if (req.method === 'GET') {
       const url = new URL(req.url ?? '/', 'http://x')
       if (url.pathname === '/aionui-panel/raw') {
-        await serveRaw(url, res)
+        await serveRaw(req, url, res)
         return
       }
       res.writeHead(405)

--- a/packages/dsh-aionui-panel/tests/host-fixes.spec.ts
+++ b/packages/dsh-aionui-panel/tests/host-fixes.spec.ts
@@ -112,6 +112,24 @@ describe('FsService.readRaw (markdown image route)', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
+  it('serves pdf bytes as application/pdf (extension and magic bytes)', async () => {
+    const dir = await realpath(await mkdtemp(join(tmpdir(), 'aionui-raw-')))
+    const root = join(dir, 'proj')
+    await mkdir(join(root, 'docs'), { recursive: true })
+    const pdf = Buffer.from('%PDF-1.7 fake body', 'latin1')
+    await writeFile(join(root, 'docs', 'doc.pdf'), pdf)
+    // No extension: the %PDF magic must still win over octet-stream.
+    await writeFile(join(root, 'docs', 'noext'), pdf)
+    const service = new FsService(gate)
+
+    const byExt = await service.readRaw(root, 'docs/doc.pdf')
+    expect(byExt).toMatchObject({ mime: 'application/pdf', size: pdf.length })
+    if ('data' in byExt) expect(byExt.data.equals(pdf)).toBe(true)
+    expect(await service.readRaw(root, 'docs/noext')).toMatchObject({ mime: 'application/pdf' })
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
   it('refuses .git paths, missing files, and directories', async () => {
     const dir = await realpath(await mkdtemp(join(tmpdir(), 'aionui-raw-')))
     const root = join(dir, 'proj')

--- a/packages/dsh-aionui-panel/tests/host-fixes.spec.ts
+++ b/packages/dsh-aionui-panel/tests/host-fixes.spec.ts
@@ -106,7 +106,7 @@ describe('FsService.readRaw (markdown image route)', () => {
 
     const image = await service.readRaw(root, 'assets/pic.png')
     expect(image).toMatchObject({ mime: 'image/png', size: png.length })
-    if ('data' in image) expect(image.data.equals(png)).toBe(true)
+    if ('abs' in image) expect(image.abs.endsWith(join('assets', 'pic.png'))).toBe(true)
     expect(await service.readRaw(root, 'a.md')).toMatchObject({ mime: 'application/octet-stream' })
 
     await rm(dir, { recursive: true, force: true })
@@ -124,7 +124,7 @@ describe('FsService.readRaw (markdown image route)', () => {
 
     const byExt = await service.readRaw(root, 'docs/doc.pdf')
     expect(byExt).toMatchObject({ mime: 'application/pdf', size: pdf.length })
-    if ('data' in byExt) expect(byExt.data.equals(pdf)).toBe(true)
+    if ('abs' in byExt) expect(byExt.abs.endsWith(join('docs', 'doc.pdf'))).toBe(true)
     expect(await service.readRaw(root, 'docs/noext')).toMatchObject({ mime: 'application/pdf' })
 
     await rm(dir, { recursive: true, force: true })

--- a/packages/dsh-aionui-panel/tests/loopback.spec.ts
+++ b/packages/dsh-aionui-panel/tests/loopback.spec.ts
@@ -128,7 +128,7 @@ describe('/aionui-panel loopback fence', () => {
   })
 
   it('rejects non-loopback GET /aionui-panel/raw with 403', async () => {
-    const readRaw = vi.fn(async () => ({ data: Buffer.from('x'), mime: 'text/plain', size: 1 }))
+    const readRaw = vi.fn(async () => ({ abs: '/w/a.txt', mime: 'text/plain', size: 1 }))
     const { ctx, registrations } = fakeCtx()
     registerPanelRoutes(ctx as never, { readRaw } as never, { status: async () => null } as never)
     const prefix = registrations.find((row) => row.kind === 'prefix')!

--- a/packages/dsh-aionui-panel/tests/pure.spec.ts
+++ b/packages/dsh-aionui-panel/tests/pure.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest'
 import { renderInline, renderMarkdown, resolveMarkdownImage } from '../src/client/preview/markdown.ts'
 import { parseCsv, normalizeUrl } from '../src/client/preview/content.tsx'
 import { parseGridTracks, trackPx } from '../src/client/layout.ts'
-import { detectContentType } from '../src/client/fileType.ts'
+import { detectContentType, pdfPreviewUrl } from '../src/client/fileType.ts'
 
 describe('renderMarkdown', () => {
   it('renders headings, paragraphs and hr', () => {
@@ -92,6 +92,20 @@ describe('detectContentType', () => {
     expect(detectContentType('pic.png')).toBe('image')
     expect(detectContentType('LICENSE')).toBe('text')
     expect(detectContentType('weird.bin')).toBe('unsupported')
+  })
+})
+
+describe('pdfPreviewUrl (issue #236)', () => {
+  it('encodes root and path and appends the nonce as &v=', () => {
+    const url = pdfPreviewUrl('C:\\work dir', 'docs/a b#1.pdf', 42)
+    expect(url).toBe(
+      `/aionui-panel/raw?root=${encodeURIComponent('C:\\work dir')}&path=${encodeURIComponent('docs/a b#1.pdf')}&v=42`,
+    )
+    // Space and # must never survive raw into the URL.
+    expect(url).not.toContain(' ')
+    expect(url).not.toContain('#')
+    expect(url).toContain('a%20b%231.pdf')
+    expect(url.endsWith('&v=42')).toBe(true)
   })
 })
 

--- a/packages/dsh-aionui-panel/tests/raw-route.spec.ts
+++ b/packages/dsh-aionui-panel/tests/raw-route.spec.ts
@@ -7,8 +7,9 @@ import { describe, expect, it } from 'vitest'
 import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Writable } from 'node:stream'
 import { FsService } from '../src/host/fs-service.ts'
-import { registerPanelRoutes } from '../src/host/routes.ts'
+import { parseRangeHeader, registerPanelRoutes } from '../src/host/routes.ts'
 import type { WorkspaceGate } from '../src/host/gate.ts'
 
 /** A minimal ctx fulfilling what registerPanelRoutes touches. */
@@ -35,24 +36,33 @@ async function request(
   handler: (req: unknown, res: unknown) => Promise<void>,
   method: string,
   url: string,
-  options: { remoteAddress?: string; host?: string } = {},
+  options: { remoteAddress?: string; host?: string; range?: string } = {},
 ): Promise<{ status: number; headers: Record<string, string>; body: Buffer }> {
   let status = 0
   let headers: Record<string, string> = {}
-  let body = Buffer.alloc(0)
-  const res = {
-    writeHead: (code: number, head: Record<string, string> = {}) => { status = code; headers = head },
-    end: (chunk?: unknown) => {
-      if (chunk !== undefined && chunk !== null) body = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))
+  const chunks: Buffer[] = []
+  // A real Writable: the raw route streams with pipeline(), so the fake
+  // response must accept backpressured writes, not just end(chunk).
+  const res = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      chunks.push(chunk)
+      callback()
     },
+  }) as Writable & { writeHead: (code: number, head?: Record<string, string | number>) => void }
+  res.writeHead = (code: number, head: Record<string, string | number> = {}) => {
+    status = code
+    headers = head as Record<string, string>
   }
   await handler({
     method,
     url,
-    headers: { host: options.host ?? '127.0.0.1:3000' },
+    headers: {
+      host: options.host ?? '127.0.0.1:3000',
+      ...(options.range !== undefined ? { range: options.range } : {}),
+    },
     socket: { remoteAddress: options.remoteAddress ?? '127.0.0.1' },
   }, res)
-  return { status, headers, body }
+  return { status, headers, body: Buffer.concat(chunks) }
 }
 
 describe('GET /aionui-panel/raw', () => {
@@ -121,5 +131,60 @@ describe('GET /aionui-panel/raw', () => {
     expect(result.status).toBe(403)
     expect(result.headers['content-type']).toBe('application/json; charset=utf-8')
     expect(JSON.parse(result.body.toString('utf8'))).toEqual({ error: 'forbidden: loopback-only' })
+  })
+
+  it('serves single byte ranges (206) and rejects unsatisfiable ones (416)', async () => {
+    const dir = await realpath(await mkdtemp(join(tmpdir(), 'aionui-route-')))
+    const root = join(dir, 'proj')
+    await mkdir(root, { recursive: true })
+    const pdf = Buffer.from('%PDF-1.7 fake body for range tests', 'latin1')
+    await writeFile(join(root, 'doc.pdf'), pdf)
+    const gate: WorkspaceGate = async () => ({ ok: true, canonical: root })
+    const { ctx, registrations } = fakeCtx()
+    registerPanelRoutes(ctx as never, new FsService(gate), { status: async () => null } as never)
+    const row = registrations.find((item) => item.kind === 'prefix')!
+    const url = `/aionui-panel/raw?root=${encodeURIComponent(root)}&path=doc.pdf`
+
+    // Full body advertises range support so pdf viewers switch to seeking.
+    const full = await request(row.handler, 'GET', url)
+    expect(full.status).toBe(200)
+    expect(full.headers['content-type']).toBe('application/pdf')
+    expect(full.headers['accept-ranges']).toBe('bytes')
+    expect(full.body.equals(pdf)).toBe(true)
+
+    const part = await request(row.handler, 'GET', url, { range: 'bytes=0-4' })
+    expect(part.status).toBe(206)
+    expect(part.headers['content-range']).toBe(`bytes 0-4/${pdf.length}`)
+    expect(part.headers['content-length']).toBe(5)
+    expect(part.body.toString('latin1')).toBe('%PDF-')
+
+    const suffix = await request(row.handler, 'GET', url, { range: 'bytes=-4' })
+    expect(suffix.status).toBe(206)
+    expect(suffix.body.toString('latin1')).toBe(pdf.subarray(pdf.length - 4).toString('latin1'))
+
+    const unsatisfiable = await request(row.handler, 'GET', url, { range: `bytes=${pdf.length + 10}-` })
+    expect(unsatisfiable.status).toBe(416)
+    expect(unsatisfiable.headers['content-range']).toBe(`bytes */${pdf.length}`)
+
+    await rm(dir, { recursive: true, force: true })
+  })
+})
+
+describe('parseRangeHeader', () => {
+  it('returns null without a header and clamps open-ended ranges', () => {
+    expect(parseRangeHeader(undefined, 100)).toBeNull()
+    expect(parseRangeHeader('bytes=10-', 100)).toEqual({ start: 10, end: 99 })
+    expect(parseRangeHeader('bytes=0-999', 100)).toEqual({ start: 0, end: 99 })
+  })
+
+  it('handles suffix ranges and rejects malformed/unsatisfiable ones', () => {
+    expect(parseRangeHeader('bytes=-10', 100)).toEqual({ start: 90, end: 99 })
+    expect(parseRangeHeader('bytes=-0', 100)).toBe('invalid')
+    expect(parseRangeHeader('bytes=-5', 0)).toBe('invalid')
+    expect(parseRangeHeader('bytes=', 100)).toBe('invalid')
+    expect(parseRangeHeader('bytes=0-1,3-4', 100)).toBe('invalid')
+    expect(parseRangeHeader('bytes=100-', 100)).toBe('invalid')
+    expect(parseRangeHeader('bytes=50-40', 100)).toBe('invalid')
+    expect(parseRangeHeader('items=0-1', 100)).toBe('invalid')
   })
 })

--- a/packages/dsh-aionui-panel/tests/stores.spec.ts
+++ b/packages/dsh-aionui-panel/tests/stores.spec.ts
@@ -170,6 +170,45 @@ describe('scm store', () => {
   })
 })
 
+describe('preview pdf tabs (issue #236)', () => {
+  it('openFile on a pdf streams via the raw route without api.read', async () => {
+    const { api } = fakeApi()
+    const s = createPanelStores(api)
+    s.preview.setRoot('/w')
+    s.preview.openFile('/w', 'docs/manual v2.pdf')
+    await vi.waitFor(() => expect(s.preview.getSnapshot().tabs[0].content).not.toBeNull())
+    const tab = s.preview.getSnapshot().tabs[0]
+    expect(tab.contentType).toBe('pdf')
+    expect(tab.content?.startsWith('/aionui-panel/raw?root=')).toBe(true)
+    expect(tab.content).toContain(`path=${encodeURIComponent('docs/manual v2.pdf')}`)
+    expect(tab.content).toContain('&v=')
+    // Pdf tabs never go through the /read endpoint.
+    expect((api.read as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0)
+  })
+
+  it('reloadTab rebuilds the raw URL with a fresh nonce', async () => {
+    const { api } = fakeApi()
+    const s = createPanelStores(api)
+    let tick = 1000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => tick++)
+    try {
+      s.preview.setRoot('/w')
+      s.preview.openFile('/w', 'doc.pdf')
+      await vi.waitFor(() => expect(s.preview.getSnapshot().tabs[0].content).not.toBeNull())
+      const id = s.preview.getSnapshot().tabs[0].id
+      const first = s.preview.getSnapshot().tabs[0].content
+      await s.preview.reloadTab(id)
+      const second = s.preview.getSnapshot().tabs[0].content
+      expect(second).not.toBe(first)
+      expect(second?.startsWith('/aionui-panel/raw?root=')).toBe(true)
+      expect(second).toContain('&v=')
+      expect((api.read as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+})
+
 describe('preview diff tabs', () => {
   it('openDiff creates a diff tab loaded through gitDiff (staged side)', async () => {
     stores.preview.setRoot('/w')


### PR DESCRIPTION
## 摘要（Summary）

修复右侧面板 PDF 预览必现失效（#239）：pdf tab 不再走 /read 的 UTF-8 文本/base64 通路，改为复用现有 GET /aionui-panel/raw 路由流式返回 application/pdf，预览 iframe 直接指向该路由 URL。兑现了根 README 与包 README 宣称的 PDF 预览能力。

## 涉及包（Affected Packages）

- [x] 右侧面板 `packages/dsh-aionui-panel`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

git fetch upstream && git switch -c fix/aionui-panel-pdf-preview upstream/main（base: 3647a33，含 v0.1.16）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek

使用的编码 Agent 工具：

DeepSeek Harness（含 AgentTeams 子代理辅助测试）

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本次无新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改 README：修复后代码行为与既有 README 宣称一致，文档无需变更）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel build
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test   # vitest run
pnpm typecheck   # 全仓
pnpm docs:check
```

结果摘要：

- aionui-panel vitest：149 pass / 1 skip / 2 fail。2 个失败为既有用例（host-fixes.spec.ts 两个 symlink escape 用例），在本 Windows 机器上创建符号链接需要 Developer Mode/管理员权限，与本次改动无关（改动不涉及 FsService 的 symlink 处理；CI Linux 环境预期通过）。
- 全仓 typecheck：10 包全部通过。
- pnpm docs:check：all documentation gates passed。
- 新增测试：pdfPreviewUrl 编码用例（pure.spec.ts）、pdf tab 经 raw 路由加载且不调 /read、reloadTab 刷新 nonce（stores.spec.ts）、readRaw 对 .pdf 返回 application/pdf（扩展名与 %PDF 魔数）（host-fixes.spec.ts）。

## 用户可见变更证据（Local Feature Evidence）

证据：

修复前（issue #239 截图）：PDF tab 显示「文件过大，仅加载前 80,000 字符」+「此格式暂不支持预览」。

修复后（本地构建经 junction 挂接到 dsh web profile 实测）：

![修复后 PDF 正常内嵌预览](https://raw.githubusercontent.com/EricWang1358/dsh-web-ui/issue-assets/.github/issue-assets/pdf-preview-fixed.png)

- 本地加载的插件为本 PR 构建产物（profile node_modules junction 到本分支 packages/dsh-aionui-panel）
- 文件树点击 .pdf 后预览面板 iframe 内嵌渲染 PDF，无大小截断提示（流式读取，无 8MB IMAGE_CAP_BYTES 上限）
- 工具栏刷新/下载可用
