### PR TITLE
fix(skins): drop dsh.bundle.patch from bundleWired:false skins (#381)

### DIFF
--- a/packages/dsh-skins/build.mjs
+++ b/packages/dsh-skins/build.mjs
@@ -47,8 +47,10 @@ function readJson(filePath) {
  * Render the minimal resolvable leaf package.json a bundled skin needs to be
  * loadable as @linxin666/dsh-client-ui-skin-<id> from the profile. Mirrors the
  * source skin package's exports shape (minus the non-shipped ./src/*) and
- * carries the official dsh.bundle manifest so the carrier is also a valid
- * turtle-ui bundle for `dsh plugin add`.
+ * omits dsh.bundle.patch: skins are bundleWired:false and inserted by
+ * dsh-skin / skin-center at the home layer. Declaring a bundle here makes
+ * `dsh plugin` reconcile re-add every skin to dsh.profile.bundles and
+ * collide with that insert (duplicate loader entry id: ui-skin-<name>).
  * @param sourcePkg - the source skin package.json (name/version source).
  * @returns the serialized package.json text.
  */
@@ -65,7 +67,6 @@ function renderCarrierPackageJson(sourcePkg) {
       './package.json': './package.json',
     },
     dsh: {
-      bundle: { patch: './cordis.patch.yml' },
       client: { inject: [], platform: 'web' },
     },
     license: 'BSD-3-Clause',

--- a/packages/dsh-skins/skins/blue-fantasy/package.json
+++ b/packages/dsh-skins/skins/blue-fantasy/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/dragon-heir/package.json
+++ b/packages/dsh-skins/skins/dragon-heir/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/harbor/package.json
+++ b/packages/dsh-skins/skins/harbor/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/matrix/package.json
+++ b/packages/dsh-skins/skins/matrix/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/miku/package.json
+++ b/packages/dsh-skins/skins/miku/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/minecraft/package.json
+++ b/packages/dsh-skins/skins/minecraft/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/qq98/package.json
+++ b/packages/dsh-skins/skins/qq98/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/ths/package.json
+++ b/packages/dsh-skins/skins/ths/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/trading/package.json
+++ b/packages/dsh-skins/skins/trading/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/whale-mom/package.json
+++ b/packages/dsh-skins/skins/whale-mom/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/whale-song/package.json
+++ b/packages/dsh-skins/skins/whale-song/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/dsh-skins/skins/xp/package.json
+++ b/packages/dsh-skins/skins/xp/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/blue-fantasy/package.json
+++ b/packages/skins/blue-fantasy/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/dragon-heir/package.json
+++ b/packages/skins/dragon-heir/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/harbor/package.json
+++ b/packages/skins/harbor/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/matrix/package.json
+++ b/packages/skins/matrix/package.json
@@ -10,9 +10,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/miku/package.json
+++ b/packages/skins/miku/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/minecraft/package.json
+++ b/packages/skins/minecraft/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/qq98/package.json
+++ b/packages/skins/qq98/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/ths/package.json
+++ b/packages/skins/ths/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [
         "@deepseek-ai/dsh-client-connection"

--- a/packages/skins/trading/package.json
+++ b/packages/skins/trading/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [
         "@deepseek-ai/dsh-client-connection"

--- a/packages/skins/whale-mom/package.json
+++ b/packages/skins/whale-mom/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/whale-song/package.json
+++ b/packages/skins/whale-song/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/packages/skins/xp/package.json
+++ b/packages/skins/xp/package.json
@@ -11,9 +11,6 @@
     "./package.json": "./package.json"
   },
   "dsh": {
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    },
     "client": {
       "inject": [],
       "platform": "web"

--- a/scripts/skin-bundle-meta.test.mjs
+++ b/scripts/skin-bundle-meta.test.mjs
@@ -1,0 +1,37 @@
+/**
+ * bundleWired:false skins must not declare dsh.bundle.patch. Otherwise
+ * `dsh plugin` reconcile re-adds them to dsh.profile.bundles and they
+ * collide with the home-layer insert (duplicate loader entry id).
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const skinsRoot = join(repoRoot, 'packages', 'skins')
+const carrierRoot = join(repoRoot, 'packages', 'dsh-skins', 'skins')
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+test('skin-center stays a real bundle; bundleWired:false skins omit dsh.bundle.patch', () => {
+  const center = readJson(join(skinsRoot, 'skin-center', 'package.json'))
+  assert.equal(center.dsh?.bundle?.patch, './cordis.patch.yml')
+
+  const skins = readdirSync(skinsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== 'skin-center')
+    .map((entry) => entry.name)
+
+  assert.ok(skins.length > 0)
+  for (const name of skins) {
+    const skin = readJson(join(skinsRoot, name, 'skin.json'))
+    const pkg = readJson(join(skinsRoot, name, 'package.json'))
+    assert.equal(skin.wiring?.bundleWired, false, name)
+    assert.equal(pkg.dsh?.bundle, undefined, name)
+    const carrier = readJson(join(carrierRoot, name, 'package.json'))
+    assert.equal(carrier.dsh?.bundle, undefined, `carrier ${name}`)
+  }
+})


### PR DESCRIPTION
## 摘要（Summary）

`bundleWired: false` 的皮肤应由 `dsh-skin` / 皮肤中心在 home 层 insert。这些包却仍声明 `dsh.bundle.patch`，`dsh plugin` reconcile 会把它们写回 `dsh.profile.bundles`，与 home insert 叠加后启动报 `duplicate loader entry id: ui-skin-<name>`。本 PR 按 issue 方案 A 去掉这些皮肤的 bundle 声明，皮肤中心本身仍保持独立 bundle。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：Cursor Grok 4.6

使用的编码 Agent 工具：Cursor

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```
node --test scripts/skin-bundle-meta.test.mjs
```

结果摘要：通过。未跑完整 `pnpm test`（本机未安装 workspace node_modules）；改动是皮肤元数据与生成器，不涉及运行时 TS。

## 用户可见变更证据（Local Feature Evidence）

N/A。纯元数据：`dsh plugin add/update` 不再把 `bundleWired: false` 皮肤写回 `dsh.profile.bundles`。

Fixes #381

Made with [Cursor](https://cursor.com)