### PR TITLE
fix(aionui-panel): rehydrate restored expanded dirs on root switch

### DIFF
--- a/packages/dsh-aionui-panel/src/client/store.ts
+++ b/packages/dsh-aionui-panel/src/client/store.ts
@@ -363,9 +363,9 @@ export function createExplorerStore(api: PanelApi): ExplorerStore {
 
   const store: ExplorerStore = Object.assign(handle, {
     setRoot(root: string) {
+      const ui = readExplorerUi(root)
       handle.update((prev) => {
         if (prev.root === root) return prev
-        const ui = readExplorerUi(root)
         return {
           ...prev,
           root,
@@ -377,6 +377,9 @@ export function createExplorerStore(api: PanelApi): ExplorerStore {
         }
       })
       void ensureDir(root, '')
+      // Rehydrate every restored expanded dir so the persisted expanded
+      // arrows render real content without a manual collapse/expand round-trip.
+      for (const rel of ui.expanded) void ensureDir(root, rel)
     },
     setActiveTab(tab: 'files' | 'changes') {
       handle.update((prev) => (prev.activeTab === tab ? prev : { ...prev, activeTab: tab }))

--- a/packages/dsh-aionui-panel/tests/stores.spec.ts
+++ b/packages/dsh-aionui-panel/tests/stores.spec.ts
@@ -185,6 +185,10 @@ describe('explorer store', () => {
     const state = fresh.explorer.getSnapshot()
     expect(state.expanded).toContain('src')
     expect(state.selected).toBe('README.md')
+    // The restored expanded dir must be rehydrated automatically: its content
+    // lands without a manual collapse/expand round-trip.
+    await vi.waitFor(() => expect(fresh.explorer.getSnapshot().dirs['src']).toBeDefined())
+    expect(setup.calls).toContain('list:src')
   })
 })
 


### PR DESCRIPTION
## 摘要（Summary）

修复 Explorer 文件树的一个一致性问题：切换/重新绑定工作区时，持久化的展开目录（expanded）被恢复、箭头显示为展开态，但这些目录的内容从未被加载，界面表现为"箭头展开但下方无内容"，需要手动点一次收起再点一次展开才能正常显示。

根因：setRoot 恢复 expanded 后只加载了根目录（nsureDir(root, '')），恢复的展开目录没有触发加载。修复为在 setRoot 中对恢复的 expanded 目录逐个 nsureDir 预加载（沿用已有的加载竞态守卫）。

## 涉及包（Affected Packages）

- [x] 右侧面板 packages/dsh-aionui-panel
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 基于 clone 时的最新 main（84b212f, v0.1.19）开发

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 新增包目录以 dsh- 前缀命名（无新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 未改动 README，无需同步双语三件套（docs:check 已通过）。

## 本地验证（Local Validation）

执行的命令：

pnpm --filter @linxin666/dsh-client-ui-aionui-panel exec vitest run tests/stores.spec.ts
pnpm --filter @linxin666/dsh-client-ui-aionui-panel typecheck
pnpm docs:check

结果摘要：

- stores.spec.ts 29/29 通过（新增断言：恢复的展开目录内容被自动加载，api.list 收到 list:src 调用）
- typecheck 通过
- docs:check 全部通过
- 全包测试 207 通过 / 2 失败：失败项为 host-fixes.spec.ts 的 symlink 用例（Windows 环境无 symlink 权限，EPERM，与本改动无关；CI/Linux 可过）

## 用户可见变更证据（Local Feature Evidence）

证据：本地已应用同一修复并实测验证：刷新页面后，之前展开过的目录（archives/reference/正文 等）恢复时立即显示内容，无需手动收起再展开。此行为修复不改变任何数据与接口，截图从略（N/A 亦可，如需截图可补充）。