### PR TITLE
fix(remote-web-ui): update standalone family plugins (#377)

### DIFF
--- a/packages/dsh-remote-web-ui/README.i18n.yaml
+++ b/packages/dsh-remote-web-ui/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 3a4ac70503ef6629ac456e3e86e0e429b90fd4b2
-README.zh.md: e16a9bd530de74cff366fc23ae143254a198989b
+README.md: 051fe9d28dea63911b3e38405890fb24daa31387
+README.zh.md: 41755f5ea321188811c8a929149cdedefd40fe1d

--- a/packages/dsh-remote-web-ui/README.md
+++ b/packages/dsh-remote-web-ui/README.md
@@ -37,7 +37,10 @@ actions, and the update panel that probes and runs the update.
   (waiting → connected → disconnected) over an SSE stream.
 - **Remote update**: the download trigger in the sidebar foot (left of the
   phone icon) opens the update panel, which probes the npm registry for the
-  installed `@linxin666/dsh-*` family releases. When a newer release exists
+  installed `@linxin666/dsh-*` family releases. Without the aggregate package,
+  checks and updates cover every registry-managed direct `@linxin666/*`
+  dependency in the profile; local link/file development dependencies are
+  skipped. When a newer release exists
   the panel runs the update automatically (`pnpm update --latest` inside the
   owning dsh profile; when pnpm is missing it falls back to `corepack pnpm`
   and then `npx --yes pnpm`, and on Windows the command runs through
@@ -47,9 +50,8 @@ actions, and the update panel that probes and runs the update.
   versions are re-checked against the registry: a green exit that left every
   version in place (e.g. the pnpm `minimumReleaseAge` gate silently skipping
   same-day releases) is reported as a stale update with configuration
-  guidance instead of a false success. Local
-  link installs (development mode) are detected and report the npm state
-  without updating.
+  guidance instead of a false success. When the anchor itself is a local link
+  install (development mode), it reports the npm state without updating.
 
 ## Screenshots
 

--- a/packages/dsh-remote-web-ui/README.zh.md
+++ b/packages/dsh-remote-web-ui/README.zh.md
@@ -13,7 +13,7 @@
 - **手机侧**：扫码将手机与一次性、限时令牌绑定，并落地到 **`/m` 独立移动端界面**——一款专为小屏设计的轻客户端（见[截图](#截图)），而不是把桌面 UI 塞进手机。链接携带 `workspace` 参数，手机落地到桌面正在查看的同一工作区。
 - **安全**：一个有效的一次性令牌（刷新会使旧链接失效；已接受的令牌不可复用；令牌会过期）。停止会撤销每一台已配对设备与当前令牌——已配对设备在下一次请求时被切断。当插件 `requirePairingForLan` 门开启（默认）时，每个非 loopback 的 `/api` 请求必须携带有效的已配对设备 cookie，因此二维码是进入暴露在局域网上的 dsh web 的唯一途径。
 - **实时状态**：桌面面板经 SSE 流实时镜像配对状态（等待 → 已连接 → 已断开）。
-- **远程更新**：侧边栏底部的下载触发按钮（手机图标左侧）打开更新面板，它探测 npm registry 上已安装的 `@linxin666/dsh-*` 全家桶版本。当存在较新版本时，面板自动执行更新（在所属 dsh profile 内 `pnpm update --latest`；pnpm 缺失时依次回退 `corepack pnpm`、`npx --yes pnpm`，Windows 上经 `cmd.exe` 执行以解析 npm 安装的 `.cmd` shim；由仅 loopback 的 `/api/update/status` + `/api/update/run` 端点驱动）并请求重启 dsh web 以生效。pnpm 绿色退出后还会对照 registry 复核已装版本：绿色退出但版本纹丝不动（例如 pnpm 的 `minimumReleaseAge` 门禁静默跳过同日发布的新版本）会报告为「未更新成功」并附配置指引，而不是误报成功。本地 link 安装（开发模式）会被探测到，只报告 npm 状态而不更新。
+- **远程更新**：侧边栏底部的下载触发按钮（手机图标左侧）打开更新面板，它探测 npm registry 上已安装的 `@linxin666/dsh-*` 全家桶版本；未安装聚合包时，检查和更新覆盖 profile 中 registry 管理的全部 `@linxin666/*` 直接依赖，本地 link / file 开发依赖会被跳过。当存在较新版本时，面板自动执行更新（在所属 dsh profile 内 `pnpm update --latest`；pnpm 缺失时依次回退 `corepack pnpm`、`npx --yes pnpm`，Windows 上经 `cmd.exe` 执行以解析 npm 安装的 `.cmd` shim；由仅 loopback 的 `/api/update/status` + `/api/update/run` 端点驱动）并请求重启 dsh web 以生效。pnpm 绿色退出后还会对照 registry 复核已装版本：绿色退出但版本纹丝不动（例如 pnpm 的 `minimumReleaseAge` 门禁静默跳过同日发布的新版本）会报告为「未更新成功」并附配置指引，而不是误报成功。锚点自身是本地 link 安装（开发模式）时，只报告 npm 状态而不更新。
 
 ## 截图
 

--- a/packages/dsh-remote-web-ui/src/update.ts
+++ b/packages/dsh-remote-web-ui/src/update.ts
@@ -1,8 +1,8 @@
 /**
  * Remote update support for the dsh-web-ui family — host half. Detects the
- * installed aggregate package (@linxin666/dsh-web-ui-all) and its family
- * children, probes the npm registry for newer releases, and runs the actual
- * update as `pnpm update --latest` inside the owning dsh profile directory.
+ * installed aggregate package (@linxin666/dsh-web-ui-all), or the directly
+ * installed family packages when the aggregate is absent, probes npm for newer
+ * releases, and runs `pnpm update --latest` inside the owning dsh profile.
  *
  * Pure logic with injected seams (manifest reading, registry fetches, process
  * spawning) so the whole surface is unit-testable without touching disk,
@@ -238,7 +238,7 @@ export function resolveUpdateTarget(
   return {
     profileName: profile.name,
     profileDir: profile.dir,
-    packages: [anchor, ...familyChildren(manifest)],
+    packages: familyUpdatePackages(anchor, manifest, profileManifest),
   }
 }
 
@@ -251,6 +251,21 @@ export function familyChildren(anchorManifest: Record<string, unknown>): string[
     if (name.startsWith(FAMILY_SCOPE) && typeof spec === 'string') names.push(name)
   }
   return names
+}
+
+/** Registry-managed family packages covered by one update operation. */
+function familyUpdatePackages(
+  anchor: string,
+  anchorManifest: Record<string, unknown>,
+  profileManifest: Record<string, unknown> | undefined,
+): string[] {
+  const names = new Set([anchor, ...familyChildren(anchorManifest)])
+  const dependencies = profileManifest?.dependencies
+  if (typeof dependencies !== 'object' || dependencies === null) return [...names]
+  for (const [name, spec] of Object.entries(dependencies)) {
+    if (name.startsWith(FAMILY_SCOPE) && typeof spec === 'string' && !isLinkedSpec(spec)) names.add(name)
+  }
+  return [...names]
 }
 
 /**
@@ -292,14 +307,21 @@ export async function fetchLatestVersion(
 const VERSION_UNKNOWN = '0.0.0'
 
 /** The resolved current version of one family package (probe failure tolerated). */
-function readInstalledVersion(resolve: (specifier: string) => string | undefined, name: string): string {
+function readInstalledVersion(
+  resolve: (specifier: string) => string | undefined,
+  name: string,
+  profileDir?: string,
+): string {
   try {
     const path = resolve(name + '/package.json')
     const version = path === undefined ? undefined : readManifest(path)?.version
-    return typeof version === 'string' ? version : VERSION_UNKNOWN
-  } catch {
-    return VERSION_UNKNOWN
-  }
+    if (typeof version === 'string') return version
+  } catch { /* fall through to the profile's direct dependency path */ }
+  // Names originate in the profile dependency map, but still validate the
+  // npm package shape before using one as path segments.
+  if (profileDir === undefined || !/^@linxin666\/[a-z0-9][a-z0-9._-]*$/.test(name)) return VERSION_UNKNOWN
+  const version = readManifest(join(profileDir, 'node_modules', ...name.split('/'), 'package.json'))?.version
+  return typeof version === 'string' ? version : VERSION_UNKNOWN
 }
 
 /**
@@ -331,7 +353,7 @@ export async function checkUpdates(deps: UpdateCheckDeps): Promise<UpdateStatus>
   if (profile === undefined) {
     return { mode: 'link', packages: [], outdated: false }
   }
-  const names = [anchor, ...familyChildren(manifest)]
+  const names = familyUpdatePackages(anchor, manifest, profileManifest)
   // The registry probes are independent: run them together instead of
   // serializing up to N x 10s of registry latency behind one status call.
   const latestList = await Promise.all(names.map(name => deps.fetchLatest(name)))
@@ -340,7 +362,7 @@ export async function checkUpdates(deps: UpdateCheckDeps): Promise<UpdateStatus>
   names.forEach((name, index) => {
     const latest = latestList[index]
     if (latest === undefined) probeFailures++
-    const current = readInstalledVersion(deps.resolve, name)
+    const current = readInstalledVersion(deps.resolve, name, profile.dir)
     packages.push({
       name,
       current,
@@ -604,7 +626,7 @@ export async function runUpdateVerified(deps: UpdateRunVerifiedDeps): Promise<Up
   // green exit that left everything in place could be mistaken for success.
   const before = new Map<string, string>()
   for (const name of deps.run.packages) {
-    const version = readInstalledVersion(deps.check.resolve, name)
+    const version = readInstalledVersion(deps.check.resolve, name, deps.run.profileDir)
     if (version !== VERSION_UNKNOWN) before.set(name, version)
   }
   const result = await runUpdate(deps.run)

--- a/packages/dsh-remote-web-ui/tests/update.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/update.spec.ts
@@ -18,6 +18,7 @@ import {
   resolveUpdateTarget,
   runUpdate,
   runUpdateVerified,
+  SELF_PACKAGE,
 } from "../src/update.ts"
 
 /** One temp fixture root per suite; removed after each test. */
@@ -61,6 +62,30 @@ function npmFixture(anchorVersion = "0.1.10", childVersion = "0.1.10"): string {
     version: childVersion,
   })
   return join(anchorDir, "package.json")
+}
+
+/** A profile with family plugins installed directly and no aggregate package. */
+function standaloneFixture(): { anchor: string; profileDir: string } {
+  const root = makeFixture()
+  const profileDir = join(root, "profiles", "web")
+  writeManifest(profileDir, {
+    name: "dsh-profile-web",
+    private: true,
+    dependencies: {
+      [SELF_PACKAGE]: "^0.1.19",
+      "@linxin666/dsh-client-ui-aionui-panel": "^0.1.19",
+      "@linxin666/dsh-pet": "link:../../../code/dsh-web-ui/packages/dsh-pet",
+      "@linxin666/dsh-ssh": "^0.1.19",
+      react: "^18.2.0",
+    },
+  })
+  for (const name of [SELF_PACKAGE, "@linxin666/dsh-client-ui-aionui-panel", "@linxin666/dsh-ssh"]) {
+    writeManifest(join(profileDir, "node_modules", ...name.split("/")), { name, version: "0.1.19" })
+  }
+  return {
+    anchor: join(profileDir, "node_modules", ...SELF_PACKAGE.split("/"), "package.json"),
+    profileDir,
+  }
 }
 
 describe("parseSemver", () => {
@@ -169,6 +194,25 @@ describe("resolveAnchorManifest", () => {
 })
 
 describe("checkUpdates", () => {
+  it("checks every directly installed family package when the aggregate is absent", async () => {
+    const { anchor } = standaloneFixture()
+    const status = await checkUpdates({
+      anchorManifestPath: anchor,
+      // Package-scoped resolution cannot see sibling direct dependencies in
+      // pnpm's strict layout; their profile manifests are the fallback.
+      resolve: specifier => specifier === SELF_PACKAGE + "/package.json" ? anchor : undefined,
+      fetchLatest: async () => "0.1.20",
+    })
+    expect(status.mode).toBe("npm")
+    expect(status.anchor).toBe(SELF_PACKAGE)
+    expect(status.packages.map(item => item.name)).toEqual([
+      SELF_PACKAGE,
+      "@linxin666/dsh-client-ui-aionui-panel",
+      "@linxin666/dsh-ssh",
+    ])
+    expect(status.packages.map(item => item.current)).toEqual(["0.1.19", "0.1.19", "0.1.19"])
+  })
+
   it("reports an outdated npm install with per-package comparison", async () => {
     const anchor = npmFixture("0.1.10", "0.1.9")
     const status = await checkUpdates({
@@ -240,6 +284,19 @@ describe("checkUpdates", () => {
 })
 
 describe("resolveUpdateTarget", () => {
+  it("updates every directly installed family package when the aggregate is absent", () => {
+    const { anchor, profileDir } = standaloneFixture()
+    expect(resolveUpdateTarget({ anchorManifestPath: anchor })).toEqual({
+      profileName: "web",
+      profileDir,
+      packages: [
+        SELF_PACKAGE,
+        "@linxin666/dsh-client-ui-aionui-panel",
+        "@linxin666/dsh-ssh",
+      ],
+    })
+  })
+
   it("resolves the npm target with anchor + children", () => {
     const anchor = npmFixture()
     const target = resolveUpdateTarget({ anchorManifestPath: anchor })
@@ -525,6 +582,25 @@ describe("runUpdateVerified", () => {
       fetchLatest,
     }
   }
+
+  it("verifies version movement for directly installed family packages", async () => {
+    const { anchor, profileDir } = standaloneFixture()
+    const packages = [SELF_PACKAGE, "@linxin666/dsh-client-ui-aionui-panel", "@linxin666/dsh-ssh"]
+    const child = new FakeChild(0)
+    const promise = runUpdateVerified({
+      run: { profileDir, packages, spawnImpl: (() => child) as never },
+      check: {
+        anchorManifestPath: anchor,
+        resolve: specifier => specifier === SELF_PACKAGE + "/package.json" ? anchor : undefined,
+        fetchLatest: async () => "0.1.20",
+      },
+    })
+    for (const name of packages) {
+      writeManifest(join(profileDir, "node_modules", ...name.split("/")), { name, version: "0.1.20" })
+    }
+    child.run(0)
+    await expect(promise).resolves.toEqual({ ok: true, exitCode: 0, output: "" })
+  })
 
   it("reports stale when pnpm exits 0 but the installed versions did not move", async () => {
     // Registry carries 0.1.11 while the installed anchor stays 0.1.10 — the


### PR DESCRIPTION
## 摘要（Summary）

修复未安装 `@linxin666/dsh-web-ui-all` 聚合包时，远程 Web UI 只检查自身更新的问题。更新检查、执行更新和更新后验证现在都会覆盖 profile 中独立安装的、由注册表管理的 `@linxin666/*` 直接依赖。

Closes #377

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

当前提交基于 `origin/main@7978c01`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

N/A（不声明，维持现有版权归属）。

## 新皮肤收录（New Skin）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A（非新增第三方插件）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
pnpm --filter @linxin666/dsh-remote-web-ui build
pnpm typecheck
pnpm docs:check
git diff --check
pnpm test
pnpm test:scripts
```

结果摘要：

- 修复前独立 profile 回归用例稳定复现两次：`2 failed / 45 passed`。
- 远程 Web UI 全量测试：`208 passed`；更新相关用例：`48 passed`。
- 包级 typecheck、包级 build、全仓 typecheck、docs:check 和 diff check 均通过。
- Windows 本地 `pnpm test` 在 `packages/dsh-liangshen/tests/custom-bash.test.ts` 有 2 个 POSIX 路径断言失败。
- Windows 本地 `pnpm test:scripts` 在 `scripts/aggregate.test.mjs` 有 1 个反斜杠路径排除断言失败。
- 上述 3 个失败均与本 PR 无关，相关文件未修改，且 rebase 前后失败一致。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（更新目标发现逻辑修复，无独立 GUI 交互面变更；独立 profile fixtures 已覆盖更新检查、更新命令和更新后验证使用同一包集合的行为。）