### PR TITLE
fix(aionui-panel): render text files in the split-pane preview

### DIFF
--- a/packages/dsh-aionui-panel/src/client/preview/content.tsx
+++ b/packages/dsh-aionui-panel/src/client/preview/content.tsx
@@ -158,7 +158,7 @@ function SplitPane({
           {tab.contentType === 'markdown' && <MarkdownViewer content={content} root={tab.root} path={tab.path} />}
           {tab.contentType === 'html' && <HtmlViewer content={content} />}
           {tab.contentType === 'csv' && <CsvViewer content={content} />}
-          {tab.contentType === 'code' && <CodeViewer content={content} language={tab.title.split('.').pop() ?? ''} />}
+          {(tab.contentType === 'code' || tab.contentType === 'text') && <CodeViewer content={content} language={tab.title.split('.').pop() ?? ''} />}
         </div>
       </div>
     </div>

--- a/packages/dsh-aionui-panel/tests/preview-split-text.spec.tsx
+++ b/packages/dsh-aionui-panel/tests/preview-split-text.spec.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+/**
+ * Split-pane text regression: a plain-text file (contentType 'text', e.g.
+ * README/LICENSE/.env) is split-eligible, but the right preview pane used to
+ * render only markdown/html/csv/code, leaving the preview side blank for
+ * 'text'. The text branch must fall through to CodeViewer, matching the
+ * non-split TabContent path.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import type { PreviewTabState } from '../src/client/store.ts'
+import { TabContent } from '../src/client/preview/content.tsx'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+;(globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverStub
+
+const noop = (): void => {}
+
+const textTab = (): PreviewTabState => ({
+  id: 't',
+  title: 'README',
+  root: '/work',
+  path: '/work/README',
+  contentType: 'text',
+  content: 'plain text body',
+  dirty: false,
+  updated: false,
+  loading: false,
+  truncated: false,
+  error: null,
+  savedAt: 0,
+})
+
+function renderSplit(tab: PreviewTabState): HTMLElement {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  act(() => {
+    root.render(<TabContent tab={tab} viewMode="preview" split={true} onContentChange={noop} onSave={noop} />)
+  })
+  return host
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('SplitPane text preview', () => {
+  it('renders the text body in the preview pane for a text file', () => {
+    const host = renderSplit(textTab())
+    // The right pane should fall through to CodeViewer, not stay blank.
+    expect(host.querySelector('.md-code-block')).not.toBeNull()
+    expect(host.textContent).toContain('plain text body')
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-aionui-panel` 分屏预览对纯文本文件（`contentType: 'text'`）右侧空白的问题。

根因：`TabContent` 的 `editable` 列表包含 `text`，所以 README / LICENSE / `.env` 等纯文本文件可进入分屏（split）布局；但 `SplitPane` 右侧预览只渲染 markdown / html / csv / code 四个分支，没有 `text` 分支，导致右侧预览列永久空白。

修复：让 `text` 与 `code` 一样走 `CodeViewer` 渲染，与 `TabContent` 非分屏路径（`contentType === 'code' || contentType === 'text'`）保持一致，并补一个分屏渲染测试。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [x] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
pnpm --filter @linxin666/dsh-client-ui-aionui-panel typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-client-ui-aionui-panel test`：30 个测试文件 292 个用例全部通过（含新增 `preview-split-text.spec.tsx` 1 个用例）。
- `pnpm --filter @linxin666/dsh-client-ui-aionui-panel typecheck`：通过。
- 页面验证：打开 README / LICENSE / `.env` 等纯文本文件进入分屏，右侧预览正确渲染正文（修复前为空白）。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即上节「结果摘要」中描述的分屏预览由空白变为渲染正文）。
