### PR TITLE
fix(git-graph): improve stock light branch feedback

### DIFF
--- a/packages/dsh-git-graph/src/client/chips/BranchChip.tsx
+++ b/packages/dsh-git-graph/src/client/chips/BranchChip.tsx
@@ -36,6 +36,39 @@ const HERO_CHIP_GAP = 2
 /** Minimum gap between window-focus git refetches (ms). */
 export const FOCUS_REFRESH_MIN_MS = 5_000
 
+const SKIN_CENTER_BODY_ATTR = 'data-dsh-skin-center'
+const DARK_THEME_BODY_ATTR = 'data-ds-dark-theme'
+const DSH_BODY_ATTR_PREFIX = 'data-dsh-'
+
+/** Whether a body attribute belongs to an applied skin rather than the skin center shell. */
+function hasAppliedSkinBodyAttr(name: string): boolean {
+  return name.startsWith(DSH_BODY_ATTR_PREFIX) && name !== SKIN_CENTER_BODY_ATTR
+}
+
+/** Whether the page is using the unskinned stock light theme. */
+function readStockLightTheme(): boolean {
+  if (typeof document === 'undefined') return false
+  const body = document.body
+  if (!body.hasAttribute(SKIN_CENTER_BODY_ATTR) || body.hasAttribute(DARK_THEME_BODY_ATTR)) return false
+  return !body.getAttributeNames().some(hasAppliedSkinBodyAttr)
+}
+
+/** Track stock-light theme changes from body attributes. */
+function useStockLightTheme(): boolean {
+  const [stockLightTheme, setStockLightTheme] = useState(readStockLightTheme)
+
+  useEffect(() => {
+    const update = (): void => { setStockLightTheme(readStockLightTheme()) }
+    update()
+    if (typeof document === 'undefined' || typeof MutationObserver !== 'function') return undefined
+    const observer = new MutationObserver(update)
+    observer.observe(document.body, { attributes: true })
+    return () => { observer.disconnect() }
+  }, [])
+
+  return stockLightTheme
+}
+
 /**
  * The right edge of the rightmost painted descendant of `root`, excluding
  * `root` itself. The hero row's direct children can be display:contents
@@ -113,6 +146,7 @@ export function BranchChip(props: BranchChipProps) {
   // lists as blank in the session store, so it may enter the hero row before
   // the composer snapshot settles to `open`.
   const heroSeat = sessionSnapshot?.composerPhase === 'blank' && (sessionSnapshot.openState === 'open' || blankSession === true)
+  const stockLightTheme = useStockLightTheme()
 
   /** Repository state: undefined = loading, null = not a repository, else the snapshot. */
   const [repo, setRepo] = useState<RepoStatus | null | undefined>(undefined)
@@ -260,6 +294,7 @@ export function BranchChip(props: BranchChipProps) {
     <div
       ref={anchorRef}
       data-gitgraph-chip-anchor
+      data-gitgraph-stock-light={stockLightTheme || undefined}
       className={cx(css.anchor, dockSeat && css.anchorDock, heroSeat && css.anchorHero)}
       style={
         heroSeat && heroPlacement !== null

--- a/packages/dsh-git-graph/src/client/chips/context.module.css
+++ b/packages/dsh-git-graph/src/client/chips/context.module.css
@@ -1,5 +1,6 @@
 /* Branch selector chip in the conversation header context hole.
-   Tokens only — no literal colors. */
+   Tokens by default; the stock-light fallback defines a small literal
+   palette because the unskinned shell tokens are too low-contrast. */
 
 .anchor {
   position: relative;
@@ -17,7 +18,11 @@
    component measures the real card edge and applies it inline so the chip
    starts exactly where the input card starts in every phase. */
 .anchorDock {
+  --gitgraph-dock-gap-tighten: -8px;
   padding-left: var(--dsh-composer-side-clearance, 16px);
+  /* The fallback dock row sits above the input card; this keeps its visual
+     gap compact without moving the hero row. */
+  margin-bottom: var(--gitgraph-dock-gap-tighten);
 }
 
 /* Hero phase: leave the dock row and join the official hero chip row. The
@@ -631,6 +636,31 @@
 .graphRefCurrent {
   background: var(--dsw-alias-brand-primary);
   color: var(--dsw-alias-button-contrast-fill);
+}
+
+/* Stock light fallback: BranchChip marks the unskinned light page at
+   runtime. */
+[data-gitgraph-chip-anchor][data-gitgraph-stock-light] {
+  --gitgraph-stock-ink-rgb: 15, 17, 21;
+  --gitgraph-stock-ink: #0f1115;
+  --gitgraph-stock-on-success: #ffffff;
+  --gitgraph-stock-success-fill: #137333;
+  --gitgraph-stock-success-border: #0f5f2b;
+  --dsw-alias-button-tool-bar-fill: rgba(var(--gitgraph-stock-ink-rgb), 0.04);
+  --dsw-alias-button-tool-bar-hover: rgba(var(--gitgraph-stock-ink-rgb), 0.08);
+  --dsw-alias-border-l2: rgba(var(--gitgraph-stock-ink-rgb), 0.16);
+  --dsw-alias-interactive-bg-hover: rgba(var(--gitgraph-stock-ink-rgb), 0.06);
+  --dsw-alias-interactive-bg-active: rgba(var(--gitgraph-stock-ink-rgb), 0.1);
+  --dsw-alias-label-primary: var(--gitgraph-stock-ink);
+  --dsw-alias-label-secondary: var(--gitgraph-stock-ink);
+  --dsw-alias-label-tertiary: rgba(var(--gitgraph-stock-ink-rgb), 0.56);
+  --dsw-alias-button-contrast-fill: var(--gitgraph-stock-on-success);
+}
+
+[data-gitgraph-chip-anchor][data-gitgraph-stock-light] .noticeOk {
+  background: var(--gitgraph-stock-success-fill);
+  color: var(--gitgraph-stock-on-success);
+  box-shadow: inset 0 0 0 1px var(--gitgraph-stock-success-border);
 }
 
 .graphEmpty {

--- a/packages/dsh-git-graph/tests/client.spec.tsx
+++ b/packages/dsh-git-graph/tests/client.spec.tsx
@@ -8,7 +8,7 @@
  * the create/graph dialogs behave (validation, duplicate copy, lane
  * rendering).
  */
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { SessionId } from '@deepseek-ai/dsh-client-runtime/client'
 import type { BranchesView, GraphView, RepoStatus, SwitchResult } from '../src/core/types.ts'
@@ -17,7 +17,12 @@ import type { BranchChipProps } from '../src/client/chips/BranchChip.tsx'
 import { BranchChip } from '../src/client/chips/BranchChip.tsx'
 import { zh, type GitGraphKey } from '../src/client/locales.ts'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  for (const name of document.body.getAttributeNames()) {
+    if (name.startsWith('data-dsh-') || name === 'data-ds-dark-theme') document.body.removeAttribute(name)
+  }
+})
 
 const sid = (value: string): SessionId => value as SessionId
 
@@ -156,6 +161,23 @@ describe('BranchChip', () => {
     bench()
     const branchChip = await screen.findByRole('button', { name: '分支' })
     expect(branchChip.textContent).toContain('main')
+  })
+
+  it('marks only the unskinned light skin-center page for stock-light fallback styles', async () => {
+    document.body.setAttribute('data-dsh-skin-center', '')
+    bench()
+    const branchChip = await screen.findByRole('button', { name: '分支' })
+    const anchor = anchorOf(branchChip)
+    expect(anchor.getAttribute('data-gitgraph-stock-light')).toBe('true')
+
+    act(() => { document.body.setAttribute('data-dsh-xp', '') })
+    await waitFor(() => { expect(anchor.hasAttribute('data-gitgraph-stock-light')).toBe(false) })
+
+    act(() => { document.body.removeAttribute('data-dsh-xp') })
+    await waitFor(() => { expect(anchor.getAttribute('data-gitgraph-stock-light')).toBe('true') })
+
+    act(() => { document.body.setAttribute('data-ds-dark-theme', '') })
+    await waitFor(() => { expect(anchor.hasAttribute('data-gitgraph-stock-light')).toBe(false) })
   })
 
   it('keeps the branch chip in a blank (hero) session — the selector row stays docked', async () => {


### PR DESCRIPTION
## 摘要（Summary）

- 修复默认明亮模式下 Git 分支 chip 和切换成功提示的低对比度问题。
- 为默认明亮模式增加 stock-light 运行时标记，避免颜色覆盖影响其他主题；分支 chip 下边距收紧作为通用布局优化。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [x] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin upstream
git branch -f main upstream/main
git push --force-with-lease=main:ae0be009a1bc8ac50be9f36fe8cc22277cd82069 origin upstream/main:main
git branch --set-upstream-to=origin/main main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5.5

使用的编码 Agent 工具：

DeepSeek Harness / Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README / docs）。

## 贡献者版权声明（Contributor Copyright）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-git-graph test
pnpm --filter @linxin666/dsh-client-ui-git-graph build
```

结果摘要：

- `vitest run`：5 个测试文件、77 个测试通过。
- `tsc -b && tsdown`：构建通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

- 使用 ego-browser 在 DSH Web GUI 默认明亮模式下回归验证。
- 分支 chip 命中 `data-gitgraph-stock-light="true"`。
- 点击当前分支触发成功提示 `已切换到分支 main`，提示元素 `_notice _noticeOk` 的 computed style 为：背景 `rgb(19, 115, 51)`、文字 `rgb(255, 255, 255)`、内描边 `rgb(15, 95, 43)`、对比度 `5.95:1`。
- 当前分支列表项保持普通选中态，未被改为绿底白字；分支 chip 到输入框间距约 `15px`。

<img width="282" height="244" alt="gitgraph-stock-light-evidence-redacted-cropped" src="https://github.com/user-attachments/assets/a0793904-4aa5-403c-8d5b-cba675c879d9" />
