### PR TITLE
fix(aionui-panel): scale split-drag pixel delta to container width in ratio mode

### DIFF
--- a/packages/dsh-aionui-panel/src/client/hooks/useResizableSplit.ts
+++ b/packages/dsh-aionui-panel/src/client/hooks/useResizableSplit.ts
@@ -30,6 +30,17 @@ export interface DragHandleProps {
 }
 
 /**
+ * Convert a drag's pixel delta into the next width in ratio (percentage) mode.
+ * The raw deltaX is pixels; a percentage width must scale that delta by the
+ * container width, otherwise a 30px drag moves a 50% width straight to the
+ * 80% maximum instead of ~4%.
+ */
+export function ratioWidthFromDelta(startWidth: number, deltaX: number, containerWidth: number): number {
+  if (containerWidth <= 0) return startWidth
+  return startWidth + (deltaX / containerWidth) * 100
+}
+
+/**
  * Resizable-split engine.
  * @param options - width contract + persistence key.
  * @returns current width, the committed setter, handle props, and the clamp.
@@ -75,11 +86,19 @@ export function useResizableSplit(options: UseResizableSplitOptions = {}) {
     handlePointerDragStart(event.nativeEvent, el, {
       reverse: el.dataset.reverse === 'true',
       getStartWidth: () => widthRef.current,
-      compute: (startWidth, deltaX) => clamp(startWidth + deltaX),
+      compute: (startWidth, deltaX) => {
+        if (isPx) return clamp(startWidth + deltaX)
+        // ratio mode: deltaX is a pixel delta, startWidth is a percentage.
+        // Scale the pixel delta by the split container width (the handle is
+        // its direct child) so the pane tracks the pointer instead of jumping
+        // to the min/max clamp on a small drag.
+        const containerWidth = el.parentElement?.clientWidth ?? 0
+        return clamp(ratioWidthFromDelta(startWidth, deltaX, containerWidth))
+      },
       onFrame: (value) => setWidthState(value),
       onEnd: (value) => setWidth(value),
     })
-  }, [clamp, setWidth])
+  }, [clamp, setWidth, isPx])
 
   const handleDoubleClick = useCallback(() => {
     setWidth(defaultWidth)

--- a/packages/dsh-aionui-panel/tests/use-resizable-split.spec.ts
+++ b/packages/dsh-aionui-panel/tests/use-resizable-split.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * Ratio-mode split drag math: a pixel delta must be scaled by the container
+ * width to move a percentage width, not added directly (which pins the pane
+ * to the min/max clamp on a tiny drag).
+ */
+import { describe, expect, it } from 'vitest'
+import { ratioWidthFromDelta } from '../src/client/hooks/useResizableSplit.ts'
+
+describe('ratioWidthFromDelta', () => {
+  it('scales a pixel delta into percentage points by the container width', () => {
+    expect(ratioWidthFromDelta(50, 30, 800)).toBeCloseTo(53.75)
+    expect(ratioWidthFromDelta(50, -30, 800)).toBeCloseTo(46.25)
+  })
+
+  it('moves more percentage points over a narrower container for the same pixel drag', () => {
+    expect(ratioWidthFromDelta(50, 30, 400)).toBeCloseTo(57.5)
+  })
+
+  it('does not move when the container width is unknown', () => {
+    expect(ratioWidthFromDelta(50, 30, 0)).toBe(50)
+    expect(ratioWidthFromDelta(50, 30, -1)).toBe(50)
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-aionui-panel` 分屏（split）拖拽在 ratio 模式下单位混用的问题。

根因：`useResizableSplit` 的 `compute` 回调把拖拽的像素增量 `deltaX` 直接加到百分比宽度 `startWidth` 上，导致轻轻一拖（约 30px）就把编辑器面板顶到 80% 上限或缩到 20% 下限，变成「二值开关」而非跟随指针。

修复：ratio 模式下把像素增量除以分屏容器宽度（手柄元素的父容器 `clientWidth`）换算成百分比增量，抽出可测的 `ratioWidthFromDelta()` 纯函数并补 vitest 用例；px 模式保持不变。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [x] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
pnpm --filter @linxin666/dsh-client-ui-aionui-panel typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-client-ui-aionui-panel test`：27 个测试文件 269 个用例全部通过（含新增 `use-resizable-split.spec.ts` 3 个用例）。
- `pnpm --filter @linxin666/dsh-client-ui-aionui-panel typecheck`：通过。
- 页面验证：打开 markdown 文件进入分屏，拖动手柄，面板按比例跟随指针而非跳到 20%/80% 极值。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即上节「结果摘要」中描述的拖拽跟随效果）。
