### PR TITLE
fix(aionui-panel): render chat mermaid blocks from shell code-block DOM (#451)

### DIFF
--- a/packages/dsh-aionui-panel/src/client/chat/mermaid-chat.tsx
+++ b/packages/dsh-aionui-panel/src/client/chat/mermaid-chat.tsx
@@ -1,7 +1,8 @@
 /**
- * Chat-transcript mermaid enhancement: the core conversation renderer emits
- * fenced code as `pre > code.language-mermaid`, and the shell has no slot
- * for message-body post-processing — so this component rides the
+ * Chat-transcript mermaid enhancement: the shell conversation renderer
+ * emits fenced code as `div.md-code-block` with the language in a banner
+ * infostring element (no language class on pre/code), and the shell has no
+ * slot for message-body post-processing — so this component rides the
  * conversation input dock as a zero-render sentinel and observes the
  * document for mermaid blocks the transcript mounts. Blocks inside the
  * preview panel's own subtree are excluded (each surface owns its blocks).
@@ -46,6 +47,15 @@ export function enhanceScopesFor(records: MutationRecord[]): Element[] {
   return Array.from(scopes)
 }
 
+/**
+ * Chat-side ownership guard: blocks inside the preview panel's own subtrees
+ * (the markdown viewer scope marker, or the preview column hosting the code
+ * viewers) belong to the panel drivers, never to the transcript enhancer.
+ */
+export function isPanelOwnedPre(pre: HTMLPreElement): boolean {
+  return pre.closest(`[${DATA_MD_SCOPE}], [data-aionui-preview-col]`) !== null
+}
+
 /** Hidden sentinel: renders nothing, owns the transcript observer. */
 export function MermaidChatEnhancer(): JSX.Element | null {
   useEffect(() => {
@@ -66,7 +76,7 @@ export function MermaidChatEnhancer(): JSX.Element | null {
         void enhanceMermaidBlocks(document.body, {
           className: previewCss.mermaidBlock,
           theme: mermaidTheme(shellIsDark()),
-          skip: (pre) => pre.closest(`[${DATA_MD_SCOPE}]`) !== null,
+          skip: isPanelOwnedPre,
         })
         return
       }
@@ -74,7 +84,7 @@ export function MermaidChatEnhancer(): JSX.Element | null {
         void enhanceMermaidBlocks(scope, {
           className: previewCss.mermaidBlock,
           theme: mermaidTheme(shellIsDark()),
-          skip: (pre) => pre.closest(`[${DATA_MD_SCOPE}]`) !== null,
+          skip: isPanelOwnedPre,
         })
       }
     }

--- a/packages/dsh-aionui-panel/src/client/index.ts
+++ b/packages/dsh-aionui-panel/src/client/index.ts
@@ -103,7 +103,8 @@ export function apply(ctx: ClientContext): void {
 
   // Transcript mermaid enhancement rides the same dock as a zero-render
   // sentinel: the shell has no message-body slot, so the sentinel observes
-  // the document for the chat renderer's `code.language-mermaid` blocks.
+  // the document for the chat renderer's mermaid blocks (shell shape:
+  // div.md-code-block with the language in its banner infostring).
   ctx.inject(['slots'], (scope: ClientContext) => {
     scope.slots.inject('conversation.input.dock', () =>
       scope.slots.register({

--- a/packages/dsh-aionui-panel/src/client/preview/mermaid.ts
+++ b/packages/dsh-aionui-panel/src/client/preview/mermaid.ts
@@ -162,22 +162,38 @@ export function sanitizeSvg(svg: string): string {
 
 /**
  * Collect the still-unclaimed fenced mermaid code blocks under one scope.
- * Both shapes are found: the panel renderer's `pre.language-mermaid` and
- * the chat renderer's `pre > code.language-mermaid` (the claim always
- * targets the <pre>). Empty blocks and blocks another driver already
- * claimed are skipped. Pure (DOM-read only) so tests can drive it in jsdom.
+ * Three shapes are found:
+ * - the panel renderer's `pre.language-mermaid`;
+ * - `pre > code.language-mermaid` (kept for older shells);
+ * - the shell chat renderer's `div.md-code-block`: its `<pre>` carries
+ *   no language class, so the banner infostring (`[class*="_infostring_"]`,
+ *   text exactly `mermaid`) is the only anchor. Mid-stream fences render
+ *   with an empty infostring and are skipped until the fence closes.
+ * The claim always targets the <pre>. Empty blocks and blocks another
+ * driver already claimed are skipped. Pure (DOM-read only) so tests can
+ * drive it in jsdom.
  */
 export function findMermaidCodeBlocks(scope: ParentNode): HTMLPreElement[] {
   const found: HTMLPreElement[] = []
   const seen = new Set<Element>()
-  for (const el of Array.from(scope.querySelectorAll('pre.language-mermaid, code.language-mermaid'))) {
-    const pre = el instanceof HTMLPreElement ? el : el.parentElement
-    if (pre === null || !(pre instanceof HTMLPreElement)) continue
-    if (seen.has(pre)) continue
+  const push = (pre: Element | null): void => {
+    if (pre === null || !(pre instanceof HTMLPreElement)) return
+    if (seen.has(pre)) return
     seen.add(pre)
-    if (pre.hasAttribute(DATA_CLAIMED)) continue
-    if ((pre.textContent ?? '').trim() === '') continue
+    if (pre.hasAttribute(DATA_CLAIMED)) return
+    if ((pre.textContent ?? '').trim() === '') return
     found.push(pre)
+  }
+  for (const el of Array.from(scope.querySelectorAll('pre.language-mermaid, code.language-mermaid'))) {
+    push(el instanceof HTMLPreElement ? el : el.parentElement)
+  }
+  const shellBlocks: Element[] = []
+  if (scope instanceof Element && scope.matches('div.md-code-block')) shellBlocks.push(scope)
+  shellBlocks.push(...Array.from(scope.querySelectorAll('div.md-code-block')))
+  for (const block of shellBlocks) {
+    const infostring = block.querySelector('[class*="_infostring_"]')
+    if ((infostring?.textContent ?? '').trim() !== 'mermaid') continue
+    push(block.querySelector('pre'))
   }
   return found
 }

--- a/packages/dsh-aionui-panel/tests/mermaid-chat.spec.ts
+++ b/packages/dsh-aionui-panel/tests/mermaid-chat.spec.ts
@@ -4,7 +4,7 @@
  * Pure against the exported helper plus real MutationRecord construction.
  */
 import { describe, expect, it } from 'vitest'
-import { enhanceScopesFor } from '../src/client/chat/mermaid-chat.tsx'
+import { enhanceScopesFor, isPanelOwnedPre } from '../src/client/chat/mermaid-chat.tsx'
 
 /** Record a single-type mutation by hand with the given added/removed lists. */
 function record(
@@ -84,5 +84,31 @@ describe('enhanceScopesFor', () => {
     const scopes = enhanceScopesFor([rec1, rec2])
     expect(scopes).toHaveLength(1)
     expect(scopes[0]).toBe(parent)
+  })
+})
+
+describe('isPanelOwnedPre', () => {
+  it('owns blocks inside the markdown scope marker or the preview column only', () => {
+    const chat = document.createElement('pre')
+    document.body.appendChild(chat)
+    expect(isPanelOwnedPre(chat)).toBe(false)
+
+    const mdScope = document.createElement('div')
+    mdScope.setAttribute('data-aionui-md-scope', '1')
+    const mdPre = document.createElement('pre')
+    mdScope.appendChild(mdPre)
+    document.body.appendChild(mdScope)
+    expect(isPanelOwnedPre(mdPre)).toBe(true)
+
+    const col = document.createElement('div')
+    col.setAttribute('data-aionui-preview-col', '')
+    const codePre = document.createElement('pre')
+    col.appendChild(codePre)
+    document.body.appendChild(col)
+    expect(isPanelOwnedPre(codePre)).toBe(true)
+
+    chat.remove()
+    mdScope.remove()
+    col.remove()
   })
 })

--- a/packages/dsh-aionui-panel/tests/mermaid.spec.ts
+++ b/packages/dsh-aionui-panel/tests/mermaid.spec.ts
@@ -44,6 +44,21 @@ function seedBlocks(root: HTMLElement): { panelPre: HTMLPreElement; chatPre: HTM
   return { panelPre: pres[0] as HTMLPreElement, chatPre: pres[1] as HTMLPreElement }
 }
 
+/** The shell chat renderer shape: div.md-code-block + banner infostring + plain pre (no language class). */
+function seedShellChatBlock(root: HTMLElement, lang: string, code = 'gitGraph\ncommit'): HTMLPreElement {
+  const block = document.createElement('div')
+  block.className = '_block_178r4_4 md-code-block'
+  block.innerHTML = [
+    '<div class="_bannerWrap_178r4_8"><div class="_banner_178r4_16">',
+    `<div class="_infostring_178r4_42">${lang}</div>`,
+    '<button type="button">copy</button>',
+    '</div></div>',
+    `<pre class="_plain_178r4_94"><code>${code}</code></pre>`,
+  ].join('')
+  root.appendChild(block)
+  return block.querySelector('pre') as HTMLPreElement
+}
+
 describe('findMermaidCodeBlocks', () => {
   it('finds both renderer shapes, skips empty and non-mermaid blocks', () => {
     const root = document.createElement('div')
@@ -57,6 +72,40 @@ describe('findMermaidCodeBlocks', () => {
     const { panelPre } = seedBlocks(root)
     panelPre.setAttribute('data-mermaid-claimed', '1')
     expect(findMermaidCodeBlocks(root)).toHaveLength(1)
+  })
+
+  it('finds the shell chat shape by its banner infostring (no language class on pre/code)', () => {
+    const root = document.createElement('div')
+    const pre = seedShellChatBlock(root, 'mermaid')
+    const found = findMermaidCodeBlocks(root)
+    expect(found).toEqual([pre])
+  })
+
+  it('skips shell blocks whose infostring is not mermaid or still empty (streaming)', () => {
+    const root = document.createElement('div')
+    seedShellChatBlock(root, 'typescript')
+    seedShellChatBlock(root, '')
+    expect(findMermaidCodeBlocks(root)).toHaveLength(0)
+  })
+
+  it('skips shell blocks with empty code text or already claimed', () => {
+    const root = document.createElement('div')
+    seedShellChatBlock(root, 'mermaid', '   ')
+    const claimed = seedShellChatBlock(root, 'mermaid')
+    claimed.setAttribute('data-mermaid-claimed', '1')
+    expect(findMermaidCodeBlocks(root)).toHaveLength(0)
+  })
+
+  it('matches the shell block when the scope is the block element itself', () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const pre = seedShellChatBlock(root, 'mermaid')
+    const block = pre.closest('div.md-code-block') as Element
+    try {
+      expect(findMermaidCodeBlocks(block)).toEqual([pre])
+    } finally {
+      root.remove()
+    }
   })
 })
 
@@ -80,6 +129,26 @@ describe('enhanceMermaidBlocks', () => {
       await enhanceMermaidBlocks(root, { className: 'mm', theme: 'default' })
       expect(fake.render).toHaveBeenCalledTimes(2)
       expect(fake.initialize).toHaveBeenCalledTimes(2)
+    } finally {
+      fake.restore()
+      root.remove()
+    }
+  })
+
+  it('renders the shell chat shape and keeps its banner intact', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const pre = seedShellChatBlock(root, 'mermaid')
+    const fake = fakeMermaid((source) => `<svg data-src="${source}"></svg>`)
+    try {
+      await enhanceMermaidBlocks(root, { className: 'mm', theme: 'default' })
+      expect(fake.render).toHaveBeenCalledTimes(1)
+      const container = root.querySelector('[data-mermaid-state="done"]')
+      expect(container).not.toBeNull()
+      expect(pre.style.display).toBe('none')
+      // The banner (infostring + copy button) stays visible above the diagram.
+      expect(root.querySelector('[class*="_infostring_"]')?.textContent).toBe('mermaid')
+      expect(container!.previousSibling).toBe(pre)
     } finally {
       fake.restore()
       root.remove()


### PR DESCRIPTION
> 提 PR 前请阅读 CONTRIBUTING.md 与 AGENTS.md；提交信息用 Conventional Commits，禁止 emoji。

## 摘要（Summary）

修复 #451：聊天区 ```mermaid 代码块从不渲染。根因是 enhancer 的选择器（`pre.language-mermaid, code.language-mermaid`）对 shell 真实 DOM 永不命中——rc.7 shell 对非空围栏渲染 `div.md-code-block` 组件，语言只出现在 banner 的 infostring 元素（`[class*="_infostring_"]`）文本里，pre/code 上没有 language class；空围栏唯一会输出 `code.language-*` 的分支又恰好被空块跳过。本 PR 在 `findMermaidCodeBlocks` 增加 shell 形状分支：扫描 `div.md-code-block`、校验 infostring 文本恰为 `mermaid`、认领块内 `pre`（沿用既有 claim/隐藏/失败恢复机制，banner 与复制按钮保留）。同时修正两处注释中固化的错误 DOM 假设，并把聊天驱动的 skip 谓词扩展为同时排除预览列（`[data-aionui-preview-col]`），避免误认领面板代码查看器里的 *.mermaid 文件块。

## 涉及包（Affected Packages）

- [x] 右侧面板 `packages/dsh-aionui-panel`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch origin && git worktree add ... origin/main`（基线 539d43aa，含 #442/#437/#448）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（k3）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README：README 仅描述预览面板 mermaid，行为不变）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-aionui-panel test   # 30 文件 299 用例全过
pnpm --filter @linxin666/dsh-client-ui-aionui-panel exec vitest run tests/mermaid.spec.ts tests/mermaid-chat.spec.ts  # 26 过
pnpm typecheck && pnpm docs:check && pnpm test             # 全仓门禁全绿
```

结果摘要：
- 新增 6 个 shell 形状用例（infostring 命中 / 非 mermaid 跳过 / 流式空 infostring 跳过 / 空块与已认领跳过 / scope 即块自身 / 端到端渲染且 banner 保留）+ 1 个面板归属谓词用例。
- 阴性对照：仅 stash `src/` 改动后新用例 4 个失败，恢复后全绿，证明测试确实咬住修复。
- shell DOM 契约证据：本机安装的 dsh-web-frontend rc.7 bundle（`index-C-1AiF3k.js`）中 `gc` 组件渲染 `div._block_178r4_4.md-code-block` + `div._infostring_178r4_42` 纯文本 + `pre._plain_178r4_94`；仓库 gallery/official-facade.js 快照含同一 178r4 哈希佐证。

## 用户可见变更证据（Local Feature Evidence）

证据：jsdom 端到端用例断言聊天形状块渲染为 SVG 容器、源 pre 隐藏、banner 保留（`tests/mermaid.spec.ts` "renders the shell chat shape and keeps its banner intact"）；真实 shell DOM 形状取自本机 rc.7 客户端 bundle 反查（见上）。真实 GUI 端到端截图在发版前由维护者补验：该修复只扩展 finder 的匹配形状，渲染/隐藏/失败恢复/主题切换均复用既有已测路径。