### PR TITLE
fix(aionui-panel): render chat mermaid blocks via infostring banner labels (#451)

### DIFF
--- a/packages/dsh-aionui-panel/src/client/chat/mermaid-chat.tsx
+++ b/packages/dsh-aionui-panel/src/client/chat/mermaid-chat.tsx
@@ -1,6 +1,8 @@
 /**
  * Chat-transcript mermaid enhancement: the core conversation renderer emits
- * fenced code as `pre > code.language-mermaid`, and the shell has no slot
+ * fenced code either as `pre > code.language-mermaid` or — in the banner
+ * layout — as a class-less `pre > code` whose sibling banner carries the
+ * language in an `infostring` label (issue #451) — and the shell has no slot
  * for message-body post-processing — so this component rides the
  * conversation input dock as a zero-render sentinel and observes the
  * document for mermaid blocks the transcript mounts. Blocks inside the

--- a/packages/dsh-aionui-panel/src/client/preview/mermaid.ts
+++ b/packages/dsh-aionui-panel/src/client/preview/mermaid.ts
@@ -161,23 +161,58 @@ export function sanitizeSvg(svg: string): string {
 }
 
 /**
+ * Language-label element shapes the shell's chat code banner emits. The
+ * shell renders a fenced block as a banner (the language text in an
+ * `infostring`-class element) beside a class-less `pre > code` (issue #451),
+ * so a `pre.language-*` selector alone never matches the transcript; older
+ * clients stamped a `language-*` class on the label span instead. pre/code
+ * elements are excluded from the label hunt so a highlighted code block
+ * whose CONTENT is literally "mermaid" is never mistaken for a label.
+ */
+const BANNER_LABEL_SELECTOR = '[class*="infostring"]:not(pre):not(code), span[class*="language-"], div[class*="language-"]'
+
+/**
+ * Climb from one banner language label to the nearest enclosing pre. The
+ * shell nests the banner and the pre inside one block container, so a short
+ * bounded climb reaches it; the depth cap keeps a stray label from ever
+ * claiming a far-away code block.
+ */
+function preForBannerLabel(label: Element): HTMLPreElement | null {
+  let ancestor = label.parentElement
+  for (let depth = 0; ancestor !== null && depth < 5; depth += 1) {
+    const pre = ancestor.querySelector('pre')
+    if (pre instanceof HTMLPreElement) return pre
+    ancestor = ancestor.parentElement
+  }
+  return null
+}
+
+/**
  * Collect the still-unclaimed fenced mermaid code blocks under one scope.
- * Both shapes are found: the panel renderer's `pre.language-mermaid` and
- * the chat renderer's `pre > code.language-mermaid` (the claim always
- * targets the <pre>). Empty blocks and blocks another driver already
- * claimed are skipped. Pure (DOM-read only) so tests can drive it in jsdom.
+ * Three shapes are found: the panel renderer's `pre.language-mermaid`, the
+ * highlighted-code path's `pre > code.language-mermaid`, and the shell chat
+ * banner — a class-less pre whose sibling banner carries an `infostring` /
+ * `language-*` label reading "mermaid" (issue #451; the claim always targets
+ * the <pre>). Empty blocks and blocks another driver already claimed are
+ * skipped. Pure (DOM-read only) so tests can drive it in jsdom.
  */
 export function findMermaidCodeBlocks(scope: ParentNode): HTMLPreElement[] {
   const found: HTMLPreElement[] = []
   const seen = new Set<Element>()
+  const consider = (candidate: Element | null): void => {
+    if (candidate === null || !(candidate instanceof HTMLPreElement)) return
+    if (seen.has(candidate)) return
+    seen.add(candidate)
+    if (candidate.hasAttribute(DATA_CLAIMED)) return
+    if ((candidate.textContent ?? '').trim() === '') return
+    found.push(candidate)
+  }
   for (const el of Array.from(scope.querySelectorAll('pre.language-mermaid, code.language-mermaid'))) {
-    const pre = el instanceof HTMLPreElement ? el : el.parentElement
-    if (pre === null || !(pre instanceof HTMLPreElement)) continue
-    if (seen.has(pre)) continue
-    seen.add(pre)
-    if (pre.hasAttribute(DATA_CLAIMED)) continue
-    if ((pre.textContent ?? '').trim() === '') continue
-    found.push(pre)
+    consider(el instanceof HTMLPreElement ? el : el.parentElement)
+  }
+  for (const label of Array.from(scope.querySelectorAll<HTMLElement>(BANNER_LABEL_SELECTOR))) {
+    if ((label.textContent ?? '').trim().toLowerCase() !== 'mermaid') continue
+    consider(preForBannerLabel(label))
   }
   return found
 }

--- a/packages/dsh-aionui-panel/tests/mermaid.spec.ts
+++ b/packages/dsh-aionui-panel/tests/mermaid.spec.ts
@@ -60,6 +60,108 @@ describe('findMermaidCodeBlocks', () => {
   })
 })
 
+/**
+ * Shell chat banner blocks (issue #451): the conversation renderer emits a
+ * class-less `pre > code` beside a banner whose infostring label carries the
+ * language. Class names mirror the real hashed CSS-module output observed in
+ * the served shell bundle.
+ */
+function seedBannerBlocks(root: HTMLElement): { mermaidPre: HTMLPreElement; tsPre: HTMLPreElement } {
+  root.innerHTML = [
+    '<div class="_block_178r4_4">',
+    '  <div class="_bannerWrap_178r4_21"><div class="_banner_178r4_21">',
+    '    <div class="_infostring_178r4_42">mermaid</div>',
+    '    <div class="_action_178r4_53"><button class="_copyButton_178r4_59" type="button">copy</button></div>',
+    '  </div></div>',
+    '  <pre class="_plain_178r4_94"><code>flowchart LR\nA--&gt;B</code></pre>',
+    '</div>',
+    '<div class="_block_178r4_4">',
+    '  <div class="_bannerWrap_178r4_21"><div class="_banner_178r4_21">',
+    '    <div class="_infostring_178r4_42">ts</div>',
+    '  </div></div>',
+    '  <pre class="_plain_178r4_94"><code>print(1)</code></pre>',
+    '</div>',
+  ].join('')
+  const pres = Array.from(root.querySelectorAll('pre'))
+  return { mermaidPre: pres[0] as HTMLPreElement, tsPre: pres[1] as HTMLPreElement }
+}
+
+describe('findMermaidCodeBlocks shell banner shape (issue #451)', () => {
+  it('matches the infostring-labelled banner block and skips other languages', () => {
+    const root = document.createElement('div')
+    const { mermaidPre } = seedBannerBlocks(root)
+    const found = findMermaidCodeBlocks(root)
+    expect(found).toHaveLength(1)
+    expect(found[0]).toBe(mermaidPre)
+  })
+
+  it('matches the older language-classed label span shape', () => {
+    const root = document.createElement('div')
+    root.innerHTML = [
+      '<div class="code-block">',
+      '  <span class="abc-language-def">mermaid</span>',
+      '  <pre class="plain"><code>graph TD\nC--&gt;D</code></pre>',
+      '</div>',
+    ].join('')
+    const found = findMermaidCodeBlocks(root)
+    expect(found).toHaveLength(1)
+    expect(found[0]!.textContent).toContain('graph TD')
+  })
+
+  it('matches the label case-insensitively', () => {
+    const root = document.createElement('div')
+    root.innerHTML = '<div><div class="_infostring_x">Mermaid</div><pre><code>graph TD</code></pre></div>'
+    expect(findMermaidCodeBlocks(root)).toHaveLength(1)
+  })
+
+  it('never mistakes a code block whose content is "mermaid" for a label', () => {
+    const root = document.createElement('div')
+    // A highlighted block (code carries the language-* class) whose CONTENT
+    // is the word mermaid, plus a banner-labelled ts block containing it.
+    root.innerHTML = [
+      '<pre class="_plain_x"><code class="language-ts">mermaid</code></pre>',
+      '<div><div class="_infostring_x">ts</div><pre class="_plain_x"><code>mermaid</code></pre></div>',
+    ].join('')
+    expect(findMermaidCodeBlocks(root)).toHaveLength(0)
+  })
+
+  it('skips claimed and empty banner blocks', () => {
+    const root = document.createElement('div')
+    const { mermaidPre } = seedBannerBlocks(root)
+    mermaidPre.setAttribute('data-mermaid-claimed', '1')
+    expect(findMermaidCodeBlocks(root)).toHaveLength(0)
+    mermaidPre.removeAttribute('data-mermaid-claimed')
+    mermaidPre.querySelector('code')!.textContent = '   '
+    expect(findMermaidCodeBlocks(root)).toHaveLength(0)
+  })
+
+  it('ignores a label with no pre in its climb budget', () => {
+    const root = document.createElement('div')
+    root.innerHTML = '<div><div class="_infostring_x">mermaid</div><span>no block here</span></div>'
+    expect(findMermaidCodeBlocks(root)).toHaveLength(0)
+  })
+})
+
+describe('enhanceMermaidBlocks shell banner shape (issue #451)', () => {
+  it('renders the banner block and restores it when the render fails', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const { mermaidPre, tsPre } = seedBannerBlocks(root)
+    const fake = fakeMermaid((source) => `<svg data-src="${source}"></svg>`)
+    try {
+      await enhanceMermaidBlocks(root, { className: 'mm', theme: 'default' })
+      // Only the mermaid banner block renders; the ts block stays code.
+      expect(fake.render).toHaveBeenCalledTimes(1)
+      expect(root.querySelectorAll('[data-mermaid-state="done"]')).toHaveLength(1)
+      expect(mermaidPre.style.display).toBe('none')
+      expect(tsPre.style.display).not.toBe('none')
+    } finally {
+      fake.restore()
+      root.remove()
+    }
+  })
+})
+
 describe('enhanceMermaidBlocks', () => {
   it('renders containers for both shapes and hides the source blocks', async () => {
     const root = document.createElement('div')


### PR DESCRIPTION
## 摘要（Summary）

Closes #451

修复 #451。聊天区 ```` ```mermaid ```` 围栏始终显示为原始代码：shell 会话渲染器把语言信息放在代码块横幅的 `infostring` 标签里，`pre/code` 上没有 `language-mermaid` class，而 `findMermaidCodeBlocks` 只匹配 `pre.language-mermaid, code.language-mermaid`，永远匹配不到 transcript。本 PR 给块发现加一条标签匹配路径（`infostring` / `language-*` 标签文本为 mermaid 时，限深向上爬取最近的 `pre`），与既有两种 class 形态并存；`pre/code` 元素被排除在标签匹配外，内容恰好是 "mermaid" 的高亮代码块不会被误认。根因已对照线上 shell bundle 源码核实（`_infostring_*` 横幅 + 无 class 的 `_plain_*` pre）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [x] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git checkout -b <branch> origin/main
```

（分支直接基于 origin/main 最新提交 b391cc6 创建。）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

Lingma

使用的编码 Agent 工具：

Lingma（Qoder IDE）

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本 PR 未新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符（已按 CI 同款码点范围扫描）。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改 README：修复恢复的是 README 已声明的既有能力，文档无需变更；`pnpm docs:check` 仍通过）

## 贡献者版权声明（Contributor Copyright）

不声明，维持现有版权归属。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
node scripts/runtime-deps-check.mjs
pnpm --filter @linxin666/dsh-client-ui-aionui-panel build
git diff --check
```

结果摘要：

- `pnpm typecheck`：全仓通过。
- `pnpm test`：全仓通过；`tests/mermaid.spec.ts` 22 用例全绿（新增 7 个：shell 横幅形态发现、旧版 language-* 标签形态、大小写不敏感、内容恰为 "mermaid" 的误报防护、已认领/空块跳过、无邻近 pre 的孤立标签、横幅形态端到端渲染且其他语言保持代码）。fixture 类名取自线上 shell bundle 的真实哈希输出（`_block_178r4_4` / `_infostring_178r4_42` / `_plain_178r4_94` 等）。
- `pnpm test:scripts`：通过。
- `pnpm docs:check`：`verify-docs: all documentation gates passed`。
- `node scripts/runtime-deps-check.mjs`：`all 24 scanned packages pass`。
- 受影响包 build 通过；`git diff --check` 无空白问题。

## 用户可见变更证据（Local Feature Evidence）

证据：

演示 harness 使用**线上 shell bundle 的真实横幅标记**（哈希类名原样复制）+ 本分支源码 esbuild 打包的 `findMermaidCodeBlocks` / `enhanceMermaidBlocks` + 包内 vendored `lib/assets/mermaid.min.js`。图中 assistant 消息含两个围栏：mermaid 块被渲染为 SVG 流程图（源 pre 隐藏），ts 块保持原始代码不受影响；DOM 实测 `data-mermaid-state="done"` 仅出现在 mermaid 块。

证据图片仅托管在贡献者 fork 的 `pr-451-evidence` 分支（不合入上游）：

![chat mermaid fix evidence](https://github.com/isdoge/dsh-web-ui/raw/pr-451-evidence/docs/pr-evidence/chat-mermaid-fix-451.png)

说明：真实 GUI 端到端验证需要向会话发送消息（需模型配置），本修复的块发现与渲染管线已被上述真实标记的 jsdom 用例与演示完整覆盖；欢迎维护者在装有本分支的环境中直接发 ```` ```mermaid ```` 消息复核。
