### PR TITLE
fix(remote-web-ui): wire the registry probe timeout to fetch

### DIFF
--- a/packages/dsh-remote-web-ui/src/update.ts
+++ b/packages/dsh-remote-web-ui/src/update.ts
@@ -280,14 +280,14 @@ function familyUpdatePackages(
  */
 export async function fetchLatestVersion(
   name: string,
-  fetchImpl: (url: string) => Promise<{ ok: boolean; json(): Promise<unknown> }>,
+  fetchImpl: (url: string, init?: RequestInit) => Promise<{ ok: boolean; json(): Promise<unknown> }>,
   timeoutMs = 10_000,
 ): Promise<string | undefined> {
   try {
     const controller = new AbortController()
     const timer = setTimeout(() => { controller.abort() }, timeoutMs)
     try {
-      const response = await fetchImpl(NPM_REGISTRY + '/' + name.replace('/', '%2F') + '/latest')
+      const response = await fetchImpl(NPM_REGISTRY + '/' + name.replace('/', '%2F') + '/latest', { signal: controller.signal })
       if (!response.ok) return undefined
       const body = await response.json()
       if (typeof body !== 'object' || body === null) return undefined

--- a/packages/dsh-remote-web-ui/tests/update.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/update.spec.ts
@@ -11,6 +11,7 @@ import {
   checkUpdates,
   compareVersions,
   familyChildren,
+  fetchLatestVersion,
   findProfile,
   isLinkedSpec,
   parseSemver,
@@ -797,5 +798,27 @@ describe("runUpdateVerified", () => {
     expect(result.ok).toBe(false)
     expect(result.errorCode).toBe("verify-failed")
     expect(result.exitCode).toBe(0)
+  })
+})
+
+describe('fetchLatestVersion', () => {
+  it('passes the abort signal to the fetch implementation', async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => ({
+      ok: true,
+      json: async () => ({ version: '1.2.3' }),
+    }))
+    const version = await fetchLatestVersion('@linxin666/dsh-remote-web-ui', fetchImpl)
+    expect(version).toBe('1.2.3')
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit | undefined]
+    expect(String(url)).toContain('/latest')
+    expect(init?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('returns undefined when the registry probe rejects', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('network down')
+    })
+    await expect(fetchLatestVersion('@linxin666/dsh-remote-web-ui', fetchImpl)).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-remote-web-ui` 的 npm 注册表探测超时失效的问题。

根因：`fetchLatestVersion` 创建了 `AbortController` 并在 `timeoutMs` 后 `abort()`，但调用 `fetchImpl` 时只传 URL、**没有把 `controller.signal` 传进去**，导致 10s 探测超时形同虚设——注册表连接挂起时，`checkUpdates`（以及 `runUpdateVerified` 的跑后校验）会阻塞到 fetch 自身的默认超时（Node/undici 约 300s）而不是按预期 ~10s 返回 `registry-unreachable`。

修复：把 `fetchImpl` 签名扩展为接收可选的 `RequestInit`，调用时传入 `{ signal: controller.signal }`。补两个测试：一个断言 signal 确实传到了 fetch，一个覆盖探测 reject 返回 undefined。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-remote-web-ui test`：24 个测试文件 244 个用例全部通过（含新增 fetchLatestVersion 2 个用例）。
- `pnpm --filter @linxin666/dsh-remote-web-ui typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：注册表不可达时更新状态检查按 ~10s 返回而非挂起数分钟）。
