### PR TITLE
fix(aionui-panel): match shell CodeBlock infostring banner for chat mermaid (#451)

### DIFF
--- a/packages/dsh-aionui-panel/src/client/preview/mermaid.ts
+++ b/packages/dsh-aionui-panel/src/client/preview/mermaid.ts
@@ -162,22 +162,36 @@ export function sanitizeSvg(svg: string): string {
 
 /**
  * Collect the still-unclaimed fenced mermaid code blocks under one scope.
- * Both shapes are found: the panel renderer's `pre.language-mermaid` and
- * the chat renderer's `pre > code.language-mermaid` (the claim always
- * targets the <pre>). Empty blocks and blocks another driver already
- * claimed are skipped. Pure (DOM-read only) so tests can drive it in jsdom.
+ * Two shapes are found (the claim always targets the <pre>):
+ * 1. the panel markdown renderer's `pre.language-mermaid` and the legacy
+ *    chat shape `pre > code.language-mermaid`;
+ * 2. the official shell CodeBlock shape (`@deepseek-ai/dsh-client-ui-primitives`):
+ *    the fence language survives only as the info-string banner text
+ *    (`[class*="infostring"]` inside a `.md-code-block` wrapper), and
+ *    because shiki has no mermaid grammar the body renders as a plain
+ *    `<pre>` with no `language-*` class — so the block is recognized
+ *    through its banner (issue #451).
+ * Empty blocks and blocks another driver already claimed are skipped.
+ * Pure (DOM-read only) so tests can drive it in jsdom.
  */
 export function findMermaidCodeBlocks(scope: ParentNode): HTMLPreElement[] {
   const found: HTMLPreElement[] = []
   const seen = new Set<Element>()
-  for (const el of Array.from(scope.querySelectorAll('pre.language-mermaid, code.language-mermaid'))) {
-    const pre = el instanceof HTMLPreElement ? el : el.parentElement
-    if (pre === null || !(pre instanceof HTMLPreElement)) continue
-    if (seen.has(pre)) continue
+  const consider = (pre: Element | null): void => {
+    if (pre === null || !(pre instanceof HTMLPreElement)) return
+    if (seen.has(pre) || pre.hasAttribute(DATA_CLAIMED)) return
+    if ((pre.textContent ?? '').trim() === '') return
     seen.add(pre)
-    if (pre.hasAttribute(DATA_CLAIMED)) continue
-    if ((pre.textContent ?? '').trim() === '') continue
     found.push(pre)
+  }
+  // Shape 1: language class on the pre/code (panel markdown, legacy chat).
+  for (const el of Array.from(scope.querySelectorAll('pre.language-mermaid, code.language-mermaid'))) {
+    consider(el instanceof HTMLPreElement ? el : el.parentElement)
+  }
+  // Shape 2: shell CodeBlock — resolve the info-string banner to its <pre>.
+  for (const info of Array.from(scope.querySelectorAll<HTMLElement>('[class*="infostring"]'))) {
+    if ((info.textContent ?? '').trim().toLowerCase() !== 'mermaid') continue
+    consider(info.closest('.md-code-block')?.querySelector('pre') ?? null)
   }
   return found
 }

--- a/packages/dsh-aionui-panel/tests/mermaid.spec.ts
+++ b/packages/dsh-aionui-panel/tests/mermaid.spec.ts
@@ -44,6 +44,28 @@ function seedBlocks(root: HTMLElement): { panelPre: HTMLPreElement; chatPre: HTM
   return { panelPre: pres[0] as HTMLPreElement, chatPre: pres[1] as HTMLPreElement }
 }
 
+/**
+ * One shell CodeBlock shape (official `@deepseek-ai/dsh-client-ui-primitives`
+ * markup): a `.md-code-block` wrapper whose language survives only as the
+ * info-string banner text; shiki has no mermaid grammar, so the body is a
+ * plain `<pre>` without any `language-*` class (issue #451).
+ */
+function seedShellBlock(root: HTMLElement, lang = 'mermaid', code = 'gitGraph\n  commit'): { shellPre: HTMLPreElement; info: HTMLElement } {
+  const block = document.createElement('div')
+  block.className = '_block_178r4_4 md-code-block'
+  block.innerHTML = [
+    '<div class="_bannerWrap_178r4_21"><div class="_banner_178r4_21">',
+    `<div class="_infostring_178r4_42">${lang}</div>`,
+    '<div class="_action_178r4_53"><button type="button">复制代码</button></div>',
+    '</div></div>',
+    `<pre class="_plain_178r4_94"><code>${code}</code></pre>`,
+  ].join('')
+  root.appendChild(block)
+  const shellPre = block.querySelector('pre') as HTMLPreElement
+  const info = block.querySelector('[class*="infostring"]') as HTMLElement
+  return { shellPre, info }
+}
+
 describe('findMermaidCodeBlocks', () => {
   it('finds both renderer shapes, skips empty and non-mermaid blocks', () => {
     const root = document.createElement('div')
@@ -56,6 +78,24 @@ describe('findMermaidCodeBlocks', () => {
     const root = document.createElement('div')
     const { panelPre } = seedBlocks(root)
     panelPre.setAttribute('data-mermaid-claimed', '1')
+    expect(findMermaidCodeBlocks(root)).toHaveLength(1)
+  })
+
+  it('finds the shell CodeBlock shape through its info-string banner', () => {
+    const root = document.createElement('div')
+    const { shellPre } = seedShellBlock(root)
+    seedShellBlock(root, 'python', 'print(1)')
+    const found = findMermaidCodeBlocks(root)
+    expect(found).toHaveLength(1)
+    expect(found[0]).toBe(shellPre)
+  })
+
+  it('matches the shell banner case-insensitively and skips claimed shell blocks', () => {
+    const root = document.createElement('div')
+    const { shellPre } = seedShellBlock(root, 'Mermaid')
+    shellPre.setAttribute('data-mermaid-claimed', '1')
+    expect(findMermaidCodeBlocks(root)).toHaveLength(0)
+    shellPre.removeAttribute('data-mermaid-claimed')
     expect(findMermaidCodeBlocks(root)).toHaveLength(1)
   })
 })
@@ -80,6 +120,27 @@ describe('enhanceMermaidBlocks', () => {
       await enhanceMermaidBlocks(root, { className: 'mm', theme: 'default' })
       expect(fake.render).toHaveBeenCalledTimes(2)
       expect(fake.initialize).toHaveBeenCalledTimes(2)
+    } finally {
+      fake.restore()
+      root.remove()
+    }
+  })
+
+  it('renders the shell CodeBlock shape and hides its plain pre', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const { shellPre, info } = seedShellBlock(root)
+    const fake = fakeMermaid((source) => `<svg data-src="${source}"></svg>`)
+    try {
+      await enhanceMermaidBlocks(root, { className: 'mm', theme: 'default' })
+      const containers = Array.from(root.querySelectorAll('[data-mermaid-state="done"]'))
+      expect(containers).toHaveLength(1)
+      expect(fake.render).toHaveBeenCalledTimes(1)
+      expect(fake.render.mock.calls[0]![1]).toBe('gitGraph\n  commit')
+      expect(shellPre.style.display).toBe('none')
+      expect(info.textContent?.trim()).toBe('mermaid')
+      // The banner and copy affordance survive; only the source pre hides.
+      expect(root.querySelector('.md-code-block')).not.toBeNull()
     } finally {
       fake.restore()
       root.remove()


### PR DESCRIPTION
## 摘要（Summary）

聊天区 ```mermaid 围栏从未渲染（#451）。根因（本机 rc.7 shell bundle 实测）：官方 shell 的 CodeBlock（@deepseek-ai/dsh-client-ui-primitives）把围栏语言只保留在 info-string banner（`[class*="infostring"]`，文本即语言名），且 shiki 没有 mermaid 语法，正文渲染为无任何 `language-*` class 的 plain `<pre>`——原选择器 `pre.language-mermaid, code.language-mermaid` 永远匹配不到。本 PR 在 `findMermaidCodeBlocks` 增加第二遍匹配：按 banner 文本识别 mermaid，再经稳定的 `.md-code-block` 包装类解析出对应 `<pre>`，与既有 DATA_CLAIMED / 空块 / 去重语义一致。

## 涉及包（Affected Packages）

- [x] 右侧面板 `packages/dsh-aionui-panel`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main   # 基线 origin/main @ b391cc6c
```

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek（deepseek-v4-pro）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本次未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test
pnpm typecheck
```

结果摘要：包测试 294/294 通过，其中新增 3 个回归测试（shell 形状发现、banner 大小写与 claimed 跳过、渲染并隐藏 plain pre）；夹具 DOM 与本机安装的 rc.7 shell（dsh-web-frontend 0.1.0-rc.7 / dsh-client-ui-primitives 0.1.0-rc.7）实际输出的结构一致；全仓 typecheck 通过；全量 test / test:scripts / docs:check / runtime-deps:check 由 CI 复核。

## 用户可见变更证据（Local Feature Evidence）

证据：jsdom 回归测试以真实 shell 输出结构为夹具断言发现与渲染路径；本次未运行图形界面实测，未附截图。
