### PR TITLE
fix(aionui-panel): polish raw route range handling and cache validators (#239)

### DIFF
--- a/packages/dsh-aionui-panel/src/host/fs-service.ts
+++ b/packages/dsh-aionui-panel/src/host/fs-service.ts
@@ -163,16 +163,22 @@ export function probeImageSize(data: Buffer): { width: number; height: number } 
   return undefined
 }
 
-/** Derive the mime type for a raw read from the extension, then the content. */
-// pdf mappings (extension + %PDF magic) contributed by EricWang1358 (#239).
-function imageMime(rel: string, data: Buffer): string {
+/** Mime lookup by file extension (undefined when the extension is unknown). */
+function mimeByExtension(rel: string): string | undefined {
   const ext = rel.split('.').pop()?.toLowerCase() ?? ''
   const byExt: Record<string, string> = {
     png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
     webp: 'image/webp', svg: 'image/svg+xml', ico: 'image/x-icon', avif: 'image/avif', bmp: 'image/bmp',
     pdf: 'application/pdf',
   }
-  if (byExt[ext]) return byExt[ext]
+  return byExt[ext]
+}
+
+/** Derive the mime type for a raw read from the extension, then the content. */
+// pdf mappings (extension + %PDF magic) contributed by EricWang1358 (#239).
+function imageMime(rel: string, data: Buffer): string {
+  const byExt = mimeByExtension(rel)
+  if (byExt !== undefined) return byExt
   if (data.length >= 3 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e) return 'image/png'
   if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8) return 'image/jpeg'
   if (data.length >= 4 && data[0] === 0x25 && data[1] === 0x50 && data[2] === 0x44 && data[3] === 0x46) return 'application/pdf'
@@ -287,11 +293,12 @@ export class FsService {
   /**
    * Resolve one file for raw streaming (the markdown image / pdf preview
    * route): gated, traversal-guarded, and .git-refusing. Returns the absolute
-   * path with the derived mime and size — the HTTP layer streams the bytes
-   * itself (createReadStream + Range), so even large files never sit in host
-   * memory. Mime magic detection reads only the first few bytes.
+   * path with the derived mime, size and mtime — the HTTP layer streams the
+   * bytes itself (createReadStream + Range), so even large files never sit in
+   * host memory. Mime magic detection reads only the first few bytes. The
+   * mtime feeds the route's ETag/Last-Modified validators.
    */
-  async readRaw(root: string, rel: string): Promise<{ abs: string; mime: string; size: number } | PanelError> {
+  async readRaw(root: string, rel: string): Promise<{ abs: string; mime: string; size: number; mtime: number } | PanelError> {
     const gated = await this.gate(root)
     if (!gated.ok) return gated.error
     if (isGitPath(rel)) return { code: 'path-outside-root', message: 'refusing to read .git' }
@@ -304,7 +311,9 @@ export class FsService {
       return { code: 'not-found', message: `cannot read ${rel}` }
     }
     if (info.isDirectory()) return { code: 'is-directory', message: `${rel} is a directory` }
-    return { abs: resolved.abs, mime: imageMime(rel, await readMagicBytes(resolved.abs)), size: info.size }
+    // Extension-known types skip the magic-bytes open/read entirely.
+    const mime = mimeByExtension(rel) ?? imageMime(rel, await readMagicBytes(resolved.abs))
+    return { abs: resolved.abs, mime, size: info.size, mtime: info.mtimeMs }
   }
 
   /** Write text content back, refusing when the file moved on disk (mtime conflict). */

--- a/packages/dsh-aionui-panel/src/host/routes.ts
+++ b/packages/dsh-aionui-panel/src/host/routes.ts
@@ -41,12 +41,14 @@ const GIT_POLL_MS = 30_000
 const HEARTBEAT_MS = 15_000
 
 /**
- * Parse a single-range `bytes=start-end` header against the file size.
- * Returns null when no range was requested, 'invalid' for malformed or
- * unsatisfiable ranges (the caller answers 416), or the clamped start/end
- * (inclusive). Multi-range requests are treated as invalid — the panel only
- * ever serves single ranges. Suffix ranges (`bytes=-N`) select the last N
- * bytes. Range support added after human review on #242 (pdf seeking).
+ * Parse a `Range: bytes=start-end` header against the file size. RFC 7233
+ * lets a server ignore any Range it does not support, so unknown units,
+ * malformed headers and multi-range requests all return null (the caller
+ * answers 200 with the full body); only a syntactically valid single range
+ * that cannot be satisfied returns 'invalid' (the caller answers 416).
+ * Suffix ranges (`bytes=-N`) select the last N bytes. Range support added
+ * after human review on #242 (pdf seeking); ignore-instead-of-416 for
+ * unsupported shapes per maintainer feedback.
  */
 export function parseRangeHeader(
   header: string | undefined,
@@ -54,7 +56,7 @@ export function parseRangeHeader(
 ): { start: number; end: number } | 'invalid' | null {
   if (header === undefined) return null
   const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim())
-  if (match === null || (match[1] === '' && match[2] === '')) return 'invalid'
+  if (match === null || (match[1] === '' && match[2] === '')) return null
   if (match[1] === '') {
     const suffix = Number(match[2])
     if (suffix <= 0 || size === 0) return 'invalid'
@@ -64,6 +66,25 @@ export function parseRangeHeader(
   const end = match[2] === '' ? size - 1 : Math.min(Number(match[2]), size - 1)
   if (size === 0 || start > end || start >= size) return 'invalid'
   return { start, end }
+}
+
+/** Strip the weak prefix and quotes so entity-tags compare by opaque value. */
+function normalizeEtag(value: string): string {
+  return value.trim().replace(/^W\//, '').replace(/^"|"$/g, '')
+}
+
+/**
+ * Whether an If-None-Match header matches the current etag. Handles `*` and
+ * comma-separated entity-tag lists; GET revalidation uses weak comparison
+ * (RFC 9110), so the weak prefix is ignored on both sides.
+ */
+export function ifNoneMatchSaidFresh(header: string | undefined, etag: string): boolean {
+  if (header === undefined) return false
+  const current = normalizeEtag(etag)
+  return header.split(',').some((candidate) => {
+    const tag = candidate.trim()
+    return tag === '*' || normalizeEtag(tag) === current
+  })
 }
 
 /**
@@ -260,8 +281,9 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
    * resolves and stats the path, the bytes are piped straight from disk with
    * the derived mime — the whole file never sits in host memory. Single byte
    * ranges are honored (206/416) so the browser pdf viewer can seek large
-   * files. No validators are negotiated, so the browser revalidates every
-   * time — a re-edited file never shows stale bytes.
+   * files; unsupported range shapes are ignored per RFC 7233 (200 full
+   * body). ETag/Last-Modified (size+mtime) keep no-cache revalidation cheap:
+   * unchanged files answer 304, If-Range mismatches fall back to 200.
    */
   const serveRaw = async (req: IncomingMessage, url: URL, res: ServerResponse): Promise<void> => {
     const root = url.searchParams.get('root')
@@ -276,18 +298,36 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
       json(res, FAIL(result), status)
       return
     }
-    const range = parseRangeHeader(req.headers.range, result.size)
-    if (range === 'invalid') {
-      res.writeHead(416, { 'content-range': `bytes */${result.size}` })
-      res.end()
-      return
-    }
-    const headers: Record<string, string | number> = {
+    // Validators from size+mtime: no-cache forces revalidation, and a match
+    // answers 304 instead of re-streaming — scrolling a large pdf issues many
+    // range requests, so they must be cheap (maintainer feedback on #242).
+    const etag = `W/"${result.size}-${Math.floor(result.mtime)}"`
+    const lastModified = new Date(result.mtime).toUTCString()
+    const baseHeaders: Record<string, string | number> = {
       'content-type': result.mime,
       'cache-control': 'no-cache',
       'x-content-type-options': 'nosniff',
       'accept-ranges': 'bytes',
+      etag,
+      'last-modified': lastModified,
     }
+    if (ifNoneMatchSaidFresh(req.headers['if-none-match'], etag) && req.headers.range === undefined) {
+      res.writeHead(304, baseHeaders)
+      res.end()
+      return
+    }
+    // If-Range guards a range against a changed file: a mismatch falls back
+    // to the full 200 body rather than serving a stale slice.
+    const ifRange = req.headers['if-range']
+    const range = ifRange !== undefined && ifRange !== etag && ifRange !== lastModified
+      ? null
+      : parseRangeHeader(req.headers.range, result.size)
+    if (range === 'invalid') {
+      res.writeHead(416, { ...baseHeaders, 'content-range': `bytes */${result.size}` })
+      res.end()
+      return
+    }
+    const headers: Record<string, string | number> = { ...baseHeaders }
     if (range === null) {
       headers['content-length'] = result.size
       res.writeHead(200, headers)

--- a/packages/dsh-aionui-panel/tests/host-fixes.spec.ts
+++ b/packages/dsh-aionui-panel/tests/host-fixes.spec.ts
@@ -106,7 +106,12 @@ describe('FsService.readRaw (markdown image route)', () => {
 
     const image = await service.readRaw(root, 'assets/pic.png')
     expect(image).toMatchObject({ mime: 'image/png', size: png.length })
-    if ('abs' in image) expect(image.abs.endsWith(join('assets', 'pic.png'))).toBe(true)
+    if ('abs' in image) {
+      expect(image.abs.endsWith(join('assets', 'pic.png'))).toBe(true)
+      // mtime feeds the route's ETag/Last-Modified validators.
+      expect(typeof image.mtime).toBe('number')
+      expect(image.mtime).toBeGreaterThan(0)
+    }
     expect(await service.readRaw(root, 'a.md')).toMatchObject({ mime: 'application/octet-stream' })
 
     await rm(dir, { recursive: true, force: true })
@@ -124,7 +129,11 @@ describe('FsService.readRaw (markdown image route)', () => {
 
     const byExt = await service.readRaw(root, 'docs/doc.pdf')
     expect(byExt).toMatchObject({ mime: 'application/pdf', size: pdf.length })
-    if ('abs' in byExt) expect(byExt.abs.endsWith(join('docs', 'doc.pdf'))).toBe(true)
+    if ('abs' in byExt) {
+      expect(byExt.abs.endsWith(join('docs', 'doc.pdf'))).toBe(true)
+      expect(typeof byExt.mtime).toBe('number')
+      expect(byExt.mtime).toBeGreaterThan(0)
+    }
     expect(await service.readRaw(root, 'docs/noext')).toMatchObject({ mime: 'application/pdf' })
 
     await rm(dir, { recursive: true, force: true })

--- a/packages/dsh-aionui-panel/tests/loopback.spec.ts
+++ b/packages/dsh-aionui-panel/tests/loopback.spec.ts
@@ -128,7 +128,7 @@ describe('/aionui-panel loopback fence', () => {
   })
 
   it('rejects non-loopback GET /aionui-panel/raw with 403', async () => {
-    const readRaw = vi.fn(async () => ({ abs: '/w/a.txt', mime: 'text/plain', size: 1 }))
+    const readRaw = vi.fn(async () => ({ abs: '/w/a.txt', mime: 'text/plain', size: 1, mtime: 1 }))
     const { ctx, registrations } = fakeCtx()
     registerPanelRoutes(ctx as never, { readRaw } as never, { status: async () => null } as never)
     const prefix = registrations.find((row) => row.kind === 'prefix')!

--- a/packages/dsh-aionui-panel/tests/pure.spec.ts
+++ b/packages/dsh-aionui-panel/tests/pure.spec.ts
@@ -95,7 +95,7 @@ describe('detectContentType', () => {
   })
 })
 
-describe('pdfPreviewUrl (issue #236)', () => {
+describe('pdfPreviewUrl (issue #239)', () => {
   it('encodes root and path and appends the nonce as &v=', () => {
     const url = pdfPreviewUrl('C:\\work dir', 'docs/a b#1.pdf', 42)
     expect(url).toBe(

--- a/packages/dsh-aionui-panel/tests/raw-route.spec.ts
+++ b/packages/dsh-aionui-panel/tests/raw-route.spec.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Writable } from 'node:stream'
 import { FsService } from '../src/host/fs-service.ts'
-import { parseRangeHeader, registerPanelRoutes } from '../src/host/routes.ts'
+import { parseRangeHeader, ifNoneMatchSaidFresh, registerPanelRoutes } from '../src/host/routes.ts'
 import type { WorkspaceGate } from '../src/host/gate.ts'
 
 /** A minimal ctx fulfilling what registerPanelRoutes touches. */
@@ -36,7 +36,7 @@ async function request(
   handler: (req: unknown, res: unknown) => Promise<void>,
   method: string,
   url: string,
-  options: { remoteAddress?: string; host?: string; range?: string } = {},
+  options: { remoteAddress?: string; host?: string; headers?: Record<string, string> } = {},
 ): Promise<{ status: number; headers: Record<string, string>; body: Buffer }> {
   let status = 0
   let headers: Record<string, string> = {}
@@ -58,7 +58,7 @@ async function request(
     url,
     headers: {
       host: options.host ?? '127.0.0.1:3000',
-      ...(options.range !== undefined ? { range: options.range } : {}),
+      ...(options.headers ?? {}),
     },
     socket: { remoteAddress: options.remoteAddress ?? '127.0.0.1' },
   }, res)
@@ -152,19 +152,88 @@ describe('GET /aionui-panel/raw', () => {
     expect(full.headers['accept-ranges']).toBe('bytes')
     expect(full.body.equals(pdf)).toBe(true)
 
-    const part = await request(row.handler, 'GET', url, { range: 'bytes=0-4' })
+    const part = await request(row.handler, 'GET', url, { headers: { range: 'bytes=0-4' } })
     expect(part.status).toBe(206)
     expect(part.headers['content-range']).toBe(`bytes 0-4/${pdf.length}`)
     expect(part.headers['content-length']).toBe(5)
     expect(part.body.toString('latin1')).toBe('%PDF-')
 
-    const suffix = await request(row.handler, 'GET', url, { range: 'bytes=-4' })
+    const suffix = await request(row.handler, 'GET', url, { headers: { range: 'bytes=-4' } })
     expect(suffix.status).toBe(206)
     expect(suffix.body.toString('latin1')).toBe(pdf.subarray(pdf.length - 4).toString('latin1'))
 
-    const unsatisfiable = await request(row.handler, 'GET', url, { range: `bytes=${pdf.length + 10}-` })
+    const unsatisfiable = await request(row.handler, 'GET', url, { headers: { range: `bytes=${pdf.length + 10}-` } })
     expect(unsatisfiable.status).toBe(416)
     expect(unsatisfiable.headers['content-range']).toBe(`bytes */${pdf.length}`)
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('answers validators (ETag/Last-Modified), 304 revalidation, and If-Range fallbacks', async () => {
+    const dir = await realpath(await mkdtemp(join(tmpdir(), 'aionui-route-')))
+    const root = join(dir, 'proj')
+    await mkdir(root, { recursive: true })
+    const pdf = Buffer.from('%PDF-1.7 fake body for validator tests', 'latin1')
+    await writeFile(join(root, 'doc.pdf'), pdf)
+    const gate: WorkspaceGate = async () => ({ ok: true, canonical: root })
+    const { ctx, registrations } = fakeCtx()
+    registerPanelRoutes(ctx as never, new FsService(gate), { status: async () => null } as never)
+    const row = registrations.find((item) => item.kind === 'prefix')!
+    const url = `/aionui-panel/raw?root=${encodeURIComponent(root)}&path=doc.pdf`
+
+    // 200 full body carries size+mtime validators (content-length is a number).
+    const full = await request(row.handler, 'GET', url)
+    expect(full.status).toBe(200)
+    expect(full.headers.etag).toMatch(/^W\/"\d+-\d+"$/)
+    expect(full.headers['last-modified']).toBe(new Date(full.headers['last-modified']).toUTCString())
+    expect(full.headers['content-length']).toBe(pdf.length)
+    expect(full.body.equals(pdf)).toBe(true)
+    const etag = full.headers.etag
+    const lastModified = full.headers['last-modified']
+
+    // 206 partial responses carry the same validators.
+    const part = await request(row.handler, 'GET', url, { headers: { range: 'bytes=0-4' } })
+    expect(part.status).toBe(206)
+    expect(part.headers.etag).toBe(etag)
+    expect(part.headers['last-modified']).toBe(lastModified)
+
+    // If-None-Match with no Range answers 304 with an empty body and validators.
+    const revalidate = await request(row.handler, 'GET', url, { headers: { 'if-none-match': etag } })
+    expect(revalidate.status).toBe(304)
+    expect(revalidate.headers.etag).toBe(etag)
+    expect(revalidate.headers['last-modified']).toBe(lastModified)
+    expect(revalidate.body.length).toBe(0)
+
+    // Multi-range requests are ignored per RFC 7233: 200 with the full body.
+    const multi = await request(row.handler, 'GET', url, { headers: { range: 'bytes=0-1,3-4' } })
+    expect(multi.status).toBe(200)
+    expect(multi.body.equals(pdf)).toBe(true)
+
+    // If-Range matching the current validator keeps the range honored (206).
+    const ifRangeMatch = await request(row.handler, 'GET', url, {
+      headers: { range: 'bytes=0-4', 'if-range': etag },
+    })
+    expect(ifRangeMatch.status).toBe(206)
+    expect(ifRangeMatch.headers['content-range']).toBe(`bytes 0-4/${pdf.length}`)
+
+    // If-Range matching Last-Modified (the date form) is also honored.
+    const ifRangeDate = await request(row.handler, 'GET', url, {
+      headers: { range: 'bytes=0-4', 'if-range': lastModified },
+    })
+    expect(ifRangeDate.status).toBe(206)
+
+    // A stale If-Range falls back to the full 200 body instead of a stale slice.
+    const ifRangeStale = await request(row.handler, 'GET', url, {
+      headers: { range: 'bytes=0-4', 'if-range': 'W/"1-1"' },
+    })
+    expect(ifRangeStale.status).toBe(200)
+    expect(ifRangeStale.body.equals(pdf)).toBe(true)
+
+    // 416 responses carry validators too, so clients can revalidate the size.
+    const unsatisfiable = await request(row.handler, 'GET', url, { headers: { range: `bytes=${pdf.length + 10}-` } })
+    expect(unsatisfiable.status).toBe(416)
+    expect(unsatisfiable.headers.etag).toBe(etag)
+    expect(unsatisfiable.headers['last-modified']).toBe(lastModified)
 
     await rm(dir, { recursive: true, force: true })
   })
@@ -177,14 +246,45 @@ describe('parseRangeHeader', () => {
     expect(parseRangeHeader('bytes=0-999', 100)).toEqual({ start: 0, end: 99 })
   })
 
-  it('handles suffix ranges and rejects malformed/unsatisfiable ones', () => {
+  it('handles suffix ranges and ignores unsupported shapes per RFC 7233', () => {
     expect(parseRangeHeader('bytes=-10', 100)).toEqual({ start: 90, end: 99 })
+    // Unknown units, malformed headers and multi-range requests return null:
+    // the caller ignores the Range and answers 200 with the full body.
+    expect(parseRangeHeader('bytes=', 100)).toBeNull()
+    expect(parseRangeHeader('bytes=0-1,3-4', 100)).toBeNull()
+    expect(parseRangeHeader('items=0-1', 100)).toBeNull()
+    expect(parseRangeHeader('garbage', 100)).toBeNull()
+  })
+
+  it('rejects unsatisfiable single ranges as invalid (416)', () => {
     expect(parseRangeHeader('bytes=-0', 100)).toBe('invalid')
     expect(parseRangeHeader('bytes=-5', 0)).toBe('invalid')
-    expect(parseRangeHeader('bytes=', 100)).toBe('invalid')
-    expect(parseRangeHeader('bytes=0-1,3-4', 100)).toBe('invalid')
     expect(parseRangeHeader('bytes=100-', 100)).toBe('invalid')
     expect(parseRangeHeader('bytes=50-40', 100)).toBe('invalid')
-    expect(parseRangeHeader('items=0-1', 100)).toBe('invalid')
+    expect(parseRangeHeader('bytes=0-1', 0)).toBe('invalid')
+  })
+})
+
+describe('ifNoneMatchSaidFresh', () => {
+  const etag = 'W/"1000-1692000000000"'
+
+  it('matches a single exact or strong-form tag', () => {
+    expect(ifNoneMatchSaidFresh(etag, etag)).toBe(true)
+    // Weak comparison: the W/ prefix and quoting are ignored on both sides.
+    expect(ifNoneMatchSaidFresh('"1000-1692000000000"', etag)).toBe(true)
+    expect(ifNoneMatchSaidFresh('W/"1000-1692000000000"', '"1000-1692000000000"')).toBe(true)
+  })
+
+  it('matches comma-separated lists and the star form', () => {
+    expect(ifNoneMatchSaidFresh('W/"1-1", W/"1000-1692000000000"', etag)).toBe(true)
+    expect(ifNoneMatchSaidFresh('  "5-5" ,  W/"1000-1692000000000" ', etag)).toBe(true)
+    expect(ifNoneMatchSaidFresh('*', etag)).toBe(true)
+  })
+
+  it('rejects missing headers and non-matching tags', () => {
+    expect(ifNoneMatchSaidFresh(undefined, etag)).toBe(false)
+    expect(ifNoneMatchSaidFresh('W/"1-1"', etag)).toBe(false)
+    expect(ifNoneMatchSaidFresh('"1000-1692000000001"', etag)).toBe(false)
+    expect(ifNoneMatchSaidFresh('', etag)).toBe(false)
   })
 })

--- a/packages/dsh-aionui-panel/tests/stores.spec.ts
+++ b/packages/dsh-aionui-panel/tests/stores.spec.ts
@@ -170,7 +170,7 @@ describe('scm store', () => {
   })
 })
 
-describe('preview pdf tabs (issue #236)', () => {
+describe('preview pdf tabs (issue #239)', () => {
   it('openFile on a pdf streams via the raw route without api.read', async () => {
     const { api } = fakeApi()
     const s = createPanelStores(api)


### PR DESCRIPTION
## 摘要（Summary）

PR #242 合并后维护者留下的三项可选打磨（Low）：多区间 Range 按 RFC 7233 忽略（200 全量）而非 416；raw 路由增加 ETag/Last-Modified 验证器（304/If-Range），消除大 PDF 滚动时的重复拉取；修正测试标签里的 issue 编号笔误（#236 → #239）。附带一项自查优化：扩展名已知时跳过魔数嗅探的 open/read。

## 涉及包（Affected Packages）

- [x] 右侧面板 `packages/dsh-aionui-panel`

## PR 类型（PR Type）

- [x] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

git fetch upstream && git switch -c fix/aionui-panel-raw-route-polish upstream/main（base: 986845a，v0.1.17）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek

使用的编码 Agent 工具：

DeepSeek Harness（含 AgentTeams 子代理辅助测试）

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本次无新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改 README）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel build
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
pnpm typecheck
pnpm docs:check
```

结果摘要：

- aionui-panel vitest：154 pass / 1 skip / 2 fail——2 个失败为既有 symlink 用例（本 Windows 机器无 Developer Mode/管理员权限，与本次改动无关，同 PR #242 已披露）。
- 新增/更新测试：parseRangeHeader 新语义（多区间/畸形/未知单位忽略，不可满足单区间 416）；ifNoneMatchSaidFresh（弱比较、逗号列表、* 形）；raw 路由 validators 集成（200/206 带 ETag+Last-Modified、If-None-Match→304、多区间→200、If-Range 匹配/不匹配、416 带验证器头）；readRaw 断言 mtime。
- 全仓 typecheck 与 pnpm docs:check 通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A——纯内部性能与协议合规打磨（无 UI/交互变更）。行为面变化仅为：多区间 Range 由 416 改为 200 全量（RFC 7233 允许）、重复请求由 304 替代全量重传。覆盖证据见上述新增测试用例；PDF 预览的可见效果已在 #242 附截图验证。
