### PR TITLE
fix(aionui-panel): reveal-in-file-manager fails on Windows due to /select, cwd (#403)

### DIFF
--- a/packages/dsh-aionui-panel/src/host/routes.ts
+++ b/packages/dsh-aionui-panel/src/host/routes.ts
@@ -53,7 +53,7 @@ export function openArgv(platform: NodeJS.Platform, abs: string): string[] {
 function spawnOsCommand(ctx: Context, argv: string[]): PanelError | null {
   const spec: SubprocessSpawnSpec = {
     argv,
-    cwd: dirname(argv[argv.length - 1] ?? process.cwd()),
+    cwd: spawnCwd(argv),
     stdio: {
       stdin: 'ignore',
       stdout: { maxBytes: 1 << 16 },
@@ -63,12 +63,29 @@ function spawnOsCommand(ctx: Context, argv: string[]): PanelError | null {
   }
   try {
     const handle = ctx.subprocess.spawn(spec)
-    void handle.done.catch(() => {})
+    void handle.done.catch((error) => {
+      // Async spawn failures (e.g. a bad cwd) surface here, not in the
+      // synchronous throw; log them so a dead GUI command is not silent.
+      ctx.logger.warn(`dsh-aionui-panel: OS command failed asynchronously ([${argv.join(', ')}]): ${String(error)}`)
+    })
     return null
   } catch (error) {
     ctx.logger.warn(`dsh-aionui-panel: OS command failed ([${argv.join(', ')}]): ${String(error)}`)
     return { code: 'internal', message: 'cannot run OS command' }
   }
+}
+
+/**
+ * Working directory for an OS GUI command. The Windows reveal argv carries a
+ * `/select,` prefix on the path argument, so the raw last argv is not a real
+ * path; strip the prefix before taking its dirname, otherwise `spawn` fails
+ * with ENOENT because the cwd does not exist. Other platforms pass a real
+ * path (or the parent directory) as the last argument.
+ */
+export function spawnCwd(argv: string[]): string {
+  let last = argv[argv.length - 1] ?? process.cwd()
+  if (last.startsWith('/select,')) last = last.slice('/select,'.length)
+  return dirname(last)
 }
 
 /** One SSE subscriber: a root and its last pushed git signature. */

--- a/packages/dsh-aionui-panel/tests/menu-routes.spec.ts
+++ b/packages/dsh-aionui-panel/tests/menu-routes.spec.ts
@@ -4,7 +4,8 @@
  * platform-specific argument shapes are locked without spawning processes.
  */
 import { describe, expect, it } from 'vitest'
-import { openArgv, revealArgv } from '../src/host/routes.ts'
+import { dirname } from 'node:path'
+import { openArgv, revealArgv, spawnCwd } from '../src/host/routes.ts'
 
 describe('revealArgv', () => {
   it('selects the entry via Explorer on Windows', () => {
@@ -31,5 +32,27 @@ describe('openArgv', () => {
 
   it('opens the path with xdg-open on Linux', () => {
     expect(openArgv('linux', '/home/x/proj/notes.md')).toEqual(['xdg-open', '/home/x/proj/notes.md'])
+  })
+})
+
+describe('spawnCwd', () => {
+  it('strips the /select, prefix from the Windows reveal argv', () => {
+    expect(spawnCwd(['explorer.exe', '/select,C:\\proj\\src\\a.ts'])).toBe('C:\\proj\\src')
+  })
+
+  it('uses the real path for macOS reveal argv', () => {
+    expect(spawnCwd(['open', '-R', '/Users/x/proj/a.ts'])).toBe('/Users/x/proj')
+  })
+
+  it('uses the parent directory for Linux reveal argv', () => {
+    expect(spawnCwd(['xdg-open', '/home/x/proj/src'])).toBe('/home/x/proj')
+  })
+
+  it('uses the real path for the Windows open-with-default argv', () => {
+    expect(spawnCwd(['cmd.exe', '/c', 'start', '', 'C:\\proj\\notes.md'])).toBe('C:\\proj')
+  })
+
+  it('falls back to the parent of the current working directory on an empty argv', () => {
+    expect(spawnCwd([])).toBe(dirname(process.cwd()))
   })
 })


### PR DESCRIPTION
## 摘要（Summary）

修复 Windows 下 Explorer 右键「在文件管理器中显示」完全无反应的问题：`spawnOsCommand` 用 `dirname(最后参数)` 计算 cwd，而 Windows 的 reveal 参数是 `/select,<abs>`，dirname 得到 `/select,E:\...` 这种不存在的路径，spawn 直接 ENOENT 失败；异步失败又被 `handle.done.catch(() => {})` 吞掉，接口仍返回 ok，用户无任何反馈。

## 涉及包（Affected Packages）

- [x] 右侧面板 `packages/dsh-aionui-panel`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 未改动 README（行为未变，纯实现修复）。

## 本地验证（Local Validation）

执行的命令：

```bash
# aionui-panel 包内
tsc -b --pretty false
vitest run
# 仓库根
pnpm docs:check
```

结果摘要：

- `tsc -b --pretty false` 通过（退出码 0）
- `vitest run` 26 个测试文件、274 个测试全部通过（含新增 5 个 `spawnCwd` 用例）
- `pnpm docs:check` 全部文档门禁通过

## 用户可见变更证据（Local Feature Evidence）

修复前：`POST /aionui-panel/reveal` 返回 `{"ok":true,"value":{"ok":true}}` 但 explorer 进程数不变（spawn ENOENT 被吞）。修复后：同接口调用 explorer 正常弹出并选中文件。Windows 本地实测 explorer 窗口正常打开。

（修复为本机 node_modules 验证 + 源码级测试锁定；PR 合入后随 0.1.21 发布生效。）