### PR TITLE
fix(skins): strip stock template [] when composing the managed skin block

### DIFF
--- a/packages/skins/skin-center/src/skin-switch.ts
+++ b/packages/skins/skin-center/src/skin-switch.ts
@@ -348,6 +348,19 @@ export function stripManaged(patch: string): string {
   return patch.slice(0, start) + patch.slice(end + MANAGED_END.length)
 }
 
+/**
+ * Drop bare top-level empty flow lists (`[]`) left by the stock profile
+ * template. The managed skin section below provides the actual patch array,
+ * and an empty flow list followed by block entries is not parseable YAML
+ * ("end of the stream or a document separator is expected"), which breaks the
+ * next dsh boot. Nested `list: []` mapping values are untouched (the line
+ * does not match a standalone `[]`).
+ * @param patch - raw patch file text.
+ */
+export function stripEmptyPatchList(patch: string): string {
+  return patch.replace(/^[ \t]*\[\s*\][ \t]*\r?\n?/gm, '')
+}
+
 /** YAML single-quoted scalar: a literal single quote doubles. `wiring.id` is
  * already validated before it ever reaches a registry, so only `package`
  * needs escaping here. */
@@ -1027,7 +1040,7 @@ export function useSkin(name: string, opts: { home?: string; profile?: string; r
     writePatchAtomic(paths.legacyPatchPath, migratedLegacyPatch)
   }
 
-  const patch = stripLegacySkinRows(stripManaged(readPatch(paths.patchPath)))
+  const patch = stripEmptyPatchList(stripLegacySkinRows(stripManaged(readPatch(paths.patchPath))))
   let next = `${patch.replace(/\s+$/, '')}\n\n${renderManaged(official ? null : name, renderRegistry)}\n`
   let skippedInsert = false
   if (!official && countInsertId(next, renderRegistry[name].id) > 1) {

--- a/packages/skins/skin-center/tests/skin-switch.spec.ts
+++ b/packages/skins/skin-center/tests/skin-switch.spec.ts
@@ -24,6 +24,7 @@ import {
   MANAGED_END,
   renderManaged,
   stripManaged,
+  stripEmptyPatchList,
   stripLegacySkinRows,
   currentActive,
   loadRegistry,
@@ -243,6 +244,14 @@ describe('pure patch helpers', () => {
     expect(() => stripManaged(patch)).toThrow(/unterminated/)
   })
 
+  it('stripEmptyPatchList drops a bare top-level [] but keeps nested lists', () => {
+    const patch = `# template\n[]\n- id: other\n  config:\n    tags: []\n`
+    const stripped = stripEmptyPatchList(patch)
+    expect(stripped).not.toContain('\n[]\n')
+    expect(stripped).toContain('tags: []')
+    expect(stripped).toContain('- id: other')
+  })
+
   it('currentActive returns null when every skin is disabled (stock look)', () => {
     const registry = miniRegistry()
     expect(currentActive(renderManaged(null, registry), registry)).toBeNull()
@@ -458,6 +467,24 @@ describe('useSkin / currentSkin against a throwaway HOME', () => {
     }
     expect(after).not.toContain('- insert:')
     expect(currentSkin(undefined, { home: h })).toBe('none')
+  })
+
+  it('useSkin on the stock template [] rewrites it to a valid patch (no bare [] next to block entries)', () => {
+    const h = fakeHome()
+    const patch = patchPath(h)
+    // The stock profile template: comments + an empty patch list. The managed
+    // block must replace it, not append after it (issue: boot YAML failure
+    // "end of the stream or a document separator is expected").
+    writeFileSync(patch, `# Your patch layer for this dsh profile, applied after every bundle layer:\n# a top-level YAML array of loader patch entries.\n[]\n`)
+    useSkin('official', { home: h })
+    const after = readFileSync(patch, 'utf8')
+    expect(after).toContain(MANAGED_START)
+    expect(/^[ \t]*\[\s*\][ \t]*$/m.test(after)).toBe(false)
+    // A second switch rewrites the managed block again without regressing.
+    useSkin('official', { home: h })
+    const again = readFileSync(patch, 'utf8')
+    expect(/^[ \t]*\[\s*\][ \t]*$/m.test(again)).toBe(false)
+    expect(again).toContain(MANAGED_START)
   })
 
   it('useSkin preserves the permission bits of an existing patch file (0600 stays 0600)', () => {

--- a/scripts/dsh-skin
+++ b/scripts/dsh-skin
@@ -152,6 +152,18 @@ function stripManaged(patch) {
   return patch.slice(0, start) + patch.slice(end + MANAGED_END.length)
 }
 
+/**
+ * Drop bare top-level empty flow lists (`[]`) left by the stock profile
+ * template. The managed skin section below provides the actual patch array,
+ * and an empty flow list followed by block entries is not parseable YAML
+ * ("end of the stream or a document separator is expected"), which breaks the
+ * next dsh boot. Nested `list: []` mapping values are untouched (the line
+ * does not match a standalone `[]`).
+ */
+function stripEmptyPatchList(patch) {
+  return patch.replace(/^[ \t]*\[\s*\][ \t]*\r?\n?/gm, '')
+}
+
 function renderManaged(active) {
   const wired = bundleWiredFromProfile()
   const lines = [MANAGED_START]
@@ -232,7 +244,7 @@ function cmdUse(name) {
   const migratedLegacyPatch = stripLegacySkinRows(stripManaged(legacyPatch))
   if (migratedLegacyPatch !== legacyPatch) writePatch(LEGACY_PATCH, migratedLegacyPatch)
 
-  const patch = stripLegacySkinRows(stripManaged(readPatch()))
+  const patch = stripEmptyPatchList(stripLegacySkinRows(stripManaged(readPatch())))
   const next = `${patch.replace(/\s+$/, '')}\n\n${renderManaged(official ? null : name)}\n`
   // Atomic replace: write a sibling temp file then rename over the target, so
   // a crash mid-write can never leave a half-written boot patch, and the
@@ -276,6 +288,7 @@ module.exports = {
   MANAGED_END,
   renderManaged,
   stripManaged,
+  stripEmptyPatchList,
   stripLegacySkinRows,
   currentActive,
 }

--- a/scripts/dsh-skin.test.mjs
+++ b/scripts/dsh-skin.test.mjs
@@ -12,7 +12,7 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import dshSkin from './dsh-skin'
 
-const { SKINS, MANAGED_START, MANAGED_END, renderManaged, stripManaged, stripLegacySkinRows, currentActive } = dshSkin
+const { SKINS, MANAGED_START, MANAGED_END, renderManaged, stripManaged, stripEmptyPatchList, stripLegacySkinRows, currentActive } = dshSkin
 
 // fileURLToPath, not URL.pathname: the latter keeps a leading slash on
 // Windows (/D:/...), which node then mis-resolves as D:\D:\...
@@ -78,6 +78,45 @@ test('stripManaged throws on an unterminated managed section', () => {
 
 test('currentActive returns null when every skin is disabled', () => {
   assert.equal(currentActive(renderManaged(null)), null)
+})
+
+test('stripEmptyPatchList drops a bare top-level [] but keeps nested lists', () => {
+  const patch = `# template\n[]\n- id: other\n  config:\n    tags: []\n`
+  const stripped = stripEmptyPatchList(patch)
+  assert.ok(!stripped.includes('\n[]\n'), 'bare [] must be removed')
+  assert.ok(!stripped.includes('[]\n-'), 'bare [] must be removed even at line start')
+  assert.ok(stripped.includes('tags: []'), 'nested mapping value must survive')
+  assert.ok(stripped.includes('- id: other'), 'other rows must survive')
+})
+
+test('use official on the stock template [] does not leave invalid YAML', () => {
+  const home = fakeHome()
+  try {
+    const repo = join(home, 'code', 'dsh-web-ui')
+    for (const name of Object.keys(SKINS)) fakeSkinDir(repo, name)
+    const patch = patchPath(home)
+    // The stock profile template: comments + an empty patch list. The managed
+    // block must replace it, not append after it (issue: boot YAML failure).
+    writeFileSync(patch, `# Your patch layer for this dsh profile, applied after every bundle layer:\n# a top-level YAML array of loader patch entries.\n[]\n`)
+    execFileSync(process.execPath, [SCRIPT, 'use', 'official'], {
+      env: { ...process.env, DSH_HOME: join(home, '.dsh'), DSH_SKIN_REPO: repo },
+    })
+    const after = readFileSync(patch, 'utf8')
+    assert.ok(after.includes(MANAGED_START))
+    assert.ok(!/^[ \t]*\[\s*\][ \t]*$/m.test(after), 'no bare [] may survive next to block entries')
+    for (const name of Object.keys(SKINS)) {
+      assert.ok(after.includes(`- id: ${SKINS[name].id}\n  disabled: true`))
+    }
+    // A second switch keeps the file valid (managed block rewrite path).
+    execFileSync(process.execPath, [SCRIPT, 'use', 'official'], {
+      env: { ...process.env, DSH_HOME: join(home, '.dsh'), DSH_SKIN_REPO: repo },
+    })
+    const again = readFileSync(patch, 'utf8')
+    assert.ok(!/^[ \t]*\[\s*\][ \t]*$/m.test(again), 're-apply must stay free of bare []')
+    assert.ok(again.includes(MANAGED_START))
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
 })
 
 test('use official restores the stock look on a throwaway DSH_HOME', () => {


### PR DESCRIPTION
## 摘要（Summary）

皮肤中心切换皮肤时，`useSkin`（host 端，`packages/skins/skin-center/src/skin-switch.ts`）与 `dsh-skin` CLI（`scripts/dsh-skin`）会把「dsh-skin managed」管理块**追加**到 profile 的 `cordis.patch.yml` 后面。但 DSH profile 默认模板自带一个空数组占位 `[]`，空 flow 序列之后不能再跟块级列表项，导致拼装结果是非法的 YAML（`end of the stream or a document separator is expected`），下一次 `dsh` 启动解析补丁直接失败。

本 PR 在拼装管理块之前移除独立的顶层 `[]` 占位行（新增 `stripEmptyPatchList`），嵌套的 `list: []` 映射值不受影响；CLI 与 host 端口同步修复，并补充回归测试（单元 + 模板场景端到端）。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`（`packages/skins/skin-center`）
- 另含维护脚本 `scripts/dsh-skin` 及其测试（维护类改动）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch origin && git rebase origin/main`（克隆后基于当时 main 提交，无冲突）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek V4 Flash

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（不适用：本次无新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（不适用：本次未改动 README / 文档，修复的是既有行为的 bug，不涉及文档描述变更）。

## 本地验证（Local Validation）

执行的命令：

```bash
node --test scripts/dsh-skin.test.mjs
vitest run tests/skin-switch.spec.ts   # 位于 packages/skins/skin-center/
```

结果摘要：全部通过。

- `scripts/dsh-skin.test.mjs`：10/10 通过（含新增 2 个回归测试：`stripEmptyPatchList` 单元测试、`use official on the stock template [] does not leave invalid YAML` 端到端测试）。
- `packages/skins/skin-center/tests/skin-switch.spec.ts`：53/53 通过（含新增 2 个回归测试）。
- 端到端验证（throwaway HOME，不触碰真实 ~/.dsh）：stock 模板（注释 + `[]`）→ `useSkin('whale-song')` → 再 `useSkin('official')` → 每次写出文件均可被 YAML 解析、不含裸 `[]` 行；用户自有的 patch 行与嵌套 `list: []` 值在重写后保留。

说明：本次在稀疏检出（仅包含 `packages/skins/skin-center`、`scripts` 与皮肤 skin.json 清单）环境下对受影响的两套测试单独运行通过；未跑全仓 `pnpm test` / `pnpm typecheck`（需完整工作区安装）。

## 用户可见变更证据（Local Feature Evidence）

Bug 修复为配置文件行为，以文本证据代替截图。

修复前（皮肤切换写出的非法文件，下一次启动失败）：

```yaml
# Your patch layer for this dsh profile, applied after every bundle layer:
# a top-level YAML array of loader patch entries (id-targeted config
# overrides, disables, and insert lists; `!!js` expressions allowed).
[]            # <- 模板空数组占位残留

# --- dsh-skin managed (auto-generated; do not edit) ---
- id: ui-skin-blue-fantasy
  disabled: true
...
```

修复后（同一次切换，`[]` 被移除，文件合法）：

```yaml
# Your patch layer for this dsh profile, applied after every bundle layer:
# a top-level YAML array of loader patch entries (id-targeted config
# overrides, disables, and insert lists; `!!js` expressions allowed).

# --- dsh-skin managed (auto-generated; do not edit) ---
- id: ui-skin-blue-fantasy
  disabled: true
...
```
