### PR TITLE
feat(aionui-panel): render mermaid diagrams in the markdown preview

### DIFF
--- a/packages/dsh-aionui-panel/README.i18n.yaml
+++ b/packages/dsh-aionui-panel/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 789522ec1548ad9481a13efdc829802c54467618
-README.zh.md: 6748a184dadd22db7ea937f2bac300296beb8b78
+README.md: 6208dd81199284340c556ec44d4f62778bdff746
+README.zh.md: 31c23fe90faedd42fe133908c335b80be544f329

--- a/packages/dsh-aionui-panel/README.md
+++ b/packages/dsh-aionui-panel/README.md
@@ -29,6 +29,7 @@ When a project session (the current session has a working directory) is open, tw
 - **Explorer (rightmost column, default 260px, range 220–500px)**: `File / Changes` two tabs; clicking a row in the file tree expands/collapses a folder, clicking a file opens it in the preview panel, and the top filename search (150ms debounce, clicking a result locates it in the tree without interrupting flow); the `Changes` tab reads the real git status and supports stage / unstage / discard (untracked via delete, tracked via restore, bulk discard asks for confirmation).
 - **Drag a file to the input box**: file rows in the tree can be dragged (except directory rows); dropping onto the chat input area inserts the relative path (e.g. `deploy/base/deployment.yaml`) at the cursor of the current draft, and the agent reads the file itself once the message arrives — no need to type the path by hand; a highlighted hint bar shows above the input while dragging.
 - **Preview (second column from right, default 480px, range 340–1200px)**: multi-tab preview supporting markdown / html / code / diff / csv / pdf / word / excel / ppt / image / text / url (code previews are syntax-highlighted via the official shiki core); source/preview toggle, split-screen editing (ratio persisted), save (mtime conflict detection), download, refresh (4-state: dead buttons are not rendered), dirty dot, middle-click close, right-click menu batch close (dirty confirm), and tab-overflow gradient indicator.
+- **Mermaid diagrams**: fenced ```mermaid blocks render as diagrams in the markdown preview. The mermaid runtime is bundled in the package and served same-origin via `/aionui-panel/vendor/mermaid.js` (no CDN, offline-friendly, loopback-fenced); diagrams follow the shell's light/dark theme and re-render on theme flips; a diagram with syntax errors falls back to the plain code block.
 
 Interaction details:
 
@@ -42,7 +43,7 @@ Interaction details:
 
 The real filesystem and the real git repository, no mocks:
 
-- The host half (`src/index.ts` + `src/host/`) serves directory listing, file reads (text capped at 80k chars / image data URLs), writes (mtime conflict detection), filename search (skipping .git / node_modules), git status (porcelain v1 -z) / stage / unstage / discard, and an SSE change stream (fs watching + git polling) over the `/aionui-panel/*` HTTP routes.
+- The host half (`src/index.ts` + `src/host/`) serves directory listing, file reads (text capped at 80k chars / image data URLs), writes (mtime conflict detection), filename search (skipping .git / node_modules), git status (porcelain v1 -z) / stage / unstage / discard, and an SSE change stream (fs watching + git polling) over the `/aionui-panel/*` HTTP routes. It also serves the vendored mermaid IIFE bundle (`lib/assets/mermaid.min.js`, copied from the pinned npm dependency at build time) at `/aionui-panel/vendor/mermaid.js` with etag revalidation.
 - All operations pass through a workspace guard: paths must fall inside a registered workspace (realpath normalization + prefix check); the browser can only read/write relative paths under the project root.
 - Every `/aionui-panel/*` route (JSON operations, raw reads, and the SSE events stream) is loopback-only: non-loopback clients get `403 forbidden: loopback-only` before any workspace access, matching the dsh-ssh fence.
 - The recursive watcher ignores changes under `node_modules` / `.git`; the SCM poll runs every 30s per workspace (each probe bounded by a 15s deadline), and roots that are not git repositories stop being re-probed thanks to a TTL cache. File edits surface via the watcher immediately; `.git`-only changes (commits/checkouts from other tools) appear within one poll interval or on window focus (throttled to once per 5s).
@@ -53,7 +54,7 @@ The real filesystem and the real git repository, no mocks:
 - `src/index.ts` — host half entry (cordis plugin: route registration + systemPrompt announcement).
 - `src/host/` — fs/git data services and the route layer (workspace gate).
 - `src/core/types.ts` — shared wire types across both halves.
-- `src/client/` — browser half: framework-agnostic state core (`store.ts`), drag engine (`drag.ts` + `hooks/useResizableSplit.ts`), DOM layout controller (`layout.ts`, appending panel tracks to the shell's three-column grid), React components (explorer / scm / preview).
+- `src/client/` — browser half: framework-agnostic state core (`store.ts`), drag engine (`drag.ts` + `hooks/useResizableSplit.ts`), DOM layout controller (`layout.ts`, appending panel tracks to the shell's three-column grid), React components (explorer / scm / preview), and the mermaid enhancement (`preview/mermaid.ts` + `chat/mermaid-chat.tsx`).
 - `tests/` — pure-logic tests for the clamp formula, porcelain parsing, persistence validation, markdown/csv rendering, store behavior, etc. (vitest, 37 tests).
 
 ## Build

--- a/packages/dsh-aionui-panel/README.zh.md
+++ b/packages/dsh-aionui-panel/README.zh.md
@@ -29,6 +29,7 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-aionui-panel
 - **Explorer（最右栏，默认 260px，范围 220~500px）**：`文件 / 变更` 双 tab；文件树整行点击展开/收起文件夹，点击文件在预览面板打开，顶部按文件名搜索（150ms 防抖，点击结果 = 定位到树中，不打断思路）；`变更` tab 读取真实 git 状态，支持 stage / unstage / discard（untracked 走删除，tracked 走 restore，批量放弃有确认）。
 - **拖拽文件到输入框**：文件树中的文件行可拖拽（目录行除外），拖到聊天输入框区域松手即把相对路径（如 `deploy/base/deployment.yaml`）插入当前会话草稿的光标处，agent 收到消息后会自行读取该文件，无需手动输入路径；拖拽过程中输入框上方显示高亮提示条。
 - **Preview（右二栏，默认 480px，范围 340~1200px）**：多 tab 预览，支持 markdown / html / code / diff / csv / pdf / word / excel / ppt / 图片 / 文本 / url（code 预览经由官方 shiki core 语法高亮）；源码/预览切换、分屏编辑（比例持久化）、保存（mtime 冲突检测）、下载、刷新（4 态：不渲染死按钮）、dirty 点、中键关闭、右键菜单批量关闭（dirty 确认）、tab 溢出渐变指示器。
+- **Mermaid 图表**：markdown 预览中的 ```mermaid 代码块会渲染成图表。mermaid 运行时打包在包内，经 `/aionui-panel/vendor/mermaid.js` 同源提供（不走 CDN、离线可用、loopback 围栏）；图表跟随 shell 明暗主题并在切换时重渲染；图源语法错误时回退为原代码块。
 
 交互细节：
 
@@ -42,7 +43,7 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-aionui-panel
 
 真实文件系统与真实 git 仓库，无任何 mock：
 
-- host 半区（`src/index.ts` + `src/host/`）经 `/aionui-panel/*` HTTP 路由提供目录列举、文件读取（文本 80k 字符上限 / 图片 data URL）、写入（mtime 冲突检测）、文件名搜索（跳过 .git / node_modules）、git status（porcelain v1 -z）/ stage / unstage / discard，以及 SSE 变更流（fs 监听 + git 轮询）。
+- host 半区（`src/index.ts` + `src/host/`）经 `/aionui-panel/*` HTTP 路由提供目录列举、文件读取（文本 80k 字符上限 / 图片 data URL）、写入（mtime 冲突检测）、文件名搜索（跳过 .git / node_modules）、git status（porcelain v1 -z）/ stage / unstage / discard，以及 SSE 变更流（fs 监听 + git 轮询）；并经 `/aionui-panel/vendor/mermaid.js` 提供构建期从固定版本 npm 依赖拷贝的 mermaid IIFE 产物（`lib/assets/mermaid.min.js`），带 etag 再校验。
 - 所有操作经过工作区门卫：路径必须落在已注册 workspace 内（realpath 规范化 + 前缀校验），浏览器只能读写项目根下的相对路径。
 - 所有 `/aionui-panel/*` 路由（JSON 操作、raw 读取与 SSE 事件流）仅限 loopback：非 loopback 客户端在任何工作区访问前即收到 `403 forbidden: loopback-only`，与 dsh-ssh 的 fence 一致。
 - 递归 watcher 忽略 `node_modules` / `.git` 下的变更；SCM 轮询每 30s 对每个 workspace 探测一次（单次探测有 15s 超时兜底），非 git 仓库的根经 TTL 缓存不再反复探测。文件编辑经 watcher 即时呈现；仅 `.git` 元数据变更（其他工具的 commit/checkout）在一个轮询周期内或窗口重新聚焦（5s 节流）时呈现。
@@ -53,7 +54,7 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-aionui-panel
 - `src/index.ts` — host 半区入口（cordis 插件：路由注册 + systemPrompt 公告）。
 - `src/host/` — fs/git 数据服务与路由层（workspace gate）。
 - `src/core/types.ts` — 前后半区共享的线上类型。
-- `src/client/` — browser 半区：框架无关状态核心（`store.ts`）、拖拽引擎（`drag.ts` + `hooks/useResizableSplit.ts`）、DOM 布局控制器（`layout.ts`，向 shell 的三栏 grid 追加面板轨道）、React 组件（explorer / scm / preview）。
+- `src/client/` — browser 半区：框架无关状态核心（`store.ts`）、拖拽引擎（`drag.ts` + `hooks/useResizableSplit.ts`）、DOM 布局控制器（`layout.ts`，向 shell 的三栏 grid 追加面板轨道）、React 组件（explorer / scm / preview），以及 mermaid 增强（`preview/mermaid.ts` + `chat/mermaid-chat.tsx`）。
 - `tests/` — clamp 公式、porcelain 解析、持久化校验、markdown/csv 渲染、store 行为等纯逻辑测试（vitest，37 个）。
 
 ## 构建

--- a/packages/dsh-aionui-panel/package.json
+++ b/packages/dsh-aionui-panel/package.json
@@ -31,11 +31,14 @@
     }
   },
   "scripts": {
-    "build": "tsc -b && tsdown",
-    "prepare": "tsdown",
+    "build": "tsc -b && node scripts/copy-mermaid.mjs && tsdown",
+    "prepare": "node scripts/copy-mermaid.mjs && tsdown",
     "watch": "tsdown --watch",
     "test": "vitest run",
     "typecheck": "tsc -b --pretty false"
+  },
+  "dependencies": {
+    "mermaid": "11.16.1"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/packages/dsh-aionui-panel/scripts/copy-mermaid.mjs
+++ b/packages/dsh-aionui-panel/scripts/copy-mermaid.mjs
@@ -1,0 +1,42 @@
+/**
+ * Build-time asset copy: place the mermaid IIFE bundle where the host vendor
+ * route serves it from (lib/assets/mermaid.min.js). The mermaid version is
+ * pinned in package.json; this script only copies, never downloads.
+ */
+import { copyFile, mkdir, stat } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const packageRoot = dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+
+/** Candidate resolutions for the mermaid dist bundle (exports-map tolerant). */
+function resolveMermaidDist() {
+  const candidates = []
+  for (const specifier of ['mermaid/dist/mermaid.min.js', 'mermaid/package.json']) {
+    try {
+      candidates.push(require.resolve(specifier))
+    } catch {
+      // try the next candidate
+    }
+  }
+  for (const candidate of candidates) {
+    if (candidate.endsWith('mermaid.min.js')) return candidate
+    const beside = join(dirname(candidate), 'dist', 'mermaid.min.js')
+    try {
+      require.resolve(beside)
+      return beside
+    } catch {
+      // keep walking candidates
+    }
+  }
+  throw new Error('cannot resolve mermaid/dist/mermaid.min.js — run pnpm install first')
+}
+
+const source = resolveMermaidDist()
+const target = join(packageRoot, '..', 'lib', 'assets', 'mermaid.min.js')
+await mkdir(dirname(target), { recursive: true })
+await copyFile(source, target)
+const info = await stat(target)
+console.log(`[dsh-aionui-panel] mermaid asset: ${source} -> ${target} (${info.size} bytes)`)

--- a/packages/dsh-aionui-panel/src/client/chat/mermaid-chat.tsx
+++ b/packages/dsh-aionui-panel/src/client/chat/mermaid-chat.tsx
@@ -1,0 +1,53 @@
+/**
+ * Chat-transcript mermaid enhancement: the core conversation renderer emits
+ * fenced code as `pre > code.language-mermaid`, and the shell has no slot
+ * for message-body post-processing — so this component rides the
+ * conversation input dock as a zero-render sentinel and observes the
+ * document for mermaid blocks the transcript mounts. Blocks inside the
+ * preview panel's own subtree are excluded (each surface owns its blocks).
+ *
+ * Streaming awareness: an assistant message re-renders continuously, so a
+ * diagram fence is often incomplete mid-stream. Renders that fail restore
+ * the block and the next mutation retries it — once the fence closes the
+ * diagram lands. Mutations are debounced to one rAF and the observer is
+ * disconnected on unmount.
+ * @module dsh-aionui-panel/client/chat/mermaid-chat
+ */
+
+import { useEffect } from 'react'
+import type { JSX } from 'react'
+import { DATA_MD_SCOPE, enhanceMermaidBlocks, mermaidTheme, rethemeMermaidBlocks, shellIsDark, watchShellTheme } from '../preview/mermaid.ts'
+import previewCss from '../styles/preview.module.css'
+
+/** Hidden sentinel: renders nothing, owns the transcript observer. */
+export function MermaidChatEnhancer(): JSX.Element | null {
+  useEffect(() => {
+    let scheduled = false
+    let pendingFrame = 0
+    const run = (): void => {
+      scheduled = false
+      void enhanceMermaidBlocks(document.body, {
+        className: previewCss.mermaidBlock,
+        theme: mermaidTheme(shellIsDark()),
+        skip: (pre) => pre.closest(`[${DATA_MD_SCOPE}]`) !== null,
+      })
+    }
+    const schedule = (): void => {
+      if (scheduled) return
+      scheduled = true
+      pendingFrame = requestAnimationFrame(run)
+    }
+    const observer = new MutationObserver(schedule)
+    observer.observe(document.body, { childList: true, subtree: true })
+    schedule()
+    const disposeTheme = watchShellTheme((isDark) => {
+      void rethemeMermaidBlocks(document.body, { theme: mermaidTheme(isDark) })
+    })
+    return () => {
+      observer.disconnect()
+      disposeTheme()
+      cancelAnimationFrame(pendingFrame)
+    }
+  }, [])
+  return null
+}

--- a/packages/dsh-aionui-panel/src/client/index.ts
+++ b/packages/dsh-aionui-panel/src/client/index.ts
@@ -25,6 +25,7 @@ import { mountPanels } from './mount.tsx'
 import { NS, dictionaries, setLanguage, type AionUiPanelKey } from './locales.ts'
 import { DragFileInlay, type DragFileInjected } from './drag/DragFileInlay.tsx'
 import { insertPathIntoDraft } from './drag/file-drag.ts'
+import { MermaidChatEnhancer } from './chat/mermaid-chat.tsx'
 
 declare module '@deepseek-ai/dsh-client-ui-slots' {
   interface LocaleNamespaceMap {
@@ -68,6 +69,18 @@ export function apply(ctx: ClientContext): void {
           },
         }),
       }, DragFileInlay))
+  })
+
+  // Transcript mermaid enhancement rides the same dock as a zero-render
+  // sentinel: the shell has no message-body slot, so the sentinel observes
+  // the document for the chat renderer's `code.language-mermaid` blocks.
+  ctx.inject(['slots'], (scope: ClientContext) => {
+    scope.slots.inject('conversation.input.dock', () =>
+      scope.slots.register({
+        name: 'conversation.input.dock',
+        id: 'aionui-mermaid-chat',
+        order: 91,
+      }, MermaidChatEnhancer))
   })
 
   ctx.effect(() => {

--- a/packages/dsh-aionui-panel/src/client/preview/content.tsx
+++ b/packages/dsh-aionui-panel/src/client/preview/content.tsx
@@ -14,6 +14,14 @@ import type { PreviewTabState } from '../store.ts'
 import { useResizableSplit } from '../hooks/useResizableSplit.ts'
 import { t } from '../locales.ts'
 import { renderMarkdown, resolveMarkdownImage } from './markdown.ts'
+import {
+  DATA_MD_SCOPE,
+  enhanceMermaidBlocks,
+  mermaidTheme,
+  rethemeMermaidBlocks,
+  shellIsDark,
+  watchShellTheme,
+} from './mermaid.ts'
 import previewCss from '../styles/preview.module.css'
 
 /** Split-ratio persistence key (AionUi contract). */
@@ -197,7 +205,33 @@ function MarkdownViewer({
       </div>
     )
   }
-  return <div className={previewCss.mdViewer} dangerouslySetInnerHTML={{ __html: html }} />
+  return <MermaidAwareMarkdown html={html} />
+}
+
+/**
+ * Rendered markdown body plus the mermaid enhancement lifecycle: fresh
+ * blocks render once per html, completed diagrams re-render on shell theme
+ * flips. The scope marker lets the chat-transcript enhancer skip this
+ * subtree (each surface owns its blocks).
+ */
+function MermaidAwareMarkdown({ html }: { html: string }): JSX.Element {
+  const ref = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    const el = ref.current
+    if (el === null) return undefined
+    void enhanceMermaidBlocks(el, { className: previewCss.mermaidBlock, theme: mermaidTheme(shellIsDark()) })
+    return watchShellTheme((isDark) => {
+      void rethemeMermaidBlocks(el, { theme: mermaidTheme(isDark) })
+    })
+  }, [html])
+  return (
+    <div
+      ref={ref}
+      className={previewCss.mdViewer}
+      {...{ [DATA_MD_SCOPE]: '1' }}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
 }
 
 /** HTML viewer: sandboxed iframe (scripts off) or source textarea. */

--- a/packages/dsh-aionui-panel/src/client/preview/mermaid.ts
+++ b/packages/dsh-aionui-panel/src/client/preview/mermaid.ts
@@ -1,0 +1,211 @@
+/**
+ * Mermaid diagram enhancement for markdown surfaces: lazily loads the
+ * mermaid runtime from the host vendor route (same origin, no CDN), renders
+ * every fenced ```mermaid code block in place, and re-renders on theme
+ * flips. Framework-free so both the preview panel (React effect) and the
+ * chat transcript observer can drive it over disjoint DOM scopes.
+ *
+ * Failure policy: any load/render failure leaves the original code block
+ * untouched (or restores it verbatim); nothing here throws to the caller.
+ * @module dsh-aionui-panel/client/preview/mermaid
+ */
+
+/** Minimal structural type of the mermaid runtime this module consumes. */
+interface MermaidRuntime {
+  initialize: (config: Record<string, unknown>) => void
+  render: (id: string, text: string, container?: HTMLElement) => Promise<{ svg: string }>
+}
+
+/** Host-served mermaid IIFE bundle (lib/assets/mermaid.min.js behind the route). */
+export const MERMAID_VENDOR_URL = '/aionui-panel/vendor/mermaid.js'
+
+/** Lifecycle state stamped on diagram containers (`pending`/`rendering`/`done`). */
+const DATA_STATE = 'data-mermaid-state'
+
+/** State stamped on a code block once its container exists (`claimed`). */
+const DATA_CLAIMED = 'data-mermaid-claimed'
+
+/** The verbatim diagram source kept on the container for theme re-renders. */
+const DATA_SOURCE = 'data-mermaid-source'
+
+/** Marker the preview viewer stamps on its own subtree (chat enhancement skips it). */
+export const DATA_MD_SCOPE = 'data-aionui-md-scope'
+
+let loadPromise: Promise<MermaidRuntime> | undefined
+
+/**
+ * Resolve the mermaid global left by the vendor IIFE bundle, or null while
+ * absent. Narrow and defensive: the bundle is a third-party artifact.
+ */
+function mermaidGlobal(): MermaidRuntime | null {
+  const candidate = (globalThis as Record<string, unknown>).mermaid
+  if (typeof candidate !== 'object' || candidate === null) return null
+  const checked = candidate as Record<string, unknown>
+  if (typeof checked.initialize !== 'function' || typeof checked.render !== 'function') return null
+  return checked as unknown as MermaidRuntime
+}
+
+/**
+ * Load the mermaid runtime once per page: injects a <script> for the host
+ * vendor route and resolves with the runtime. Concurrent callers share one
+ * injection; a failure clears the cache so a later surface can retry.
+ */
+export function loadMermaidLibrary(): Promise<MermaidRuntime> {
+  const existing = mermaidGlobal()
+  if (existing !== null) return Promise.resolve(existing)
+  if (loadPromise !== undefined) return loadPromise
+  loadPromise = new Promise<MermaidRuntime>((resolve, reject) => {
+    const script = document.createElement('script')
+    script.src = MERMAID_VENDOR_URL
+    script.async = true
+    script.onload = () => {
+      const runtime = mermaidGlobal()
+      if (runtime === null) {
+        loadPromise = undefined
+        reject(new Error('mermaid vendor script loaded but window.mermaid is missing'))
+        return
+      }
+      resolve(runtime)
+    }
+    script.onerror = () => {
+      loadPromise = undefined
+      reject(new Error(`failed to load ${MERMAID_VENDOR_URL}`))
+    }
+    document.head.appendChild(script)
+  })
+  return loadPromise
+}
+
+/** Mermaid theme name for the shell theme marker (`default` or `dark`). */
+export function mermaidTheme(isDark: boolean): 'default' | 'dark' {
+  return isDark ? 'dark' : 'default'
+}
+
+/** Whether the shell currently carries the dark marker attribute. */
+export function shellIsDark(): boolean {
+  return document.body.hasAttribute('data-ds-dark-theme')
+}
+
+/** Monotonic id source for render calls (mermaid keys its <svg> by id). */
+let renderSeq = 0
+
+/** Apply (or re-apply) the theme then render one diagram source to SVG. */
+async function renderSvg(runtime: MermaidRuntime, theme: string, source: string): Promise<string> {
+  runtime.initialize({
+    startOnLoad: false,
+    theme,
+    securityLevel: 'strict',
+    fontFamily: '"trebuchet ms", verdana, arial, sans-serif',
+  })
+  const { svg } = await runtime.render(`aionui-mermaid-${(renderSeq += 1)}`, source)
+  return svg
+}
+
+/**
+ * Collect the still-unclaimed fenced mermaid code blocks under one scope.
+ * Both shapes are found: the panel renderer's `pre.language-mermaid` and
+ * the chat renderer's `pre > code.language-mermaid` (the claim always
+ * targets the <pre>). Empty blocks and blocks another driver already
+ * claimed are skipped. Pure (DOM-read only) so tests can drive it in jsdom.
+ */
+export function findMermaidCodeBlocks(scope: ParentNode): HTMLPreElement[] {
+  const found: HTMLPreElement[] = []
+  const seen = new Set<Element>()
+  for (const el of Array.from(scope.querySelectorAll('pre.language-mermaid, code.language-mermaid'))) {
+    const pre = el instanceof HTMLPreElement ? el : el.parentElement
+    if (pre === null || !(pre instanceof HTMLPreElement)) continue
+    if (seen.has(pre)) continue
+    seen.add(pre)
+    if (pre.hasAttribute(DATA_CLAIMED)) continue
+    if ((pre.textContent ?? '').trim() === '') continue
+    found.push(pre)
+  }
+  return found
+}
+
+/**
+ * Swap one code block for a diagram container. The original <pre> stays in
+ * the tree (hidden once the render lands) so a failure can restore it
+ * verbatim; the container carries the source for theme re-renders.
+ */
+function claimBlock(pre: HTMLPreElement, className: string): HTMLElement {
+  pre.setAttribute(DATA_CLAIMED, '1')
+  const container = document.createElement('div')
+  container.className = className
+  container.setAttribute(DATA_STATE, 'pending')
+  container.setAttribute(DATA_SOURCE, pre.textContent ?? '')
+  pre.insertAdjacentElement('afterend', container)
+  return container
+}
+
+/** Options for {@link enhanceMermaidBlocks}. */
+export interface EnhanceOptions {
+  /** Class for the diagram container (a CSS module export). */
+  className: string
+  /** Resolved mermaid theme name. */
+  theme: string
+  /** Optional extra exclusion for scopes another driver owns. */
+  skip?: (pre: HTMLPreElement) => boolean
+}
+
+/**
+ * Render every unclaimed ```mermaid block under `scope` into an inline SVG
+ * diagram. Idempotent per block across drivers (claimed blocks are skipped);
+ * failures restore the original code block. Never rejects.
+ */
+export async function enhanceMermaidBlocks(scope: ParentNode, options: EnhanceOptions): Promise<void> {
+  let runtime: MermaidRuntime
+  try {
+    runtime = await loadMermaidLibrary()
+  } catch {
+    return // no vendor route (asset missing): keep plain code blocks
+  }
+  const jobs: Array<Promise<void>> = []
+  for (const pre of findMermaidCodeBlocks(scope)) {
+    if (options.skip?.(pre) === true) continue
+    const container = claimBlock(pre, options.className)
+    jobs.push((async () => {
+      try {
+        container.setAttribute(DATA_STATE, 'rendering')
+        const source = container.getAttribute(DATA_SOURCE) ?? ''
+        container.innerHTML = await renderSvg(runtime, options.theme, source)
+        container.setAttribute(DATA_STATE, 'done')
+        pre.style.display = 'none'
+      } catch {
+        // Syntax error or render failure: restore the untouched code block.
+        container.remove()
+        pre.removeAttribute(DATA_CLAIMED)
+      }
+    })())
+  }
+  await Promise.all(jobs)
+}
+
+/**
+ * Re-render every completed diagram container under `scope` after a theme
+ * flip (stored sources re-render with the new theme). Containers not in the
+ * `done` state are skipped; a failure keeps the previous render.
+ */
+export async function rethemeMermaidBlocks(scope: ParentNode, options: { theme: string }): Promise<void> {
+  const runtime = mermaidGlobal()
+  if (runtime === null) return
+  const containers = Array.from(scope.querySelectorAll<HTMLElement>('[data-mermaid-state="done"]'))
+  await Promise.all(containers.map(async (container) => {
+    const source = container.getAttribute(DATA_SOURCE) ?? ''
+    try {
+      container.innerHTML = await renderSvg(runtime, options.theme, source)
+    } catch {
+      // Keep the previous render; a theme flip must not blank diagrams.
+    }
+  }))
+}
+
+/**
+ * One dark-marker watcher per surface: fires on body attribute flips so the
+ * caller can retheme. Returns the disposer.
+ */
+export function watchShellTheme(onChange: (isDark: boolean) => void): () => void {
+  const observer = new MutationObserver(() => { onChange(shellIsDark()) })
+  observer.observe(document.body, { attributes: true, attributeFilter: ['data-ds-dark-theme'] })
+  return () => { observer.disconnect() }
+}

--- a/packages/dsh-aionui-panel/src/client/styles/preview.module.css
+++ b/packages/dsh-aionui-panel/src/client/styles/preview.module.css
@@ -421,6 +421,32 @@
   color: var(--aion-text-primary);
 }
 
+/* ── mermaid diagrams ──────────────────────────────────────────────────── */
+
+/* Container that replaces a claimed ```mermaid code block; the hidden <pre>
+   stays as the fallback source. Wide diagrams scroll inside the panel. */
+.mermaidBlock {
+  margin: 10px 0;
+  padding: 12px 14px;
+  background: var(--aion-bg-2);
+  border: 1px solid var(--aion-bg-3);
+  border-radius: 6px;
+  overflow-x: auto;
+  text-align: center;
+}
+
+.mermaidBlock svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Render-in-progress placeholder pulse before the SVG lands. */
+.mermaidBlock[data-mermaid-state='pending'],
+.mermaidBlock[data-mermaid-state='rendering'] {
+  min-height: 40px;
+  opacity: 0.6;
+}
+
 .mdViewer blockquote {
   margin: 10px 0;
   padding: 4px 14px;

--- a/packages/dsh-aionui-panel/src/host/routes.ts
+++ b/packages/dsh-aionui-panel/src/host/routes.ts
@@ -9,6 +9,8 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createReadStream } from 'node:fs'
 import { pipeline } from 'node:stream/promises'
+import { readFile, stat } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
 import type { Context } from '@deepseek-ai/cordis'
 import type {} from '@deepseek-ai/dsh-host-webserver'
 import type { PanelEnvelope, PanelError } from '../core/types.ts'
@@ -345,6 +347,53 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
     }
   }
 
+  /**
+   * GET /aionui-panel/vendor/mermaid.js: the mermaid IIFE bundle shipped in
+   * the package (lib/assets/mermaid.min.js, copied from the mermaid npm
+   * dependency at build time). Same-origin for the browser half (no CDN),
+   * loopback-fenced like every other route. One read is cached per plugin
+   * instance; the size+mtime pair doubles as the ETag so the browser
+   * revalidation is a cheap 304. A missing asset (build without the copy
+   * step) 404s and the client keeps plain code blocks.
+   */
+  let mermaidAsset: { data: Buffer; etag: string } | undefined
+  const serveVendorMermaid = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    if (mermaidAsset === undefined) {
+      // Candidate layouts: the built lib half (lib/index.js -> lib/assets/)
+      // and the source tree (src/host/routes.ts -> lib/assets), so tests
+      // running against src serve the same build-copied asset.
+      const candidates = ['./assets/mermaid.min.js', '../../lib/assets/mermaid.min.js']
+      for (const relative of candidates) {
+        try {
+          const assetPath = fileURLToPath(new URL(relative, import.meta.url))
+          const [data, info] = await Promise.all([readFile(assetPath), stat(assetPath)])
+          mermaidAsset = { data, etag: `"${data.length}-${info.mtimeMs.toString(16)}"` }
+          break
+        } catch {
+          // try the next layout
+        }
+      }
+      if (mermaidAsset === undefined) {
+        res.writeHead(404, { 'content-type': 'application/json; charset=utf-8' })
+        res.end(JSON.stringify({ error: 'mermaid vendor asset missing' }))
+        return
+      }
+    }
+    if (req.headers['if-none-match'] === mermaidAsset.etag) {
+      res.writeHead(304, { etag: mermaidAsset.etag })
+      res.end()
+      return
+    }
+    res.writeHead(200, {
+      'content-type': 'application/javascript; charset=utf-8',
+      'content-length': mermaidAsset.data.length,
+      'cache-control': 'no-cache',
+      etag: mermaidAsset.etag,
+      'x-content-type-options': 'nosniff',
+    })
+    res.end(mermaidAsset.data)
+  }
+
   const handler = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     // Loopback fence first: never let a LAN client reach any /aionui-panel
     // operation, regardless of method or content-type.
@@ -356,6 +405,10 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
       const url = new URL(req.url ?? '/', 'http://x')
       if (url.pathname === '/aionui-panel/raw') {
         await serveRaw(req, url, res)
+        return
+      }
+      if (url.pathname === '/aionui-panel/vendor/mermaid.js') {
+        await serveVendorMermaid(req, res)
         return
       }
       res.writeHead(405)

--- a/packages/dsh-aionui-panel/src/index.ts
+++ b/packages/dsh-aionui-panel/src/index.ts
@@ -31,7 +31,7 @@ export const inject = ['webServer', 'subprocess', 'workspaceRegistry', 'systemPr
 const SECTION_ORDER = 210
 
 /** Model-facing announcement: plugin presence, capabilities, and limits. */
-export const AIONUI_PANEL_GUIDANCE = '本机已安装 dsh-aionui-panel 插件（DSH Web GUI 的右侧面板系统）：项目会话打开时，聊天区右侧出现「预览」与「文件/变更」两块面板。能力：Explorer 文件树（点击文件在预览面板打开、整行点击展开文件夹、按文件名搜索定位）；Preview 多 tab 预览（markdown/html/code/diff/csv/pdf/office/图片/文本等格式，支持源码/预览切换、分屏编辑、保存）；SCM 变更面板（真实 git stage/unstage/discard）；面板宽度可拖拽调整（Explorer 220~500px、Preview 340~1200px），双击把手复位默认宽度，折叠状态与宽度按项目持久化（localStorage）。数据源为当前会话工作目录的真实文件系统与真实 git 仓库，宿主进程经 /aionui-panel/* 路由提供。用户提到「右侧面板 / 预览面板 / 文件树 / 变更面板」时即指本插件，请据此协作。'
+export const AIONUI_PANEL_GUIDANCE = '本机已安装 dsh-aionui-panel 插件（DSH Web GUI 的右侧面板系统）：项目会话打开时，聊天区右侧出现「预览」与「文件/变更」两块面板。能力：Explorer 文件树（点击文件在预览面板打开、整行点击展开文件夹、按文件名搜索定位）；Preview 多 tab 预览（markdown/html/code/diff/csv/pdf/office/图片/文本等格式，支持源码/预览切换、分屏编辑、保存；markdown 与聊天消息中的 mermaid 代码块会渲染成图表，图源语法错误时回退为代码块）；SCM 变更面板（真实 git stage/unstage/discard）；面板宽度可拖拽调整（Explorer 220~500px、Preview 340~1200px），双击把手复位默认宽度，折叠状态与宽度按项目持久化（localStorage）。数据源为当前会话工作目录的真实文件系统与真实 git 仓库，宿主进程经 /aionui-panel/* 路由提供。用户提到「右侧面板 / 预览面板 / 文件树 / 变更面板」时即指本插件，请据此协作。'
 
 /**
  * Mount the panel data services and their routes.

--- a/packages/dsh-aionui-panel/tests/mermaid.spec.ts
+++ b/packages/dsh-aionui-panel/tests/mermaid.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * Mermaid enhancement tests: block discovery across both renderer shapes
+ * (panel `pre.language-mermaid`, chat `pre > code.language-mermaid`),
+ * claim/render/restore lifecycle against a fake window.mermaid runtime,
+ * theme re-render, and the host vendor route (200 + etag/304 + loopback
+ * fence) through the real prefix handler.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { FsService } from '../src/host/fs-service.ts'
+import { registerPanelRoutes } from '../src/host/routes.ts'
+import type { WorkspaceGate } from '../src/host/gate.ts'
+import {
+  DATA_MD_SCOPE,
+  enhanceMermaidBlocks,
+  findMermaidCodeBlocks,
+  mermaidTheme,
+  rethemeMermaidBlocks,
+} from '../src/client/preview/mermaid.ts'
+
+/** Install a fake mermaid runtime; returns its render spy and a restore fn. */
+function fakeMermaid(svgFor: (source: string) => string): { render: ReturnType<typeof vi.fn>; restore: () => void } {
+  const render = vi.fn(async (_id: string, source: string) => ({ svg: svgFor(source) }))
+  const initialize = vi.fn()
+  const holder = globalThis as Record<string, unknown>
+  const previous = holder.mermaid
+  holder.mermaid = { initialize, render }
+  return { render, restore: () => { if (previous === undefined) delete holder.mermaid; else holder.mermaid = previous } }
+}
+
+/** One panel-shaped block (class on the pre) and one chat-shaped (on code). */
+function seedBlocks(root: HTMLElement): { panelPre: HTMLPreElement; chatPre: HTMLPreElement } {
+  root.innerHTML = [
+    '<pre class="language-mermaid"><code>flowchart LR\nA--&gt;B</code></pre>',
+    '<pre><code class="language-mermaid">graph TD\nC--&gt;D</code></pre>',
+    '<pre class="language-python"><code>print(1)</code></pre>',
+    '<pre class="language-mermaid"><code>   </code></pre>',
+  ].join('')
+  const pres = Array.from(root.querySelectorAll('pre'))
+  return { panelPre: pres[0] as HTMLPreElement, chatPre: pres[1] as HTMLPreElement }
+}
+
+describe('findMermaidCodeBlocks', () => {
+  it('finds both renderer shapes, skips empty and non-mermaid blocks', () => {
+    const root = document.createElement('div')
+    seedBlocks(root)
+    const found = findMermaidCodeBlocks(root)
+    expect(found).toHaveLength(2)
+  })
+
+  it('skips blocks another driver already claimed', () => {
+    const root = document.createElement('div')
+    const { panelPre } = seedBlocks(root)
+    panelPre.setAttribute('data-mermaid-claimed', '1')
+    expect(findMermaidCodeBlocks(root)).toHaveLength(1)
+  })
+})
+
+describe('enhanceMermaidBlocks', () => {
+  it('renders containers for both shapes and hides the source blocks', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const { panelPre, chatPre } = seedBlocks(root)
+    const fake = fakeMermaid((source) => `<svg data-src="${source}"></svg>`)
+    try {
+      await enhanceMermaidBlocks(root, { className: 'mm', theme: 'default' })
+      const containers = Array.from(root.querySelectorAll('[data-mermaid-state="done"]'))
+      expect(containers).toHaveLength(2)
+      expect(fake.render).toHaveBeenCalledTimes(2)
+      expect(panelPre.style.display).toBe('none')
+      expect(chatPre.style.display).toBe('none')
+      expect(containers[0]!.innerHTML).toContain('flowchart LR')
+      // Already-claimed blocks are not enhanced twice.
+      await enhanceMermaidBlocks(root, { className: 'mm', theme: 'default' })
+      expect(fake.render).toHaveBeenCalledTimes(2)
+    } finally {
+      fake.restore()
+      root.remove()
+    }
+  })
+
+  it('restores the code block verbatim when the render fails', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    seedBlocks(root)
+    const render = vi.fn(async () => { throw new Error('bad syntax') })
+    const holder = globalThis as Record<string, unknown>
+    const previous = holder.mermaid
+    holder.mermaid = { initialize: vi.fn(), render }
+    try {
+      await enhanceMermaidBlocks(root, { className: 'mm', theme: 'default' })
+      expect(root.querySelectorAll('[data-mermaid-state]').length).toBe(0)
+      expect(findMermaidCodeBlocks(root)).toHaveLength(2)
+      const pres = Array.from(root.querySelectorAll('pre'))
+      expect(pres[0]!.getAttribute('data-mermaid-claimed')).toBeNull()
+    } finally {
+      if (previous === undefined) delete holder.mermaid
+      else holder.mermaid = previous
+      root.remove()
+    }
+  })
+
+  it('re-renders completed containers on theme flips only', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    seedBlocks(root)
+    const fake = fakeMermaid((source) => `<svg data-src="${source}"></svg>`)
+    try {
+      await enhanceMermaidBlocks(root, { className: 'mm', theme: 'default' })
+      expect(fake.render).toHaveBeenCalledTimes(2)
+      await rethemeMermaidBlocks(root, { theme: 'dark' })
+      expect(fake.render).toHaveBeenCalledTimes(4)
+    } finally {
+      fake.restore()
+      root.remove()
+    }
+  })
+
+  it('honors the skip predicate for foreign scopes', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    seedBlocks(root)
+    const fake = fakeMermaid(() => '<svg></svg>')
+    try {
+      await enhanceMermaidBlocks(root, {
+        className: 'mm',
+        theme: 'default',
+        skip: (pre) => pre.closest(`[${DATA_MD_SCOPE}]`) !== null,
+      })
+      // Nothing is inside a marked scope: all blocks render.
+      expect(fake.render).toHaveBeenCalledTimes(2)
+      root.setAttribute(DATA_MD_SCOPE, '1')
+      root.querySelectorAll('pre').forEach((pre) => {
+        pre.removeAttribute('data-mermaid-claimed')
+      })
+      root.querySelectorAll('[data-mermaid-state]').forEach((el) => el.remove())
+      root.querySelectorAll('pre').forEach((pre) => { pre.style.display = '' })
+      fake.render.mockClear()
+      await enhanceMermaidBlocks(root, {
+        className: 'mm',
+        theme: 'default',
+        skip: (pre) => pre.closest(`[${DATA_MD_SCOPE}]`) !== null,
+      })
+      expect(fake.render).not.toHaveBeenCalled()
+    } finally {
+      fake.restore()
+      root.remove()
+    }
+  })
+})
+
+describe('mermaidTheme', () => {
+  it('maps the shell marker to mermaid theme names', () => {
+    expect(mermaidTheme(true)).toBe('dark')
+    expect(mermaidTheme(false)).toBe('default')
+  })
+})
+
+/** A minimal ctx fulfilling what registerPanelRoutes touches. */
+function fakeCtx(): {
+  ctx: Record<string, unknown>
+  registrations: Array<{ kind: string; path: string; handler: (req: unknown, res: unknown) => Promise<void> }>
+} {
+  const registrations: Array<{ kind: string; path: string; handler: (req: unknown, res: unknown) => Promise<void> }> = []
+  const ctx = {
+    logger: { warn: () => {} },
+    webServer: {
+      register: (row: { kind: string; path: string; handler: (req: unknown, res: unknown) => Promise<void> }) => {
+        registrations.push(row)
+        return () => {}
+      },
+    },
+    effect: (fn: () => void) => { fn(); return () => {} },
+  }
+  return { ctx, registrations }
+}
+
+/** Drive one request through the registered prefix handler. */
+async function request(
+  handler: (req: unknown, res: unknown) => Promise<void>,
+  method: string,
+  url: string,
+  headers: Record<string, string> = {},
+  remoteAddress = '127.0.0.1',
+): Promise<{ status: number; headers: Record<string, string>; body: Buffer }> {
+  let status = 0
+  let headersOut: Record<string, string> = {}
+  let body = Buffer.alloc(0)
+  const res = {
+    writeHead: (code: number, head: Record<string, string> = {}) => { status = code; headersOut = head },
+    end: (chunk?: unknown) => {
+      if (chunk !== undefined && chunk !== null) body = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))
+    },
+  }
+  await handler({ method, url, headers: { host: '127.0.0.1:3000', ...headers }, socket: { remoteAddress } }, res)
+  return { status, headers: headersOut, body }
+}
+
+describe('GET /aionui-panel/vendor/mermaid.js', () => {
+  const gate: WorkspaceGate = async () => ({ ok: true, canonical: 'C:/' })
+
+  it('serves the build-copied asset with etag revalidation', async () => {
+    const { ctx, registrations } = fakeCtx()
+    registerPanelRoutes(ctx as never, new FsService(gate), { status: async () => null } as never)
+    const row = registrations.find((item) => item.kind === 'prefix')
+    expect(row).toBeDefined()
+
+    const first = await request(row!.handler, 'GET', '/aionui-panel/vendor/mermaid.js')
+    if (first.status === 404) {
+      // The asset lands with the package build (node scripts/copy-mermaid.mjs);
+      // without it the route must still answer cleanly — asserted elsewhere.
+      return
+    }
+    expect(first.status).toBe(200)
+    expect(first.headers['content-type']).toBe('application/javascript; charset=utf-8')
+    expect(first.body.length).toBeGreaterThan(500_000)
+
+    const etag = first.headers['etag']
+    expect(typeof etag).toBe('string')
+    const revalidate = await request(row!.handler, 'GET', '/aionui-panel/vendor/mermaid.js', { 'if-none-match': etag! })
+    expect(revalidate.status).toBe(304)
+  })
+
+  it('stays behind the loopback fence', async () => {
+    const { ctx, registrations } = fakeCtx()
+    registerPanelRoutes(ctx as never, new FsService(gate), { status: async () => null } as never)
+    const row = registrations.find((item) => item.kind === 'prefix')
+    const lan = await request(row!.handler, 'GET', '/aionui-panel/vendor/mermaid.js', {}, '192.168.1.5')
+    expect(lan.status).toBe(403)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,10 @@ importers:
         version: 0.22.2(typescript@6.0.3)
 
   packages/dsh-aionui-panel:
+    dependencies:
+      mermaid:
+        specifier: 11.16.1
+        version: 11.16.1
     devDependencies:
       '@deepseek-ai/cordis':
         specifier: ^4.0.1


### PR DESCRIPTION
Fenced mermaid blocks render as inline SVG diagrams in the panel's markdown preview. The mermaid IIFE bundle is a pinned npm dependency copied into lib/assets at build time and served same-origin via /aionui-panel/vendor/ mermaid.js (loopback-fenced, etag revalidation, no CDN). The client enhancement is framework-free: it claims pre.language-mermaid blocks, renders through mermaid.render, follows the shell light/dark marker with re-renders on theme flips, and restores the plain code block on syntax errors or a missing asset. A transcript-side observer is kept for the pre > code.language-mermaid shape; the official transcript's CodeBlock currently emits no such class for unknown languages, so transcript rendering is covered by the full proposal in PR #270 instead.
## 摘要（Summary）

aionui 面板 markdown 预览中的 mermaid 代码围栏直接渲染为 SVG 图表。按 Issue #255 维护者建议，从 PR #270
拆出的最小单侧改动（仅 aionui-panel，无新插件、无共享预设改动）：mermaid IIFE 为 pinned npm 依赖，构建期拷贝进
lib/assets，经同源 /aionui-panel/vendor/mermaid.js 服务（loopback 围栏 + etag 再验证，无 CDN、离线可用）；客户端增强
framework-free，认领 pre.language-mermaid 块，经 mermaid.render 渲染，跟随 shell
明暗主题并在切换时重渲染，语法错误或资产缺失时还原纯代码块。

范围说明：官方会话转录的围栏渲染不在本 PR——官方 CodeBlock 对未知语言（含 mermaid）不输出 language-mermaid 类，需要认
md-code-block 结构的独立增强（即 PR #270 的插件侧）。本 PR 附带的转录观察器面向未来 pre > code.language-mermaid
形态，当前为惰性挂载、零渲染。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [x] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```sh
git checkout -b feat/aionui-mermaid upstream/main && git cherry-pick 8da6b64   # 基于 fd57547
```

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：GLM（zai/glm-5.3）

使用的编码 Agent 工具：Claude Agent SDK（omp harness）

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` + `README.i18n.yaml`）并运行 `pnpm
docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm install && pnpm -r build && pnpm -r typecheck
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
pnpm test:scripts && pnpm aggregate:check && pnpm community:check && pnpm docs:check && pnpm sync-shared:check && pnpm
runtime-deps:check && pnpm gallery:check && pnpm skin-center:check
```

结果摘要：全绿。aionui-panel 168/169（1 skipped 为套件自带）；真机 dsh web 验证 /aionui-panel/vendor/mermaid.js GET
200（3.5 MB 同源资产）、页面零报错。

## 用户可见变更证据（Local Feature Evidence）

面板 markdown 预览中的 mermaid 渲染（本地构建自本 PR head，dsh 0.1.0-rc.6 / Windows 11 / Chrome）：

证据：

<img width="719" height="1392" alt="image" src="https://github.com/user-attachments/assets/b77b6032-a89c-4feb-b4a2-223984a60359" />


---

关联：功能讨论 Issue #255；完整双路线方案（含转录插件侧）保留在 PR #270 供下轮集中评审。