### PR TITLE
fix(task-board): keep mobile board columns readable

### DIFF
--- a/packages/dsh-task-board/src/client/board.module.css
+++ b/packages/dsh-task-board/src/client/board.module.css
@@ -18,6 +18,8 @@
   inset: 0;
   display: none;
   z-index: 60;
+  container-name: task-board-view;
+  container-type: inline-size;
   /* Opaque backdrop: the conversation subtree stays mounted under the view.
      Even if the hide rule below were defeated by a stronger host inline
      style, this background keeps sticky code-block banners (host z-index 6)
@@ -103,6 +105,7 @@ html[data-dsh-taskboard-active]:not([data-dsh-ssh-active]) [class*='centerCol'] 
 .board {
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
   height: 100%;
   min-width: 0;
   min-height: 0;
@@ -148,10 +151,38 @@ html[data-dsh-taskboard-active]:not([data-dsh-ssh-active]) [class*='centerCol'] 
 
 .columns {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(220px, 1fr);
   gap: 12px;
   flex: 1;
   min-height: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-inline: contain;
+  padding-bottom: 6px;
+  scrollbar-color: var(--dsw-alias-border-l3) var(--dsw-alias-interactive-bg-hover);
+  scrollbar-width: thin;
+}
+
+.columns::-webkit-scrollbar {
+  height: 10px;
+}
+
+.columns::-webkit-scrollbar-track {
+  background: var(--dsw-alias-interactive-bg-hover);
+  border-radius: 999px;
+}
+
+.columns::-webkit-scrollbar-thumb {
+  background: var(--dsw-alias-border-l3);
+  background-clip: content-box;
+  border: 2px solid transparent;
+  border-radius: 999px;
+}
+
+.columns::-webkit-scrollbar-thumb:hover {
+  background: var(--dsw-alias-border-l4);
+  background-clip: content-box;
 }
 
 .column {
@@ -768,6 +799,36 @@ html[data-dsh-taskboard-active]:not([data-dsh-ssh-active]) [class*='centerCol'] 
   margin-left: auto;
   font-size: 11px;
   color: var(--dsw-alias-label-tertiary);
+}
+
+/* --- constrained board containers ------------------------------------------ */
+
+@container task-board-view (max-width: 720px) {
+  .board {
+    gap: 10px;
+    padding: 10px;
+  }
+
+  .columns {
+    gap: 10px;
+  }
+}
+
+@container task-board-view (max-width: 600px) {
+  .boardHeader {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .search {
+    flex: 1 1 calc(100% - 72px);
+    min-width: 0;
+  }
+
+  .boardHeader > button {
+    flex: 1 1 0;
+    min-width: max-content;
+  }
 }
 
 /* -----------------------------------------------------------------------------

--- a/packages/dsh-task-board/tests/responsive-css.spec.ts
+++ b/packages/dsh-task-board/tests/responsive-css.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Constrained-layout guard: the board must preserve readable columns and let
+ * the board scroll horizontally instead of compressing cards into slivers.
+ */
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const css = readFileSync(new URL('../src/client/board.module.css', import.meta.url), 'utf8')
+
+describe('board responsive css', () => {
+  it('keeps the columns container horizontally scrollable', () => {
+    const columnsBlock = css.match(/\.columns\s*\{([^}]*)\}/)?.[1] ?? ''
+    expect(columnsBlock).toContain('overflow-x: auto')
+    expect(columnsBlock).toContain('overflow-y: hidden')
+  })
+
+  it('preserves a readable minimum width for every rendered column', () => {
+    const columnsBlock = css.match(/\.columns\s*\{([^}]*)\}/)?.[1] ?? ''
+    expect(columnsBlock).toContain('grid-auto-flow: column')
+    expect(columnsBlock).toContain('grid-auto-columns: minmax(220px, 1fr)')
+  })
+
+  it('renders a visible horizontal scrollbar affordance', () => {
+    expect(css).toMatch(/\.columns::\-webkit-scrollbar\s*\{[^}]*height:\s*10px/s)
+    expect(css).toMatch(/\.columns::\-webkit-scrollbar-track\s*\{[^}]*background:/s)
+    expect(css).toMatch(/\.columns::\-webkit-scrollbar-thumb\s*\{[^}]*background:/s)
+    expect(css).toContain('scrollbar-width: thin')
+  })
+
+  it('keeps the bottom scrollbar inside the board viewport', () => {
+    const boardBlock = css.match(/\.board\s*\{([^}]*)\}/)?.[1] ?? ''
+    expect(boardBlock).toContain('box-sizing: border-box')
+    expect(boardBlock).toContain('height: 100%')
+  })
+
+  it('responds to the board container rather than only the viewport', () => {
+    expect(css).toMatch(/\[data-dsh-taskboard-view\]\s*\{[^}]*container-name:\s*task-board-view/s)
+    expect(css).toContain('@container task-board-view (max-width: 720px)')
+    expect(css).toContain('@container task-board-view (max-width: 600px)')
+    expect(css).toMatch(/\.boardHeader\s*\{[^}]*flex-wrap:\s*wrap/s)
+    expect(css).toMatch(/\.search\s*\{[^}]*flex:\s*1 1 calc\(100% - 72px\)/s)
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

优化任务看板在移动视口和被侧栏 / 文件面板挤窄的容器中的视觉排布：每个状态列设置 220px 硬下限，看板区域承担横向滚动并显示主题化底部滚动条；窄容器下标题与搜索、三个既有操作分两行。使用容器查询而非只判断视口，桌面宽容器和所有任务业务逻辑保持不变。

布局原则参考 Multica 看板对固定可读列宽与横向溢出的处理，但本 PR 不引入新功能、组件或交互，只调整现有内容的响应式样式并增加 CSS 回归测试。

Closes #296

## 涉及包（Affected Packages）

- [x] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin main
git rebase origin/main
```

最终基线：`0ea284c`。本分支未纳入此前任务看板 / SSH 返回按钮改动。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）；本 PR 未新增包。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`；本 PR 未修改 README。

## 贡献者版权声明（Contributor Copyright）

N/A。本 PR 不新增插件、皮肤或版权声明。

## 社区插件索引登记（Community Plugin Index）

N/A。本 PR 不新增社区插件。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-task-board test
pnpm --filter @linxin666/dsh-client-ui-task-board typecheck
pnpm --filter @linxin666/dsh-client-ui-task-board build
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
```

结果摘要：

任务看板 13 个测试文件、175 项测试通过；包级类型检查与构建，以及全仓 `pnpm typecheck`、`pnpm test`、`pnpm test:scripts`、`pnpm docs:check` 均通过。


浏览器验证：746×770 且右侧文件面板展开时，看板实际宽度 470px，五列均保持 220px，滚动宽度 1140px，已实际横向滚动至 `scrollLeft=500`；10px 底部滚动条完整位于视口内，页面主体无横纵向溢出。

## 用户可见变更证据（Local Feature Evidence）

证据：

完整设计说明与初始对比见 [Issue #296 的视觉对比](https://github.com/zhu1090093659/dsh-web-ui/issues/296#issuecomment-5306717184)；右侧文件面板场景的最终尺寸记录见 [窄容器复验](https://github.com/zhu1090093659/dsh-web-ui/issues/296#issuecomment-5306819916)。

### 任务看板 · 窄容器最终复验（746×770）

![任务看板窄容器横向滚动](https://github.com/user-attachments/assets/18c6bd35-97b0-431b-ada0-9e1d8eafa1b0)

此时任务看板实际宽度为 470px；截图已横向滚动到后续状态列，底部轨道和滑块保持可见。

### 任务看板 · 初始窄屏对比（390×844）

| 改动前 | 初始适配后 |
| --- | --- |
| ![任务看板窄屏改动前](https://github.com/user-attachments/assets/d3b26f30-546f-4cca-8735-e68921f75caf) | ![任务看板窄屏初始适配后](https://github.com/user-attachments/assets/f45b5de0-bc72-4697-bc3e-de4881b12acb) |

### 任务看板 · 桌面端（1280×720）

| 改动前 | 改动后 |
| --- | --- |
| ![任务看板桌面端改动前](https://github.com/user-attachments/assets/48cc0f6c-c641-457d-905b-d72cbc12fcf5) | ![任务看板桌面端改动后](https://github.com/user-attachments/assets/8ef82e75-f64a-4c6a-ad4a-fe0e33ed7f5e) |

最终实现按看板容器宽度响应，包含列宽下限、局部横向滚动、可见滚动条和标题栏换行；不含此前返回按钮改动。