### PR TITLE
feat(liangshen): reset to controlled phase after compaction, degrade instead of throw

### DIFF
--- a/packages/dsh-liangshen/presets/liangshen/agent.cordis.yml
+++ b/packages/dsh-liangshen/presets/liangshen/agent.cordis.yml
@@ -55,6 +55,10 @@
 # step after promotion. `bootstrapMaxTokens` caps the phase-1 request output
 # budget (community-observed "We need" trigger window, 1024) and is stripped
 # again after promotion so the cap never solders into later requests.
+# After a compaction the session falls back to the controlled phase — the
+# bootstrap pair plus `compactionTools` (a core work set) — until a NEW
+# promotion signal exists past the boundary, and Code Mode is released until
+# the session re-promotes.
 - id: tool-bootstrap
   name: ./tool-bootstrap.mjs
   config:
@@ -65,6 +69,7 @@
     maxBootstrapSteps: 4
     promoteAfterFirstResponse: true
     bootstrapMaxTokens: 1024
+    compactionTools: [read, write, edit, glob, grep, todo_write, ask_user_question]
     deferredSources: [agent-instructions, skill-catalog]
     deferredGraceSteps: 1
     promotedPresentation: code

--- a/packages/dsh-liangshen/presets/liangshen/tool-bootstrap.mjs
+++ b/packages/dsh-liangshen/presets/liangshen/tool-bootstrap.mjs
@@ -22,6 +22,20 @@
  * `deferredGraceSteps` delay selected injected message kinds (workspace
  * instructions, skill catalog) for a few steps after promotion.
  *
+ * COMPACTION (local addition, ported from the upstream compaction-epoch
+ * semantics): a compaction rewrites the whole model-visible surface, so the
+ * first post-compaction request is a "second first request". A
+ * `compaction/end` event releases Code Mode (the presentation disposer) and
+ * resets the promotion state to the CONTROLLED phase — bootstrap pair plus
+ * `compactionTools` (a core work set, default none) — until a NEW durable
+ * promotion signal exists past that boundary. The reset lives both in the
+ * live `session/event` path and inside the durable-log scan, so resume and
+ * reload reconstruct the same phase.
+ *
+ * ROBUSTNESS: composition drift (a missing bootstrap shell or common tool)
+ * degrades to the full catalog with a one-time warning instead of throwing,
+ * so a broken composition can never lock a session out of every request.
+ *
  * Source: https://github.com/xiaobright/dsh-anchored-standard (MIT), extended
  * with the phase-1 quarantine and the stabilization controls above.
  */
@@ -151,10 +165,43 @@ function stateFor(session) {
       steps: 0,
       deferredSteps: 0,
       presentationApplied: false,
+      hasCompacted: false,
+      presentationDisposer: undefined,
     }
     promotionBySession.set(session, state)
   }
   return state
+}
+
+/**
+ * Reset one session back to the CONTROLLED phase after a compaction. A
+ * compaction rewrites the whole model-visible surface — the first
+ * post-compaction request is a "second first request" with the same
+ * first-token conditions the bootstrap exists to control — so the session
+ * re-anchors: promotion state is cleared (the durable `next` scan pointer is
+ * kept, so events recorded BEFORE the boundary never re-promote), and the
+ * Code Mode presentation is disposed so the next assembly sees the native
+ * catalog and the phase-1 filter can narrow it again.
+ */
+function resetToControlled(state) {
+  if (typeof state.presentationDisposer === 'function') {
+    try {
+      state.presentationDisposer()
+    } catch {
+      // A failed presentation reset must never break the session; the
+      // next promotion re-declares Code Mode anyway.
+    }
+    state.presentationDisposer = undefined
+  }
+  state.promoted = false
+  state.toolCalled = false
+  state.responded = false
+  state.anchored = false
+  state.turnEnded = false
+  state.steps = 0
+  state.deferredSteps = 0
+  state.presentationApplied = false
+  state.hasCompacted = true
 }
 
 /**
@@ -167,7 +214,10 @@ function applyPresentation(agent, state, policy) {
   state.presentationApplied = true
   const tools = agent.ctx.tools
   if (tools === undefined) return
-  tools.presentAs('code')
+  // The disposer restores the deployment-default (native) presentation; it is
+  // kept on the state so a post-compaction reset can release Code Mode and
+  // let the phase-1 catalog filter see the native tool list again.
+  state.presentationDisposer = tools.presentAs('code')
 }
 
 /**
@@ -193,7 +243,14 @@ function scanEvents(state, session) {
   for (; state.next < events.length; state.next += 1) {
     const event = events[state.next]
     if (event === undefined) continue
-    if (event.type === 'tool/call') {
+    if (event.type === 'compaction/end') {
+      // A compaction rewrites the model-visible surface: the session falls
+      // back to the controlled phase until a NEW promotion signal exists
+      // past this boundary (the `next` pointer stays, so events before the
+      // boundary never re-promote). Handled inside the scan so cold starts
+      // reconstruct the same phase from the durable log.
+      resetToControlled(state)
+    } else if (event.type === 'tool/call') {
       state.toolCalled = true
     } else if (event.type === 'step/start') {
       state.steps += 1
@@ -253,9 +310,25 @@ export function apply(ctx, config) {
   if (presentation !== 'native' && presentation !== 'code') {
     throw new TypeError(`${name}: promotedPresentation must be "native" or "code"`)
   }
+
+  let warned = false
+  const warnOnce = (message) => {
+    if (warned) return
+    warned = true
+    try {
+      ctx.logger.warn(message)
+    } catch {
+      // Logger unavailable — the guard exists only to avoid spamming.
+    }
+  }
   const bootstrapMaxTokens = config.bootstrapMaxTokens === undefined
     ? undefined
     : integerAtLeast(config.bootstrapMaxTokens, 'bootstrapMaxTokens', 1)
+  // Core work set exposed during the post-compaction controlled phase, so a
+  // mid-task model keeps working with a small catalog instead of the full
+  // Standard set. Defaults to none: the session stays on the bootstrap pair
+  // until a new promotion signal (the composition may widen it via config).
+  const compactionTools = stringListOrEmpty(config.compactionTools, 'compactionTools')
   const policy = {
     anchorGate: config.anchorGate === true,
     promoteAfterFirstResponse: config.promoteAfterFirstResponse === true,
@@ -263,14 +336,22 @@ export function apply(ctx, config) {
     deferredGraceSteps: integerAtLeast(config.deferredGraceSteps ?? 0, 'deferredGraceSteps', 0),
     promotedPresentation: presentation,
     bootstrapMaxTokens,
+    compactionTools,
   }
 
   // Promotion is applied at step/turn boundaries, never while a step is still
   // executing tools: switching the presentation mid-step would collapse the
   // native calls that step already planned. By `step/end` the tool-call and
   // reasoning events are durable, so the NEXT prompt assembly already sees
-  // Code Mode with its generated SDK section.
+  // Code Mode with its generated SDK section. A `compaction/end` event
+  // releases Code Mode and resets the promotion state (see
+  // resetToControlled); the reset also runs inside scanEvents, so a cold
+  // start reconstructs the same controlled phase from the durable log.
   ctx.on('session/event', (session, event) => {
+    if (event.type === 'compaction/end') {
+      resetToControlled(stateFor(session))
+      return
+    }
     if (event.type !== 'step/end' && event.type !== 'turn/end') return
     const state = stateFor(session)
     if (!state.promoted) {
@@ -288,6 +369,8 @@ export function apply(ctx, config) {
   // result (including messages appended by listener order, not row order)
   // before the quarantine strips it.
   ctx.on('system-prompt/assemble', async (_assembly, context, next) => {
+    // Downstream errors propagate untouched; only this filter's own logic is
+    // guarded (a filter bug must never brick every request of a session).
     const assembled = await next()
     const agent = context.agent
     if (agent === undefined) return assembled
@@ -298,13 +381,21 @@ export function apply(ctx, config) {
     const selectedShells = shellTools.filter(toolName => available.has(toolName))
     const missingCommon = commonTools.filter(toolName => !available.has(toolName))
     if (selectedShells.length !== 1 || missingCommon.length > 0) {
-      throw new Error(
+      // Composition drift must not lock a session out: degrade to the full
+      // catalog with a one-time warning instead of throwing (the bootstrap
+      // phase surfaces will simply not apply).
+      warnOnce(
         `${name}: expected exactly one bootstrap shell and every common tool; `
-        + `shells=${JSON.stringify(selectedShells)}, missing=${JSON.stringify(missingCommon)}`,
+        + `shells=${JSON.stringify(selectedShells)}, missing=${JSON.stringify(missingCommon)} — `
+        + 'bootstrap disabled, full catalog exposed',
       )
+      return assembled
     }
 
     const bootstrap = new Set([...selectedShells, ...commonTools])
+    // After a compaction the controlled phase widens with the core work set
+    // so mid-task work can continue before re-promotion.
+    if (state.hasCompacted) for (const toolName of compactionTools) bootstrap.add(toolName)
     return {
       ...assembled,
       tools: assembled.tools.filter(tool => bootstrap.has(tool.name)),

--- a/packages/dsh-liangshen/tests/tool-bootstrap.test.ts
+++ b/packages/dsh-liangshen/tests/tool-bootstrap.test.ts
@@ -455,10 +455,20 @@ describe('anchored-tool-bootstrap', () => {
     expect(() => register({ promotedPresentation: 'ptc' })).toThrow(/promotedPresentation/)
   })
 
-  test('misconfigured bootstrap catalogs fail loudly', async () => {
-    await expect(assemble(listener(register(), 'system-prompt/assemble'), [], [{ name: 'read' }, { name: 'edit' }])).rejects.toThrow(
-      /expected exactly one bootstrap shell/,
-    )
+  test('a missing bootstrap shell degrades to the full catalog instead of throwing', async () => {
+    const result = await assemble(listener(register(), 'system-prompt/assemble'), [], [
+      { name: 'read' },
+      { name: 'edit' },
+    ])
+    expect(result.tools.map((tool: any) => tool.name)).toEqual(['read', 'edit'])
+  })
+
+  test('a missing common tool degrades to the full catalog instead of throwing', async () => {
+    const result = await assemble(listener(register(), 'system-prompt/assemble'), [], [
+      { name: 'bash' },
+      { name: 'edit' },
+    ])
+    expect(result.tools.map((tool: any) => tool.name)).toEqual(['bash', 'edit'])
   })
 
   test('invalid stability config fails loudly', () => {
@@ -507,5 +517,115 @@ describe('anchored-tool-bootstrap', () => {
       async () => ({ provider: 'p', model: 'm', maxTokens: 384000 }),
     )
     expect(result.maxTokens).toBe(384000)
+  })
+
+  test('a compaction falls the session back to the controlled phase', async () => {
+    const listeners = register()
+    const assembleListener = listener(listeners, 'system-prompt/assemble')
+    const eventListener = listener(listeners, 'session/event')
+    const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }, { name: 'write' }]
+    const events: unknown[] = [{ type: 'tool/call' }]
+    const sessionObj = { events, header: { cwd: '/workspace' } }
+
+    // Promoted before the compaction: the full catalog is exposed.
+    const promoted = await assembleListener(
+      undefined,
+      { agent: { session: sessionObj } },
+      async () => ({ system: 'minimal persona', tools, contexts: [], sections: SECTIONS }),
+    )
+    expect(promoted.tools).toEqual(tools)
+
+    // The compaction rewrites the surface; the next assembly is controlled
+    // again: bootstrap pair only, empty contexts, persona section only.
+    events.push({ type: 'compaction/end', seq: 10 })
+    await eventListener(sessionObj, { type: 'compaction/end', seq: 10 })
+    const after = await assembleListener(
+      undefined,
+      { agent: { session: sessionObj } },
+      async () => ({ system: 'minimal persona', tools, contexts: [], sections: SECTIONS }),
+    )
+    expect(after.tools.map((tool: any) => tool.name)).toEqual(['bash', 'read'])
+    expect(after.contexts).toEqual([])
+    expect(after.sections.map((section: any) => section.name)).toEqual(['deployment:persona'])
+  })
+
+  test('a cold session with a durable compaction boundary reconstructs the controlled phase', async () => {
+    // A fresh session object simulates a process restart: the full durable
+    // log is scanned from scratch, and the pre-boundary tool call must NOT
+    // re-promote the session.
+    const assembleListener = listener(register(), 'system-prompt/assemble')
+    const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }]
+    const events = [
+      { type: 'tool/call' },
+      { type: 'assistant/message', data: { message: { content: [{ type: 'text', text: 'done' }] } } },
+      { type: 'compaction/end', seq: 10 },
+    ]
+    const result = await assemble(assembleListener, events, tools)
+    expect(result.tools.map((tool: any) => tool.name)).toEqual(['bash', 'read'])
+  })
+
+  test('a new tool call after the compaction boundary re-promotes', async () => {
+    const assembleListener = listener(register(), 'system-prompt/assemble')
+    const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }]
+    const events = [
+      { type: 'tool/call' },
+      { type: 'compaction/end', seq: 10 },
+      { type: 'tool/call' },
+    ]
+    const result = await assemble(assembleListener, events, tools)
+    expect(result.tools).toEqual(tools)
+  })
+
+  test('the post-compaction controlled phase includes the compactionTools work set', async () => {
+    const listeners = register({ compactionTools: ['write', 'edit', 'todo_write'] })
+    const assembleListener = listener(listeners, 'system-prompt/assemble')
+    const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }, { name: 'edit' }, { name: 'grep' }]
+    const events = [{ type: 'tool/call' }, { type: 'compaction/end', seq: 10 }]
+    const result = await assemble(assembleListener, events, tools)
+    expect(result.tools.map((tool: any) => tool.name)).toEqual(['bash', 'read', 'write', 'edit'])
+  })
+
+  test('compaction/end disposes the Code Mode presentation and re-declares on re-promotion', async () => {
+    const listeners = register({ promotedPresentation: 'code', anchorGate: true })
+    const assembleListener = listener(listeners, 'system-prompt/assemble')
+    const eventListener = listener(listeners, 'session/event')
+    const modes: string[] = []
+    let disposed = 0
+    const sessionObj = {
+      events: [stepEvent(), reasoningEvent('We need inspect the repo.'), { type: 'tool/call' }],
+      header: { cwd: '/workspace' },
+    }
+    const agent = {
+      session: sessionObj,
+      ctx: { tools: { presentAs: (mode: string) => { modes.push(mode); return () => { disposed += 1 } } } },
+    }
+    const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }]
+    const next = async () => ({ system: 'minimal persona', tools, contexts: [], sections: SECTIONS })
+
+    // Promoted: Code Mode declared.
+    await assembleListener(undefined, { agent }, next)
+    expect(modes).toEqual(['code'])
+    expect(disposed).toBe(0)
+
+    // The compaction releases Code Mode.
+    sessionObj.events.push({ type: 'compaction/end', seq: 10 })
+    await eventListener(sessionObj, { type: 'compaction/end', seq: 10 })
+    expect(disposed).toBe(1)
+
+    // Still controlled: the phase-1 catalog is back.
+    const after = await assembleListener(undefined, { agent }, next)
+    expect(after.tools.map((tool: any) => tool.name)).toEqual(['bash', 'read'])
+
+    // A new anchor re-promotes and re-declares Code Mode.
+    sessionObj.events.push(stepEvent(), reasoningEvent('We need inspect the repo again.'), { type: 'tool/call' })
+    await eventListener(sessionObj, { type: 'step/end' })
+    const rePromoted = await assembleListener(undefined, { agent }, next)
+    expect(rePromoted.tools).toEqual(tools)
+    expect(modes).toEqual(['code', 'code'])
+  })
+
+  test('invalid compactionTools values fail at apply time', () => {
+    expect(() => register({ compactionTools: [''] })).toThrow(/compactionTools/)
+    expect(() => register({ compactionTools: [42] as any })).toThrow(/compactionTools/)
   })
 })


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；
> 提交信息用 Conventional Commits（`type(scope): subject`），禁止 emoji。
> 本仓库接受修复、增强与优化类 PR（bug 修复、现有功能的增强、性能 / 体验优化、维护与文档修正）；新皮肤始终欢迎。全新特性 / 新功能的 PR 暂不接受，请先提 Issue 讨论。

## 摘要（Summary）

压缩会重写整个模型可见面——压缩后的首次请求是「第二个首请求」，与锚定 bootstrap 要控制的首 token 条件相同。梁神模式的状态机此前完全忽略 `compaction/end`：一旦晋升，会话永远停留在完整表面；压缩后模型面对的是被重写的对话 + Code Mode（run_code + SDK section）的陌生组合。另外，bootstrap shell 或 common tool 缺失时原实现会在**装配期（即运行期、每次请求）抛错**，组合漂移可能锁死会话的所有请求。

两个修复把上游来源（[xiaobright/dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) 的 compaction-epoch.mjs）的生命周期语义移植进梁神两阶段设计。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-liangshen`

## PR 类型（PR Type）

- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改动 README，不适用）

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-liangshen
vitest run
node --check presets/liangshen/tool-bootstrap.mjs
node -e "import('./src/schema.ts').then(({validateAgentCordis}) => ...)" # agent.cordis.yml 结构校验
```

结果摘要：

- `vitest run`：5 个测试文件 72/72 全过（tool-bootstrap 36 项，含 7 个新增 compaction / 降级用例；analyze-session 7；schema 8；index 6；sync 15）。
- `node --check presets/liangshen/tool-bootstrap.mjs`：语法通过。
- `agent.cordis.yml` 通过 `validateAgentCordis` 结构校验（零问题）。
- 已同步 `~/.dsh/profiles/web/node_modules/@linxin666/dsh-liangshen` 与 `~/.dsh/.agent-presets/liangshen`，新建会话即生效。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（纯内部行为变更：preset 状态机生命周期，无 UI 表面。压缩回落的验证依赖会话事件序列与单测断言，见「本地验证」结果摘要。）

---

## Changes

### `presets/liangshen/tool-bootstrap.mjs`

- **`compaction/end` → controlled phase**（`resetToControlled`）：dispose Code Mode 呈现（`presentAs` disposer 恢复 native 目录，phase-1 过滤器才能再次收窄它）、清空晋升态、置 `hasCompacted` 使受控目录扩展 `compactionTools` 工作集。持久 `next` 扫描指针保留——boundary 之前的事件永不重新触发晋升。
- **冷启动正确**：重置同时写在 `scanEvents` 内，重启进程从持久日志重建同一受控阶段。
- **再晋升**：boundary 之后的新晋升信号重新晋升并重新声明 Code Mode（disposer 执行后可再次 `presentAs`）。
- **降级替代 throw**：bootstrap shell / common tool 缺失时返回完整 assembled 目录并一次性 `warnOnce`，不再在装配期抛错。
- `applyPresentation` 在 per-session state 上保存 `tools.presentAs('code')` 返回的 disposer。

### `presets/liangshen/agent.cordis.yml`

- 新增 `compactionTools: [read, write, edit, glob, grep, todo_write, ask_user_question]`——压缩后受控阶段的核心工作集（与上游 preset 配置一致），任务中途的模型用小目录继续干活，而不是全量 Standard 集。

### `tests/tool-bootstrap.test.ts`

7 个新用例（72/72 全过）：

- 压缩将会话回落到受控阶段（目录 / contexts / sections 三面验证）
- 含持久 compaction boundary 的冷会话重建受控阶段（boundary 前的 tool call 不重新晋升）
- boundary 后的新 tool call 重新晋升
- 压缩后受控阶段包含 `compactionTools` 工作集
- `compaction/end` dispose Code Mode 呈现并在再晋升时重新声明
- 两条降级路径（缺 shell、缺 common tool）返回全量目录而非抛错
- 非法 `compactionTools` 值在 apply 时报错

原「misconfigured bootstrap catalogs fail loudly」测试被降级路径测试替换（行为有意变更）。

## Behavior notes

- 压缩后会话重新锚定：bootstrap 双工具 + `compactionTools`、空 contexts、仅 persona section、仅 user 消息 pre-step——直到 boundary 之后出现新的持久晋升信号。
- `bootstrapMaxTokens`（1024）在压缩后受控阶段再次生效、再晋升时解除，与首请求语义一致。
- 压缩前的生命周期不变：首请求、anchor gate、step/turn 边界的 PTC 切换、延迟注入均保持原行为。
