### PR TITLE
fix(remote-web-ui): re-run the workspace roster fetch on retry

### DIFF
--- a/packages/dsh-remote-web-ui/src/mobile/views/WorkspaceView.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/WorkspaceView.tsx
@@ -27,6 +27,8 @@ export interface WorkspaceViewProps {
 export function WorkspaceView({ initialWorkspaceId, onPick }: WorkspaceViewProps) {
   const [items, setItems] = useState<WorkspaceRow[] | undefined>(undefined)
   const [error, setError] = useState<string | undefined>(undefined)
+  // Bumped by the retry button to re-run the roster fetch effect.
+  const [reload, setReload] = useState(0)
 
   useEffect(() => {
     let cancelled = false
@@ -48,7 +50,7 @@ export function WorkspaceView({ initialWorkspaceId, onPick }: WorkspaceViewProps
       },
     )
     return () => { cancelled = true }
-  }, [initialWorkspaceId, onPick])
+  }, [initialWorkspaceId, onPick, reload])
 
   if (error !== undefined) {
     return (
@@ -59,7 +61,7 @@ export function WorkspaceView({ initialWorkspaceId, onPick }: WorkspaceViewProps
         </header>
         <div className="mobile-empty">
           <p className="mobile-error">加载失败：{error}</p>
-          <button type="button" className="mobile-button" onClick={() => { setError(undefined); setItems(undefined) }}>
+          <button type="button" className="mobile-button" onClick={() => { setError(undefined); setItems(undefined); setReload(n => n + 1) }}>
             重试
           </button>
         </div>

--- a/packages/dsh-remote-web-ui/tests/workspace-view.spec.tsx
+++ b/packages/dsh-remote-web-ui/tests/workspace-view.spec.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+/** Workspace roster retry: the retry button must re-run the roster fetch. */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { WorkspaceView } from '../src/mobile/views/WorkspaceView.tsx'
+import { listWorkspaces } from '../src/mobile/api.ts'
+
+vi.mock('../src/mobile/api.ts', () => ({
+  listWorkspaces: vi.fn(),
+}))
+
+const listWorkspacesMock = vi.mocked(listWorkspaces)
+
+const workspaceRow = (id: string) => ({ workspaceId: id, title: `Workspace ${id}`, path: `/w/${id}` })
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('WorkspaceView retry', () => {
+  it('re-fetches the roster when the retry button is clicked', async () => {
+    listWorkspacesMock.mockRejectedValueOnce(new Error('network down'))
+    listWorkspacesMock.mockResolvedValueOnce([workspaceRow('ws-1')] as never)
+
+    render(<WorkspaceView onPick={() => {}} />)
+
+    // First fetch fails -> error + retry button.
+    await waitFor(() => expect(screen.getByText(/加载失败/)).toBeTruthy())
+    expect(listWorkspacesMock).toHaveBeenCalledTimes(1)
+
+    // Retry re-fetches and renders the roster.
+    fireEvent.click(screen.getByRole('button', { name: '重试' }))
+    await waitFor(() => expect(screen.getByText('Workspace ws-1')).toBeTruthy())
+    expect(listWorkspacesMock).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-remote-web-ui` 移动端工作区列表的「重试」按钮不重新拉取的问题。

根因：错误态的「重试」按钮只 `setError(undefined)` / `setItems(undefined)`，仅让组件重渲染进「加载中…」分支；而拉取 effect 依赖 `[initialWorkspaceId, onPick]`，二者在重试时都不变，`listWorkspaces()` 不会被再次调用，列表只能靠整页刷新恢复。

修复：新增一个 `reload` 计数并加入 effect 依赖，重试按钮递增它触发重新 fetch。补一个测试锁定「重试会重新拉取名单」。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-remote-web-ui test`：25 个测试文件 243 个用例全部通过（含新增 workspace-view 1 个用例）。
- `pnpm --filter @linxin666/dsh-remote-web-ui typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：工作区列表加载失败后点击「重试」会重新拉取并显示名单，而非卡在「加载中…」）。
