### PR TITLE
fix(web-ui-settings): honor allowlist key with trailing comment and unindented items

### DIFF
--- a/packages/dsh-web-ui-settings/src/allowlist.ts
+++ b/packages/dsh-web-ui-settings/src/allowlist.ts
@@ -137,14 +137,17 @@ export function extractWebSettingsNamespaces(text: string): string[] {
     return entries
   }
   const lines = text.split(/\r?\n/)
-  const start = lines.findIndex(line => /^\s*web_settings_namespaces\s*:\s*$/.test(line.trim()))
+  const start = lines.findIndex(line => /^\s*web_settings_namespaces\s*:\s*(?:#.*)?$/.test(line.trim()))
   if (start < 0) return []
   const entries: string[] = []
   for (const line of lines.slice(start + 1)) {
-    if (line.trim() === '') break
-    if (!/^\s/.test(line)) break
     const trimmed = line.trim()
+    if (trimmed === '') break
     if (trimmed.startsWith('#')) continue
+    // A sequence item may sit at column 0 (YAML allows unindented list items
+    // under a key); only a non-indented, non-item line starts the next
+    // top-level key and ends this block.
+    if (!/^\s/.test(line) && !trimmed.startsWith('-')) break
     const name = entryOfItem(trimmed)
     if (name !== undefined) entries.push(name)
   }

--- a/packages/dsh-web-ui-settings/tests/allowlist.spec.ts
+++ b/packages/dsh-web-ui-settings/tests/allowlist.spec.ts
@@ -42,6 +42,23 @@ describe('extractWebSettingsNamespaces', () => {
     expect(extractWebSettingsNamespaces(text)).toEqual(['dsh-ssh'])
   })
 
+  it('reads a block list when the key line carries a trailing comment', () => {
+    const text = [
+      'web_settings_namespaces:  # expose only task-board',
+      '  - task-board',
+    ].join('\n')
+    expect(extractWebSettingsNamespaces(text)).toEqual(['task-board'])
+  })
+
+  it('reads an unindented block list (YAML allows column-0 sequence items)', () => {
+    const text = [
+      'web_settings_namespaces:',
+      '- dsh-ssh',
+      '- dsh-live-stats',
+    ].join('\n')
+    expect(extractWebSettingsNamespaces(text)).toEqual(['dsh-ssh', 'dsh-live-stats'])
+  })
+
   it('returns the empty list when the key is absent or the file is empty', () => {
     expect(extractWebSettingsNamespaces('llm:\n  provider: x\n')).toEqual([])
     expect(extractWebSettingsNamespaces('')).toEqual([])


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-web-ui-settings` 的 `web_settings_namespaces` allowlist 解析器对两种合法 YAML 写法失效、静默回退到「全家族开放」（fail-open）的问题。

根因：`extractWebSettingsNamespaces` 手写解析 raw YAML 文本，两处缺陷：
1. 键行正则 `/^\s*web_settings_namespaces\s*:\s*$/` 要求冒号后紧跟行尾，键行带尾注释（`web_settings_namespaces:  # expose only task-board`）时匹配失败，键被当作不存在；
2. 块列表扫描在首个无前导空白的行处 `break`，而 `- dsh-ssh` 顶格（列 0）是合法 YAML 列表项，却被误判为下一个顶层 key。

两者都导致解析返回空 `[]`，`composeAllowlist` 把空当「用户未配置」而回退到全量 `FAMILY_NAMESPACES`，使本应受限的命名空间反而全部开放读写。

修复：键行正则允许尾注释；块列表扫描只在「无缩进且非 `-` 列表项」的行处停止。补两个解析测试锁定这两种写法。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-web-ui-settings test
pnpm --filter @linxin666/dsh-client-ui-web-ui-settings typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-client-ui-web-ui-settings test`：6 个测试文件 53 个用例全部通过（含新增 allowlist 解析 2 个用例）。
- `pnpm --filter @linxin666/dsh-client-ui-web-ui-settings typecheck`：通过。
- 行为验证：`extractWebSettingsNamespaces` 对「键行带尾注释」和「`-` 列表项顶格」两种 YAML 现在都能正确解析出受限条目，不再回退全家族。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即上节「结果摘要」中描述的 allowlist 由「失效回退全家族」变为「正确解析受限条目」）。
