### PR TITLE
fix(remote-web-ui): drop the status stream when the panel closes mid-issue

### DIFF
--- a/packages/dsh-remote-web-ui/src/client/RemoteEntry.tsx
+++ b/packages/dsh-remote-web-ui/src/client/RemoteEntry.tsx
@@ -57,6 +57,10 @@ export function RemoteEntry({ wide, useWorkspaces, t }: RemoteEntryProps) {
   useEffect(() => { stateRef.current = state }, [state])
   const [copied, setCopied] = useState(false)
   const eventSource = useRef<EventSource | undefined>(undefined)
+  // Generation counter for the open flow: closing (or re-opening) the panel
+  // bumps it, so an in-flight issue() that resolves after a close does not
+  // spawn a stray EventSource.
+  const openSeq = useRef(0)
 
   // The current workspace (the recent-workspace projection the shell's New
   // Session flow targets) — the deep-link target for the phone.
@@ -104,8 +108,13 @@ export function RemoteEntry({ wide, useWorkspaces, t }: RemoteEntryProps) {
   }, [workspaceId])
 
   const openPanel = useCallback(async (): Promise<void> => {
+    const seq = ++openSeq.current
     setOpen(true)
     const next = await mint()
+    // A close (or re-open) during the await invalidates this issue: skip the
+    // state write and the stream so a panel closed mid-mint neither leaks an
+    // EventSource nor resurrects a stale QR.
+    if (seq !== openSeq.current) return
     setState(next)
     // Live status: the desktop panel mirrors the pairing service state. The
     // stream makes sense in the ready state and on the lan-required banner —
@@ -143,6 +152,7 @@ export function RemoteEntry({ wide, useWorkspaces, t }: RemoteEntryProps) {
   }, [mint])
 
   const closePanel = useCallback(() => {
+    openSeq.current += 1
     closeEventSource()
     setOpen(false)
   }, [closeEventSource])

--- a/packages/dsh-remote-web-ui/tests/remote-entry.spec.tsx
+++ b/packages/dsh-remote-web-ui/tests/remote-entry.spec.tsx
@@ -203,6 +203,40 @@ describe('RemoteEntry', () => {
     expect(document.querySelector('[data-testid="remote-qr"]')).toBeNull()
   })
 
+  it('does not leak an EventSource when the panel is closed during the issue fetch', async () => {
+    let resolveIssue: ((r: Response) => void) | undefined
+    const fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/api/update/status') {
+        return Promise.resolve(new Response(JSON.stringify({ mode: 'npm', packages: [], outdated: false }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      return new Promise<Response>((resolve) => { resolveIssue = resolve })
+    })
+    vi.stubGlobal('fetch', fetch)
+    vi.stubGlobal('EventSource', FakeEventSource)
+    render(
+      <RemoteEntry
+        wide={true}
+        useSessions={neverHook}
+        useWorkspaces={(selector: (s: { recentWorkspaceId: string }) => unknown) => selector({ recentWorkspaceId: 'ws-1' })}
+        t={t}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Mobile remote control' }))
+    // The issue fetch is in flight; close the panel before it resolves.
+    fireEvent.click(screen.getByRole('button', { name: 'Close mobile remote control panel' }))
+    resolveIssue?.(new Response(JSON.stringify({
+      ok: true,
+      url: 'http://192.168.1.5:3080/m/?pair=tok-1',
+      token: 'tok-1',
+      expiresAt: Date.now() + 60_000,
+      lanAddresses: ['192.168.1.5'],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    // The stale issue continuation must not spawn a stream.
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(0))
+    expect(FakeEventSource.instances).toHaveLength(0)
+  })
+
   it('renders the address picker on multi-homed hosts and re-mints on switch', async () => {
     const { fetch } = mount({ ok: true, url: 'http://192.168.1.5:3080/m/?pair=tok-1', token: 'tok-1', expiresAt: Date.now() + 60_000, lanAddresses: ['192.168.1.5', '10.0.0.3'] })
     fireEvent.click(screen.getByRole('button', { name: 'Mobile remote control' }))


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-remote-web-ui` 配对面板在 issue 请求进行中关闭时泄漏 EventSource 的问题。

根因：`openPanel` 在 `await mint()` 之后才 `new EventSource('/api/pair/events')`，期间不复查面板是否仍打开；`closePanel` 调 `closeEventSource()` 时 `eventSource.current` 还是 `undefined`（空操作），导致 fetch 返回后才创建的 SSE 连接永远不关闭，泄漏到会话结束（且服务端配对监听也被持有）。

修复：引入「打开序号」generation counter——`openPanel` 在 `await` 前记录 `seq`，返回后若 `seq` 已变（期间关闭或重开）则直接 return（不写 state、不建流）；`closePanel` 递增序号使 in-flight 的 issue 失效。补一个测试锁定「issue 进行中关闭面板不产生流」。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-remote-web-ui test`：24 个测试文件 243 个用例全部通过（含新增 close-during-issue 1 个用例）。
- `pnpm --filter @linxin666/dsh-remote-web-ui typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：issue 请求进行中关闭面板后，不再遗留 `/api/pair/events` 的挂起连接）。
