### PR TITLE
fix(aionui-panel): 补偿官方 details 拖拽把手在 5 轨 grid 下的位置偏移

### DIFF
--- a/packages/dsh-aionui-panel/src/client/layout.ts
+++ b/packages/dsh-aionui-panel/src/client/layout.ts
@@ -370,6 +370,19 @@ export class PanelLayoutController {
       this.previewHandle.style.display = preview > 0 && state.root !== '' ? 'block' : 'none'
     }
 
+    // The official shell renders its own details drag handle at
+    // `viewport - details` (details treated as the last track). Once this
+    // panel extends the grid with preview/explorer tracks, the real
+    // center/details boundary shifts left by preview + explorer — re-derive
+    // the handle position from the actual tracks so it stays on the details
+    // column's left edge (degenerates to the official value when both panels
+    // are closed).
+    const detailsTrack = trackPx(this.shellTracks[2])
+    const detailsHandle = frame.querySelector<HTMLElement>('[data-side="details"]')
+    if (detailsHandle !== null) {
+      detailsHandle.style.left = `${Math.round(width - detailsTrack - preview - explorer)}px`
+    }
+
     // Floating expand button: visible only when the explorer is collapsed.
     if (this.floatingButton !== null) {
       const show = state.root !== '' && state.explorerCollapsed


### PR DESCRIPTION
## 摘要（Summary）

aionui 把 shell frame 的 grid 从 3 轨扩展为 5 轨（sidebar | center | details | preview | explorer）后，官方 details 拖拽把手仍按 `left = frameWidth - details` 定位（假设 details 是最后一轨），真实边界已左移 preview + explorer px，把手悬浮在预览列上方。本 PR 在 applyGrid() 内按实际轨宽重算官方 `[data-side="details"]` 把手位置；两面板关闭时退化为官方原值，无副作用。关联 issue #310。

## 涉及包（Affected Packages）

- [x] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

git fetch origin && git rebase origin/main

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

DeepSeek

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

不声明。

## 社区插件索引登记（Community Plugin Index）

不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
pnpm --filter @linxin666/dsh-client-ui-aionui-panel typecheck
```

结果摘要：

vitest 21 个测试文件 192 passed / 1 skipped 全过；tsc typecheck 通过。真机验证：本 PR head 构建产物替换本地安装后，details 列 + 预览面板同时打开，官方拖拽把手贴合「会话区 ⇄ 会话详情」边界，拖拽调整宽度正常（截图见下方证据）。

## 用户可见变更证据（Local Feature Evidence）

证据：

![details 把手修复后贴合边界](https://gist.githubusercontent.com/YeqingTang/8113c2e07a4f2915b3d4177a32cf1557/raw/8fdf0d98b67bff3eaea2ae506df2e1f58b5a2315/handle-fixed.png)

真机截图说明：从左到右为导航侧栏、主对话区、会话流详情栏（details 列）、最右 aionui 预览面板；details 拖拽把手贴合会话区与会话详情边界，不再悬浮于预览列上方。
