### PR TITLE
fix(dsh-remote-web-ui): 更新命令携带 --config.minimumReleaseAge=0 绕过 pnpm 11 发布年龄门禁

### DIFF
--- a/packages/dsh-remote-web-ui/src/update.ts
+++ b/packages/dsh-remote-web-ui/src/update.ts
@@ -413,6 +413,17 @@ const OUTPUT_CAP = 16 * 1024
 const WIN_CMD_MISSING_RE = /not recognized as an internal or external command/i
 
 /**
+ * Bypass for pnpm 11's supply-chain gate: `minimumReleaseAge` (default 24 h)
+ * silently skips same-day releases — `pnpm update --latest` then exits 0
+ * without moving anything and the post-run verification would misreport a
+ * stale no-op. The update here is explicitly user-initiated and the panel
+ * shows exactly which versions are being installed, so the gate only adds a
+ * confusing silent no-op; override it per-invocation instead of asking every
+ * user to edit the profile's pnpm-workspace.yaml.
+ */
+const MIN_RELEASE_AGE_OVERRIDE = '--config.minimumReleaseAge=0'
+
+/**
  * Run the update inside the profile directory. Tries pnpm first, falls back
  * to corepack and then npx when the previous command is missing (ENOENT);
  * all candidates share one hard timeout and keep accumulating output.
@@ -438,10 +449,14 @@ export function runUpdate(deps: UpdateRunDeps): Promise<UpdateRunResult> {
     // "0.1.12" without a range), and plain `pnpm update` treats an exact spec
     // as pinned — it prints "Already up to date" and exits 0 without moving
     // the installed version, so the panel would report a false success.
+    // `MIN_RELEASE_AGE_OVERRIDE` rides along every candidate: without it the
+    // pnpm 11 minimumReleaseAge gate (default 24 h) silently keeps same-day
+    // releases in place, which the post-run verification would then have to
+    // surface as `stale` even though the update is legitimate.
     const candidates: ReadonlyArray<{ command: string; args: string[] }> = [
-      { command: 'pnpm', args: ['update', '--latest', ...packages] },
-      { command: 'corepack', args: ['pnpm', 'update', '--latest', ...packages] },
-      { command: 'npx', args: ['--yes', 'pnpm', 'update', '--latest', ...packages] },
+      { command: 'pnpm', args: ['update', '--latest', MIN_RELEASE_AGE_OVERRIDE, ...packages] },
+      { command: 'corepack', args: ['pnpm', 'update', '--latest', MIN_RELEASE_AGE_OVERRIDE, ...packages] },
+      { command: 'npx', args: ['--yes', 'pnpm', 'update', '--latest', MIN_RELEASE_AGE_OVERRIDE, ...packages] },
     ]
     // `output` accumulates across candidates for UI display; `currentOutput`
     // is reset per candidate and carries only that candidate's own diagnostics
@@ -553,9 +568,11 @@ export interface UpdateRunVerifiedDeps {
 
 /**
  * Run the update, then verify the installed versions actually moved. pnpm
- * exits 0 even when it silently kept the installed versions — the pnpm 11
- * `minimumReleaseAge` gate refuses same-day releases by default — so a green
- * exit alone would report a misleading "update complete". Re-read the
+ * exits 0 even when it silently kept the installed versions — runUpdate
+ * overrides pnpm 11's `minimumReleaseAge` gate (default 24 h) with
+ * `--config.minimumReleaseAge=0`, but an older pnpm without the override or
+ * another silent no-op can still keep versions in place — so a green exit
+ * alone must not report a misleading "update complete". Re-read the
  * installed versions afterwards and surface a `stale` failure (with the
  * captured pnpm output) when nothing moved, so the panel can tell the user
  * how to unblock the gate instead of claiming success.

--- a/packages/dsh-remote-web-ui/tests/update.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/update.spec.ts
@@ -314,7 +314,7 @@ describe("runUpdate", () => {
     child.emitOutput("Progress 1/2")
     child.run(0)
     const result = await promise
-    expect(spawned).toEqual({ command: "pnpm", args: ["update", "--latest", "a", "b"], cwd: "/p" })
+    expect(spawned).toEqual({ command: "pnpm", args: ["update", "--latest", "--config.minimumReleaseAge=0", "a", "b"], cwd: "/p" })
     expect(result).toEqual({ ok: true, exitCode: 0, output: "Progress 1/2" })
   })
   it("reports pnpm-failed on a non-zero exit", async () => {
@@ -339,11 +339,12 @@ describe("runUpdate", () => {
     const result = await promise
     expect(order).toEqual(["pnpm", "corepack"])
     // Every fallback candidate must keep --latest (exact specs in the profile
-    // are otherwise treated as pinned and never move); corepack prefixes the
-    // pnpm subcommand.
+    // are otherwise treated as pinned and never move) and the release-age
+    // override (pnpm 11's minimumReleaseAge gate would silently skip
+    // same-day releases); corepack prefixes the pnpm subcommand.
     expect(argo.map(entry => entry.args)).toEqual([
-      ["update", "--latest", "a"],
-      ["pnpm", "update", "--latest", "a"],
+      ["update", "--latest", "--config.minimumReleaseAge=0", "a"],
+      ["pnpm", "update", "--latest", "--config.minimumReleaseAge=0", "a"],
     ])
     expect(result).toEqual({ ok: true, exitCode: 0, output: "corepack pnpm 1/2" })
   })
@@ -360,11 +361,12 @@ describe("runUpdate", () => {
     npx.run(0)
     const result = await promise
     expect(order).toEqual(["pnpm", "corepack", "npx"])
-    // Every fallback candidate keeps --latest (npx prefixes --yes before pnpm).
+    // Every fallback candidate keeps --latest and the release-age override
+    // (npx prefixes --yes before pnpm).
     expect(argo.map(entry => entry.args)).toEqual([
-      ["update", "--latest", "a"],
-      ["pnpm", "update", "--latest", "a"],
-      ["--yes", "pnpm", "update", "--latest", "a"],
+      ["update", "--latest", "--config.minimumReleaseAge=0", "a"],
+      ["pnpm", "update", "--latest", "--config.minimumReleaseAge=0", "a"],
+      ["--yes", "pnpm", "update", "--latest", "--config.minimumReleaseAge=0", "a"],
     ])
     expect(result.ok).toBe(true)
     expect(result.output).toBe("npx pnpm ok")


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；
> 提交信息用 Conventional Commits（`type(scope): subject`），禁止 emoji。
> 本仓库接受修复、增强与优化类 PR（bug 修复、现有功能的增强、性能 / 体验优化、维护与文档修正）；新皮肤始终欢迎。全新特性 / 新功能的 PR 暂不接受，请先提 Issue 讨论。
## 摘要（Summary）

修复更新面板误报「已是最新」：pnpm 11 默认的供应链安全策略（`minimumReleaseAge`，发布未满 24 小时的新版本）会让 `pnpm update --latest` 退出码为 0 但版本纹丝不动。更新命令现统一追加 `--config.minimumReleaseAge=0`，允许更新当天发布的新版本（pnpm / corepack / npx 三个候选命令均覆盖）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream && git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek（deepseek-v4-flash / 长推理模型系列）

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm typecheck
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm test:scripts
pnpm docs:check
```

结果摘要：

`pnpm --filter @linxin666/dsh-remote-web-ui test` 176/176 通过；typecheck、test:scripts 87/87、docs:check 全部通过。`minimumReleaseAge` 覆盖以 spawn 参数数组传递（非 shell 字符串拼接），无注入面。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（修复项为更新流程的依赖版本策略参数，属内部行为修正；已由 176/176 单测覆盖命令构造）。

## 贡献者版权声明（Contributor Copyright）

不新增版权行，维持现有版权归属。

## 社区插件索引登记（Community Plugin Index）

不适用（本 PR 不涉及第三方插件登记）。
