### PR TITLE
fix(scripts): make runtime-deps-check actually scan package lib files

### DIFF
--- a/scripts/runtime-deps-check.mjs
+++ b/scripts/runtime-deps-check.mjs
@@ -62,18 +62,40 @@ export function checkRuntimeImports(pkgJson, files) {
   return violations
 }
 
+/**
+ * Group git-tracked files under packages/ by the package directory that owns
+ * them. A package directory is any directory under packages/ that contains a
+ * package.json; every other file is assigned to the package whose dir is its
+ * longest directory prefix (this handles the two-level packages/skins/<id>
+ * layout). Previously files were grouped by their immediate `dirname`, which
+ * split a package's lib/*.js from its package.json and made the whole scan a
+ * no-op.
+ *
+ * Pure function so the node:test suite can feed it inline fixtures.
+ *
+ * @param {string[]} files git-tracked paths under packages/
+ * @returns {Map<string, string[]>} package dir -> its files (incl. package.json)
+ */
+export function groupByPackageDir(files) {
+  const packageDirs = files
+    .filter((f) => f.endsWith('/package.json'))
+    .map((f) => dirname(f))
+    .sort((a, b) => b.length - a.length)
+  const byDir = new Map()
+  for (const file of files) {
+    const dir = packageDirs.find((pkgDir) => file.startsWith(`${pkgDir}/`)) ?? dirname(file)
+    if (!byDir.has(dir)) byDir.set(dir, [])
+    byDir.get(dir).push(file)
+  }
+  return byDir
+}
+
 /** All git-tracked files under packages/, grouped by package dir. */
 function trackedPackageFiles() {
   const files = execFileSync('git', ['ls-files', 'packages'], { encoding: 'utf8', cwd: ROOT })
     .split('\n')
     .filter(Boolean)
-  const byDir = new Map()
-  for (const file of files) {
-    const dir = dirname(file)
-    if (!byDir.has(dir)) byDir.set(dir, [])
-    byDir.get(dir).push(file)
-  }
-  return byDir
+  return groupByPackageDir(files)
 }
 
 const isCli = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url

--- a/scripts/runtime-deps-check.test.mjs
+++ b/scripts/runtime-deps-check.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { checkRuntimeImports } from './runtime-deps-check.mjs'
+import { checkRuntimeImports, groupByPackageDir } from './runtime-deps-check.mjs'
 
 test('flags a runtime import of a devDependencies-only package (issue #70)', () => {
   const violations = checkRuntimeImports(
@@ -50,4 +50,37 @@ test('flags dynamic import() of a devDependencies-only package', () => {
   )
   assert.equal(violations.length, 1)
   assert.equal(violations[0].specifier, 'some-optional-runtime-dep')
+})
+
+test('groupByPackageDir keeps a package lib file together with its package.json', () => {
+  const byDir = groupByPackageDir([
+    'packages/dsh-ssh/lib/index.js',
+    'packages/dsh-ssh/package.json',
+    'packages/skins/skin-center/lib/client.js',
+    'packages/skins/skin-center/package.json',
+  ])
+  assert.deepEqual(new Set(byDir.keys()), new Set([
+    'packages/dsh-ssh',
+    'packages/skins/skin-center',
+  ]))
+  assert.deepEqual(new Set(byDir.get('packages/dsh-ssh')), new Set([
+    'packages/dsh-ssh/lib/index.js',
+    'packages/dsh-ssh/package.json',
+  ]))
+  assert.deepEqual(new Set(byDir.get('packages/skins/skin-center')), new Set([
+    'packages/skins/skin-center/lib/client.js',
+    'packages/skins/skin-center/package.json',
+  ]))
+})
+
+test('groupByPackageDir uses the longest prefix so a sibling package name is not misattributed', () => {
+  const byDir = groupByPackageDir([
+    'packages/dsh-ssh/package.json',
+    'packages/dsh-ssh/lib/index.js',
+    'packages/dsh-ssh2/package.json',
+    'packages/dsh-ssh2/lib/index.js',
+  ])
+  assert.ok(byDir.get('packages/dsh-ssh').includes('packages/dsh-ssh/lib/index.js'))
+  assert.ok(byDir.get('packages/dsh-ssh2').includes('packages/dsh-ssh2/lib/index.js'))
+  assert.ok(!byDir.get('packages/dsh-ssh').includes('packages/dsh-ssh2/lib/index.js'))
 })


### PR DESCRIPTION
## 摘要（Summary）

修复 `scripts/runtime-deps-check.mjs` 的 runtime 依赖检查在 CI 中空转（no-op）的问题，恢复 issue-#70 的 `ERR_MODULE_NOT_FOUND` 启动崩溃护栏。

根因：`trackedPackageFiles()` 用 `dirname(file)` 分组，把包的 `lib/*.js` 与 `package.json` 分到不同桶，主循环对每个桶都 `continue`，导致 `checkRuntimeImports` 从未对任何包执行。

修复：改为按「包含 package.json 的包目录」分组（最长目录前缀匹配，正确处理 `packages/skins/<id>` 两级布局与兄弟包名边界），抽出可测的 `groupByPackageDir()` 纯函数并补 node:test 用例。

## 涉及包（Affected Packages）

仅 `scripts/` 维护脚本改动，不涉及任何插件/皮肤包。

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）：`scripts/` 维护脚本

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
node --test scripts/runtime-deps-check.test.mjs
node scripts/runtime-deps-check.mjs
pnpm test:scripts
```

结果摘要：

- `node --test scripts/runtime-deps-check.test.mjs`：8/8 通过（含新增 2 个分组用例）。
- `node scripts/runtime-deps-check.mjs`：从「空转」变为输出 26 个 `[OK]` 包，exit 0（当前无真实违规）；负向验证（临时塞入不存在的 import）正确输出 `[FAIL]` 并 exit 1。
- `pnpm test:scripts`：91 pass / 0 fail（4 skipped）。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（纯内部 CI 脚本修复，无面向用户的功能变更）。
