### PR TITLE
fix(aionui-panel): restore preview visibility on initial bind

### DIFF
--- a/packages/dsh-aionui-panel/src/client/index.ts
+++ b/packages/dsh-aionui-panel/src/client/index.ts
@@ -178,12 +178,16 @@ export function apply(ctx: ClientContext): void {
 
         disposeEvents?.()
         disposeEvents = undefined
-        const previewOpen = stores.preview.getSnapshot().open
-        lastPreviewOpen = previewOpen
-        layoutSetRoot(stores.layout, root, previewOpen)
         stores.explorer.setRoot(root)
         stores.scm.setRoot(root)
         stores.preview.setRoot(root)
+        // Read the open state AFTER setRoot restores the new root's persisted
+        // tabs, so layout.previewOpen matches the preview store instead of the
+        // stale pre-setRoot value (which kept the preview column hidden until
+        // the first unrelated preview-store change).
+        const previewOpen = stores.preview.getSnapshot().open
+        lastPreviewOpen = previewOpen
+        layoutSetRoot(stores.layout, root, previewOpen)
 
         if (root === '') return
         disposeEvents = subscribePanelEvents(root, (event) => {

--- a/packages/dsh-aionui-panel/tests/stores.spec.ts
+++ b/packages/dsh-aionui-panel/tests/stores.spec.ts
@@ -204,6 +204,15 @@ describe('preview store', () => {
     expect(second.activeTabId).toBe(first.tabs[0].id)
   })
 
+  it('restores open=true from persisted tabs on setRoot (bind order)', () => {
+    localStorage.setItem('preview-ui:/w', JSON.stringify({
+      savedAt: 1,
+      tabs: [{ id: 't1', title: 'README.md', root: '/w', path: '/w/README.md', contentType: 'markdown', savedAt: 1 }],
+    }))
+    stores.preview.setRoot('/w')
+    expect(stores.preview.getSnapshot().open).toBe(true)
+  })
+
   it('marks dirty on edit and saves through the api', async () => {
     stores.preview.setRoot('/w')
     stores.preview.openFile('/w', 'README.md')


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-aionui-panel` 刷新后预览面板消失的问题。

根因：`bindRoot` 在 `preview.setRoot` **之前**读取 `stores.preview.getSnapshot().open`（此时仍是旧根/初始值 `false`），把它传给 `layoutSetRoot`，之后 `preview.setRoot` 才恢复新根持久化的标签并置 `open=true`；而 `mirrorPreviewOpen` 的订阅在其后才建立且不会立即触发，导致 `layout.previewOpen` 残留 `false`，预览列在启动后被算成 `0px + visibility:hidden`，直到后续某次无关的 preview store 变化才恢复。

修复：把「读取 open + layoutSetRoot」移到 `preview.setRoot` 之后，使 `layout.previewOpen` 用恢复后的正确值，并补一个 store 测试锁定 `setRoot` 恢复持久化标签的 `open`。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [x] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
pnpm --filter @linxin666/dsh-client-ui-aionui-panel typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-client-ui-aionui-panel test`：29 个测试文件 292 个用例全部通过（含新增 store 测试 1 个）。
- `pnpm --filter @linxin666/dsh-client-ui-aionui-panel typecheck`：通过。
- 页面验证：打开含 PDF/预览标签的会话，刷新页面后预览列正确恢复显示（修复前为 0px 隐藏，需再开文件才出现）。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即上节「结果摘要」中描述的刷新后预览面板由隐藏变为正常恢复显示）。
