### PR TITLE
fix(dsh-skill-explorer): Escape-safe form dismiss and last-good list refresh (#194)

### DIFF
--- a/packages/dsh-skill-explorer/src/client/SkillPanel.tsx
+++ b/packages/dsh-skill-explorer/src/client/SkillPanel.tsx
@@ -127,12 +127,16 @@ function ListTab({ api, refreshTick, onCwd }: { api: SkillApi; refreshTick: numb
 
   useEffect(() => { void load() }, [api, refreshTick])
 
-  if (error !== undefined) return <div className={css.status}>{error}</div>
+  // Last-good policy: a failed refresh keeps the previous payload visible and
+  // reports the error inline; the error state replaces the list only when
+  // there is nothing to fall back to.
+  if (error !== undefined && payload === undefined) return <div className={css.status}>{error}</div>
   if (payload === undefined) return <div className={css.status}>{tt('list.loading')}</div>
   if (payload.groups.length === 0) return <div className={css.status}>{tt('list.empty')}</div>
 
   return (
     <div>
+      {error !== undefined && <p className={css.feedback}>{error}</p>}
       {payload.groups.map((group) => {
         const groupKey = `group.${group.key}` as keyof typeof zh
         const hintKey = `groupHint.${group.key}` as keyof typeof zh
@@ -228,7 +232,12 @@ export function SkillPanel({ api, onClose }: SkillPanelProps): React.JSX.Element
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent): void => {
-      if (event.key === 'Escape') onClose()
+      if (event.key !== 'Escape') return
+      // Typing in the create form must not close the panel: Escape there is
+      // an editing gesture, not a dismiss gesture.
+      const target = event.target as HTMLElement | null
+      if (target instanceof HTMLElement && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT' || target.isContentEditable)) return
+      onClose()
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)

--- a/packages/dsh-skill-explorer/tests/panel.spec.tsx
+++ b/packages/dsh-skill-explorer/tests/panel.spec.tsx
@@ -1,0 +1,128 @@
+/**
+ * Panel interaction tests (jsdom): Escape-dismiss semantics around form
+ * fields, and the last-good list policy when a refresh fails.
+ */
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SkillPanel } from '../src/client/SkillPanel.tsx'
+import type { ListPayload } from '../src/client/api.ts'
+
+/** Minimal fake api: list is controllable per call, other methods never used here. */
+function fakeApi(listResults: Array<() => Promise<ListPayload>>) {
+  let calls = 0
+  return {
+    calls: () => calls,
+    list: async () => { const fn = listResults[Math.min(calls, listResults.length - 1)]; calls += 1; return fn() },
+    setEnabled: async () => ({ name: '', enabled: true }),
+    remove: async () => ({ ok: true as const, name: '', moved: '' }),
+    create: async () => { throw new Error('unused') },
+  }
+}
+
+const payload = (names: string[]): ListPayload => ({
+  cwd: '/work',
+  projectRoots: [],
+  complete: true,
+  groups: [{ key: 'user-dsh', title: 'User skills', hint: '', skills: names.map((name) => ({
+    name, description: 'desc', provider: 'filesystem', level: 'user-dsh', path: '/work/' + name + '/SKILL.md',
+    modelInvocable: true, userInvocable: true,
+  })) }],
+})
+
+function mount(api: ReturnType<typeof fakeApi>, onClose: () => void): { container: HTMLDivElement; dispose: () => void } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  root.render(<SkillPanel api={api as never} onClose={onClose} />)
+  return {
+    container,
+    dispose: () => {
+      root.unmount()
+      container.remove()
+    },
+  }
+}
+
+async function flush(): Promise<void> {
+  await act(async () => { await Promise.resolve() })
+}
+
+describe('SkillPanel escape handling', () => {
+  afterEach(() => { document.body.innerHTML = '' })
+
+  it('Escape dismisses the panel when not typing in a form field', async () => {
+    const api = fakeApi([async () => payload(['demo-skill'])])
+    let closed = 0
+    const mount_ = mount(api, () => { closed += 1 })
+    await flush()
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+    expect(closed).toBe(1)
+    mount_.dispose()
+  })
+
+  it('Escape while typing in the create form keeps the panel open', async () => {
+    const api = fakeApi([async () => payload(['demo-skill'])])
+    let closed = 0
+    const mount_ = mount(api, () => { closed += 1 })
+    await flush()
+    // Switch to the create tab and focus the name input.
+    await act(async () => {
+      const tab = Array.from(mount_.container.querySelectorAll('button')).find((b) => b.textContent?.trim() === '创建')
+      tab?.click()
+    })
+    const input = mount_.container.querySelector('input') as HTMLInputElement
+    input.focus()
+    expect(document.activeElement).toBe(input)
+    // Dispatch from the focused element so the event target is the input.
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+    expect(closed).toBe(0)
+    mount_.dispose()
+  })
+
+  it('Escape in a select keeps the panel open', async () => {
+    const api = fakeApi([async () => payload(['demo-skill'])])
+    let closed = 0
+    const mount_ = mount(api, () => { closed += 1 })
+    await flush()
+    await act(async () => {
+      const tab = Array.from(mount_.container.querySelectorAll('button')).find((b) => b.textContent?.trim() === '创建')
+      tab?.click()
+    })
+    const select = mount_.container.querySelector('select') as HTMLSelectElement
+    select.focus()
+    await act(async () => {
+      select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+    expect(closed).toBe(0)
+    mount_.dispose()
+  })
+})
+
+describe('SkillPanel last-good list policy', () => {
+  afterEach(() => { document.body.innerHTML = '' })
+
+  it('a failed refresh keeps the previous payload and shows an inline error', async () => {
+    const api = fakeApi([
+      async () => payload(['demo-skill']),
+      async () => { throw new Error('boom') },
+    ])
+    const mount_ = mount(api, () => {})
+    await flush()
+    expect(mount_.container.textContent).toContain('demo-skill')
+    // Trigger a refresh that will fail.
+    await act(async () => {
+      const refresh = Array.from(mount_.container.querySelectorAll('button')).find((b) => b.textContent?.trim() === '刷新')
+      refresh?.click()
+    })
+    await flush()
+    const text = mount_.container.textContent ?? ''
+    expect(text).toContain('demo-skill')
+    expect(text).toContain('boom')
+    mount_.dispose()
+  })
+})

--- a/packages/dsh-skill-explorer/vitest.setup.ts
+++ b/packages/dsh-skill-explorer/vitest.setup.ts
@@ -1,3 +1,8 @@
 // Vitest setup: jsdom environment already provides DOM globals; nothing
 // extra is needed for the skill-explorer test surface.
+//
+// React 18 act() requires the act-environment flag; without it every act call
+// in panel interaction tests warns (and the warning pollutes CI output).
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
 export {}


### PR DESCRIPTION
## 摘要（Summary）

跟进 dsh-skill-explorer 接入审查（issue #194 / PR #470 合并后）剩余的 UI nits：

- **Escape 误关面板**：在创建表单输入时按 Escape 现在不会关闭面板（input / textarea / select / contentEditable 视为编辑手势，不触发 dismiss）；
- **列表刷新失败丢数据**：刷新失败时保留上次成功数据并内联显示错误，仅在无任何数据时才整页显示错误态（last-good 策略）。

## 涉及包（Affected Packages）

- [x] 其他（请说明）: `packages/dsh-skill-explorer`（仅 client 面板 + 测试）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：修复与测试由 AI 产出，由维护者接受 / 审查。

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码。
- [x] 新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-skill-explorer typecheck
pnpm --filter @linxin666/dsh-client-ui-skill-explorer test   # 46/46（+4 面板交互用例）
pnpm --filter @linxin666/dsh-client-ui-skill-explorer build
pnpm typecheck && pnpm test && pnpm test:scripts
node scripts/verify-docs.mjs
node scripts/aggregate.mjs --check
node scripts/community-index --check
node scripts/sync-shared.mjs --check
node scripts/runtime-deps-check.mjs
```

结果摘要：

- 包级 typecheck / 46 用例 vitest / build 全绿；
- 全仓 typecheck、test、test:scripts、docs、aggregate、community、sync-shared、runtime-deps 全绿；
- 新增 `tests/panel.spec.tsx`（jsdom + react act）：Escape 非编辑态关闭、输入框/下拉框内 Escape 不关闭、刷新失败保留上次数据并内联报错。