### PR TITLE
feat(describe-image): control vision thinking via model id suffix

### DIFF
--- a/packages/dsh-tool-describe-image/README.i18n.yaml
+++ b/packages/dsh-tool-describe-image/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 706c6fb69cc853aa5d237a2a2ef9e3a240e0932d
-README.zh.md: 07bdc7c7611781825da8446dcce5227253e2270f
+README.md: 838ae7695f9b7b70297ecdade880013eb1ec6601
+README.zh.md: a0d78f73549f67e2177b3dfc6db98e896c12ac47

--- a/packages/dsh-tool-describe-image/README.md
+++ b/packages/dsh-tool-describe-image/README.md
@@ -22,6 +22,7 @@ browser half, live settings, no dsh source changes.
 | Custom instructions | The `prompt` argument carries your precise instruction (OCR, chart reading, UI diagnosis, translation…); the `defaultPrompt` config sets the fallback when the model passes none |
 | Live config card | Settings → Plugin config → Web UI Plugins → "Image understanding" card edits `baseURL` / `apiStyle` / `model` / API key / default instruction / bounds (through the settings seam); effective immediately, no restart |
 | Protocol styles | `apiStyle: chat-completions` (default) posts to `baseURL/chat/completions`; `apiStyle: responses` posts to `baseURL/responses` with `input` / `max_output_tokens` and reads `output_text` |
+| Thinking control | The model id carries an optional suffix: `model:off` disables thinking, `model:low` / `model:medium` / `model:high` enable it, and a bare `model` sends no control so the endpoint default applies (MiMo-V2.5 and DeepSeek V4 think by default) |
 | Raw image route | `GET /describe-image/raw/<id>` serves the stored bytes (loopback-only, content-addressed id) so the pasted reference renders in the conversation |
 | Per-call key resolution | Inline `apiKey` → credential seam (`apiKeyEnv`, default `VISION_API_KEY`) → launch environment, tiered fallback |
 | Safety and bounds | All requests refuse redirects; `maxBytes` / `maxOutputTokens` / `timeoutMs` caps; magic-byte type gate; bounded error excerpts (200 chars); keys never logged |
@@ -59,7 +60,7 @@ actually configures it and per-call otherwise.)
 | --- | --- | --- |
 | `baseURL` | — (required) | OpenAI-compatible endpoint root (e.g. `https://dashscope.aliyuncs.com/compatible-mode/v1`); trailing slashes stripped |
 | `apiStyle` | `chat-completions` | Protocol style: `chat-completions` appends `/chat/completions`; `responses` appends `/responses` (OpenAI Responses API `input` / `max_output_tokens` / `output_text` shapes) |
-| `model` | — (required) | Vision model id |
+| `model` | — (required) | Vision model id, optionally with a thinking suffix (`:off` / `:low` / `:medium` / `:high`). The suffix is stripped before the id reaches the endpoint: `:off` maps to `thinking.type: disabled` (`chat-completions`) or `reasoning.effort: none` (`responses`); every other level maps to `enabled` or is forwarded as the `reasoning.effort` value. No suffix means no thinking control field |
 | `apiKey` | — | Inline key for local debugging; prefer `!!js process.env.VISION_API_KEY` over a hardcoded secret |
 | `apiKeyEnv` | `VISION_API_KEY` | Credential reference (environment-variable name); empty string disables reference resolution |
 | `defaultPrompt` | see source | The instruction used when a call omits its `prompt` — tune it to your workload (OCR, UI review, translation…) |
@@ -88,6 +89,17 @@ Endpoints exposing only the Responses API set `apiStyle: responses`:
     baseURL: https://api.openai.com/v1
     apiStyle: responses
     model: gpt-4o-mini
+    apiKey: !!js process.env.VISION_API_KEY
+```
+
+Endpoints whose models enable extended thinking by default (MiMo-V2.5, DeepSeek V4) can turn it off per call so reasoning tokens do not consume the output budget:
+
+```yaml
+- id: describe-image
+  name: '@linxin666/dsh-tool-describe-image'
+  config:
+    baseURL: https://api.xiaomimimo.com/v1
+    model: mimo-v2.5:off
     apiKey: !!js process.env.VISION_API_KEY
 ```
 
@@ -123,6 +135,12 @@ text stays as-is.
 - Extracting text still costs one VLM call: OCR-only deployments can point `baseURL` at a cheaper OCR model.
 - OpenAI-compatible protocol only: Chat Completions (`/chat/completions`) and Responses (`/responses`)
   are supported; vendors with other request/response shapes need separate adapters.
+- The model thinking suffix is a plugin shorthand that adds provider-specific fields
+  (`thinking.type` / `reasoning.effort`) to the request; endpoints that do not accept them (for
+  example plain OpenAI vision models) should use a bare model id. Chat Completions has no effort
+  levels, so `:low` / `:medium` / `:high` all map to `thinking.type: enabled` there. Only the four
+  known suffixes are stripped — ids that end in other colon variants (for example OpenRouter
+  `:free`) are forwarded verbatim.
 
 ## Source and copyright
 

--- a/packages/dsh-tool-describe-image/README.zh.md
+++ b/packages/dsh-tool-describe-image/README.zh.md
@@ -20,6 +20,7 @@ OpenAI 兼容的视觉模型端点（Qwen-VL、GLM-4V、GPT-4o、本地 Ollama �
 | 自定义指令 | `prompt` 参数携带你的精确指令（OCR、图表解读、UI 诊断、翻译…）；`defaultPrompt` 配置设置模型未传指令时的兜底文案 |
 | 实时配置卡 | 设置 → 插件配置 → Web UI 插件组 → 「图像理解」卡修改 `baseURL` / `apiStyle` / `model` / API key / 默认指令 / 各项上限（走设置服务），即时生效，无需重启 |
 | 双协议 | `apiStyle: chat-completions`（默认）请求 `baseURL/chat/completions`；`apiStyle: responses` 请求 `baseURL/responses`，使用 `input` / `max_output_tokens` 并读取 `output_text` |
+| 思考控制 | 模型 id 带可选后缀：`model:off` 禁用思考，`model:low` / `model:medium` / `model:high` 开启思考；不带后缀则不发送控制、沿用端点默认（MiMo-V2.5、DeepSeek V4 默认开启思考） |
 | 原图路由 | `GET /describe-image/raw/<id>` 回读已存字节（仅回环、内容寻址 id），让贴入的引用在会话中渲染 |
 | 每次调用解析密钥 | 内联 `apiKey` → 凭证服务（`apiKeyEnv`，默认 `VISION_API_KEY`）→ 启动环境，逐级回退 |
 | 安全与边界 | 所有请求拒绝重定向；`maxBytes` / `maxOutputTokens` / `timeoutMs` 上限；magic-byte 类型门；错误摘要有界（200 字符）；密钥不进日志 |
@@ -56,7 +57,7 @@ dsh plugin --profile web add @linxin666/dsh-tool-describe-image
 | --- | --- | --- |
 | `baseURL` | —（必填） | OpenAI 兼容端点根（如 `https://dashscope.aliyuncs.com/compatible-mode/v1`），末尾斜杠自动去除 |
 | `apiStyle` | `chat-completions` | 接口协议：`chat-completions` 追加 `/chat/completions`；`responses` 追加 `/responses`（OpenAI Responses API 的 `input` / `max_output_tokens` / `output_text` 形态） |
-| `model` | —（必填） | 视觉模型 id |
+| `model` | —（必填） | 视觉模型 id，可带思考后缀（`:off` / `:low` / `:medium` / `:high`）。后缀在发往端点前剥除：`:off` 映射为 `thinking.type=disabled`（`chat-completions`）或 `reasoning.effort=none`（`responses`）；其余档位映射为 `enabled`，或原样作为 `reasoning.effort` 的值。不带后缀则不发送任何思考控制字段 |
 | `apiKey` | — | 内联密钥；本地调试用。建议用 `!!js process.env.VISION_API_KEY` 从环境注入，勿写死明文 |
 | `apiKeyEnv` | `VISION_API_KEY` | 凭证引用（环境变量名）；空字符串禁用引用解析 |
 | `defaultPrompt` | 见源码 | 调用未带 `prompt` 时的指令——按你的场景调优（OCR、UI 评审、翻译…） |
@@ -88,6 +89,17 @@ dsh plugin --profile web add @linxin666/dsh-tool-describe-image
     apiKey: !!js process.env.VISION_API_KEY
 ```
 
+模型默认开启扩展思考的端点（MiMo-V2.5、DeepSeek V4）可按调用关闭思考，避免思考 token 消耗输出预算：
+
+```yaml
+- id: describe-image
+  name: '@linxin666/dsh-tool-describe-image'
+  config:
+    baseURL: https://api.xiaomimimo.com/v1
+    model: mimo-v2.5:off
+    apiKey: !!js process.env.VISION_API_KEY
+```
+
 ## 使用
 
 ### 自定义指令
@@ -113,6 +125,10 @@ DSH 输入框对纯文本模型没有图片入口，因此在输入框里拖拽�
 - 抽取文本仍消耗一次 VLM 调用：仅需 OCR 的部署可把 `baseURL` 指向更便宜的 OCR 模型。
 - 仅 OpenAI 兼容协议：支持 Chat Completions（`/chat/completions`）与 Responses（`/responses`）
   两种形态，请求 / 响应形态不同的厂商需要单独适配。
+- 模型思考后缀是插件简写，会向请求注入厂商专用字段（`thinking.type` / `reasoning.effort`）；
+  不接受这些字段的端点（如普通 OpenAI 视觉模型）应使用不带后缀的模型 id。chat-completions
+  协议没有 effort 档位，`:low` / `:medium` / `:high` 在该协议下都映射为 `thinking.type=enabled`。
+  只剥除这四个已知后缀，以其他冒号变体结尾的 id（如 OpenRouter 的 `:free`）原样发送。
 
 ## 来源与版权
 

--- a/packages/dsh-tool-describe-image/src/config-resolve.ts
+++ b/packages/dsh-tool-describe-image/src/config-resolve.ts
@@ -19,6 +19,10 @@ import { DEFAULT_MAX_BYTES } from './media.ts'
 export const DEFAULT_API_KEY_ENV = 'VISION_API_KEY'
 /** Per-call output-token cap sent to the vision model. */
 export const DEFAULT_MAX_OUTPUT_TOKENS = 1024
+/** Thinking-level suffixes accepted after the model id: `:off` disables thinking, the rest enable it. */
+export const THINKING_SUFFIXES = ['off', 'low', 'medium', 'high'] as const
+/** One parsed thinking level from a model-id suffix, or undefined when the model id carries none. */
+export type ThinkingMode = typeof THINKING_SUFFIXES[number]
 /** Per-call vision request timeout in milliseconds. */
 export const DEFAULT_TIMEOUT_MS = 60_000
 /** Protocol styles the tool can speak to the configured endpoint. */
@@ -33,6 +37,21 @@ export const DEFAULT_PROMPT =
   'Analyze this image: describe what is visible factually, transcribe legible text verbatim, and call out layout, notable details, or anything anomalous.'
 
 /**
+ * Split a model id into the id the endpoint receives and its thinking-level suffix. A trailing
+ * `:off` / `:low` / `:medium` / `:high` is the plugin's shorthand for the thinking control:
+ * the suffix never reaches the endpoint, and a model id without one (or with any other suffix) is
+ * forwarded verbatim with no thinking control.
+ * @param model - the raw configured model id.
+ * @returns the cleaned id and the parsed level, if any.
+ */
+export function splitModelSuffix(model: string): { model: string; thinking: ThinkingMode | undefined } {
+  const trimmed = model.trim()
+  const match = /:(off|low|medium|high)$/.exec(trimmed)
+  if (match === null) return { model: trimmed, thinking: undefined }
+  return { model: trimmed.slice(0, -match[0].length), thinking: match[1] as ThinkingMode }
+}
+
+/**
  * Deployment configuration for the describe-image tool. The interface keeps every field optional so
  * programmatic construction is re-judged by {@link resolveConfig}; the schema requires `baseURL` and
  * `model` for composition entries.
@@ -40,7 +59,11 @@ export const DEFAULT_PROMPT =
 export interface Config {
   /** Root of the OpenAI-compatible endpoint, e.g. `https://api.openai.com/v1`; trailing slashes are stripped. */
   baseURL?: string
-  /** Vision model id for the configured endpoint. */
+  /**
+   * Vision model id for the configured endpoint, optionally with a trailing thinking suffix
+   * (`:off` / `:low` / `:medium` / `:high`) — see {@link splitModelSuffix}. The suffix
+   * controls the thinking field the request sends and is stripped before the id reaches the endpoint.
+   */
   model?: string
   /** Inline API key; prefer `apiKeyEnv` with the credential seam. Feed from the environment via `!!js process.env.VISION_API_KEY`. */
   apiKey?: string
@@ -95,6 +118,7 @@ export interface ResolvedConfig {
   maxOutputTokens: number
   timeoutMs: number
   apiStyle: ApiStyle
+  thinking: ThinkingMode | undefined
   renderImagePreview: boolean
 }
 
@@ -111,8 +135,8 @@ export function resolveConfig(config: Config): ResolvedConfig {
   if (!/^https?:\/\//.test(baseURL)) {
     throw new Error('describe-image: baseURL must be an absolute http(s) URL')
   }
-  const model = (config.model ?? '').trim()
-  if (model.length === 0) throw new Error('describe-image: model must be a non-empty model id')
+  const { model, thinking } = splitModelSuffix(config.model ?? '')
+  if (model.length === 0) throw new Error('describe-image: model must be a non-empty model id before any :off/:low/:medium/:high suffix')
   const apiKey = config.apiKey
   if (apiKey !== undefined && apiKey.length === 0) {
     throw new Error('describe-image: apiKey must be non-empty when set')
@@ -138,7 +162,7 @@ export function resolveConfig(config: Config): ResolvedConfig {
   if (!API_STYLES.includes(apiStyle)) {
     throw new Error(`describe-image: apiStyle must be one of ${API_STYLES.map(style => JSON.stringify(style)).join(', ')}`)
   }
-  return { baseURL, model, apiKey, apiKeyEnv, defaultPrompt: config.defaultPrompt ?? DEFAULT_PROMPT, maxBytes, maxOutputTokens, timeoutMs, apiStyle, renderImagePreview: config.renderImagePreview ?? DEFAULT_RENDER_IMAGE_PREVIEW }
+  return { baseURL, model, apiKey, apiKeyEnv, defaultPrompt: config.defaultPrompt ?? DEFAULT_PROMPT, maxBytes, maxOutputTokens, timeoutMs, apiStyle, thinking, renderImagePreview: config.renderImagePreview ?? DEFAULT_RENDER_IMAGE_PREVIEW }
 }
 
 /**

--- a/packages/dsh-tool-describe-image/src/index.ts
+++ b/packages/dsh-tool-describe-image/src/index.ts
@@ -42,10 +42,12 @@ export {
   DEFAULT_RENDER_IMAGE_PREVIEW,
   DEFAULT_TIMEOUT_MS,
   DESCRIBE_IMAGE_SETTINGS_NAMESPACE,
+  THINKING_SUFFIXES,
   resolveApiKey,
   resolveConfig,
+  splitModelSuffix,
 } from './config-resolve.ts'
-export type { ApiStyle, ResolvedConfig } from './config-resolve.ts'
+export type { ApiStyle, ResolvedConfig, ThinkingMode } from './config-resolve.ts'
 export {
   callVision,
   createVisionCache,

--- a/packages/dsh-tool-describe-image/src/vision-client.ts
+++ b/packages/dsh-tool-describe-image/src/vision-client.ts
@@ -272,7 +272,13 @@ export function extractResponsesContent(payload: unknown): string {
   return text
 }
 
-/** Build the request the configured style sends: its path and JSON body. */
+/**
+ * Build the request the configured style sends: its path and JSON body. When the model id carried
+ * a thinking suffix, Chat Completions maps it to `thinking.type` (`off` -> `disabled`, every
+ * other level -> `enabled`) and Responses forwards it as `reasoning.effort` (`off` ->
+ * `none`, levels pass through); without a suffix no thinking control is sent, so the endpoint
+ * keeps its own default.
+ */
 export function buildVisionRequest(spec: ResolvedConfig, prompt: string, image: LoadedImage): { path: string; body: string } {
   const dataUrl = `data:${image.mimeType};base64,${image.bytes.toString('base64')}`
   if (spec.apiStyle === 'responses') {
@@ -281,6 +287,7 @@ export function buildVisionRequest(spec: ResolvedConfig, prompt: string, image: 
       body: JSON.stringify({
         model: spec.model,
         max_output_tokens: spec.maxOutputTokens,
+        ...spec.thinking === undefined ? {} : { reasoning: { effort: spec.thinking === 'off' ? 'none' : spec.thinking } },
         input: [{
           role: 'user',
           content: [
@@ -296,6 +303,7 @@ export function buildVisionRequest(spec: ResolvedConfig, prompt: string, image: 
     body: JSON.stringify({
       model: spec.model,
       max_tokens: spec.maxOutputTokens,
+      ...spec.thinking === undefined ? {} : { thinking: { type: spec.thinking === 'off' ? 'disabled' : 'enabled' } },
       messages: [{
         role: 'user',
         content: [
@@ -363,7 +371,7 @@ export function createVisionCache(options?: { ttlMs?: number; maxEntries?: numbe
 /** The semantic identity of one vision request: endpoint fields plus the same image bytes and prompt. */
 export function semanticRequestKey(spec: ResolvedConfig, prompt: string, image: LoadedImage): string {
   return JSON.stringify([
-    spec.baseURL, spec.model, spec.maxOutputTokens, spec.apiStyle,
+    spec.baseURL, spec.model, spec.maxOutputTokens, spec.apiStyle, spec.thinking,
     image.bytes.toString('base64'), image.mimeType, prompt,
   ])
 }

--- a/packages/dsh-tool-describe-image/tests/settings.spec.ts
+++ b/packages/dsh-tool-describe-image/tests/settings.spec.ts
@@ -116,6 +116,21 @@ describe('describe-image settings section', () => {
     expect(server.request(0).path).toBe('/responses')
   })
 
+  it('a model thinking suffix committed through the section drives the next call body', async () => {
+    const { ctx, server } = await boot()
+    const path = await tempPng()
+
+    await ctx.settings.update(tool.DESCRIBE_IMAGE_SETTINGS_NAMESPACE, { model: 'entry-model:off' })
+
+    const result = await callDescribe(ctx, path)
+    expect(result.isError).toBe(false)
+    if (result.isError) throw new Error('expected describe_image success')
+    expect(result.value).toMatchObject({ model: 'entry-model' })
+    const body = server.request(0).body as { model?: unknown; thinking?: unknown }
+    expect(body.model).toBe('entry-model')
+    expect(body.thinking).toEqual({ type: 'disabled' })
+  })
+
   it('an inline apiKey committed through the section drives the next call', async () => {
     const { ctx, server } = await boot({ 'describe-image': { apiKey: 'sk-settings' } })
     const path = await tempPng()

--- a/packages/dsh-tool-describe-image/tests/tool.spec.ts
+++ b/packages/dsh-tool-describe-image/tests/tool.spec.ts
@@ -213,6 +213,31 @@ describe('successful descriptions', () => {
     expect(textPart?.text).toBe('Is there text in this image?')
   })
 
+  it('strips the model thinking suffix and maps it to thinking.type', async () => {
+    const server = await startMockServer((_request, res) => { jsonReply(res, 200, chatReply('ok')) })
+    cleanup.push(server.close)
+    const path = await tempPng()
+
+    const inheritCtx = await setup({ baseURL: server.url })
+    const inheritResult = await callDescribe(inheritCtx, { image: path })
+    expect(inheritResult.isError).toBe(false)
+    expect((server.request(0).body as { model?: unknown; thinking?: unknown }).model).toBe('vision-1')
+    expect((server.request(0).body as { thinking?: unknown }).thinking).toBeUndefined()
+
+    const offCtx = await setup({ baseURL: server.url, model: 'vision-1:off' })
+    const offResult = await callDescribe(offCtx, { image: path })
+    expect(offResult.isError).toBe(false)
+    expect((server.request(1).body as { model?: unknown; thinking?: unknown }).model).toBe('vision-1')
+    expect((server.request(1).body as { thinking?: unknown }).thinking).toEqual({ type: 'disabled' })
+
+    const highCtx = await setup({ baseURL: server.url, model: 'vision-1:high' })
+    const highResult = await callDescribe(highCtx, { image: path })
+    expect(highResult.isError).toBe(false)
+    if (!highResult.isError) expect(highResult.value).toMatchObject({ model: 'vision-1' })
+    expect((server.request(2).body as { model?: unknown; thinking?: unknown }).model).toBe('vision-1')
+    expect((server.request(2).body as { thinking?: unknown }).thinking).toEqual({ type: 'enabled' })
+  })
+
   it('downloads an http(s) image when given a URL', async () => {
     const server = await startMockServer((request, res) => {
       if (request.path === '/img.png') rawReply(res, 200, PNG_BYTES, 'image/png')
@@ -267,6 +292,24 @@ describe('Responses API style', () => {
     expect(body.max_output_tokens).toBe(7)
     const [textPart] = sentInputContent(server.request(0)) as Array<{ text?: string }>
     expect(textPart?.text).toBe('Is there text in this image?')
+  })
+
+  it('maps the model thinking suffix to reasoning.effort in the responses body', async () => {
+    const server = await startMockServer((_request, res) => { jsonReply(res, 200, responsesReply('ok')) })
+    cleanup.push(server.close)
+    const path = await tempPng()
+
+    const inheritCtx = await setup({ baseURL: server.url, apiStyle: 'responses' })
+    await callDescribe(inheritCtx, { image: path })
+    expect((server.request(0).body as { reasoning?: unknown }).reasoning).toBeUndefined()
+
+    const offCtx = await setup({ baseURL: server.url, apiStyle: 'responses', model: 'vision-1:off' })
+    await callDescribe(offCtx, { image: path })
+    expect((server.request(1).body as { reasoning?: unknown }).reasoning).toEqual({ effort: 'none' })
+
+    const highCtx = await setup({ baseURL: server.url, apiStyle: 'responses', model: 'vision-1:high' })
+    await callDescribe(highCtx, { image: path })
+    expect((server.request(2).body as { reasoning?: unknown }).reasoning).toEqual({ effort: 'high' })
   })
 
   it('joins every output_text part of the first assistant message', async () => {
@@ -710,6 +753,30 @@ describe('resolveConfig, sniffing, and bounded reads', () => {
 
   it('honors an explicit renderImagePreview override', () => {
     expect(tool.resolveConfig({ ...minimal, renderImagePreview: false }).renderImagePreview).toBe(false)
+  })
+
+  it('splits a model thinking suffix off the id and leaves bare ids untouched', () => {
+    expect(tool.resolveConfig(minimal)).toMatchObject({ model: 'vision-1', thinking: undefined })
+    expect(tool.resolveConfig({ ...minimal, model: 'vision-1:off' })).toMatchObject({ model: 'vision-1', thinking: 'off' })
+    expect(tool.resolveConfig({ ...minimal, model: 'vision-1:low' })).toMatchObject({ model: 'vision-1', thinking: 'low' })
+    expect(tool.resolveConfig({ ...minimal, model: 'vision-1:medium' })).toMatchObject({ model: 'vision-1', thinking: 'medium' })
+    expect(tool.resolveConfig({ ...minimal, model: 'vision-1:high' })).toMatchObject({ model: 'vision-1', thinking: 'high' })
+    // Unknown or non-trailing colons are part of the id, not a thinking suffix: real ids
+    // carry colon variants (OpenRouter ':free', Replicate ':version'), so only the four known
+    // thinking tokens are stripped.
+    expect(tool.resolveConfig({ ...minimal, model: 'vision-1:unknown' })).toMatchObject({ model: 'vision-1:unknown', thinking: undefined })
+    expect(tool.resolveConfig({ ...minimal, model: 'vision-1:high-custom' })).toMatchObject({ model: 'vision-1:high-custom', thinking: undefined })
+    expect(tool.resolveConfig({ ...minimal, model: 'openrouter/openai/gpt-4o:free' })).toMatchObject({ model: 'openrouter/openai/gpt-4o:free', thinking: undefined })
+  })
+
+  it('rejects a model id that is only a thinking suffix', () => {
+    expect(() => tool.resolveConfig({ ...minimal, model: ':off' })).toThrow(/model must be a non-empty model id/)
+  })
+
+  it('parses thinking suffixes through splitModelSuffix with surrounding whitespace', () => {
+    expect(tool.splitModelSuffix('  mimo-v2.5:off  ')).toEqual({ model: 'mimo-v2.5', thinking: 'off' })
+    expect(tool.splitModelSuffix('mimo-v2.5:high')).toEqual({ model: 'mimo-v2.5', thinking: 'high' })
+    expect(tool.splitModelSuffix('mimo-v2.5')).toEqual({ model: 'mimo-v2.5', thinking: undefined })
   })
 
   it('accepts the responses style and rejects anything else', () => {

--- a/packages/dsh-tool-describe-image/tests/vision-cache.spec.ts
+++ b/packages/dsh-tool-describe-image/tests/vision-cache.spec.ts
@@ -33,6 +33,7 @@ const SPEC: tool.ResolvedConfig = {
   maxOutputTokens: tool.DEFAULT_MAX_OUTPUT_TOKENS,
   timeoutMs: 60_000,
   apiStyle: 'chat-completions',
+  thinking: undefined,
   renderImagePreview: tool.DEFAULT_RENDER_IMAGE_PREVIEW,
 }
 
@@ -134,10 +135,12 @@ describe('semantic request key', () => {
     const same = tool.semanticRequestKey(SPEC, 'q', loadedImage())
     const otherPrompt = tool.semanticRequestKey(SPEC, 'r', loadedImage())
     const otherModel = tool.semanticRequestKey({ ...SPEC, model: 'vision-2' }, 'q', loadedImage())
+    const otherThinking = tool.semanticRequestKey({ ...SPEC, thinking: 'off' }, 'q', loadedImage())
     const otherImage = tool.semanticRequestKey(SPEC, 'q', loadedImage(Buffer.from('different bytes')))
     expect(a).toBe(same)
     expect(a).not.toBe(otherPrompt)
     expect(a).not.toBe(otherModel)
+    expect(a).not.toBe(otherThinking)
     expect(a).not.toBe(otherImage)
   })
 })


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；
> 提交信息用 Conventional Commits（`type(scope): subject`），禁止 emoji。
> 本仓库接受修复、增强与优化类 PR（bug 修复、现有功能的增强、性能 / 体验优化、维护与文档修正）；新皮肤始终欢迎。全新特性 / 新功能的 PR 暂不接受，请先提 Issue 讨论。

## 摘要（Summary）

为 `dsh-tool-describe-image` 增加思考控制：在 `model` 字段末尾追加可选后缀，不新增配置键与 UI，README 已随代码同步该能力。

- `mimo-v2.5`：不发送任何思考控制字段，沿用端点默认
- `mimo-v2.5:off`：禁用模型思考（chat-completions 发 `thinking.type=disabled`；responses 发 `reasoning.effort=none`）
- `mimo-v2.5:low` / `:medium` / `:high`：开启模型思考（chat-completions 发 `thinking.type=enabled`；responses 把档位原样作为 `reasoning.effort`）

后缀在请求发出前剥除，端点收到的 `model` 是不带后缀的 id。只有以 `:off` / `:low` / `:medium` / `:high` 结尾才算思考后缀；现实中的冒号模型 id 变体（OpenRouter `:free`、Replicate `:version`）以及其他未知后缀原样保留，不做「冒号后一律是档位」的简化解析。不带后缀时不发送思考字段，因此不会给不识别 `thinking` / `reasoning` 参数的端点注入非标准字段；MiMo-V2.5、DeepSeek V4 这类默认开启深度思考的视觉模型写 `:off` 即可，思考 token 不再吃掉 `maxOutputTokens` 输出预算（修复 `vision endpoint returned no text content` / `finish: length` 一类空回答）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）：`packages/dsh-tool-describe-image`（host 侧配置解析与请求构造、双语 README 三件套、测试）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main   # 基线 origin/main = f57b766
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek（deepseek-v4-pro）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。（N/A：未改动 tsconfig）
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（N/A：未新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。（已同步并重录配对，`pnpm docs:check` 通过）

## 贡献者版权声明（Contributor Copyright）

N/A（沿用现有版权归属，未追加声明）

## 社区插件索引登记（Community Plugin Index）

N/A（本 PR 未新增第三方插件索引项）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-tool-describe-image typecheck
pnpm --filter @linxin666/dsh-tool-describe-image test
pnpm --filter @linxin666/dsh-tool-describe-image build
pnpm typecheck
pnpm docs:check
```

结果摘要：

- 本包 8 个测试文件、148 项用例全部通过（新增模型后缀解析、chat/responses 请求体映射、设置区覆盖、语义缓存键与冒号模型 id 保留测试）；本包 typecheck / build 通过。
- `pnpm typecheck` 全仓通过；`pnpm docs:check` 通过（README 双语三件套已重录配对）。
- 全仓 `pnpm test` 在本机仅 `dsh-git-graph` 12 例失败（临时仓库分支名读取为空，本 PR 未触碰该包，CI 的 Ubuntu 干净环境不出现）；`pnpm test:scripts` 在本机仅 `release-notes` 2 例失败（本机全局 `commit.gpgsign` 导致测试内 git commit 无法签名，与本 PR 无关）。两项失败均与本次改动无关。

## 用户可见变更证据（Local Feature Evidence）

N/A：本 PR 不修改任何 UI，只改 host 侧请求构造并同步 README；请求体映射由单测覆盖（`:off` 时 chat-completions 发 `thinking.type=disabled`、responses 发 `reasoning.effort=none`；`:low/:medium/:high` 时 chat-completions 发 `enabled`、responses 原样转发档位；不带后缀时不发送任何思考字段，且 `model` 原样发送）。
