### PR TITLE
feat(dsh-live-stats): TPS 行与官方统计行合并为一行，hover 气泡加宽

### DIFF
--- a/packages/dsh-live-stats/src/client/TpsLine.tsx
+++ b/packages/dsh-live-stats/src/client/TpsLine.tsx
@@ -21,21 +21,22 @@ const STYLE = {
   fontSize: '12px',
   fontVariantNumeric: 'tabular-nums',
   lineHeight: '20px',
-  margin: '0 auto',
-  maxWidth: 'var(--dsh-chat-content-width)',
-  overflow: 'hidden',
-  padding: '0 var(--dsh-composer-side-clearance)',
-  textAlign: 'center',
-  textOverflow: 'ellipsis',
+  // 注意：不要在这里设置 overflow，合并样式表需要 overflow: visible
+  // 让零高度的 TPS 行内容上浮到官方统计行。
+  padding: '4px 0 0',
   whiteSpace: 'nowrap',
-  width: '100%',
 } as const
 
-/** Second composer-status line for active or latest response throughput. */
+/**
+ * Second composer-status line for active or latest response throughput.
+ * The root carries `data-dsh-live-tps`: the merge stylesheet (merge-css.ts)
+ * anchors on it to pull this row onto the same line as the official
+ * StatsLine, which renders right before it in the composer dock.
+ */
 export const TpsLine = memo(function TpsLine({ useProjection }: TpsLineProps) {
   const rate = useProjection('liveTokenUsage')?.tokensPerSecond
   if (rate === undefined) return null
-  return <div style={STYLE}>TPS {formatTokensPerSecond(rate)} tok/s</div>
+  return <div data-dsh-live-tps style={STYLE}>TPS {formatTokensPerSecond(rate)} tok/s</div>
 })
 
 /**

--- a/packages/dsh-live-stats/src/client/TpsLine.tsx
+++ b/packages/dsh-live-stats/src/client/TpsLine.tsx
@@ -21,8 +21,8 @@ const STYLE = {
   fontSize: '12px',
   fontVariantNumeric: 'tabular-nums',
   lineHeight: '20px',
-  // 注意：不要在这里设置 overflow，合并样式表需要 overflow: visible
-  // 让零高度的 TPS 行内容上浮到官方统计行。
+  // 注意：不要在这里设置 overflow——合并样式表依赖常规行内盒；截断由
+  // 官方统计行自己的 nowrap + ellipsis 承担。
   padding: '4px 0 0',
   whiteSpace: 'nowrap',
 } as const
@@ -32,11 +32,16 @@ const STYLE = {
  * The root carries `data-dsh-live-tps`: the merge stylesheet (merge-css.ts)
  * anchors on it to pull this row onto the same line as the official
  * StatsLine, which renders right before it in the composer dock.
+ *
+ * The slot stays mounted even while no rate sample exists (renders empty):
+ * the merge layout keys on the slot's presence, so unmounting it on idle
+ * would flip the official stats row between content width and full width on
+ * every stream start or end.
  */
 export const TpsLine = memo(function TpsLine({ useProjection }: TpsLineProps) {
   const rate = useProjection('liveTokenUsage')?.tokensPerSecond
-  if (rate === undefined) return null
-  return <div data-dsh-live-tps style={STYLE}>TPS {formatTokensPerSecond(rate)} tok/s</div>
+  const label = rate === undefined ? '' : `TPS ${formatTokensPerSecond(rate)} tok/s`
+  return <div data-dsh-live-tps style={STYLE}>{label}</div>
 })
 
 /**

--- a/packages/dsh-live-stats/src/client/index.ts
+++ b/packages/dsh-live-stats/src/client/index.ts
@@ -7,6 +7,7 @@ import type {} from '@deepseek-ai/dsh-client-ui-conversation/client'
 import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
 import type {} from '@deepseek-ai/dsh-token-meter/client'
 import { LiveStatsSettingsCard, LiveStatsSettingsCardController, type LiveStatsSettings } from './LiveStatsSettingsCard.tsx'
+import { ensureMergeCss } from './merge-css.ts'
 import { TpsLineDockEntry } from './TpsLine.tsx'
 import { en, zh, type SettingsCardKey } from './locales.ts'
 
@@ -66,6 +67,11 @@ export const inject = ['slots', 'locale', 'connection', 'settingsScope', 'remote
  */
 export function apply(ctx: ClientContext): void {
   ctx.effect(() => ctx.locale.register(NS, { zh, en }), 'live-stats: dictionaries')
+
+  // Merge stylesheet: pulls the TPS row onto the official StatsLine's row
+  // (see merge-css.ts). Injected once; rules are :has()-anchored on the TPS
+  // row, so nothing changes while it is unmounted.
+  ensureMergeCss()
 
   // Plugin configuration card: one staged form over the `live-stats` settings
   // namespace, contributed to the plugin-configuration section.

--- a/packages/dsh-live-stats/src/client/merge-css.ts
+++ b/packages/dsh-live-stats/src/client/merge-css.ts
@@ -1,20 +1,27 @@
 /**
- * Stylesheet that merges the live TPS row into the official StatsLine row —
+ * Stylesheet that merges the live TPS slot into the official StatsLine row —
  * always on ONE line, no wrapping at any width.
  *
  * The composer dock (`conversation.composer.dock`) is a list slot: every
  * registered entry renders, and the renderer emits them inside a wrapper —
  * `<div data-slot="conversation.composer.dock" style="display: contents">`.
- * The merge turns that wrapper into a horizontal flex row (the inline
- * `display: contents` is overridden with `!important`, which only affects
- * layout — the wrapper still carries no visual box), so the official
- * StatsLine and the TPS sit side by side as one compact, centered unit:
+ * While the TPS slot is mounted the merge turns that wrapper into a
+ * horizontal flex row (the inline `display: contents` is overridden with
+ * `!important`, which only affects layout — the wrapper still carries no
+ * visual box), so the official StatsLine and the TPS sit side by side as one
+ * compact, centered unit:
  *
- * - the official row shrinks to its content width (capped so the merged
- *   line stays compact; its own `white-space: nowrap` + ellipsis handle the
- *   rest — the row can never wrap);
- * - the TPS row is a fixed-width item right after it, separated by a `·`
- *   in the official separator style.
+ * - the official row shrinks to its content width (capped at 620px so the
+ *   merged line stays compact even on very wide docks; its own
+ *   `white-space: nowrap` + ellipsis handle the rest — the row can never
+ *   wrap);
+ * - the TPS slot is a fixed-width item right after it, separated by a `·`
+ *   in the official separator style (hidden while the slot has no content).
+ *
+ * The TPS slot stays mounted even when no rate sample exists yet (it renders
+ * empty instead of unmounting), so the merged layout — and the official
+ * row's width — never flips between content width and full width when a
+ * stream starts or ends.
  *
  * Selector notes (all verified against the real rendered DOM):
  * - the slot renderer wraps entries in `div[data-slot="conversation.composer.dock"]`,
@@ -22,13 +29,14 @@
  *   wrapper;
  * - nested `:has()` (a `:has()` whose argument contains another `:has()`
  *   with a combinator) fails to parse and the whole rule is silently dropped
- *   by the engine, so the merge uses flat selectors only: `*:has(+ ...)` for
- *   the official row (find the element right before the TPS) and the plain
- *   sibling combinator `* + [data-dsh-live-tps]` for the TPS row.
+ *   by the engine, so the merge uses flat selectors only: `:has(> ...)` on
+ *   the wrapper (scoping the merge to the moment the TPS slot is mounted)
+ *   and the plain sibling combinator `* + [data-dsh-live-tps]` for the slot.
  *
- * When only one of the two entries is present the rules degrade gracefully:
- * the official row alone keeps its original full-width look (the stats rule
- * does not match), and the TPS alone stays visible and centered.
+ * When the plugin is inactive the slot does not exist and no merge rule
+ * matches: the dock keeps its original full-width look. While the slot is
+ * mounted but the official row is absent, the TPS alone stays visible and
+ * centered.
  */
 export const MERGE_CSS = `
 /* 官方行缺席时的兜底：TPS 独立成行、居中 */
@@ -37,11 +45,11 @@ export const MERGE_CSS = `
 }
 
 /* ── 合并：官方统计行 + 实时 TPS 恒为一行 ──
-   把渲染器的槽位包装层（内联 display: contents）覆盖为横向 flex 行：
-   两个条目并排、整体居中、永不换行。仅官方行时它保持原样
-   （官方行 width:100% 填满整行，视觉不变）。 */
+   仅当 TPS 槽位存在（插件激活）时，把渲染器的槽位包装层（内联
+   display: contents）覆盖为横向 flex 行：两个条目并排、整体居中、
+   永不换行。插件未激活时此规则不匹配，官方行保持原样。 */
 
-div[data-slot="conversation.composer.dock"] {
+div[data-slot="conversation.composer.dock"]:has(> [data-dsh-live-tps]) {
   display: flex !important;
   flex-direction: row;
   flex-wrap: nowrap;
@@ -51,31 +59,38 @@ div[data-slot="conversation.composer.dock"] {
   box-sizing: border-box;
 }
 
-/* 官方行：收缩为内容宽度（上限 min(620px, 容器-150px)，行窄时省略截断）；
-   清掉官方 margin/padding 的横向占位，保留 4px 上内边距与文字行高对齐。
+/* 官方行：收缩为内容宽度（上限 620px）；清掉官方 margin/padding 的横向
+   占位，保留 4px 上内边距与文字行高对齐。极窄容器下由 flex 收缩
+   （0 1 auto + min-width: 0 + 省略号）让位给 TPS 槽位，无需负值
+   max-width 兜底。
    hover/focus 时官方 Tooltip 会把气泡 span 插到统计行与 TPS 之间
    （DOM: [统计行, span[role=tooltip], TPS]），所以同时匹配两种相邻形态：
    「下一兄弟是 TPS」或「下一兄弟是气泡、再下一兄弟是 TPS」，
    否则气泡一出现统计行就回退官方样式、变宽把 TPS 挤走。 */
 div[data-slot="conversation.composer.dock"] > *:not([role="tooltip"]):has(+ [data-dsh-live-tps], + [role="tooltip"] + [data-dsh-live-tps]) {
   width: auto;
-  max-width: min(620px, calc(100% - 150px));
+  max-width: 620px;
   min-width: 0;
   margin: 0;
   padding: 4px 0 0;
   flex: 0 1 auto;
 }
 
-/* TPS：固定宽度条目，紧跟官方行 */
+/* TPS 槽位：固定宽度条目，紧跟官方行 */
 div[data-slot="conversation.composer.dock"] > * + [data-dsh-live-tps] {
   flex: 0 0 auto;
 }
 
-/* 与官方行同风格的分隔符（仅合并态显示） */
+/* 与官方行同风格的分隔符（仅合并态、且槽位有内容时显示） */
 div[data-slot="conversation.composer.dock"] > * + [data-dsh-live-tps]::before {
   content: '\\B7';
   color: var(--dsw-alias-separator-primary);
   margin: 0 10px;
+}
+
+/* 无速率样本时槽位为空：隐藏分隔符，保持布局稳定 */
+div[data-slot="conversation.composer.dock"] > * + [data-dsh-live-tps]:empty::before {
+  content: none;
 }
 
 /* 官方行 hover 的 Tooltip 气泡：按内容宽度单行显示（官方默认最大

--- a/packages/dsh-live-stats/src/client/merge-css.ts
+++ b/packages/dsh-live-stats/src/client/merge-css.ts
@@ -1,0 +1,101 @@
+/**
+ * Stylesheet that merges the live TPS row into the official StatsLine row —
+ * always on ONE line, no wrapping at any width.
+ *
+ * The composer dock (`conversation.composer.dock`) is a list slot: every
+ * registered entry renders, and the renderer emits them inside a wrapper —
+ * `<div data-slot="conversation.composer.dock" style="display: contents">`.
+ * The merge turns that wrapper into a horizontal flex row (the inline
+ * `display: contents` is overridden with `!important`, which only affects
+ * layout — the wrapper still carries no visual box), so the official
+ * StatsLine and the TPS sit side by side as one compact, centered unit:
+ *
+ * - the official row shrinks to its content width (capped so the merged
+ *   line stays compact; its own `white-space: nowrap` + ellipsis handle the
+ *   rest — the row can never wrap);
+ * - the TPS row is a fixed-width item right after it, separated by a `·`
+ *   in the official separator style.
+ *
+ * Selector notes (all verified against the real rendered DOM):
+ * - the slot renderer wraps entries in `div[data-slot="conversation.composer.dock"]`,
+ *   so the entries are its direct children — selectors must anchor on the
+ *   wrapper;
+ * - nested `:has()` (a `:has()` whose argument contains another `:has()`
+ *   with a combinator) fails to parse and the whole rule is silently dropped
+ *   by the engine, so the merge uses flat selectors only: `*:has(+ ...)` for
+ *   the official row (find the element right before the TPS) and the plain
+ *   sibling combinator `* + [data-dsh-live-tps]` for the TPS row.
+ *
+ * When only one of the two entries is present the rules degrade gracefully:
+ * the official row alone keeps its original full-width look (the stats rule
+ * does not match), and the TPS alone stays visible and centered.
+ */
+export const MERGE_CSS = `
+/* 官方行缺席时的兜底：TPS 独立成行、居中 */
+[data-dsh-live-tps] {
+  align-self: center;
+}
+
+/* ── 合并：官方统计行 + 实时 TPS 恒为一行 ──
+   把渲染器的槽位包装层（内联 display: contents）覆盖为横向 flex 行：
+   两个条目并排、整体居中、永不换行。仅官方行时它保持原样
+   （官方行 width:100% 填满整行，视觉不变）。 */
+
+div[data-slot="conversation.composer.dock"] {
+  display: flex !important;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* 官方行：收缩为内容宽度（上限 min(620px, 容器-150px)，行窄时省略截断）；
+   清掉官方 margin/padding 的横向占位，保留 4px 上内边距与文字行高对齐。
+   hover/focus 时官方 Tooltip 会把气泡 span 插到统计行与 TPS 之间
+   （DOM: [统计行, span[role=tooltip], TPS]），所以同时匹配两种相邻形态：
+   「下一兄弟是 TPS」或「下一兄弟是气泡、再下一兄弟是 TPS」，
+   否则气泡一出现统计行就回退官方样式、变宽把 TPS 挤走。 */
+div[data-slot="conversation.composer.dock"] > *:not([role="tooltip"]):has(+ [data-dsh-live-tps], + [role="tooltip"] + [data-dsh-live-tps]) {
+  width: auto;
+  max-width: min(620px, calc(100% - 150px));
+  min-width: 0;
+  margin: 0;
+  padding: 4px 0 0;
+  flex: 0 1 auto;
+}
+
+/* TPS：固定宽度条目，紧跟官方行 */
+div[data-slot="conversation.composer.dock"] > * + [data-dsh-live-tps] {
+  flex: 0 0 auto;
+}
+
+/* 与官方行同风格的分隔符（仅合并态显示） */
+div[data-slot="conversation.composer.dock"] > * + [data-dsh-live-tps]::before {
+  content: '\\B7';
+  color: var(--dsw-alias-separator-primary);
+  margin: 0 10px;
+}
+
+/* 官方行 hover 的 Tooltip 气泡：按内容宽度单行显示（官方默认最大
+   半视口宽，长统计文本会折行）；窄屏时受视口限制自动回退换行 */
+div[data-slot="conversation.composer.dock"] > [role="tooltip"] {
+  width: max-content;
+  max-width: calc(100vw - 32px);
+}
+`.trim()
+
+/** Injected-once guard for the merge stylesheet (one tag per page load). */
+let mergeCssInjected = false
+
+/** Inject the merge stylesheet once; no-op outside the browser or when already present. */
+export function ensureMergeCss(): void {
+  if (mergeCssInjected || typeof document === 'undefined') return
+  mergeCssInjected = true
+  if (document.querySelector('style[data-dsh-live-stats-merge]') !== null) return
+  const style = document.createElement('style')
+  style.dataset.dshLiveStatsMerge = ''
+  style.textContent = MERGE_CSS
+  document.head.appendChild(style)
+}

--- a/packages/dsh-live-stats/tests/tps-line.spec.tsx
+++ b/packages/dsh-live-stats/tests/tps-line.spec.tsx
@@ -3,9 +3,21 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { cleanup, render } from '@testing-library/react'
 import type { UseProjection } from '@deepseek-ai/dsh-client-runtime/client'
+import { ensureMergeCss, MERGE_CSS } from '../src/client/merge-css.ts'
 import { TpsLine, formatTokensPerSecond } from '../src/client/TpsLine.tsx'
 
 afterEach(cleanup)
+
+const live = ((key: string): unknown => key === 'liveTokenUsage'
+  ? {
+    estimated: true,
+    uncachedInputTokens: 10,
+    outputTokens: 8,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    tokensPerSecond: 42.64,
+  }
+  : undefined) as UseProjection
 
 describe('TPS composer line', () => {
   it('formats stable compact rates', () => {
@@ -20,17 +32,49 @@ describe('TPS composer line', () => {
     const view = render(<TpsLine useProjection={absent} />)
     expect(view.container.textContent).toBe('')
 
-    const live = ((key: string): unknown => key === 'liveTokenUsage'
-      ? {
-        estimated: true,
-        uncachedInputTokens: 10,
-        outputTokens: 8,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
-        tokensPerSecond: 42.64,
-      }
-      : undefined) as UseProjection
     view.rerender(<TpsLine useProjection={live} />)
     expect(view.container.textContent).toBe('TPS 42.6 tok/s')
+  })
+
+  it('anchors the row with the data-dsh-live-tps merge hook', () => {
+    const view = render(<TpsLine useProjection={live} />)
+    const row = view.container.querySelector('[data-dsh-live-tps]')
+    expect(row).not.toBeNull()
+    expect(row?.textContent).toBe('TPS 42.6 tok/s')
+  })
+})
+
+describe('TPS merge stylesheet', () => {
+  it('anchors on the dock wrapper with flat, parse-safe selectors', () => {
+    // The slot renderer wraps dock entries in div[data-slot="conversation.composer.dock"];
+    // nested :has() fails to parse (rules silently dropped), so the merge uses
+    // the plain sibling combinator for the TPS and a flat :has for the row.
+    expect(MERGE_CSS).not.toContain(':has(> *:has(')
+    expect(MERGE_CSS).toContain('div[data-slot="conversation.composer.dock"] > *:not([role="tooltip"]):has(+ [data-dsh-live-tps]')
+    // also matches when the official Tooltip bubble is inserted between the
+    // stats row and the TPS (hover/focus) — otherwise the row reverts to its
+    // official full-width styles and pushes the TPS away.
+    expect(MERGE_CSS).toContain('+ [role="tooltip"] + [data-dsh-live-tps]')
+    expect(MERGE_CSS).toContain('div[data-slot="conversation.composer.dock"] > * + [data-dsh-live-tps]')
+    // The wrapper becomes a horizontal flex row (overriding the renderer's
+    // inline display: contents), so the pair is one centered line.
+    expect(MERGE_CSS).toContain('display: flex !important')
+    expect(MERGE_CSS).toContain('flex-direction: row')
+    expect(MERGE_CSS).toContain('flex-wrap: nowrap')
+    expect(MERGE_CSS).toContain('justify-content: center')
+  })
+
+  it('never wraps: nowrap + capped official row that ellipsizes', () => {
+    expect(MERGE_CSS).not.toContain('flex-wrap: wrap')
+    expect(MERGE_CSS).toContain('max-width: min(620px, calc(100% - 150px))')
+    expect(MERGE_CSS).toContain('min-width: 0')
+  })
+
+  it('injects the stylesheet once under a stable tag', () => {
+    ensureMergeCss()
+    ensureMergeCss()
+    const tags = document.querySelectorAll('style[data-dsh-live-stats-merge]')
+    expect(tags.length).toBe(1)
+    expect(tags[0]?.textContent).toContain('display: flex !important')
   })
 })

--- a/packages/dsh-live-stats/tests/tps-line.spec.tsx
+++ b/packages/dsh-live-stats/tests/tps-line.spec.tsx
@@ -25,15 +25,20 @@ describe('TPS composer line', () => {
     expect(formatTokensPerSecond(142.64)).toBe('143')
   })
 
-  it('renders only after an elapsed output sample exists', () => {
+  it('keeps the merge slot mounted, empty until a rate sample exists', () => {
     const absent = ((key: string): unknown => key === 'liveTokenUsage'
       ? { estimated: true, uncachedInputTokens: 10, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 }
       : undefined) as UseProjection
     const view = render(<TpsLine useProjection={absent} />)
-    expect(view.container.textContent).toBe('')
+    // The slot stays mounted while idle: the merge layout keys on its
+    // presence, so an unmount would flip the official stats row between
+    // content width and full width on every stream start/end.
+    const slot = view.container.querySelector('[data-dsh-live-tps]')
+    expect(slot).not.toBeNull()
+    expect(slot?.textContent).toBe('')
 
     view.rerender(<TpsLine useProjection={live} />)
-    expect(view.container.textContent).toBe('TPS 42.6 tok/s')
+    expect(view.container.querySelector('[data-dsh-live-tps]')?.textContent).toBe('TPS 42.6 tok/s')
   })
 
   it('anchors the row with the data-dsh-live-tps merge hook', () => {
@@ -50,6 +55,9 @@ describe('TPS merge stylesheet', () => {
     // nested :has() fails to parse (rules silently dropped), so the merge uses
     // the plain sibling combinator for the TPS and a flat :has for the row.
     expect(MERGE_CSS).not.toContain(':has(> *:has(')
+    // The wrapper merge is scoped to the moment the TPS slot is mounted, so
+    // the stylesheet never restyles the dock while the plugin is inactive.
+    expect(MERGE_CSS).toContain('div[data-slot="conversation.composer.dock"]:has(> [data-dsh-live-tps])')
     expect(MERGE_CSS).toContain('div[data-slot="conversation.composer.dock"] > *:not([role="tooltip"]):has(+ [data-dsh-live-tps]')
     // also matches when the official Tooltip bubble is inserted between the
     // stats row and the TPS (hover/focus) — otherwise the row reverts to its
@@ -66,8 +74,17 @@ describe('TPS merge stylesheet', () => {
 
   it('never wraps: nowrap + capped official row that ellipsizes', () => {
     expect(MERGE_CSS).not.toContain('flex-wrap: wrap')
-    expect(MERGE_CSS).toContain('max-width: min(620px, calc(100% - 150px))')
+    // The 620px cap keeps the merged unit compact on wide docks; narrow
+    // containers rely on flex shrink (0 1 auto + min-width: 0), so no
+    // container-relative calc that could go negative is involved.
+    expect(MERGE_CSS).toContain('max-width: 620px')
+    expect(MERGE_CSS).not.toContain('calc(100% - 150px)')
     expect(MERGE_CSS).toContain('min-width: 0')
+  })
+
+  it('hides the separator while the slot is empty (idle layout stays stable)', () => {
+    expect(MERGE_CSS).toContain('[data-dsh-live-tps]:empty::before')
+    expect(MERGE_CSS).toContain('content: none')
   })
 
   it('injects the stylesheet once under a stable tag', () => {


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；
> 提交信息用 Conventional Commits（`type(scope): subject`），禁止 emoji。
> 本仓库接受修复、增强与优化类 PR（bug 修复、现有功能的增强、性能 / 体验优化、维护与文档修正）；新皮肤始终欢迎。全新特性 / 新功能的 PR 暂不接受，请先提 Issue 讨论。
## 摘要（Summary）

把 composer dock 里的官方统计行与实时 TPS 槽位合并为一行：任何宽度下不换行，窄屏官方文字省略号截断；修复官方行 hover 气泡插入时统计行回退全宽、把 TPS 挤走的问题，并把气泡改为按内容宽度单行显示。同时按评审打磨：合并样式表以 `:has()` 收窄到 TPS 槽位挂载时生效（插件未激活时官方行保持原样）、官方行 max-width 去掉会为负的容器相减式、TPS 槽位常驻（无速率样本时渲染为空）消除挂载 / 卸载时的宽度翻转。原 PR 中的 LF dotfiles 与 remote-web-ui 修复已按评审拆分为独立 PR。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [x] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream && git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek（deepseek-v4-flash / 长推理模型系列）

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm typecheck
pnpm build
pnpm --filter @linxin666/dsh-live-stats test
pnpm test:scripts
pnpm docs:check
pnpm aggregate:check && pnpm gallery:check && pnpm skin-center:check && pnpm community:check && pnpm runtime-deps:check
```

结果摘要：

dsh-live-stats 30/30 通过（含新增的槽位常驻、`:has` 收窄作用域、max-width 下限断言）；typecheck、build、test:scripts 87/87、docs:check 及全部一致性检查（aggregate / gallery / skin-center / community / runtime-deps）通过。全仓 `pnpm test` 在 Windows 上除 4 处既有环境性失败外全绿：dsh-ssh 需真实 sshd 二进制、skin-center 的 POSIX chmod 权限位断言、shared/dsh-home 与 dsh-pet 的 POSIX 路径断言（均与本 PR 无关，Linux CI 上通过）。

## 用户可见变更证据（Local Feature Evidence）

证据：

实测环境：本机隔离 `dsh web` 实例（独立 `DSH_HOME` + 本地构建的 `@linxin666/dsh-web-ui-all` / `@linxin666/dsh-live-stats`），live-stats client bundle rev `37976554c19e`，head `87e7523`，Playwright + headless Edge 驱动真实会话并发送消息触发流式响应。

合并行布局实测（1440px 宽）：dock 包装层计算样式 `display: flex; flex-direction: row; justify-content: center`；官方统计行与 TPS 槽位同一行（y 均为 868，行宽 573px + TPS 95px 紧邻）；700px 窄视口下仍单行，官方行自动收窄至 289px 省略截断；官方行计算 `max-width: 620px`，TPS 槽位 `flex: 0 0 auto`、分隔符 `·` 正常显示；流式响应结束后 TPS 槽位保持挂载（空内容、无分隔符），布局不翻转。

宽屏 1920（合并单行）：
![宽屏 1920](https://raw.githubusercontent.com/matriox1003/dsh-web-ui/evidence/pr251-feat/docs/e2e/live-stats/tps-wide-1920.png)

常规宽 1400（合并单行）：
![常规宽 1400](https://raw.githubusercontent.com/matriox1003/dsh-web-ui/evidence/pr251-feat/docs/e2e/live-stats/tps-wide-1400.png)

窄屏 640（合并单行、官方文字省略截断）：
![窄屏 640](https://raw.githubusercontent.com/matriox1003/dsh-web-ui/evidence/pr251-feat/docs/e2e/live-stats/tps-narrow-640.png)

官方行 hover（统计行不回退、TPS 不被挤走）：
![hover 稳定](https://raw.githubusercontent.com/matriox1003/dsh-web-ui/evidence/pr251-feat/docs/e2e/live-stats/tps-hover-stable.png)

hover 气泡按内容宽度单行加宽显示：
![气泡加宽](https://raw.githubusercontent.com/matriox1003/dsh-web-ui/evidence/pr251-feat/docs/e2e/live-stats/tps-tooltip-wider.png)

最新 head 87e7523 实测（宽屏 1440 合并单行）：
![最新 head 宽屏](https://raw.githubusercontent.com/matriox1003/dsh-web-ui/evidence/pr251-feat/docs/e2e/live-stats/current-wide-1440.png)

最新 head 87e7523 实测（窄屏 700 合并单行）：
![最新 head 窄屏](https://raw.githubusercontent.com/matriox1003/dsh-web-ui/evidence/pr251-feat/docs/e2e/live-stats/current-narrow-700.png)

最新 head 87e7523 实测（dock 区域裁剪）：
![dock 裁剪](https://raw.githubusercontent.com/matriox1003/dsh-web-ui/evidence/pr251-feat/docs/e2e/live-stats/current-dock-crop.png)

## 贡献者版权声明（Contributor Copyright）

不新增版权行，维持现有版权归属。

## 社区插件索引登记（Community Plugin Index）

不适用（本 PR 不涉及第三方插件登记）。
