### PR TITLE
fix(dsh-aionui-panel): keep panel frame chrome below the shell overlay layer (#234)

### DIFF
--- a/packages/dsh-aionui-panel/src/client/layout.ts
+++ b/packages/dsh-aionui-panel/src/client/layout.ts
@@ -237,7 +237,10 @@ export class PanelLayoutController {
     el.style.position = 'absolute'
     el.style.top = '0'
     el.style.bottom = '0'
-    el.style.zIndex = '30'
+    // Frame chrome must stay below the shell overlay layer (z-index 20,
+    // AppFrame .overlayLayer) so the drag line never floats over
+    // shell.overlay surfaces such as the emoji drawer (issue #234).
+    el.style.zIndex = '10'
     el.style.cursor = 'col-resize'
     el.style.width = `${hitWidth}px`
     if (reverse) {

--- a/packages/dsh-aionui-panel/src/client/styles/tokens.module.css
+++ b/packages/dsh-aionui-panel/src/client/styles/tokens.module.css
@@ -134,7 +134,11 @@
    the whole frame). Right-edge overlay plugins would otherwise paint on top of
    the Explorer / Preview columns' content (issue #195). Kept below dialogs
    (1000+) so modals/toasts still stack above the panels. Matches the tab-bar
-   z-index 30 convention (issues #169 / #87), so the three stay consistent. */
+   z-index 30 convention (issues #169 / #87), so the three stay consistent.
+   Full-screen drawer overlays (e.g. the biaoqingbao emoji manager) must
+   therefore render at the ROOT stacking context (portal to document.body,
+   z in (100, 1000)) to cover the panels; the panel's frame chrome below
+   stays under the overlay layer so it never floats over them (#234). */
 :global(.aionui-preview-col),
 :global(.aionui-explorer-col) {
   min-width: 0;
@@ -209,7 +213,8 @@
   opacity: 1;
 }
 
-/* Floating expand button (explorer collapsed). */
+/* Floating expand button (explorer collapsed). Below the shell overlay
+   layer (z-index 20) so it never floats over shell.overlay surfaces. */
 :global(.aionui-floating-expand) {
   position: fixed;
   top: 50%;
@@ -227,7 +232,7 @@
   color: var(--aion-text-secondary);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
   cursor: pointer;
-  z-index: 100;
+  z-index: 10;
   transition: background-color 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
 :global(.aionui-floating-expand:hover) {
@@ -242,7 +247,8 @@
   outline-offset: 2px;
 }
 
-/* The collapse chevron inside the explorer tab bar (top-right). */
+/* The collapse chevron inside the explorer tab bar (top-right). Below the
+   shell overlay layer (z-index 20) so it never floats over overlay drawers. */
 :global(.aionui-collapse-chevron) {
   position: absolute;
   /* In desktop wrappers with the Window Controls Overlay, the native
@@ -251,7 +257,7 @@
      unchanged there (issue #169). */
   top: calc(6px + env(titlebar-area-height, 0px));
   right: 8px;
-  z-index: 30;
+  z-index: 10;
   width: 24px;
   height: 24px;
   display: flex;


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；
> 提交信息用 Conventional Commits（`type(scope): subject`），禁止 emoji。

## 摘要（Summary）

修复 #234 的第一部分（面板侧）：右侧面板（aionui-panel）的三处框级装饰元素——两条拖拽手柄（内联 `z-index:30`）、Explorer 收起按钮（`z-index:30`）、右侧悬浮展开按钮（`z-index:100`）——都被直接 append 到 shell 的 `[data-dsh-frame]` 网格（该元素不是层叠上下文），因此以根层 30/100 参与排序，恒高于 shell 的 `shell.overlay` 层（`AppFrame .overlayLayer`，z-index 20）。任何挂载于 `shell.overlay` 的全屏抽屉（如 dsh-biaoqingbao 表情包抽屉，其 z-901 被封装在 overlay 层内、根层有效层级仅 20）都会被这些装饰元素盖住。

本次将三处装饰层统一降到 `z-index:10`（低于 overlay 层 20），使面板装饰不再浮在任何 overlay 表面之上；并扩展 #195 的层级注释，写明完整约定：面板列保持 z-30（#195），全屏抽屉类 overlay 须以**根层渲染**（portal 到 `document.body`，z 取 100~1000）才能盖住面板列。

> **范围说明（重要）**：本 PR 只修复面板侧的**浮动装饰**（拖拽手柄 / 收起按钮 / 悬浮展开按钮）。Explorer / Preview **列本身**仍保持 #195 的 `z-index:30`，因此仍会盖在抽屉类 overlay（含表情包抽屉）之上——该部分无法在面板侧解决（shell.overlay 层 z-20 与列 z-30 之间没有中间层级），需要抽屉侧以根层渲染配合，见 #234 及配套的 dsh-biaoqingbao PR。

## 涉及包（Affected Packages）

- [x] 右侧面板 `packages/dsh-aionui-panel`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch upstream main && git rebase upstream/main`

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改动 README）

## 贡献者版权声明（Contributor Copyright）

本 PR 不贡献新插件 / 皮肤，无需登记版权。

## 社区插件索引登记（Community Plugin Index）

不适用（非新增第三方插件）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm install
pnpm --filter @linxin666/dsh-client-ui-aionui-panel build
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
```

结果摘要：

- `build`（tsc -b && tsdown）：成功，`lib/client.js` 产出中 `zIndex = "10"`、chevron / floating 的 `z-index:10` 均已生效（`lib/` 被包级 gitignore，未入库）；
- `test`（vitest run）：**15 个测试文件 / 148 个用例全部通过**；
- 浏览器实测（无头 Chromium 1440x900，web profile 0.1.16 + 本 PR 构建产物，打开表情包抽屉后 `document.elementFromPoint`）：
  - 拖拽线位置 (1176,500)：修复前命中 `aionui-explorer-handle`，修复后命中 `.bqb-panel`；
  - 悬浮按钮位置 (1430,450)：修复前命中 `aionui-floating-expand`，修复后命中 `.bqb-panel`。

## 用户可见变更证据（Local Feature Evidence）

证据：

场景 A（Explorer 展开：表情包抽屉右侧的拖拽线不再浮在抽屉上）

修复前：![before](https://raw.githubusercontent.com/lpreterite/dsh-web-ui/pr-evidence/before-A-explorer-expanded-drawer.png)

修复后：![after](https://raw.githubusercontent.com/lpreterite/dsh-web-ui/pr-evidence/after-A-explorer-expanded-drawer.png)

场景 B（Explorer 折叠：右侧悬浮展开按钮不再浮在抽屉上）

修复前：![before](https://raw.githubusercontent.com/lpreterite/dsh-web-ui/pr-evidence/before-B-explorer-collapsed-drawer.png)

修复后：![after](https://raw.githubusercontent.com/lpreterite/dsh-web-ui/pr-evidence/after-B-explorer-collapsed-drawer.png)

悬浮按钮区域特写：

修复前：![before](https://raw.githubusercontent.com/lpreterite/dsh-web-ui/pr-evidence/before-B-floating-crop.png)

修复后：![after](https://raw.githubusercontent.com/lpreterite/dsh-web-ui/pr-evidence/after-B-floating-crop.png)

说明：
- 截图均在本地 web profile（0.1.16，biaoqingbao 0.2.0）加载本 PR 构建产物后截取；`elementFromPoint` 实测结果见「本地验证」。
- 注意场景 A「修复后」图中 Explorer 列（`z-index:30`，#195）**仍会盖住抽屉右侧**——本 PR 仅移除浮动装饰（拖拽线 / 悬浮按钮），列盖抽屉属已知范围，由配套的抽屉侧根层渲染修复（#234 + dsh-biaoqingbao PR）。
