### PR TITLE
docs(dsh-web-ui-all): extend manual-upgrade checklist with new sub-pa…

### DIFF
--- a/packages/dsh-web-ui-all/README.i18n.yaml
+++ b/packages/dsh-web-ui-all/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 540fea697d3d60284fbaeaebd87c9f545fd5d24a
-README.zh.md: 63e6ebb5c82e10559dac13da1d22a5c0f2059d2b
+README.md: 17c166a3c9f6d9c047f74703df24e46ea5d2ef1d
+README.zh.md: 94cf27777cac792e1da1c5ffb717dfd2681ca0ac

--- a/packages/dsh-web-ui-all/README.md
+++ b/packages/dsh-web-ui-all/README.md
@@ -31,7 +31,11 @@ Restart `dsh web` for the plugins to take effect.
 
 ### Manual upgrade
 
-When you upgrade by bumping the version in the profile `package.json` and running `pnpm install`, the top-level `node_modules/@linxin666/*` entries are not always refreshed: they can stay linked to the previous version's store directory until recreated. After upgrading, verify the links resolve to the new version (on Windows: `cmd /c rmdir <link>` then `cmd /c mklink /J <link> <target>`), then restart `dsh web`.
+When you upgrade by bumping the version in the profile `package.json` and running `pnpm install`, the top-level `node_modules/@linxin666/*` entries are not always refreshed: they can stay linked to the previous version's store directory until recreated. After upgrading, verify the following three points, then restart `dsh web`:
+
+1. **Links resolve to the new version**: confirm each link points at the new version's store entity (on Windows: `cmd /c rmdir <link>` then `cmd /c mklink /J <link> <target>`).
+2. **Newly added sub-packages need links created**: an upgrade can introduce sub-packages that did not exist before (e.g. `dsh-client-ui-community-plugins` is new in 0.1.19) and no top-level link appears for them automatically — a missing link makes dsh crash on startup with `Cannot find package`. Compare the package list in the release notes and create a link under `node_modules/@linxin666/` for each missing sub-package (targeting the matching version entity under `.pnpm`).
+3. **Skin sub-packages moved into `dsh-skins`**: since 0.1.19, `dsh-client-ui-skin-blue-fantasy` / `-harbor` / `-qq98` / `-whale-song` no longer ship as standalone package entities; their code lives under `dsh-skins`'s `skins/<name>/`. Repoint old links to `skins/<name>` inside the new `dsh-skins` entity (do not keep the previous version as the target — a stale target fails skin loading with a version mismatch).
 
 ## Known limitations
 

--- a/packages/dsh-web-ui-all/README.zh.md
+++ b/packages/dsh-web-ui-all/README.zh.md
@@ -31,7 +31,11 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-web-ui-all
 
 ### 手工升级
 
-在 profile 的 `package.json` 中改版本后执行 `pnpm install`，顶层 `node_modules/@linxin666/*` 条目不会总是被刷新：它们可能仍链接到旧版本的 store 目录，直到手动重建。升级后请确认这些链接已指向新版本目录（Windows 下：先 `cmd /c rmdir <链接>` 再 `cmd /c mklink /J <链接> <目标>`），然后重启 `dsh web`。
+在 profile 的 `package.json` 中改版本后执行 `pnpm install`，顶层 `node_modules/@linxin666/*` 条目不会总是被刷新：它们可能仍链接到旧版本的 store 目录，直到手动重建。升级后请按以下三步核对，再重启 `dsh web`：
+
+1. **确认链接指向新版本目录**（Windows 下：先 `cmd /c rmdir <链接>` 再 `cmd /c mklink /J <链接> <目标>`）。
+2. **新引入的子包需要新建链接**：升级可能引入此前没有的子包（例如 0.1.19 新增 `dsh-client-ui-community-plugins`），顶层不会自动出现它的链接——缺失时 dsh 启动即报 `Cannot find package`。请对照发布说明中的包清单，在 `node_modules/@linxin666/` 下为每个缺失的子包新建链接（指向 `.pnpm` 中对应版本实体）。
+3. **皮肤子包已并入 `dsh-skins`**：自 0.1.19 起 `dsh-client-ui-skin-blue-fantasy` / `-harbor` / `-qq98` / `-whale-song` 不再有独立包实体，代码位于 `dsh-skins` 的 `skins/<name>/`。升级后请把旧链接 repoint 到 `dsh-skins` 新版本实体的 `skins/<name>` 目录（不要保留旧版本目标，否则皮肤加载会因版本错位失败）。
 
 ## 已知限制
 


### PR DESCRIPTION
## 摘要（Summary）

补全 #208 加入的「手工升级」小节：0.1.19 升级实测遇到两类 #208 未覆盖的顶层链接问题：(1) 新引入的子包（dsh-client-ui-community-plugins）顶层无链接，dsh 启动即报 Cannot find package；(2) 皮肤子包自 0.1.19 起并入 dsh-skins/skins/，旧链接保留旧版本目标会导致版本错位、皮肤加载失败。把这两步补进 README 升级核对清单（中英三件套 + docs:write-pair 重录配对）。

## 涉及包（Affected Packages）

- [x] 聚合包 / 设置 packages/dsh-web-ui-all（README 三件套）

## PR 类型（PR Type）

- [x] 仅文档

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：git fetch upstream && git checkout -b docs/manual-upgrade-extend-links upstream/main

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（deepseek-v4-pro）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 新增包目录以 dsh- 前缀命名（如 packages/dsh-xxx）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（README.md / README.zh.md / README.i18n.yaml）并运行 pnpm docs:check。

## 本地验证（Local Validation）

执行的命令：pnpm docs:write-pair 与 pnpm docs:check

结果摘要：docs:write-pair 重录 dsh-web-ui-all 的 README.i18n.yaml 配对 hash；docs:check 输出 all documentation gates passed。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（仅文档改动）。背景事故依据（本机 0.1.19 升级实测）：新子包 dsh-client-ui-community-plugins 顶层链接缺失 → dsh 启动报 Cannot find package；皮肤链接保留旧版本目标 → active 皮肤 client bundle 构建失败。修复（新建链接 / repoint 到 dsh-skins 实体 skins/<name>）后 3080 恢复正常。