### PR TITLE
fix(web-ui-settings): support authenticated proxy hosts

### DIFF
--- a/packages/dsh-web-ui-settings/README.i18n.yaml
+++ b/packages/dsh-web-ui-settings/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: ba31edc70a7fbc9538373535b66743163dfb6421
-README.zh.md: ce5560e775fb484a709f99056ed78a058b6844ca
+README.md: 1fb1d41c75368143eb2f3e066d069b32948cda00
+README.zh.md: 01d051dc0db2ba514bab7c68ba57f78452cf8aa8

--- a/packages/dsh-web-ui-settings/README.md
+++ b/packages/dsh-web-ui-settings/README.md
@@ -28,6 +28,39 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-web-ui-settings
 
 Restart `dsh web` for the section to appear in the settings page.
 
+## Config
+
+The bridge remains loopback-only when `trustedProxyHosts` is empty. A deployment whose authenticated reverse proxy runs on the same Host may opt in an exact authority and name the environment variable that holds a shared proxy token:
+
+```yaml
+- id: ui-web-ui-settings
+  config:
+    trustedProxyHosts:
+      - dsh.example.com
+    proxyTokenEnv: DSH_WEB_UI_SETTINGS_PROXY_TOKEN
+```
+
+Set the named environment variable for both DSH and the reverse proxy. Generate a dedicated high-entropy value; do not put its value in `cordis.patch.yml`. After the authentication handler, replace the internal header before proxying to the loopback-only DSH listener. For Caddy, the upstream portion is:
+
+```caddyfile
+reverse_proxy 127.0.0.1:3080 {
+    header_up X-Dsh-Web-Ui-Settings-Proxy-Token {$DSH_WEB_UI_SETTINGS_PROXY_TOKEN}
+}
+```
+
+`header_up` with a value replaces any client-supplied value. Do not combine that line with a deletion of the same field: Caddy 2.6 applies grouped deletes after sets. If the Caddy systemd unit starts `caddy run --environ`, remove that flag or otherwise protect its output because it prints environment variables at startup.
+
+`web_settings_namespaces` in `settings.yaml` still decides which family namespaces the bridge serves; when absent, the built-in family list applies. Config changes require a DSH restart, while `web_settings_namespaces` is re-read for every bridge call.
+
+## Security model
+
+- Remote bridge access is off by default. Direct access requires a loopback socket and a loopback Host exactly as before.
+- Authenticated-proxy access requires a loopback socket, a canonical configured Host, a same-origin browser request, and the shared token injected upstream. The browser never receives the token.
+- The reverse proxy is the authentication boundary: keep DSH bound to loopback, run authentication before `reverse_proxy`, and replace rather than forward the client-supplied internal header.
+- The bridge exposes only the intersection of registered family namespaces and `web_settings_namespaces`. It does not expose credentials, native paths, or any other privileged DSH API.
+
 ## Known limitations
 
 - The section shows on the dsh settings page only when its prerequisite (`@deepseek-ai/dsh-client-ui-settings`) is present.
+- Authenticated-proxy mode does not provide authentication itself; a deployment without a correctly ordered authentication proxy must leave `trustedProxyHosts` empty.
+- The compatibility bridge serves dsh-web-ui family settings only. It does not make the official DSH settings or credentials plane remotely available.

--- a/packages/dsh-web-ui-settings/README.zh.md
+++ b/packages/dsh-web-ui-settings/README.zh.md
@@ -28,6 +28,39 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-web-ui-settings
 
 安装后重启 `dsh web`，设置页出现该菜单项。
 
+## 配置
+
+`trustedProxyHosts` 为空时，桥接仍仅限 loopback。认证反向代理与 DSH 运行在同一 Host 的部署，可以显式加入准确的 authority，并指定保存代理共享令牌的环境变量名：
+
+```yaml
+- id: ui-web-ui-settings
+  config:
+    trustedProxyHosts:
+      - dsh.example.com
+    proxyTokenEnv: DSH_WEB_UI_SETTINGS_PROXY_TOKEN
+```
+
+为 DSH 和反向代理设置该环境变量。请生成专用的高熵值，不要把令牌值写入 `cordis.patch.yml`。在认证处理完成后，先替换内部请求头，再把请求转发到仅监听 loopback 的 DSH。Caddy 的 upstream 部分如下：
+
+```caddyfile
+reverse_proxy 127.0.0.1:3080 {
+    header_up X-Dsh-Web-Ui-Settings-Proxy-Token {$DSH_WEB_UI_SETTINGS_PROXY_TOKEN}
+}
+```
+
+带值的 `header_up` 会覆盖客户端提供的同名请求头。不要再同时删除同一字段：Caddy 2.6 会在分组操作中先设置、后删除。如果 Caddy 的 systemd 单元以 `caddy run --environ` 启动，请去掉该参数或严格保护其输出，因为该参数会在启动时打印环境变量。
+
+`settings.yaml` 中的 `web_settings_namespaces` 继续决定桥接开放哪些全家桶命名空间；未配置时使用内置全家桶列表。修改插件配置需要重启 DSH，`web_settings_namespaces` 则在每次桥接调用时重新读取。
+
+## 安全模型
+
+- 远程桥接默认关闭。直接访问仍与此前一致，同时要求 loopback socket 和 loopback Host。
+- 认证代理访问要求 loopback socket、规范且已配置的 Host、浏览器同源请求，以及由代理向 upstream 注入的共享令牌。浏览器不会收到该令牌。
+- 反向代理是认证边界：DSH 必须只监听 loopback，认证必须排在 `reverse_proxy` 之前，内部请求头必须由代理替换而不能透传客户端值。
+- 桥接只开放已注册全家桶命名空间与 `web_settings_namespaces` 的交集，不开放凭据、本机路径或其他 DSH 特权 API。
+
 ## 已知限制
 
 - 仅当依赖的 `@deepseek-ai/dsh-client-ui-settings` 存在时，该菜单项才会出现在 dsh 设置页。
+- 认证代理模式本身不提供认证；没有正确配置并排序认证代理的部署必须让 `trustedProxyHosts` 保持为空。
+- 兼容桥只服务 dsh-web-ui 全家桶设置，不会让 DSH 官方设置或凭据平面可被远程访问。

--- a/packages/dsh-web-ui-settings/package.json
+++ b/packages/dsh-web-ui-settings/package.json
@@ -34,6 +34,9 @@
   "peerDependencies": {
     "react": "^18.2.0"
   },
+  "dependencies": {
+    "schemastery": "^3.18.0"
+  },
   "devDependencies": {
     "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",

--- a/packages/dsh-web-ui-settings/src/bridge.ts
+++ b/packages/dsh-web-ui-settings/src/bridge.ts
@@ -1,16 +1,18 @@
 /**
  * Host-side settings bridge for the Web UI plugin group.
  *
- * Serves the dsh-web-ui family settings namespaces over a same-origin,
- * loopback-only HTTP pair because rc.6 host-apiproxy refuses every
- * third-party namespace at the RPC boundary. The handlers ride the host
- * settings seam (ctx.settings), which keeps the official schema validation,
- * revision fencing, persistence, and event emission for free; the bridge only
- * adds the allowlist gate the apiproxy normally provides. Error codes mirror
- * the official RPC codes so the client controller treats refusals exactly
- * like an apiproxy answer.
+ * Serves the dsh-web-ui family settings namespaces over a same-origin HTTP
+ * pair because rc.6 host-apiproxy refuses every third-party namespace at the
+ * RPC boundary. Access is loopback-only by default; deployments may opt in an
+ * authenticated local reverse proxy. The handlers ride the host settings
+ * seam (ctx.settings), which keeps the official schema validation, revision
+ * fencing, persistence, and event emission for free; the bridge only adds the
+ * allowlist gate the apiproxy normally provides. Error codes mirror the
+ * official RPC codes so the client controller treats refusals exactly like an
+ * apiproxy answer.
  */
 
+import { timingSafeEqual } from 'node:crypto'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { SettingsNamespace, SettingsDescriptor, SettingsPathOp, SettingsProvider } from '@deepseek-ai/dsh-settings'
 import { SettingsConflictError, settingsNamespace } from '@deepseek-ai/dsh-settings'
@@ -22,19 +24,81 @@ import type { BridgeDescribeResult, BridgeMutateRequest, BridgeMutateResult, Bri
 /** Cap on JSON request bodies (a single mutate is tiny). */
 const MAX_JSON_BODY_BYTES = 64 * 1024
 
-/** Loopback literal check plus browser same-origin markers (mirrors the dsh-ssh route fence). */
-function isLoopbackRequest(request: IncomingMessage): boolean {
-  const address = request.socket.remoteAddress
-  if (address !== '127.0.0.1' && address !== '::1' && address !== '::ffff:127.0.0.1') return false
-  const host = request.headers.host
-  if (typeof host !== 'string') return false
-  let hostUrl: URL
+/** Header an authenticated same-host reverse proxy replaces before forwarding. */
+export const WEB_UI_SETTINGS_PROXY_TOKEN_HEADER = 'x-dsh-web-ui-settings-proxy-token'
+
+/** Optional authenticated reverse-proxy access layered over the loopback default. */
+export interface BridgeAccess {
+  /** Canonical Host authorities accepted from the local reverse proxy. */
+  trustedProxyHosts?: readonly string[]
+  /** Shared token read from the Host environment; never sent to the browser. */
+  proxyToken?: string
+}
+
+/** Resolved access policy used by every bridge route. */
+interface ResolvedBridgeAccess {
+  trustedProxyHosts: ReadonlySet<string>
+  proxyToken?: string
+}
+
+/** Whether a socket address is a literal loopback peer. */
+function isLoopbackAddress(address: string | undefined): boolean {
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1'
+}
+
+/** Whether a normalized hostname is a literal loopback authority. */
+function isLoopbackHostname(hostname: string): boolean {
+  if (hostname === 'localhost' || hostname === '[::1]') return true
+  const parts = hostname.split('.')
+  return parts.length === 4 && parts[0] === '127' && parts.every(part => /^\d{1,3}$/.test(part) && Number(part) <= 255)
+}
+
+/** Parse one bare Host authority. */
+function parseAuthority(authority: string): { canonical: string; url: URL } | undefined {
+  if (authority.trim() !== authority) return undefined
+  const authorityMatch = authority.startsWith('[')
+    ? /^\[[^\]]+\](?::([0-9]+))?$/.exec(authority)
+    : /^[^:@/?#\s]+(?::([0-9]+))?$/.exec(authority)
+  if (authorityMatch === null) return undefined
   try {
-    hostUrl = new URL('http://' + host)
+    const url = new URL('http://' + authority)
+    if (url.username !== '' || url.password !== '' || url.pathname !== '/' || url.search !== '' || url.hash !== '') return undefined
+    const rawPort = authorityMatch[1]
+    if (rawPort !== undefined && (String(Number(rawPort)) !== rawPort || Number(rawPort) > 65_535)) return undefined
+    const canonical = url.hostname.toLowerCase() + (rawPort === undefined ? '' : ':' + rawPort)
+    return { canonical, url }
   } catch {
-    return false
+    return undefined
   }
-  if (hostUrl.hostname !== '127.0.0.1' && hostUrl.hostname !== 'localhost' && hostUrl.hostname !== '[::1]') return false
+}
+
+/** Resolve and validate the opt-in proxy policy once, when routes mount. */
+function resolveBridgeAccess(access: BridgeAccess | undefined): ResolvedBridgeAccess {
+  const trustedProxyHosts = new Set<string>()
+  for (const entry of access?.trustedProxyHosts ?? []) {
+    const parsed = parseAuthority(entry)
+    if (parsed === undefined || parsed.canonical !== entry.toLowerCase()) {
+      throw new Error('web-ui-settings: trustedProxyHosts entry ' + JSON.stringify(entry) + ' is not a canonical host[:port] authority')
+    }
+    trustedProxyHosts.add(parsed.canonical)
+  }
+  const proxyToken = access?.proxyToken
+  if (trustedProxyHosts.size > 0 && (proxyToken === undefined || proxyToken === '')) {
+    throw new Error('web-ui-settings: authenticated proxy hosts require a non-empty proxy token')
+  }
+  return { trustedProxyHosts, ...(proxyToken === undefined ? {} : { proxyToken }) }
+}
+
+/** Compare the proxy token without content-dependent early exit. */
+function matchesProxyToken(candidate: string | string[] | undefined, expected: string | undefined): boolean {
+  if (typeof candidate !== 'string' || expected === undefined || candidate === '' || expected === '') return false
+  const candidateBytes = Buffer.from(candidate)
+  const expectedBytes = Buffer.from(expected)
+  return candidateBytes.length === expectedBytes.length && timingSafeEqual(candidateBytes, expectedBytes)
+}
+
+/** Browser same-origin markers shared by direct loopback and proxy requests. */
+function isSameOriginRequest(request: IncomingMessage, hostUrl: URL): boolean {
   if (request.headers['sec-fetch-site'] === 'cross-site') return false
   const origin = request.headers.origin
   if (origin === undefined) return true
@@ -43,6 +107,30 @@ function isLoopbackRequest(request: IncomingMessage): boolean {
   } catch {
     return false
   }
+}
+
+/**
+ * Decide whether one request may enter the settings bridge.
+ *
+ * Direct loopback retains the existing socket + Host fence. Authenticated
+ * proxy mode additionally requires a canonical configured Host and the
+ * server-injected shared token; the browser never sees or supplies it.
+ */
+export function isTrustedBridgeRequest(request: IncomingMessage, access?: BridgeAccess): boolean {
+  return isTrustedBridgeRequestResolved(request, resolveBridgeAccess(access))
+}
+
+/** Hot-path trust decision over an already validated policy. */
+function isTrustedBridgeRequestResolved(request: IncomingMessage, access: ResolvedBridgeAccess): boolean {
+  const address = request.socket.remoteAddress
+  if (!isLoopbackAddress(address)) return false
+  const host = request.headers.host
+  if (typeof host !== 'string') return false
+  const parsedHost = parseAuthority(host)
+  if (parsedHost === undefined || parsedHost.canonical !== host.toLowerCase() || !isSameOriginRequest(request, parsedHost.url)) return false
+  if (isLoopbackHostname(parsedHost.url.hostname)) return true
+  if (!access.trustedProxyHosts.has(parsedHost.canonical)) return false
+  return matchesProxyToken(request.headers[WEB_UI_SETTINGS_PROXY_TOKEN_HEADER], access.proxyToken)
 }
 
 /** One JSON response. */
@@ -161,15 +249,18 @@ export function makeBridgeHandlers(deps: BridgeDeps): BridgeHandlers {
 }
 
 /**
- * Build the loopback-only bridge routes.
+ * Build the loopback-default bridge routes, optionally admitting one
+ * authenticated same-host reverse proxy.
  * @param deps - handler dependencies.
+ * @param access - opt-in authenticated proxy policy.
  * @returns the exact-path route registrations.
  */
-export function makeBridgeRoutes(deps: BridgeDeps): WebRoute[] {
+export function makeBridgeRoutes(deps: BridgeDeps, access?: BridgeAccess): WebRoute[] {
   const handlers = makeBridgeHandlers(deps)
+  const resolvedAccess = resolveBridgeAccess(access)
   const guard = (req: IncomingMessage, res: ServerResponse): boolean => {
-    if (!isLoopbackRequest(req)) {
-      writeJson(res, 403, { error: 'loopback requests only' })
+    if (!isTrustedBridgeRequestResolved(req, resolvedAccess)) {
+      writeJson(res, 403, { error: 'forbidden' })
       return false
     }
     if (req.method !== 'POST') {

--- a/packages/dsh-web-ui-settings/src/client/compat-settings-scope.ts
+++ b/packages/dsh-web-ui-settings/src/client/compat-settings-scope.ts
@@ -5,13 +5,13 @@
  * namespace on rc.6 hosts (the apiproxy allowlist is hard-coded), which turns
  * every family plugin card into a read-only explanation. This binder wraps
  * the official scope: when it reports the namespace ready, the wrapper is a
- * pass-through; when it reports unavailable on a loopback connection, a
+ * pass-through; when it reports unavailable, a same-origin
  * bridge controller takes over and serves the same SettingsScope contract
  * from this package's host-side bridge routes (/api/dsh-web-ui-settings).
- * Remote browsers (non-loopback) never use the bridge, matching the official
- * process-local policy. Family plugins opt in through ctx.get('webUiSettings')
- * without a hard service dependency, so a deployment without this package
- * keeps the previous behavior.
+ * The Host keeps the bridge loopback-only by default and may explicitly admit
+ * an authenticated same-host reverse proxy. Family plugins opt in through
+ * ctx.get('webUiSettings') without a hard service dependency, so a deployment
+ * without this package keeps the previous behavior.
  */
 
 import { Service, type Context } from '@deepseek-ai/cordis'
@@ -19,7 +19,6 @@ import { Service, type Context } from '@deepseek-ai/cordis'
 // the forwarded settings invalidation face (ctx.remote).
 import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
 import type {} from '@deepseek-ai/dsh-api-remotes/client'
-import type { ConnectionHandle } from '@deepseek-ai/dsh-client-connection/client'
 import type { SettingsScope, SettingsScopeSnapshot, SettingsScopeSpec, SnapshotStore } from '@deepseek-ai/dsh-client-runtime/client'
 import { createSnapshotStore } from '@deepseek-ai/dsh-client-runtime/client'
 import { WEB_UI_SETTINGS_BRIDGE_PREFIX } from '../protocol.ts'
@@ -86,7 +85,7 @@ export interface BridgeBatchResult {
  * Build the fetch-backed settings face for the bridge routes. Network and
  * HTTP failures collapse into an ok:false envelope so the controller keeps
  * its unavailable state instead of throwing into plugin activation.
- * @param fetchFn - the fetch implementation (the global fetch on loopback).
+ * @param fetchFn - the same-origin fetch implementation.
  * @returns the settings face.
  */
 export function createBridgeApi(fetchFn: typeof fetch): BridgeSettingsFace {
@@ -376,8 +375,9 @@ export interface WebUiSettingsBinderFace {
 /**
  * The rc.6 compatibility binder, provided as the webUiSettings service. Its
  * bind() rides the official binder first and hands the bridge controller in
- * only when the official scope settles as unavailable on a loopback
- * connection, so official behavior stays untouched wherever it works.
+ * only when the official scope settles as unavailable, so official behavior
+ * stays untouched wherever it works and the Host remains the authority for
+ * loopback or explicitly configured authenticated-proxy access.
  */
 export class WebUiSettingsBinder extends Service {
   constructor(ctx: Context) {
@@ -393,13 +393,10 @@ export class WebUiSettingsBinder extends Service {
       throw new Error('webUiSettings: the official settingsScope binder is unavailable')
     }
     const primary = official.bind(spec)
-    const connectionValue = ctx.get('connection')
-    const connection = isConnectionHandle(connectionValue) ? connectionValue : undefined
-    const loopback = connection?.isLoopback === true
     const scope = createCompatScope<T>({
       namespace: spec.namespace,
       primary,
-      fetchFn: loopback ? ((input, init) => fetch(input, init)) : undefined,
+      fetchFn: (input, init) => fetch(input, init),
     })
     // Bridge refreshes ride the same invalidation edges as the official
     // scope: forwarded settings-document updates and connection resets.
@@ -425,13 +422,6 @@ export class WebUiSettingsBinder extends Service {
 /** True when the value exposes the official settings binder's bind() seam. */
 function isBinderFace(value: unknown): value is WebUiSettingsBinderFace {
   return typeof value === 'object' && value !== null && typeof (value as { bind?: unknown }).bind === 'function'
-}
-
-/** True when the value looks like the client connection handle this wrapper reads. */
-function isConnectionHandle(value: unknown): value is ConnectionHandle {
-  if (typeof value !== 'object' || value === null) return false
-  const record = value as Record<string, unknown>
-  return record.isLoopback === undefined || typeof record.isLoopback === 'boolean'
 }
 
 /** True when the value exposes the settings invalidation face the wrapper listens to. */

--- a/packages/dsh-web-ui-settings/src/index.ts
+++ b/packages/dsh-web-ui-settings/src/index.ts
@@ -1,11 +1,13 @@
 /**
  * Host half of the dsh-web-ui-settings group. Mounts the rc.6 compatibility
- * settings bridge: a loopback-only HTTP pair that serves the family plugins'
- * settings namespaces through the host settings seam, gated by the user's
- * web_settings_namespaces allowlist from settings.yaml (with the built-in
- * family fallback list). The browser half uses it only when the official
- * settings scope reports the namespace unavailable, so hosts whose apiproxy
- * already exposes the namespaces never touch the bridge.
+ * settings bridge: a loopback-default HTTP pair that serves the family
+ * plugins' settings namespaces through the host settings seam, gated by the
+ * user's web_settings_namespaces allowlist from settings.yaml (with the
+ * built-in family fallback list). An explicit authenticated-proxy config may
+ * admit exact same-origin Hosts without changing the default. The browser
+ * half uses it only when the official settings scope reports the namespace
+ * unavailable, so hosts whose apiproxy already exposes the namespaces never
+ * touch the bridge.
  */
 
 import { readFileSync } from 'node:fs'
@@ -14,7 +16,37 @@ import { join } from 'node:path'
 import type { Context } from '@deepseek-ai/cordis'
 import type {} from '@deepseek-ai/dsh-host-webserver'
 import type {} from '@deepseek-ai/dsh-settings'
+import z from 'schemastery'
 import { makeBridgeRoutes } from './bridge.ts'
+
+/** Default environment variable holding the reverse-proxy shared token. */
+export const DEFAULT_PROXY_TOKEN_ENV = 'DSH_WEB_UI_SETTINGS_PROXY_TOKEN'
+
+/** Host-side compatibility bridge config. */
+export interface Config {
+  /** Canonical Host authorities admitted only from the local authenticated proxy. */
+  trustedProxyHosts?: string[]
+  /** Environment variable whose non-empty value the proxy injects upstream. */
+  proxyTokenEnv?: string
+}
+
+export const Config: z<Config> = z.object({
+  trustedProxyHosts: z.array(String).default([]),
+  proxyTokenEnv: z.string().min(1).default(DEFAULT_PROXY_TOKEN_ENV),
+})
+
+/** Resolve the opt-in proxy token without putting its value in plugin config. */
+export function resolveProxyAccess(config?: Config, env: NodeJS.ProcessEnv = process.env): { trustedProxyHosts: string[]; proxyToken?: string } {
+  const trustedProxyHosts = config?.trustedProxyHosts ?? []
+  if (trustedProxyHosts.length === 0) return { trustedProxyHosts }
+  const proxyTokenEnv = config?.proxyTokenEnv ?? DEFAULT_PROXY_TOKEN_ENV
+  if (proxyTokenEnv.trim() === '') throw new Error('web-ui-settings: proxyTokenEnv must not be empty')
+  const proxyToken = env[proxyTokenEnv]
+  if (proxyToken === undefined || proxyToken === '') {
+    throw new Error('web-ui-settings: trustedProxyHosts requires a non-empty ' + proxyTokenEnv + ' environment variable')
+  }
+  return { trustedProxyHosts, proxyToken }
+}
 
 /** Required services before the bridge routes can mount. */
 export const inject = ['webServer'] as const
@@ -23,8 +55,10 @@ export const inject = ['webServer'] as const
  * Mount the settings bridge when a settings seam exists (the seam is what the
  * bridge serves, so without one there is nothing to expose).
  * @param ctx - host plugin context.
+ * @param config - loopback-default bridge and authenticated-proxy config.
  */
-export function apply(ctx: Context): void {
+export function apply(ctx: Context, config?: Config): void {
+  const access = resolveProxyAccess(config)
   ctx.inject(['settings'], (sctx) => {
     const settingsYamlPath = sctx.settings.documentPath ?? join(homedir(), '.dsh', 'settings.yaml')
     sctx.effect(() => {
@@ -37,7 +71,7 @@ export function apply(ctx: Context): void {
             return ''
           }
         },
-      }).map(route => sctx.webServer.register(route))
+      }, access).map(route => sctx.webServer.register(route))
       return () => {
         for (const dispose of disposers) dispose()
       }

--- a/packages/dsh-web-ui-settings/tests/bridge.spec.ts
+++ b/packages/dsh-web-ui-settings/tests/bridge.spec.ts
@@ -4,10 +4,11 @@
  * controller understands.
  */
 
+import type { IncomingMessage } from 'node:http'
 import { describe, expect, it } from 'vitest'
 import { SettingsConflictError } from '@deepseek-ai/dsh-settings'
 import type { SettingsNamespace, SettingsProvider } from '@deepseek-ai/dsh-settings'
-import { makeBridgeHandlers } from '../src/bridge.ts'
+import { isTrustedBridgeRequest, makeBridgeHandlers, WEB_UI_SETTINGS_PROXY_TOKEN_HEADER } from '../src/bridge.ts'
 
 /** One fake settings registration the fake seam serves. */
 interface FakeRegistration {
@@ -59,6 +60,90 @@ const userYaml = (): string => [
   '  - dsh-skins',
   '  - dsh-web-ui',
 ].join('\n')
+
+/** Minimal request facts consumed by the bridge trust fence. */
+function request(options: {
+  address?: string
+  host?: string
+  origin?: string
+  fetchSite?: string
+  proxyToken?: string
+} = {}): IncomingMessage {
+  const headers: Record<string, string> = { host: options.host ?? '127.0.0.1:3080' }
+  if (options.origin !== undefined) headers.origin = options.origin
+  if (options.fetchSite !== undefined) headers['sec-fetch-site'] = options.fetchSite
+  if (options.proxyToken !== undefined) headers[WEB_UI_SETTINGS_PROXY_TOKEN_HEADER] = options.proxyToken
+  return {
+    socket: { remoteAddress: options.address ?? '127.0.0.1' },
+    headers,
+  } as unknown as IncomingMessage
+}
+
+describe('bridge request trust', () => {
+  const proxyAccess = { trustedProxyHosts: ['dsh.example.test'], proxyToken: 'test-proxy-token' }
+
+  it('keeps direct loopback access without proxy config', () => {
+    expect(isTrustedBridgeRequest(request())).toBe(true)
+    expect(isTrustedBridgeRequest(request({ host: 'localhost:3080', origin: 'http://localhost:3080' }))).toBe(true)
+  })
+
+  it('denies a domain Host by default', () => {
+    expect(isTrustedBridgeRequest(request({
+      host: 'dsh.example.test',
+      origin: 'https://dsh.example.test',
+      proxyToken: 'test-proxy-token',
+    }))).toBe(false)
+  })
+
+  it('admits an authenticated same-origin request from the local proxy', () => {
+    expect(isTrustedBridgeRequest(request({
+      host: 'dsh.example.test',
+      origin: 'https://dsh.example.test',
+      fetchSite: 'same-origin',
+      proxyToken: 'test-proxy-token',
+    }), proxyAccess)).toBe(true)
+  })
+
+  it.each([
+    ['non-loopback proxy socket', { address: '192.0.2.10', host: 'dsh.example.test', origin: 'https://dsh.example.test', proxyToken: 'test-proxy-token' }],
+    ['unknown Host', { host: 'other.example.test', origin: 'https://other.example.test', proxyToken: 'test-proxy-token' }],
+    ['mismatched Origin', { host: 'dsh.example.test', origin: 'https://other.example.test', proxyToken: 'test-proxy-token' }],
+    ['cross-site marker', { host: 'dsh.example.test', origin: 'https://dsh.example.test', fetchSite: 'cross-site', proxyToken: 'test-proxy-token' }],
+    ['missing proxy token', { host: 'dsh.example.test', origin: 'https://dsh.example.test' }],
+    ['wrong proxy token', { host: 'dsh.example.test', origin: 'https://dsh.example.test', proxyToken: 'wrong-token' }],
+  ])('denies %s', (_label, options) => {
+    expect(isTrustedBridgeRequest(request(options), proxyAccess)).toBe(false)
+  })
+
+  it('rejects non-canonical trusted proxy authorities at mount time', () => {
+    for (const authority of [
+      'https://dsh.example.test/path',
+      'user@dsh.example.test',
+      'dsh.example.test:08080',
+      'dsh.example.test/path',
+    ]) {
+      expect(() => isTrustedBridgeRequest(request(), {
+        trustedProxyHosts: [authority],
+        proxyToken: 'test-proxy-token',
+      })).toThrow(/canonical host\[:port\] authority/)
+    }
+  })
+
+  it('rejects a non-canonical request Host even when it normalizes to a trusted Host', () => {
+    expect(isTrustedBridgeRequest(request({
+      host: 'dsh.example.test:08080',
+      origin: 'https://dsh.example.test:8080',
+      proxyToken: 'test-proxy-token',
+    }), {
+      trustedProxyHosts: ['dsh.example.test:8080'],
+      proxyToken: 'test-proxy-token',
+    })).toBe(false)
+  })
+
+  it('requires a token whenever proxy Hosts are configured', () => {
+    expect(() => isTrustedBridgeRequest(request(), { trustedProxyHosts: ['dsh.example.test'] })).toThrow(/require a non-empty proxy token/)
+  })
+})
 
 describe('bridge describe', () => {
   it('serves the built-in family allowlist when the user configured none', async () => {

--- a/packages/dsh-web-ui-settings/tests/compat-scope.spec.ts
+++ b/packages/dsh-web-ui-settings/tests/compat-scope.spec.ts
@@ -3,8 +3,8 @@
 /**
  * Compatibility scope state machine: the official scope stays authoritative
  * while it serves the namespace; the bridge controller takes over its
- * unavailable state on loopback; writes route to the active transport; and a
- * remote browser (no fetch) keeps the official process-local behavior.
+ * unavailable state over same-origin fetch; writes route to the active
+ * transport; and a missing fetch keeps the official unavailable behavior.
  */
 
 import { describe, expect, it, vi } from 'vitest'
@@ -131,7 +131,7 @@ describe('createCompatScope', () => {
     expect(scope.getSnapshot().status).toBe('unavailable')
   })
 
-  it('never builds a bridge without a fetch (remote browser)', async () => {
+  it('never builds a bridge when the caller provides no fetch', async () => {
     const primary = fakePrimary<{ enabled: boolean }>(unavailable())
     const scope = createCompatScope<{ enabled: boolean }>({ namespace: 'task-board', primary: primary.scope })
     await vi.waitFor(() => { expect(scope.getSnapshot().status).toBe('unavailable') })

--- a/packages/dsh-web-ui-settings/tests/config.spec.ts
+++ b/packages/dsh-web-ui-settings/tests/config.spec.ts
@@ -1,0 +1,38 @@
+/** Host config keeps authenticated proxy access opt-in and secret values in the environment. */
+
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_PROXY_TOKEN_ENV, resolveProxyAccess } from '../src/index.ts'
+
+describe('authenticated proxy config', () => {
+  it('keeps the bridge loopback-only by default', () => {
+    expect(resolveProxyAccess(undefined, {})).toEqual({ trustedProxyHosts: [] })
+  })
+
+  it('reads the shared token from the configured environment variable', () => {
+    expect(resolveProxyAccess({
+      trustedProxyHosts: ['dsh.example.test'],
+      proxyTokenEnv: 'CUSTOM_PROXY_TOKEN',
+    }, { CUSTOM_PROXY_TOKEN: 'test-proxy-token' })).toEqual({
+      trustedProxyHosts: ['dsh.example.test'],
+      proxyToken: 'test-proxy-token',
+    })
+  })
+
+  it('uses the documented default token environment variable', () => {
+    expect(resolveProxyAccess({ trustedProxyHosts: ['dsh.example.test'] }, {
+      [DEFAULT_PROXY_TOKEN_ENV]: 'test-proxy-token',
+    }).proxyToken).toBe('test-proxy-token')
+  })
+
+  it('fails loud when proxy access is enabled without a token', () => {
+    expect(() => resolveProxyAccess({ trustedProxyHosts: ['dsh.example.test'] }, {}))
+      .toThrow(DEFAULT_PROXY_TOKEN_ENV)
+  })
+
+  it('rejects a blank environment variable name', () => {
+    expect(() => resolveProxyAccess({
+      trustedProxyHosts: ['dsh.example.test'],
+      proxyTokenEnv: ' ',
+    }, {})).toThrow(/proxyTokenEnv must not be empty/)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,6 +783,10 @@ importers:
         version: link:../dsh-tool-describe-image
 
   packages/dsh-web-ui-settings:
+    dependencies:
+      schemastery:
+        specifier: ^3.18.0
+        version: 3.18.0
     devDependencies:
       '@deepseek-ai/cordis':
         specifier: ^4.0.1


### PR DESCRIPTION
## 摘要（Summary）

为 `dsh-web-ui-settings` 增加默认关闭的认证反向代理模式，使域名访问下的 Web UI 插件、宠物、社区插件等第三方设置表单可以使用现有兼容桥，而无需修改 DSH 官方包。默认 loopback 行为保持不变。

Host 端仅接受来自 loopback socket、精确匹配 `trustedProxyHosts`、浏览器同源且携带代理注入共享令牌的请求；Client 端在官方 settings scope 不可用时尝试同源兼容桥，最终访问权限仍由 Host 决定。

Closes #342

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin main --prune
test "$(git rev-parse HEAD^)" = "$(git rev-parse origin/main)"
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`；本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

N/A。本 PR 未新增插件或皮肤。

## 社区插件索引登记（Community Plugin Index）

N/A。本 PR 未新增第三方插件索引项。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-web-ui-settings typecheck
pnpm --filter @linxin666/dsh-client-ui-web-ui-settings test
pnpm --filter @linxin666/dsh-client-ui-web-ui-settings build
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm runtime-deps:check
pnpm aggregate:check
pnpm sync-shared:check
pnpm gallery:check
pnpm skin-center:check
pnpm community:check
pnpm build
```

结果摘要：全部通过。改动包 6 个测试文件、50 项测试通过；全仓类型检查、测试、构建、脚本、文档及生成物一致性门禁均通过。

## 用户可见变更证据（Local Feature Evidence）

在 `https://rsi.grivn.dev/` 将本分支提交 `0f3cd060536b72644a244c28f60379a534ce07ca` 链接到实际 web profile，以同一构建切换 `trustedProxyHosts` 做前后对比：

| 设置页 | 配置前 | 配置后 |
| --- | ---: | ---: |
| Web UI 插件 | 4 张卡片不可编辑，桥请求 403 | 同类警告 0，73 个可见控件，桥请求 200 |
| 皮肤中心 | 同类警告 0 | 同类警告 0，64 个可见控件 |
| 宠物 | 同类警告 1 | 同类警告 0，49 个可见控件 |
| 社区插件 | 同类警告 1 | 同类警告 0，48 个可见控件 |

| Web UI 插件：配置前 | Web UI 插件：配置后 |
| --- | --- |
| ![Web UI 插件配置前](https://raw.githubusercontent.com/Grivn/dsh-web-ui/refs/heads/codex/pr-342-evidence/before-web-ui-plugins.png) | ![Web UI 插件配置后](https://raw.githubusercontent.com/Grivn/dsh-web-ui/refs/heads/codex/pr-342-evidence/after-web-ui-plugins.png) |

| 社区插件：配置前 | 社区插件：配置后 |
| --- | --- |
| ![社区插件配置前](https://raw.githubusercontent.com/Grivn/dsh-web-ui/refs/heads/codex/pr-342-evidence/before-community-plugins.png) | ![社区插件配置后](https://raw.githubusercontent.com/Grivn/dsh-web-ui/refs/heads/codex/pr-342-evidence/after-community-plugins.png) |

安全边界验证：未认证公网请求返回 401；本机伪造域名但缺少代理令牌返回 403；认证代理的同源请求返回 200，并仅返回 8 个已登记且允许的家族命名空间。截图证据保存在 fork 的独立分支，不进入本 PR 的代码差异。
