### PR TITLE
fix(aionui-panel): localize the write-conflict save error

### DIFF
--- a/packages/dsh-aionui-panel/src/client/preview/content.tsx
+++ b/packages/dsh-aionui-panel/src/client/preview/content.tsx
@@ -42,9 +42,10 @@ export function TabContent({
   onSave: () => void
 }): JSX.Element {
   if (tab.error !== null) {
+    const message = tab.error === 'write-conflict' ? t('preview.saveConflict') : tab.error
     return <div className={previewCss.placeholder}>
       <div className={previewCss.placeholderTitle}>{tab.title}</div>
-      <div className={previewCss.placeholderError}>{tab.error}</div>
+      <div className={previewCss.placeholderError}>{message}</div>
     </div>
   }
 

--- a/packages/dsh-aionui-panel/src/client/store.ts
+++ b/packages/dsh-aionui-panel/src/client/store.ts
@@ -1133,7 +1133,7 @@ export function createPreviewStore(api: PanelApi): PreviewStore {
                 ...item,
                 loading: false,
                 error: result.error.code === 'write-conflict'
-                  ? '文件已在磁盘上被修改，保存冲突：请刷新后重试'
+                  ? 'write-conflict'
                   : result.error.message,
               }
             }

--- a/packages/dsh-aionui-panel/tests/stores.spec.ts
+++ b/packages/dsh-aionui-panel/tests/stores.spec.ts
@@ -413,7 +413,7 @@ describe('regression: search debounce + failure paths + save race', () => {
     s.preview.updateContent(id, '# edited')
     await s.preview.saveTab(id)
     const tab = s.preview.getSnapshot().tabs[0]
-    expect(tab.error).toContain('保存冲突')
+    expect(tab.error).toBe('write-conflict')
     expect(tab.dirty).toBe(true)
   })
 


### PR DESCRIPTION
## 摘要（Summary）

`preview.saveConflict` 的中英双语文案键已在 locales.ts 中定义，但保存冲突（write-conflict）时 store 层却硬编码了中文字符串直接写入 `tab.error`，导致英文界面用户看到中文报错，且该 locale 键从未被引用（死键）。本 PR 让 store 层按文档契约（core/types.ts: "the client prefers its own copy by code"）存储稳定错误码 `write-conflict`，渲染层（preview/content.tsx）用 `t('preview.saveConflict')` 按当前语言翻译。

## 涉及包（Affected Packages）

- [x] 右侧面板 `packages/dsh-aionui-panel`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。
同步命令：`git fetch origin && git rebase origin/main`（已执行）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接管 / 审查
使用的 AI 模型：deepseek-v4-flash-free
使用的编码 Agent 工具：opencode

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`
- [x] 所有新增 / 修改文件不含任何 emoji 字符
- [x] 未改动 README（无三件套同步需求）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel typecheck
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
```

结果摘要：typecheck 通过（exit 0）；vitest 267 通过 / 2 失败，失败均为 `tests/host-fixes.spec.ts` 在 Windows 上创建 symlink 的 EPERM 环境问题（非本改动引入，CI Linux 上不受影响）；改动相关的 `tests/stores.spec.ts` 29/29 通过（含更新后的 write-conflict 断言）。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（纯内部改动：错误消息文案来源从 store 硬编码改为 locale 字典；行为对中文用户无变化，对英文用户恢复为英文）