### PR TITLE
fix(live-stats): fold surface replacements by position

### DIFF
--- a/packages/dsh-live-stats/src/projection.ts
+++ b/packages/dsh-live-stats/src/projection.ts
@@ -86,12 +86,21 @@ interface SettledSample {
   tokensPerSecond: number | null
 }
 
+interface SurfaceNode {
+  /** Surface event seq, retained in model-visible order. */
+  seq: number
+  /** Estimated token count for the message at `seq`. */
+  tokens: number
+}
+
 interface State {
   settled: TokenUsageProjection
   settledEstimates: number
   last: SettledSample | null
-  /** Surface message seq -> estimated tokens, kept in increasing seq order. */
-  surface: Record<number, number>
+  /** Priced surface in model-visible order. Replacements splice at their
+   *  declared range, so `seq` values are NOT necessarily increasing after a
+   *  compaction checkpoint lands at the surface head. */
+  surface: SurfaceNode[]
   surfaceTokens: number
   header: EpochHeader | null
   active: ActiveStep | null
@@ -114,34 +123,23 @@ function applySurface(
 ): Pick<State, 'surface' | 'surfaceTokens'> {
   const tokens = estimateMessageTokens(surfaceMessage(event), spec)
   if (event.surfaceOp === 'append') {
-    state.surface[event.seq] = tokens
+    state.surface.push({ seq: event.seq, tokens })
     return {
       surface: state.surface,
       surfaceTokens: state.surfaceTokens + tokens,
     }
   }
   const operation = event.surfaceOp
-  if (
-    !Object.prototype.hasOwnProperty.call(state.surface, operation.start)
-    || !Object.prototype.hasOwnProperty.call(state.surface, operation.end)
-    || operation.start > operation.end
-  ) {
+  const startIdx = state.surface.findIndex(node => node.seq === operation.start)
+  const endIdx = state.surface.findIndex(node => node.seq === operation.end)
+  if (startIdx === -1 || endIdx === -1 || startIdx > endIdx) {
     throw new Error(
       'live-stats: replace at seq ' + event.seq + ' has invalid current range ' + operation.start + '-' + operation.end,
     )
   }
-  // Seq keys enter in increasing order (appends grow, and a replace's own seq
-  // is always the newest), and integer-like object keys enumerate in ascending
-  // numeric order, so one pass with an early exit removes the exact range.
   let removed = 0
-  for (const seqKey of Object.keys(state.surface)) {
-    const seq = Number(seqKey)
-    if (seq < operation.start) continue
-    if (seq > operation.end) break
-    removed += state.surface[seq]
-    delete state.surface[seq]
-  }
-  state.surface[event.seq] = tokens
+  for (const node of state.surface.slice(startIdx, endIdx + 1)) removed += node.tokens
+  state.surface.splice(startIdx, endIdx - startIdx + 1, { seq: event.seq, tokens })
   return {
     surface: state.surface,
     surfaceTokens: state.surfaceTokens - removed + tokens,
@@ -285,7 +283,7 @@ export function createLiveTokenUsageProjectionDefinition(
       settled: zeroBuckets(),
       settledEstimates: 0,
       last: null,
-      surface: {},
+      surface: [],
       surfaceTokens: 0,
       header: null,
       active: null,
@@ -389,10 +387,10 @@ export function createLiveTokenUsageProjectionDefinition(
       return next
     },
     view,
-    // Bumped with the pure-JSON state shape (surface Map->Record,
-    // header/tokensPerSecond undefined->null, sparse blocks->Record):
-    // a checkpoint row with the old shape is discarded at read time
-    // instead of revived into the new shape (issue #250 follow-up).
-    stateVersion: 3,
+    // Bumped with each persisted state shape change so a checkpoint row with
+    // an old shape is discarded at read time instead of revived into the new
+    // shape. v3 moved to pure-JSON (Map->Record, nulls, Record blocks); v4
+    // changes surface from a Record to an ordered array for positional folds.
+    stateVersion: 4,
   }
 }

--- a/packages/dsh-live-stats/tests/projection.spec.ts
+++ b/packages/dsh-live-stats/tests/projection.spec.ts
@@ -638,13 +638,21 @@ describe('liveTokenUsage projection', () => {
     state = definition.apply(state, surfaceEvent(1, 'one', 'append'))
     state = definition.apply(state, surfaceEvent(2, 'two', 'append'))
     state = definition.apply(state, surfaceEvent(3, 'three', { op: 'replace', start: 1, end: 2 }))
-    expect(Object.prototype.hasOwnProperty.call(state.surface, 1)).toBe(false)
-    expect(Object.prototype.hasOwnProperty.call(state.surface, 2)).toBe(false)
-    expect(Object.prototype.hasOwnProperty.call(state.surface, 3)).toBe(true)
-    expect(state.surfaceTokens).toBe(estimateMessageTokens(
+    const threeTokens = estimateMessageTokens(
       createUserMessage({ content: [{ type: 'text', text: 'three' }], source: { kind: 'user' } }),
       spec,
-    ))
+    )
+    expect(state.surface).toEqual([{ seq: 3, tokens: threeTokens }])
+    expect(state.surfaceTokens).toBe(threeTokens)
+
+    // Replacements are positional: after a prior compaction, a newer checkpoint
+    // seq can sit at the surface head while the replaced tail has smaller seqs.
+    state = definition.apply(state, surfaceEvent(98403, 'checkpoint', 'append'))
+    state = definition.apply(state, surfaceEvent(98395, 'older tail', 'append'))
+    state = definition.apply(state, surfaceEvent(125255, 'new checkpoint', { op: 'replace', start: 98403, end: 98395 }))
+    expect(state.surface.map(node => node.seq)).toEqual([3, 125255])
+    expect(state.surfaceTokens).toBe(state.surface.reduce((total, node) => total + node.tokens, 0))
+
     expect(() => definition.apply(state, surfaceEvent(4, 'bad', { op: 'replace', start: 5, end: 2 })))
       .toThrow('invalid current range')
     expect(() => definition.apply(state, surfaceEvent(4, 'bad', { op: 'replace', start: 3, end: 99 })))


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-live-stats` 在会话压缩检查点携带**非单调 seq 区间**时崩溃的问题。压缩会把较新的检查点消息放在模型可见表面的头部，使 `replace` 区间的 `start` seq 大于 `end` seq（例如 `98403..98395`）。原实现按 seq 数值序折叠，误判为非法区间并抛出 `live-stats: replace at seq ... has invalid current range`，导致会话历史无法加载。

改为按**表面可见位置**折叠：在有序的 `SurfaceNode[]` 上 `findIndex(start/end)` + `splice`，只校验位置关系 `startIdx <= endIdx`，与官方 token-meter 的 positional fold 语义一致。表面状态从 `Record<number, number>` 变为有序数组，`stateVersion` 升到 4，旧形状 checkpoint 在读取时丢弃。

## 涉及包（Affected Packages）

- [x] 实时令牌统计 `packages/dsh-live-stats`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

本 PR 基于 `origin/main` `0ea284c`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

说明：本次未新增包目录（N/A）；未改动任何包 README（N/A）。

## 贡献者版权声明（Contributor Copyright）

N/A（本次为既有包 bug 修复，不新增版权行）。

## 社区插件索引登记（Community Plugin Index）

N/A（非新增第三方插件）。

## 本地验证（Local Validation）

执行的命令：

```bash
# live-stats 相关测试（projection + estimator）
pnpm exec vitest run tests/projection.spec.ts tests/estimator.spec.ts
# 改动模块类型检查（含 projection map 增补声明）
pnpm exec tsc --noEmit src/projection.ts src/estimator.ts src/types/token-meter.d.ts
# 空白/换行检查
git diff --check
```

结果摘要：

- `tests/projection.spec.ts`：14 passed（含新增非单调区间回归用例）
- `tests/estimator.spec.ts`：5 passed
- `tsc --noEmit`：通过
- `git diff --check`：通过

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A：内部投影折叠逻辑修复，无面向用户的新功能或界面变更。
