### PR TITLE
docs(contributors): recognize Twelveeee for PR #102

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -405,6 +405,7 @@ This repository is licensed under [Apache-2.0](LICENSE). Third-party code merged
   <a href="https://github.com/Starfie1d1272"><img src="https://github.com/Starfie1d1272.png?size=64" width="48" height="48" alt="Starfie1d1272" title="Starfie1d1272" /></a>
   <a href="https://github.com/great-man2096"><img src="https://github.com/great-man2096.png?size=64" width="48" height="48" alt="great-man2096" title="great-man2096" /></a>
   <a href="https://github.com/cncolder"><img src="https://github.com/cncolder.png?size=64" width="48" height="48" alt="cncolder" title="cncolder" /></a>
+  <a href="https://github.com/Twelveeee"><img src="https://github.com/Twelveeee.png?size=64" width="48" height="48" alt="Twelveeee" title="Twelveeee" /></a>
 </p>
 <p align="center">
   <sub><a href="https://github.com/zhu1090093659/dsh-web-ui/graphs/contributors">View all contributors</a></sub>

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ A: 可以。聚合包的行 id 统一带 `web-ui-` 前缀（如 `web-ui-describe
   <a href="https://github.com/Starfie1d1272"><img src="https://github.com/Starfie1d1272.png?size=64" width="48" height="48" alt="Starfie1d1272" title="Starfie1d1272" /></a>
   <a href="https://github.com/great-man2096"><img src="https://github.com/great-man2096.png?size=64" width="48" height="48" alt="great-man2096" title="great-man2096" /></a>
   <a href="https://github.com/cncolder"><img src="https://github.com/cncolder.png?size=64" width="48" height="48" alt="cncolder" title="cncolder" /></a>
+  <a href="https://github.com/Twelveeee"><img src="https://github.com/Twelveeee.png?size=64" width="48" height="48" alt="Twelveeee" title="Twelveeee" /></a>
 </p>
 <p align="center">
   <sub><a href="https://github.com/zhu1090093659/dsh-web-ui/graphs/contributors">查看全部贡献者</a></sub>

--- a/scripts/update-contributors.mjs
+++ b/scripts/update-contributors.mjs
@@ -39,6 +39,26 @@ const EXCLUDED_LOGINS = new Set([
   'github-actions[bot]', // auto-commits README syncs; not a human contributor
 ])
 
+/**
+ * External contributors recognized for substantive work that did not become a
+ * commit on main. Keep this explicit list so GitHub's /contributors endpoint
+ * does not erase that acknowledgement.
+ */
+const ACKNOWLEDGED_CONTRIBUTORS = [
+  { login: 'Twelveeee', html_url: 'https://github.com/Twelveeee' }, // PR #102
+]
+
+function buildContributors(githubContributors) {
+  const byLogin = new Map()
+  for (const contributor of githubContributors) {
+    if (!EXCLUDED_LOGINS.has(contributor.login)) byLogin.set(contributor.login, contributor)
+  }
+  for (const contributor of ACKNOWLEDGED_CONTRIBUTORS) {
+    if (!byLogin.has(contributor.login)) byLogin.set(contributor.login, contributor)
+  }
+  return [...byLogin.values()]
+}
+
 async function fetchContributors() {
   let page = 1
   const all = []
@@ -83,7 +103,7 @@ function replaceSection(text, section) {
   return text.slice(0, i) + section + text.slice(j + END.length)
 }
 
-const contributors = (await fetchContributors()).filter((c) => !EXCLUDED_LOGINS.has(c.login))
+const contributors = buildContributors(await fetchContributors())
 for (const { rel, viewAllLabel } of files) {
   const path = join(root, rel)
   const original = readFileSync(path, 'utf8')


### PR DESCRIPTION
## 摘要

这是一次维护者纠正。将 @Twelveeee 加入根 README 的贡献者名单，并让同步脚本保留这项认可。

## 依据

PR #102 实现了通用多宠物选择和独立命名。它在 2026-08-15 07:13（+08:00）因新增功能策略被关闭；同日 18:04，main 的 `f1f3747c` 合入了同一核心能力。两份实现没有直接 cherry-pick 或相同 patch，但关闭后立即自行交付相同需求，仍然没有公平对待这份贡献。

这是维护者的纠正，不应按外部仅文档 PR 处理。

## 涉及包（Affected Packages）

- [x] 其他：根 README 贡献者名单与同步脚本

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发。

同步命令：`git fetch origin`

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部改动由 AI 产出，并由维护者审查。

使用的 AI 模型：GPT-5.6 Terra

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig 配置。
- [x] 所有新增 / 修改文件不含 emoji 字符。

## 本地验证（Local Validation）

`node --check scripts/update-contributors.mjs`
`node scripts/update-contributors.mjs`
`pnpm docs:check`
`pnpm test:scripts`
`pnpm typecheck`
`pnpm test`

结果：全部通过。

## 用户可见变更证据（Local Feature Evidence）

N/A（贡献者名单修正）。