### PR TITLE
feat(pet): diversify pet reactions and move the hover panel below the pet

### DIFF
--- a/packages/dsh-pet/src/affinity.test.ts
+++ b/packages/dsh-pet/src/affinity.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   AFFINITY_MAX,
   AFFINITY_RANKS,
+  FEED_COOLDOWN_REACTIONS,
+  FEED_REACTIONS,
+  PET_COOLDOWN_REACTIONS,
+  PET_REACTIONS,
   applyInteraction,
   applyTurnReward,
   defaultAffinityConfig,
@@ -52,6 +56,46 @@ describe('applyInteraction', () => {
     const state = { ...emptyAffinity(), points: AFFINITY_MAX - 1 }
     const outcome = applyInteraction(state, 'pet', 1_000_000)
     expect(outcome.affinity.points).toBe(AFFINITY_MAX)
+  })
+
+  it('rotates pet reactions by the lifetime pet count', () => {
+    const now = 1_000_000
+    for (let i = 0; i < PET_REACTIONS.length; i++) {
+      const state = { ...emptyAffinity(), pets: i, lastPetAt: now - defaultAffinityConfig.petCooldownMs }
+      const outcome = applyInteraction(state, 'pet', now)
+      expect(outcome.accepted).toBe(true)
+      expect(outcome.reaction).toBe(PET_REACTIONS[i])
+    }
+  })
+
+  it('rotates pet cooldown reactions by the lifetime pet count', () => {
+    const now = 1_000_000
+    for (let i = 0; i < PET_COOLDOWN_REACTIONS.length; i++) {
+      const state = { ...emptyAffinity(), pets: i, lastPetAt: now }
+      const outcome = applyInteraction(state, 'pet', now)
+      expect(outcome.accepted).toBe(false)
+      expect(outcome.reaction).toBe(PET_COOLDOWN_REACTIONS[i])
+    }
+  })
+
+  it('rotates feed reactions by the lifetime feed count', () => {
+    const now = 1_000_000
+    for (let i = 0; i < FEED_REACTIONS.length; i++) {
+      const state = { ...emptyAffinity(), feeds: i, lastFeedAt: now - defaultAffinityConfig.feedCooldownMs }
+      const outcome = applyInteraction(state, 'feed', now)
+      expect(outcome.accepted).toBe(true)
+      expect(outcome.reaction).toBe(FEED_REACTIONS[i])
+    }
+  })
+
+  it('rotates feed cooldown reactions by the lifetime feed count', () => {
+    const now = 1_000_000
+    for (let i = 0; i < FEED_COOLDOWN_REACTIONS.length; i++) {
+      const state = { ...emptyAffinity(), feeds: i, lastFeedAt: now }
+      const outcome = applyInteraction(state, 'feed', now)
+      expect(outcome.accepted).toBe(false)
+      expect(outcome.reaction).toBe(FEED_COOLDOWN_REACTIONS[i])
+    }
   })
 })
 

--- a/packages/dsh-pet/src/affinity.ts
+++ b/packages/dsh-pet/src/affinity.ts
@@ -122,6 +122,48 @@ function clamp(points: number): number {
 }
 
 /**
+ * Reaction pools (plain strings; the repo bans emoji). The interaction picks
+ * one line deterministically by rotating on the lifetime interaction count,
+ * so repeated petting/feeding stays lively and the choice is testable.
+ */
+export const PET_REACTIONS: string[] = [
+  '咕噜咕噜～被摸摸好舒服！',
+  '蹭蹭你的手心～',
+  '唔…这里也要摸摸！',
+  '尾巴开心地翘起来啦～',
+  '被摸得眯起了眼睛…',
+  '哼～再摸一下下就原谅你',
+  '好温暖…不想动了…',
+]
+
+/** Pet cooldown pool, rotated by the lifetime pet count. */
+export const PET_COOLDOWN_REACTIONS: string[] = [
+  '摸过头啦，让鲸鱼娘歇口气～',
+  '头有点晕晕的…先停一下！',
+  '毛都要被摸秃啦！',
+  '让鱼鳍先缓缓…',
+  '呜…再摸就要咬你了！',
+]
+
+/** Feed success pool, rotated by the lifetime feed count. */
+export const FEED_REACTIONS: string[] = [
+  '呜哇！小鱼干好好吃！',
+  '咔嚓咔嚓～尾巴都翘起来啦！',
+  '好吃到眯起了眼睛～',
+  '再多给一点嘛！',
+  '今天的鱼干格外香！',
+]
+
+/** Feed cooldown pool, rotated by the lifetime feed count. */
+export const FEED_COOLDOWN_REACTIONS: string[] = [
+  '吃饱啦，晚点再喂～',
+  '肚子圆滚滚的了…',
+  '鱼干先留着，待会再吃！',
+  '嗝～真的吃不下了！',
+  '省着点吃，明天还有！',
+]
+
+/**
  * Apply one interaction to a copy of the state (immutable style: returns a
  * new object; the caller replaces the persisted state). Cooldowns only
  * apply once the pet has been interacted with at least once (last*At === 0
@@ -136,7 +178,12 @@ export function applyInteraction(
   const next = { ...state }
   if (kind === 'pet') {
     if (state.lastPetAt !== 0 && nowMs - state.lastPetAt < config.petCooldownMs) {
-      return { affinity: state, delta: 0, reaction: '摸过头啦，让鲸鱼娘歇口气～', accepted: false }
+      return {
+        affinity: state,
+        delta: 0,
+        reaction: PET_COOLDOWN_REACTIONS[state.pets % PET_COOLDOWN_REACTIONS.length]!,
+        accepted: false,
+      }
     }
     next.lastPetAt = nowMs
     next.pets += 1
@@ -144,13 +191,18 @@ export function applyInteraction(
     return {
       affinity: next,
       delta: config.petReward,
-      reaction: '咕噜咕噜～被摸摸好舒服！',
+      reaction: PET_REACTIONS[state.pets % PET_REACTIONS.length]!,
       accepted: true,
     }
   }
   if (kind === 'feed') {
     if (state.lastFeedAt !== 0 && nowMs - state.lastFeedAt < config.feedCooldownMs) {
-      return { affinity: state, delta: 0, reaction: '吃饱啦，晚点再喂～', accepted: false }
+      return {
+        affinity: state,
+        delta: 0,
+        reaction: FEED_COOLDOWN_REACTIONS[state.feeds % FEED_COOLDOWN_REACTIONS.length]!,
+        accepted: false,
+      }
     }
     next.lastFeedAt = nowMs
     next.feeds += 1
@@ -158,7 +210,7 @@ export function applyInteraction(
     return {
       affinity: next,
       delta: config.feedReward,
-      reaction: '呜哇！小鱼干好好吃！',
+      reaction: FEED_REACTIONS[state.feeds % FEED_REACTIONS.length]!,
       accepted: true,
     }
   }

--- a/packages/dsh-pet/src/client/pet.module.css
+++ b/packages/dsh-pet/src/client/pet.module.css
@@ -69,7 +69,7 @@
 
 .panel {
   position: absolute;
-  bottom: 100%;
+  top: 100%;
   background: rgba(15, 23, 42, 0.92);
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 10px;
@@ -84,15 +84,15 @@
   min-width: 132px;
 }
 
-/* 面板底边与图标顶边之间的 hover 桥接（issue #49）：
-   面板绝对定位在图标上方（bottom: 100%），若两者之间存在哪怕几个
+/* 面板顶边与图标底边之间的 hover 桥接（issue #49）：
+   面板绝对定位在图标下方（top: 100%），若两者之间存在哪怕几个
    像素的间隙，指针滑过间隙时会触发容器的 pointerleave，面板在指针
-   抵达按钮前就收起。这段透明伪元素把命中区向下延伸、覆盖图标顶部，
+   抵达按钮前就收起。这段透明伪元素把命中区向上延伸、覆盖图标底部，
    使指针在图标与按钮之间始终停留在 hover 区域内。 */
 .panel::after {
   content: '';
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   left: 0;
   right: 0;
   height: 14px;

--- a/packages/dsh-pet/tests/service-enabled.spec.ts
+++ b/packages/dsh-pet/tests/service-enabled.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Context } from '@deepseek-ai/cordis'
 import type { Session, SessionEvent, TurnEndReason } from '@deepseek-ai/dsh-session'
+import { FEED_COOLDOWN_REACTIONS } from '../src/affinity.ts'
 import { loadPetPersist } from '../src/persist.ts'
 import { PetService } from '../src/service.ts'
 import { resolvePetManifest, type PetRegistry } from '../src/registry.ts'
@@ -429,7 +430,7 @@ describe('PetService (rc.6 session events)', () => {
       // Inside the feed cooldown the feed is refused and burns nothing.
       const second = await service.interact('feed')
       expect(second.delta).toBe(0)
-      expect(second.reaction).toContain('吃饱啦')
+      expect(FEED_COOLDOWN_REACTIONS).toContain(second.reaction)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## 摘要（Summary）

桌宠互动反馈去单调化 + 悬浮面板位置调整：

1. 摸摸 / 喂食的反馈文案从固定两句改为按累计互动次数轮换的语料池（方案 A）：摸摸成功 7 句、摸摸冷却 5 句、喂食成功 5 句、喂食冷却 5 句，轮换确定性（按 `pets` / `feeds` 计数取模），可单测。
2. 鼠标悬停出现的悬浮面板从宠物头部上方移到脚下（`.panel` 由 `bottom: 100%` 改为 `top: 100%`），hover 桥接伪元素同步翻转，仍保持图标与面板之间指针不丢失。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发（克隆自 0ea284c）。

同步命令：git fetch origin && git rebase origin/main

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本次未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本次未改动 README，互动反馈与面板位置不在 README 描述范围内）。

## 本地验证（Local Validation）

执行的命令：

```bash
# packages/dsh-pet 内
node node_modules/vitest/vitest.mjs run       # vitest
node node_modules/typescript/bin/tsc -b        # typecheck (build)
node node_modules/typescript/bin/tsc -p tsconfig.test.json
node node_modules/.bin/tsdown                  # client bundle
```

结果摘要：

- vitest：88/89 通过；新增 4 个轮换用例（摸摸/摸摸冷却/喂食/喂食冷却各一组，覆盖语料池全量索引）。唯一失败为 `registry.test.ts` 中 Windows 路径分隔符与 POSIX 期望不符的既有用例（与本次改动无关，Windows 环境同样失败）。
- typecheck：build 与 test 两个 tsconfig 全绿。
- tsdown：`lib/client.js` 已重建。

## 用户可见变更证据（Local Feature Evidence）

证据：

- 互动反馈轮换行为由单测覆盖（`src/affinity.test.ts`：每个语料池的全部索引按 `pets` / `feeds` 计数逐一断言；`tests/service-enabled.spec.ts` 冷却断言改为语料池成员断言）。
- 悬浮面板位置为 CSS 改动（`pet.module.css`），实际效果需在启用本分支的 dsh web 中查看：悬停桌宠时面板出现在脚下（喂食 / 改名 / 隐藏 + 亲密度信息）。