### PR TITLE
fix(live-stats): keep projection checkpoint state lossless JSON

### DIFF
--- a/packages/dsh-live-stats/src/estimator.ts
+++ b/packages/dsh-live-stats/src/estimator.ts
@@ -150,12 +150,12 @@ export function estimateMessageTokens(message: Message, spec: EstimatorSpec): nu
 }
 
 /** Estimate the system prompt and tool schemas carried outside the surface.
- * @param header - the epoch header, or undefined when none was recorded.
+ * @param header - the epoch header, or null when none was recorded.
  * @param spec - resolved estimator settings.
  * @returns the estimated token count (zero for an absent header).
  */
-export function estimateHeaderTokens(header: EpochHeader | undefined, spec: EstimatorSpec): number {
-  if (header === undefined) return 0
+export function estimateHeaderTokens(header: EpochHeader | null, spec: EstimatorSpec): number {
+  if (header === undefined || header === null) return 0
   let tokens = 0
   if (header.system !== undefined) {
     tokens += Math.ceil(header.system.length / spec.charsPerToken) + spec.roleOverhead

--- a/packages/dsh-live-stats/src/projection.ts
+++ b/packages/dsh-live-stats/src/projection.ts
@@ -64,7 +64,10 @@ interface ActiveStep {
   step: number
   buckets: TokenUsageProjection
   exact: boolean
-  blocks: Array<OutputBlock | undefined>
+  /** Priced blocks by stream index. A plain record — never a sparse array —
+   *  so the persisted projection checkpoint stays lossless JSON even when
+   *  the model emits deltas at far-apart indices. */
+  blocks: Record<number, OutputBlock>
   /** Running sum of the per-block estimates of every non-undefined block. */
   pricedTokens: number
   /** Count of non-undefined blocks (guards the role overhead and zero case). */
@@ -78,8 +81,9 @@ interface SettledSample {
   step: number
   buckets: TokenUsageProjection
   estimated: boolean
-  /** Last measured throughput; carried across rate-less steps. */
-  tokensPerSecond: number | undefined
+  /** Last measured throughput; carried across rate-less steps (`null` when
+   *  none was ever measured, so the checkpoint stays lossless JSON). */
+  tokensPerSecond: number | null
 }
 
 interface State {
@@ -87,9 +91,9 @@ interface State {
   settledEstimates: number
   last: SettledSample | null
   /** Surface message seq -> estimated tokens, kept in increasing seq order. */
-  surface: Map<number, number>
+  surface: Record<number, number>
   surfaceTokens: number
-  header: EpochHeader | undefined
+  header: EpochHeader | null
   active: ActiveStep | null
 }
 
@@ -110,29 +114,34 @@ function applySurface(
 ): Pick<State, 'surface' | 'surfaceTokens'> {
   const tokens = estimateMessageTokens(surfaceMessage(event), spec)
   if (event.surfaceOp === 'append') {
-    state.surface.set(event.seq, tokens)
+    state.surface[event.seq] = tokens
     return {
       surface: state.surface,
       surfaceTokens: state.surfaceTokens + tokens,
     }
   }
   const operation = event.surfaceOp
-  if (!state.surface.has(operation.start) || !state.surface.has(operation.end) || operation.start > operation.end) {
+  if (
+    !Object.prototype.hasOwnProperty.call(state.surface, operation.start)
+    || !Object.prototype.hasOwnProperty.call(state.surface, operation.end)
+    || operation.start > operation.end
+  ) {
     throw new Error(
       'live-stats: replace at seq ' + event.seq + ' has invalid current range ' + operation.start + '-' + operation.end,
     )
   }
-  // Keys enter in increasing seq order (appends grow, and a replace's own
-  // seq is always the newest), so one pass with an early exit removes the
-  // exact range. Deleting entries while iterating a Map is safe.
+  // Seq keys enter in increasing order (appends grow, and a replace's own seq
+  // is always the newest), and integer-like object keys enumerate in ascending
+  // numeric order, so one pass with an early exit removes the exact range.
   let removed = 0
-  for (const [seq, nodeTokens] of state.surface) {
+  for (const seqKey of Object.keys(state.surface)) {
+    const seq = Number(seqKey)
     if (seq < operation.start) continue
     if (seq > operation.end) break
-    removed += nodeTokens
-    state.surface.delete(seq)
+    removed += state.surface[seq]
+    delete state.surface[seq]
   }
-  state.surface.set(event.seq, tokens)
+  state.surface[event.seq] = tokens
   return {
     surface: state.surface,
     surfaceTokens: state.surfaceTokens - removed + tokens,
@@ -226,7 +235,7 @@ function exactStep(step: ActiveStep, usage: TokenUsage, time: number): ActiveSte
     exact: true,
     // The exact usage supersedes every block priced from streamed deltas;
     // retain only the exact buckets so later deltas cannot re-estimate.
-    blocks: [],
+    blocks: {},
     pricedTokens: 0,
     pricedBlocks: 0,
     ...(usage.outputTokens > 0
@@ -253,8 +262,8 @@ function view(state: State): LiveTokenUsageProjection {
   // step before its first chunk) and after a rate-less step settles — the
   // stats band must not flicker while the other groups stay put.
   const rate = active === null
-    ? state.last?.tokensPerSecond
-    : rateOf(active) ?? state.last?.tokensPerSecond
+    ? state.last?.tokensPerSecond ?? undefined
+    : rateOf(active) ?? state.last?.tokensPerSecond ?? undefined
   return {
     ...buckets,
     estimated: estimates > 0,
@@ -276,9 +285,9 @@ export function createLiveTokenUsageProjectionDefinition(
       settled: zeroBuckets(),
       settledEstimates: 0,
       last: null,
-      surface: new Map(),
+      surface: {},
       surfaceTokens: 0,
-      header: undefined,
+      header: null,
       active: null,
     }),
     apply: (state, event: SessionEvent) => {
@@ -293,7 +302,7 @@ export function createLiveTokenUsageProjectionDefinition(
               uncachedInputTokens: estimateHeaderTokens(state.header, spec) + state.surfaceTokens,
             },
             exact: false,
-            blocks: [],
+            blocks: {},
             pricedTokens: 0,
             pricedBlocks: 0,
           },
@@ -360,7 +369,7 @@ export function createLiveTokenUsageProjectionDefinition(
             estimated: !active.exact,
             // Carry the last measured rate across a rate-less step instead of
             // clobbering it: the row stays resident (see view()).
-            tokensPerSecond: rate ?? state.last?.tokensPerSecond,
+            tokensPerSecond: rate ?? state.last?.tokensPerSecond ?? null,
           },
           active: null,
         }

--- a/packages/dsh-live-stats/tests/projection.spec.ts
+++ b/packages/dsh-live-stats/tests/projection.spec.ts
@@ -611,8 +611,7 @@ describe('liveTokenUsage projection', () => {
     if (final === null) throw new Error('active step is absent')
     const rescan = (): number => {
       const tokens: number[] = []
-      for (const block of final.blocks) {
-        if (block === undefined) continue
+      for (const block of Object.values(final.blocks)) {
         tokens.push(block.kind === 'text' || block.kind === 'reasoning'
           ? estimateTextBlockTokens(block.characters, spec)
           : block.kind === 'tool-call'
@@ -639,9 +638,9 @@ describe('liveTokenUsage projection', () => {
     state = definition.apply(state, surfaceEvent(1, 'one', 'append'))
     state = definition.apply(state, surfaceEvent(2, 'two', 'append'))
     state = definition.apply(state, surfaceEvent(3, 'three', { op: 'replace', start: 1, end: 2 }))
-    expect(state.surface.has(1)).toBe(false)
-    expect(state.surface.has(2)).toBe(false)
-    expect(state.surface.has(3)).toBe(true)
+    expect(Object.prototype.hasOwnProperty.call(state.surface, 1)).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(state.surface, 2)).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(state.surface, 3)).toBe(true)
     expect(state.surfaceTokens).toBe(estimateMessageTokens(
       createUserMessage({ content: [{ type: 'text', text: 'three' }], source: { kind: 'user' } }),
       spec,
@@ -651,4 +650,87 @@ describe('liveTokenUsage projection', () => {
     expect(() => definition.apply(state, surfaceEvent(4, 'bad', { op: 'replace', start: 3, end: 99 })))
       .toThrow('invalid current range')
   })
+
+  it('keeps the projection state losslessly JSON-serializable across a stress stream', () => {
+    const spec = resolveEstimatorConfig({})
+    const definition = createLiveTokenUsageProjectionDefinition(spec)
+    let state = definition.init()
+    const apply = (event: SessionEvent): void => { state = definition.apply(state, event) }
+    expect(() => assertLosslessJson(state)).not.toThrow()
+
+    // Header before any step, then a step whose deltas land at a far-apart
+    // index (a sparse blocks layout under the old array representation).
+    apply({
+      type: 'request/header',
+      time: 1,
+      data: { header: { config: { provider: 'mock', model: 'mock' }, system: 'abcd' }, reason: 'initial' },
+    } as unknown as SessionEvent)
+    apply({ type: 'step/start', time: 2, data: { turn: 1, step: 1 } } as unknown as SessionEvent)
+    apply({
+      type: 'assistant/chunk',
+      time: 3,
+      data: { turn: 1, step: 1, chunk: { type: 'text-delta', index: 7, text: 'sparse' } },
+    } as unknown as SessionEvent)
+    // Mid-stream: the active step holds priced blocks.
+    expect(() => assertLosslessJson(state)).not.toThrow()
+
+    // A rate-less step settles with no measured throughput: the carried
+    // tokensPerSecond must be null, never undefined.
+    apply({ type: 'step/end', time: 4, data: { turn: 1, step: 1 } } as unknown as SessionEvent)
+    expect(state.last?.tokensPerSecond).toBeNull()
+    expect(() => assertLosslessJson(state)).not.toThrow()
+
+    // Surface appends plus a range replace exercise the plain-object map.
+    const surfaceEvent = (seq: number, text: string, surfaceOp: unknown): SessionEvent => ({
+      type: 'user/message',
+      seq,
+      time: 5,
+      data: createUserMessage({ content: [{ type: 'text', text }], source: { kind: 'user' } }),
+      surfaceOp,
+    } as unknown as SessionEvent)
+    apply(surfaceEvent(1, 'one', 'append'))
+    apply(surfaceEvent(2, 'two', 'append'))
+    apply(surfaceEvent(3, 'three', { op: 'replace', start: 1, end: 2 }))
+    expect(() => assertLosslessJson(state)).not.toThrow()
+
+    // The persisted-checkpoint contract: a lossless JSON round trip.
+    expect(JSON.parse(JSON.stringify(state))).toEqual(state)
+  })
 })
+
+/**
+ * Assert the DSH session-projection checkpoint contract: every value must
+ * survive a lossless JSON round trip (no undefined, no non-finite or -0
+ * numbers, no sparse arrays, no exotic objects such as Map/Set/Date, and no
+ * class instances). A violation here would poison the persisted projection
+ * cache checkpoint for the whole session.
+ */
+function assertLosslessJson(value: unknown, path = '$'): void {
+  if (value === null) return
+  if (value === undefined) throw new Error(`lossless JSON violation: undefined at ${path}`)
+  const type = typeof value
+  if (type === 'number') {
+    if (!Number.isFinite(value)) throw new Error(`lossless JSON violation: non-finite number at ${path}`)
+    if (Object.is(value, -0)) throw new Error(`lossless JSON violation: negative zero at ${path}`)
+    return
+  }
+  if (type === 'string' || type === 'boolean') return
+  if (type === 'bigint' || type === 'function' || type === 'symbol') {
+    throw new Error(`lossless JSON violation: ${type} at ${path}`)
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (!(i in value)) throw new Error(`lossless JSON violation: sparse array at ${path}[${i}]`)
+      assertLosslessJson(value[i], `${path}[${i}]`)
+    }
+    return
+  }
+  if (value instanceof Map || value instanceof Set || value instanceof Date) {
+    throw new Error(`lossless JSON violation: ${value.constructor.name} at ${path}`)
+  }
+  const proto = Object.getPrototypeOf(value)
+  if (proto !== Object.prototype && proto !== null) {
+    throw new Error(`lossless JSON violation: non-plain object (${(value as object).constructor?.name}) at ${path}`)
+  }
+  for (const [key, child] of Object.entries(value)) assertLosslessJson(child, `${path}.${key}`)
+}


### PR DESCRIPTION
## 摘要（Summary）

`liveTokenUsage` 投影单元的 checkpoint state 不是纯 JSON（`surface: Map`、`header: undefined`、流式时稀疏 `blocks` 数组、`last.tokensPerSecond: undefined`），违反 DSH 投影单元契约，导致整个会话的投影缓存记录（含 title）写入失败（fail-soft 静默）。DSH 重启后冷会话侧边栏标题丢失、回退为工作区目录名。本 PR 将全部 checkpoint 字段改为纯 JSON 形态，并新增无损 JSON 往返回归测试。

## 涉及包（Affected Packages）

- [x] 实时令牌统计 `packages/dsh-live-stats`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 仅文档
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch origin && git rebase origin/main`（已确认分支包含最新 origin/main）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（未改动 README）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-live-stats test
pnpm --filter @linxin666/dsh-live-stats typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-live-stats test`：25/25 通过（projection.spec.ts 14 项，含新增「压力流之后 state 可无损 JSON 往返」回归测试）
- typecheck 通过
- 本机实装验证：修复后投影缓存恢复写入（此前 21 小时无任何落盘），DSH 重启后 18 个冷会话标题全部恢复

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（内部状态序列化修复，无新增用户界面；行为影响为恢复既有标题显示，已由本地实装验证与回归测试覆盖）
