### PR TITLE
fix(git-graph): keep branch-switch notice text visible on dark themes (#275)

### DIFF
--- a/packages/dsh-git-graph/src/client/chips/context.module.css
+++ b/packages/dsh-git-graph/src/client/chips/context.module.css
@@ -275,13 +275,18 @@
   margin: 0 8px 8px;
   padding: 6px 10px;
   border-radius: 8px;
-  background: var(--dsw-alias-state-error-secondary);
+  /* Never pair a solid state-secondary fill with state-primary text: dark
+     themes alias both onto the same static color (the official dark theme
+     maps both error tokens to red-400), which renders the message invisible.
+     Tint the banner from the primary token instead (the aionui-panel scm
+     banner idiom). */
+  background: color-mix(in srgb, var(--dsw-alias-state-error-primary) 14%, transparent);
   color: var(--dsw-alias-state-error-primary);
   font-size: 12px;
 }
 
 .noticeOk {
-  background: var(--dsw-alias-state-success-secondary);
+  background: color-mix(in srgb, var(--dsw-alias-state-success-primary) 14%, transparent);
   color: var(--dsw-alias-state-success-primary);
 }
 

--- a/packages/dsh-git-graph/tests/client.spec.tsx
+++ b/packages/dsh-git-graph/tests/client.spec.tsx
@@ -16,6 +16,7 @@ import type { GitGraphInjected } from '../src/client/index.ts'
 import type { BranchChipProps } from '../src/client/chips/BranchChip.tsx'
 import { BranchChip } from '../src/client/chips/BranchChip.tsx'
 import { zh, type GitGraphKey } from '../src/client/locales.ts'
+import css from '../src/client/chips/context.module.css'
 
 afterEach(() => {
   cleanup()
@@ -316,7 +317,12 @@ describe('BranchChip', () => {
     fireEvent.click(await screen.findByRole('button', { name: '分支' }))
     fireEvent.click(await screen.findByRole('option', { name: 'feature/x' }))
     expect(calls.switchBranch).toEqual([['sess-1', 'feature/x']])
-    expect(await screen.findByText('已切换到分支 feature/x')).toBeTruthy()
+    const notice = await screen.findByText('已切换到分支 feature/x')
+    // The success banner carries the base notice class plus the ok variant
+    // (the variant re-tints the banner; losing it would paint success as an
+    // error banner).
+    expect(notice.classList.contains(css.notice)).toBe(true)
+    expect(notice.classList.contains(css.noticeOk)).toBe(true)
     expect(injected.switchBranch).toHaveBeenCalled()
   })
 
@@ -326,7 +332,10 @@ describe('BranchChip', () => {
     })
     fireEvent.click(await screen.findByRole('button', { name: '分支' }))
     fireEvent.click(await screen.findByRole('option', { name: 'feature/x' }))
-    expect(await screen.findByText('当前仓库还有未解决的冲突，先处理完再切换分支。')).toBeTruthy()
+    const notice = await screen.findByText('当前仓库还有未解决的冲突，先处理完再切换分支。')
+    // The error banner is the base notice only (never the ok variant).
+    expect(notice.classList.contains(css.notice)).toBe(true)
+    expect(notice.classList.contains(css.noticeOk)).toBe(false)
   })
 
   it('shows the overwrite copy with blocked paths', async () => {

--- a/packages/dsh-git-graph/tests/notice-contrast.spec.ts
+++ b/packages/dsh-git-graph/tests/notice-contrast.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Switch-notice contrast guard: the feedback banners must never pair a
+ * solid state-secondary fill with state-primary text. Dark themes alias
+ * both state tokens onto the same static color (the official dark theme
+ * maps error primary and secondary to red-400), which rendered the
+ * rejection copy invisible — an empty-looking solid red box. The banners
+ * tint from the primary token over transparent instead (the aionui-panel
+ * scm banner idiom).
+ */
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(new URL('../src/client/chips/context.module.css', import.meta.url), 'utf8')
+
+/** Extract one top-level rule block's body by its class name. */
+function ruleBody(name: string): string {
+  const match = new RegExp(`\\.${name}\\s*\\{([^}]*)\\}`).exec(source)
+  if (match === null) throw new Error(`.${name} rule not found in context.module.css`)
+  return match[1] ?? ''
+}
+
+describe('switch notice contrast', () => {
+  it('never uses a solid state-secondary fill for the notice banners', () => {
+    // The exact invisible pairing this guard exists to ban.
+    expect(source).not.toMatch(/background(-color)?:\s*var\(--dsw-alias-state-error-secondary\)/)
+    expect(source).not.toMatch(/background(-color)?:\s*var\(--dsw-alias-state-success-secondary\)/)
+  })
+
+  it('tints the error banner from the primary token over transparent', () => {
+    const body = ruleBody('notice')
+    expect(body).toMatch(/background:\s*color-mix\(in srgb,\s*var\(--dsw-alias-state-error-primary\)\s+\d+%,\s*transparent\)/)
+    expect(body).toMatch(/color:\s*var\(--dsw-alias-state-error-primary\)/)
+  })
+
+  it('tints the success banner from the primary token over transparent', () => {
+    const body = ruleBody('noticeOk')
+    expect(body).toMatch(/background:\s*color-mix\(in srgb,\s*var\(--dsw-alias-state-success-primary\)\s+\d+%,\s*transparent\)/)
+    expect(body).toMatch(/color:\s*var\(--dsw-alias-state-success-primary\)/)
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 git 分支切换成功 / 失败提示横幅在暗色主题下文字不可见的问题（Closes #275）：横幅原本用 `--dsw-alias-state-*-secondary` 实心背景 + `-primary` 文字色，而官方暗色主题把 error 的 primary 与 secondary 映射为同一个 red-400（多个皮肤包同样同色 / 近同色），导致切换被守卫拒绝时（典型：目标分支已在其他 worktree 检出）只显示无字空红块。改为从 primary token 派生的半透明底色（`color-mix(in srgb, ... 14%, transparent)`，与 aionui-panel scm banner 同款写法）+ primary 文字色，并新增 CSS 源守卫测试与横幅类名断言防回退。#244 的 stock-light 覆盖保持不变。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [x] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

`git fetch upstream && git rebase --onto upstream/main origin/main fix/git-graph-switch-notice`（基于 upstream/main f3951e8，包含已发布的 #244 stock-light 修复）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness（DSH）

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本 PR 无新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改 README）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-git-graph run typecheck
pnpm --filter @linxin666/dsh-client-ui-git-graph test
pnpm --filter @linxin666/dsh-client-ui-git-graph run build
pnpm typecheck
pnpm docs:check
```

结果摘要：

包级 typecheck / test / build 全绿（vitest 80 通过，含新增 tests/notice-contrast.spec.ts 的 CSS 源守卫与 client.spec.tsx 的横幅类名断言）；全仓 `pnpm typecheck` 与 `pnpm docs:check` 通过。全仓 `pnpm test` 中 dsh-aionui-panel 有 2 个 Windows 符号链接权限（EPERM）失败，`pnpm test:scripts` 有 4 个预存失败（sync-shared 漂移、community-index、dsh-skin symlink EPERM），均在未包含本改动的检出上同样复现，与本 PR 无关。

## 用户可见变更证据（Local Feature Evidence）

修复后实测（本地 web profile 换装本 PR head 构建的 client bundle，深色主题，DSH 0.1.0-rc.6）：

切换被 worktree 守卫拒绝：浅红半透明横幅，文案「目标分支已在其他 worktree 中被检出，当前工作区无法直接切换。」清晰可读（修复前为无字空红块）：

![修复后失败提示](https://raw.githubusercontent.com/EricWang1358/dsh-web-ui/issue-assets/.github/issue-assets/git-graph-switch-rejected-notice-fixed.png)

切换成功：浅绿半透明横幅，文案「已切换到分支 …」清晰可读：

![修复后成功提示](https://raw.githubusercontent.com/EricWang1358/dsh-web-ui/issue-assets/.github/issue-assets/git-graph-switch-success-notice-fixed.png)

修复前（故障）截图见 #275。
