### PR TITLE
fix(aionui-panel): guard SSE writes after client disconnect

### DIFF
--- a/packages/dsh-aionui-panel/src/host/routes.ts
+++ b/packages/dsh-aionui-panel/src/host/routes.ts
@@ -76,6 +76,8 @@ interface Subscriber {
   root: string
   lastGit: string
   res: ServerResponse
+  /** Set when the client disconnects; guards against late fs/git/heartbeat writes. */
+  closed: boolean
 }
 
 /**
@@ -229,8 +231,34 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
   let gitPoll: PollGuard | undefined
   let heartbeatTimer: NodeJS.Timeout | undefined
 
+  const removeSubscriber = (subscriber: Subscriber): void => {
+    subscriber.closed = true
+    subscribers.delete(subscriber)
+    if (subscribers.size === 0) {
+      stopGitPoll()
+      if (heartbeatTimer !== undefined) clearInterval(heartbeatTimer)
+      heartbeatTimer = undefined
+    }
+  }
+
+  const sseWrite = (subscriber: Subscriber, chunk: string): boolean => {
+    if (subscriber.closed) return false
+    const { res } = subscriber
+    if (res.writableEnded || res.destroyed) {
+      removeSubscriber(subscriber)
+      return false
+    }
+    try {
+      res.write(chunk)
+      return true
+    } catch {
+      removeSubscriber(subscriber)
+      return false
+    }
+  }
+
   const push = (subscriber: Subscriber, payload: unknown): void => {
-    subscriber.res.write(`event: change\ndata: ${JSON.stringify(payload)}\n\n`)
+    sseWrite(subscriber, `event: change\ndata: ${JSON.stringify(payload)}\n\n`)
   }
 
   // One-shot availability state: a machine without a git binary must not
@@ -653,7 +681,7 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
       connection: 'keep-alive',
     })
     res.write('retry: 2000\n\n')
-    const subscriber: Subscriber = { root: gated.canonical, lastGit: '', res }
+    const subscriber: Subscriber = { root: gated.canonical, lastGit: '', res, closed: false }
     subscribers.add(subscriber)
     // A stream opened after the one-shot probe already failed gets the
     // unavailable event right away; streams open during the probe receive it
@@ -662,20 +690,19 @@ export function registerPanelRoutes(ctx: Context, fs: FsService, git: GitService
     startGitPoll()
     if (heartbeatTimer === undefined) {
       heartbeatTimer = setInterval(() => {
-        for (const current of subscribers) current.res.write(': ping\n\n')
+        for (const current of [...subscribers]) sseWrite(current, ': ping\n\n')
       }, HEARTBEAT_MS)
     }
     const disposeWatch = fs.watch(gated.canonical, () => {
       push(subscriber, { kind: 'fs' })
     })
+    res.on('error', () => {
+      disposeWatch()
+      removeSubscriber(subscriber)
+    })
     req.on('close', () => {
       disposeWatch()
-      subscribers.delete(subscriber)
-      if (subscribers.size === 0) {
-        stopGitPoll()
-        if (heartbeatTimer !== undefined) clearInterval(heartbeatTimer)
-        heartbeatTimer = undefined
-      }
+      removeSubscriber(subscriber)
     })
   }
 

--- a/packages/dsh-aionui-panel/tests/git-unavailable.spec.ts
+++ b/packages/dsh-aionui-panel/tests/git-unavailable.spec.ts
@@ -19,6 +19,7 @@ import type { WorkspaceGate } from '../src/host/gate.ts'
 interface Connection {
   writes: string[]
   close: () => void
+  emitError: () => void
 }
 
 /** A minimal ctx/webServer/fs/git harness for registerPanelRoutes. */
@@ -58,13 +59,24 @@ function makeEnv(): {
 }
 
 /** Open one SSE connection and collect everything the host writes to it. */
-async function connect(sse: (req: unknown, res: unknown) => Promise<void>, root: string): Promise<Connection> {
+async function connect(
+  sse: (req: unknown, res: unknown) => Promise<void>,
+  root: string,
+  resOverrides: Partial<{ writableEnded: boolean; destroyed: boolean; write: (chunk: unknown) => void }> = {},
+): Promise<Connection> {
   const writes: string[] = []
   const closeHandlers: Array<() => void> = []
+  const errorHandlers: Array<() => void> = []
   const res = {
+    writableEnded: false,
+    destroyed: false,
     writeHead: () => {},
     write: (chunk: unknown) => { writes.push(String(chunk)) },
     end: () => {},
+    on: (event: string, handler: () => void) => {
+      if (event === 'error') errorHandlers.push(handler)
+    },
+    ...resOverrides,
   }
   const req = {
     url: '/aionui-panel/events?root=' + encodeURIComponent(root),
@@ -80,6 +92,9 @@ async function connect(sse: (req: unknown, res: unknown) => Promise<void>, root:
     close: () => {
       for (const handler of closeHandlers) handler()
     },
+    emitError: () => {
+      for (const handler of errorHandlers) handler()
+    },
   }
 }
 
@@ -87,6 +102,56 @@ async function connect(sse: (req: unknown, res: unknown) => Promise<void>, root:
 function eventsOfKind(writes: string[], kind: string): number {
   return writes.filter((write) => write.includes('"kind":"' + kind + '"')).length
 }
+
+describe('SSE subscriber lifecycle', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('does not write to a closed response during heartbeat or fs watch', async () => {
+    const env = makeEnv()
+    let watchCallback: (() => void) | undefined
+    const fs = {
+      verify: async (root: string) => ({ ok: true, canonical: root }),
+      watch: (_root: string, onChange: () => void) => {
+        watchCallback = onChange
+        return () => { watchCallback = undefined }
+      },
+    }
+    const warn = vi.fn()
+    const registrations: Array<{ kind: string; path: string; handler: (req: unknown, res: unknown) => Promise<void> }> = []
+    const ctx = {
+      logger: { warn },
+      webServer: {
+        register: (row: { kind: string; path: string; handler: (req: unknown, res: unknown) => Promise<void> }) => {
+          registrations.push(row)
+          return () => {}
+        },
+      },
+    }
+    const git = {
+      gitAvailable: vi.fn(async () => true),
+      isRepositoryCanonical: vi.fn(async () => true),
+      statusCanonical: vi.fn(async () => null),
+    }
+    registerPanelRoutes(ctx as never, fs as never, git as never)
+    const row = registrations.find((item) => item.kind === 'exact')
+    if (row === undefined) throw new Error('SSE route not registered')
+
+    let writeCalls = 0
+    const conn = await connect(row.handler, '/w', {
+      write: () => {
+        writeCalls += 1
+        if (writeCalls > 1) throw new Error('write after end')
+      },
+    })
+    conn.close()
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    watchCallback?.()
+
+    expect(writeCalls).toBe(1)
+  })
+})
 
 describe('SSE git polling with a missing git binary', () => {
   beforeEach(() => { vi.useFakeTimers() })

--- a/packages/dsh-aionui-panel/tests/loopback.spec.ts
+++ b/packages/dsh-aionui-panel/tests/loopback.spec.ts
@@ -72,6 +72,7 @@ function fakeResponse(): {
       if (chunk !== undefined && chunk !== null) state.writes.push(String(chunk))
       state.body = state.writes.join('')
     },
+    on: vi.fn(),
   }
   return {
     res,


### PR DESCRIPTION
## 摘要（Summary）

修复 `/aionui-panel/events` SSE 在客户端断开后仍向已关闭的 `ServerResponse` 写入，导致 `ERR_STREAM_WRITE_AFTER_END` 并崩溃 Node 进程的问题。通过安全写入辅助函数与统一订阅者清理逻辑，避免 heartbeat、fs watch、git poll 在连接关闭后继续写入。

## 涉及包（Affected Packages）

- [x] 右侧面板 `packages/dsh-aionui-panel`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

## AI 编码 Disclosure（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

Composer

使用的编码 Agent 工具：

Cursor

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-aionui-panel
npx vitest run tests/git-unavailable.spec.ts tests/loopback.spec.ts
```

结果摘要：

14 tests passed (2 files). Added regression test for post-close heartbeat/fs watch writes; loopback SSE test updated for `res.on` handler.

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（纯 host 侧稳定性修复，无用户可见 UI 变更；修复的是 dsh web 进程崩溃问题。）