### PR TITLE
fix(pet): support v2 11-row spritesheet atlases

### DIFF
--- a/packages/dsh-pet/README.i18n.yaml
+++ b/packages/dsh-pet/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: b8705d67cb561b581ecfad2d644e6d70e17cf6b1
-README.zh.md: fb5bc5846a273a667c0f72adac1ecc1c9e0d5130
+README.md: 4cc4487b3559a16c002a501b15773b76bfc44260
+README.zh.md: 19199551347706fd2c691349bfd729d624ee869b

--- a/packages/dsh-pet/README.md
+++ b/packages/dsh-pet/README.md
@@ -38,6 +38,7 @@ A pet is a directory holding one `pet.json` manifest and one atlas image. Nothin
   "spritesheetPath": "spritesheet.webp",   // atlas, relative to the manifest
   "cell": { "width": 192, "height": 208 }, // optional; defaults to the Codex contract
   "columns": 8,                            // optional; default 8
+  "spriteVersionNumber": 1,                // optional; 2 marks an 11-row v2 atlas (9 animation rows + 2 look rows)
   "frames": [6, 8, 8, 4, 5, 8, 6, 6, 6],   // optional per-row frame counts
   "tracks": {                              // optional per-track rhythm overrides
     "idle": { "durations": [400, 400, 500, 400, 400, 500] }
@@ -49,7 +50,7 @@ A pet is a directory holding one `pet.json` manifest and one atlas image. Nothin
 }
 ```
 
-- The atlas is an 8-column × 9-row grid (192×208 cells by default); rows are fixed in this order: 0 idle, 1 running-right, 2 running-left, 3 waving, 4 jumping, 5 failed, 6 waiting, 7 running, 8 review. Unused cells stay fully transparent.
+- The atlas is an 8-column × 9-row grid (192×208 cells by default); rows are fixed in this order: 0 idle, 1 running-right, 2 running-left, 3 waving, 4 jumping, 5 failed, 6 waiting, 7 running, 8 review. Unused cells stay fully transparent. v2 Codex atlases declare `"spriteVersionNumber": 2` and hold 11 rows — the same 9 animation rows plus 2 trailing look rows; the plugin renders the 9 animation rows and ignores the look rows.
 - The optional remarks block overrides the reaction bubbles the pet speaks on pet / petCooldown / feed / feedCooldown / noTreats events. Each slot accepts one line or a pool of lines (cycled round-robin); a declared slot replaces the built-in pool for that slot only. This is how community contributions give their pet its own witty voice.
 - `frames` counts the used columns per row (defaults to the hatch-pet contract table `[6, 8, 8, 4, 5, 8, 6, 6, 6]`); `tracks` overrides per-frame durations (cycled to the row's frame count), `loop`, and `fallback` per animation (defaults: everything loops; `jumping` and `failed` hold their last frame, then fall back to `idle`).
 

--- a/packages/dsh-pet/README.zh.md
+++ b/packages/dsh-pet/README.zh.md
@@ -38,6 +38,7 @@
   "spritesheetPath": "spritesheet.webp",   // 图集，相对 manifest 所在目录
   "cell": { "width": 192, "height": 208 }, // 可选；默认 Codex 契约
   "columns": 8,                            // 可选；默认 8
+  "spriteVersionNumber": 1,                // 可选；2 表示 11 行 v2 图集（9 行动画行 + 2 行视线跟随行）
   "frames": [6, 8, 8, 4, 5, 8, 6, 6, 6],   // 可选的每行帧数
   "tracks": {                              // 可选的每轨节奏覆盖
     "idle": { "durations": [400, 400, 500, 400, 400, 500] }
@@ -49,7 +50,7 @@
 }
 ```
 
-- 图集是 8 列 × 9 行网格（默认 192×208 单元格）；行序固定：0 idle、1 running-right、2 running-left、3 waving、4 jumping、5 failed、6 waiting、7 running、8 review。未使用的格子保持全透明。
+- 图集是 8 列 × 9 行网格（默认 192×208 单元格）；行序固定：0 idle、1 running-right、2 running-left、3 waving、4 jumping、5 failed、6 waiting、7 running、8 review。未使用的格子保持全透明。v2（Codex）图集在 manifest 里声明 `"spriteVersionNumber": 2`，共 11 行——同样的 9 行动画行外加末尾 2 行视线跟随行；插件渲染这 9 行动画行、忽略视线行。
 - 可选 remarks 块覆盖宠物在 pet（摸头）/ petCooldown / feed（喂食）/ feedCooldown / noTreats（缺粮）事件上的气泡台词。每个槽位接受一句或一组台词（轮询循环）；声明过的槽位只替换该槽位的内置默认池。社区贡献就是这样给自家宠物配上专属妙语的。
 - `frames` 记录每行用到的列数（缺省按 hatch-pet 契约表 `[6, 8, 8, 4, 5, 8, 6, 6, 6]`）；`tracks` 按动画覆盖每帧时长（按该行帧数循环补足）、`loop` 与 `fallback`（默认：全部循环；`jumping` 与 `failed` 停在最后一帧后回到 `idle`）。
 

--- a/packages/dsh-pet/src/client/PetSprite.test.tsx
+++ b/packages/dsh-pet/src/client/PetSprite.test.tsx
@@ -27,6 +27,7 @@ function petDefinition(): PetDefinition {
     cell: { width: 192, height: 208 },
     columns: 8,
     rows: [6, 8, 8, 4, 5, 8, 6, 6, 6],
+    atlasRows: 9,
     tracks: {
       idle: track([0, 1, 2, 3, 4, 5], [400, 400, 400, 400, 400, 400]),
       'running-right': track([0, 1, 2, 3, 4, 5, 6, 7], [225, 225, 225, 225, 225, 225, 225, 225]),

--- a/packages/dsh-pet/src/client/PetSprite.tsx
+++ b/packages/dsh-pet/src/client/PetSprite.tsx
@@ -252,7 +252,7 @@ export function PetSprite(props: PetSpriteProps): ReactPortal {
           width: spriteWidth,
           height: spriteHeight,
           backgroundImage: imageReady ? 'url(' + definition.atlasUrl + ')' : undefined,
-          backgroundSize: (cell.width * columns * spriteScale) + 'px ' + (cell.height * rows.length * spriteScale) + 'px',
+          backgroundSize: (cell.width * columns * spriteScale) + 'px ' + (cell.height * (definition.atlasRows ?? rows.length) * spriteScale) + 'px',
           backgroundRepeat: 'no-repeat',
           backgroundPosition: '0 0',
           cursor: dragRef.current === null ? 'grab' : 'grabbing',

--- a/packages/dsh-pet/src/registry.test.ts
+++ b/packages/dsh-pet/src/registry.test.ts
@@ -25,6 +25,7 @@ describe('resolvePetManifest', () => {
     expect(entry!.id).toBe('otter')
     expect(entry!.cell).toEqual(DEFAULT_PET_CELL)
     expect(entry!.columns).toBe(8)
+    expect(entry!.atlasRows).toBe(9)
     expect(entry!.rows).toEqual([...DEFAULT_FRAME_COUNTS])
     expect(entry!.atlasUrl).toBe('/pet/otter/spritesheet.webp')
     expect(entry!.manifestUrl).toBe('/pet/otter/pet.json')
@@ -35,6 +36,21 @@ describe('resolvePetManifest', () => {
     expect(entry!.tracks.jumping.fallback).toBe('idle')
     expect(entry!.tracks.failed.loop).toBe(false)
     expect(entry!.tracks.running.loop).toBe(true)
+  })
+
+  it('marks v2 (spriteVersionNumber 2) atlases with 11 rows', () => {
+    const entry = resolvePetManifest({
+      id: 'firefly',
+      displayName: 'Firefly',
+      spritesheetPath: 'spritesheet.webp',
+      spriteVersionNumber: 2,
+    }, join(tmpdir(), 'firefly'))
+    expect(entry).toBeDefined()
+    // v2 atlases carry 11 rows: the 9 animation rows plus 2 look rows.
+    expect(entry!.atlasRows).toBe(11)
+    // The 9 animation rows still resolve the hatch-pet contract.
+    expect(entry!.rows).toEqual([...DEFAULT_FRAME_COUNTS])
+    expect(entry!.tracks.idle.frames.length).toBe(entry!.rows[0])
   })
 
   it('keeps the legacy whale-girl frame counts and its own durations', () => {
@@ -152,8 +168,9 @@ describe('loadPetRegistry', () => {
 
 describe('codexPetsDir', () => {
   it('honors CODEX_HOME and expands a leading tilde', () => {
-    expect(codexPetsDir({ CODEX_HOME: '/opt/codex' }, '/home/user')).toBe('/opt/codex/pets')
-    expect(codexPetsDir({ CODEX_HOME: '~/codex' }, '/home/user')).toBe('/home/user/codex/pets')
-    expect(codexPetsDir({}, '/home/user')).toBe('/home/user/.codex/pets')
+    // Expected values join through the platform separator (POSIX on CI).
+    expect(codexPetsDir({ CODEX_HOME: '/opt/codex' }, '/home/user')).toBe(join('/opt/codex', 'pets'))
+    expect(codexPetsDir({ CODEX_HOME: '~/codex' }, '/home/user')).toBe(join('/home/user', 'codex', 'pets'))
+    expect(codexPetsDir({}, '/home/user')).toBe(join('/home/user', '.codex', 'pets'))
   })
 })

--- a/packages/dsh-pet/src/registry.ts
+++ b/packages/dsh-pet/src/registry.ts
@@ -165,6 +165,8 @@ export interface PetDefinition {
   columns: number
   /** Per-row frame counts (length 9, row order above). */
   rows: number[]
+  /** Total atlas rows (9 for v1, 11 for v2 look-row atlases). */
+  atlasRows: number
   /** Fully resolved animation tracks (frames + durations + loop/fallback). */
   tracks: Record<PetAnimation, PetTrackDef>
   /** Browser URL of the atlas (served by the host asset route). */
@@ -256,6 +258,8 @@ export function resolvePetManifest(
     height: finiteInt(rawCell.height, DEFAULT_PET_CELL.height, 2048),
   }
   const columns = finiteInt(source.columns, DEFAULT_PET_COLUMNS, 32)
+  // v2 atlases (spriteVersionNumber 2) hold 11 rows: 9 animation rows + 2 look rows.
+  const atlasRowCount = source.spriteVersionNumber === 2 ? 11 : DEFAULT_PET_ROW_COUNT
   const rows = DEFAULT_FRAME_COUNTS.map((fallback, index) => {
     const value = Array.isArray(source.frames) ? source.frames[index] : undefined
     return finiteInt(value, fallback, columns)
@@ -295,6 +299,7 @@ export function resolvePetManifest(
     cell,
     columns,
     rows,
+    atlasRows: atlasRowCount,
     tracks,
     atlasUrl: assetUrl(assetPrefix, id, spritesheet),
     manifestUrl: assetUrl(assetPrefix, id, 'pet.json'),
@@ -393,6 +398,7 @@ export function petEntryView(entry: PetEntry): PetDefinition {
     cell: entry.cell,
     columns: entry.columns,
     rows: entry.rows,
+    atlasRows: entry.atlasRows,
     tracks: entry.tracks,
     atlasUrl: entry.atlasUrl,
     manifestUrl: entry.manifestUrl,


### PR DESCRIPTION
## 鎽樿锛圫ummary锛?
淇 dsh-pet 瀵?v2 Codex 妗屽疇锛坄spriteVersionNumber: 2`锛?1 琛屽浘闆嗭級鐨勬覆鏌擄細姝ゅ墠鎵€鏈夊浘闆嗘寜 9 琛屽绾﹀鐞嗭紝v2 鍥鹃泦锛?536脳2288锛夎缂╂斁鍒?9 琛屽嚑浣曪紙1872 楂橈級锛屽鑷村瀭鐩村帇鎵併€佽鍋忕Щ閿欎綅锛坘azuha / firefly / nastya 鍙楀奖鍝嶏級銆傜幇鍦ㄦ敞鍐岃〃瑙ｆ瀽 `atlasRows`锛坴2 = 11锛寁1 = 9锛夊苟闅忓疇鐗╁畾涔変笅鍙戯紝瀹㈡埛绔?`backgroundSize` 楂樺害鎸?`atlasRows` 璁＄畻锛寁2 鍥鹃泦浠ュ師鐢熷嚑浣曟覆鏌擄紝鍔ㄧ敾琛屼粛涓?0-8銆?
Fixes #424

## 娑夊強鍖咃紙Affected Packages锛?
- [x] 瀹犵墿 `packages/dsh-pet`

## PR 绫诲瀷锛圥R Type锛?
- [x] 闈㈠悜鐢ㄦ埛鐨勫姛鑳芥垨琛屼负鍙樻洿
- [x] Bug 淇

## 鏈€鏂颁唬鐮佺‘璁わ紙Latest Codebase Confirmation锛?
- [x] 鎴戝凡鍩轰簬鏈€鏂?`main` 鍒嗘敮寮€鍙戯紙`2e98a2d merge: integrate remote pushes`锛夈€?
鍚屾鍛戒护锛歚git fetch origin && git rebase origin/main`锛堝垎鏀熀浜庢渶鏂?main锛屾棤闇€ rebase锛?
## AI 缂栫爜鎶湶锛圓I Coding Disclosure锛?
- [x] 瀹屽叏 AI 缂栫爜锛氬叏閮ㄧ紪绋嬫敼鍔ㄧ敱 AI 浜у嚭锛屽苟鐢辫础鐚€呮帴鍙?/ 瀹℃煡銆?
浣跨敤鐨?AI 妯″瀷锛欴eepSeek锛坉eepseek-v4-flash锛?
浣跨敤鐨勭紪鐮?Agent 宸ュ叿锛欴eepSeek Harness

## 浠撳簱瑙勮寖妫€鏌ワ紙Repo Rules锛?
- [x] 鏈慨鏀?DSH 瀹樻柟婧愮爜锛屼粎鍩轰簬瀹樻柟 NPM SDK锛坄@deepseek-ai/*`锛夊紑鍙戙€?- [x] 鏈柊澧炴寚鍚?DSH 婧愮爜 checkout 鐨?tsconfig `extends` / `paths` / `references`銆?- [x] 鎵€鏈夋柊澧?/ 淇敼鏂囦欢涓嶅惈浠讳綍 emoji 瀛楃銆?- [x] 鏀瑰姩鍖?README 鏃跺悓姝ョ淮鎶や腑鑻卞弻璇笁浠跺锛坄README.md` / `README.zh.md` / `README.i18n.yaml`锛夊苟杩愯 `pnpm docs:check`銆?
锛堟湰 PR 鏈柊澧炲寘锛宍dsh-` 鍓嶇紑鍛藉悕瑙勫垯涓嶉€傜敤銆傦級

## 鏈湴楠岃瘉锛圠ocal Validation锛?
鎵ц鐨勫懡浠わ細

```bash
pnpm --filter @linxin666/dsh-pet test
tsc -b --pretty false && tsc -p tsconfig.test.json --pretty false
node scripts/verify-docs.mjs
```

缁撴灉鎽樿锛?
- 娴嬭瘯锛?3 涓祴璇曟枃浠躲€?*112/112 鍏ㄩ儴閫氳繃**锛堝惈鏂板 v2 鐢ㄤ緥锛歚spriteVersionNumber: 2` 鈫?`atlasRows: 11`锛岄粯璁?鈫?`atlasRows: 9`锛?- 绫诲瀷妫€鏌ワ細`tsc -b` 涓?`tsc -p tsconfig.test.json` 鍧囬€氳繃
- `docs:check`锛氶€氳繃锛坕18n 閰嶅鍝堝笇宸茬敤 `verify-docs.mjs --write` 閲嶅綍锛?- 椤哄甫淇 `codexPetsDir` 娴嬭瘯鐨?POSIX 璺緞鏂█锛堟敼涓烘寜骞冲彴鍒嗛殧绗?join锛夛紝浣垮浠跺湪 Windows 鏈湴涔熻兘鍏ㄧ豢

## 鐢ㄦ埛鍙鍙樻洿璇佹嵁锛圠ocal Feature Evidence锛?
鐢ㄥ畨瑁呭寘鍐呯湡瀹炴敞鍐岃〃浠ｇ爜鍔犺浇 `~/.codex/pets` 鐨勮瘖鏂緭鍑猴紙淇鍚庯級锛?
```text
=== discovered entries: 16 ===
  whale-girl           椴搁奔濞?           atlasRows=9
  firefly              Firefly        atlasRows=11
  kazuha               Kazuha         atlasRows=11
  nastya               濞滄柉浣?           atlasRows=11
  ...锛堝叾浣?v1 瀹犵墿 atlasRows=9锛?=== warnings: 0 ===
```

- v2 瀹犵墿锛坒irefly / kazuha / nastya锛塦atlasRows=11`锛屽浘闆?1536脳2288锛屽鎴风鎸夊師鐢熷嚑浣曟覆鏌撱€佷笉鍐嶅帇鎵侊紝鍔ㄧ敾琛?0-8 瀵归綈姝ｇ‘
- v1 瀹犵墿 `atlasRows=9`锛岃涓哄畬鍏ㄤ笉鍙?
锛堜慨澶嶅墠/鍚?GUI 鎴浘鍙悗琛ャ€傦級
