### PR TITLE
fix(skin-center): self-heal the managed skin patch against pruned skin packages (#495)

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -874,7 +874,7 @@ function useSkin(name, opts = {}) {
 	}
 	const legacyPatch = readPatch(paths.legacyPatchPath);
 	const migratedLegacyPatch = stripLegacySkinRows(stripManaged(legacyPatch));
-	if (migratedLegacyPatch !== legacyPatch) writePatchAtomic(paths.legacyPatchPath, migratedLegacyPatch);
+	if (migratedLegacyPatch !== legacyPatch) writePatchOrRemove(paths.legacyPatchPath, migratedLegacyPatch);
 	const patch = normalizePatchForManagedAppend(stripEmptyPatchList(stripLegacySkinRows(stripManaged(readPatch(paths.patchPath)))));
 	let next = appendManagedPatch(patch, renderManaged(official ? null : name, renderRegistry));
 	let skippedInsert = false;
@@ -905,6 +905,112 @@ function currentSkin(patch, opts = {}) {
 	let activePatch = patch ?? readPatch(paths.patchPath);
 	if (patch === void 0 && !activePatch.includes("# --- dsh-skin managed (auto-generated; do not edit) ---")) activePatch = readPatch(paths.legacyPatchPath);
 	return currentActive(activePatch, registryWithProfileWiring(registry, paths.profileModulesDir, paths.profileManifestPath)) ?? "none";
+}
+/**
+* Write a patch file, or remove it when the new content is empty — the boot
+* parser rejects an empty patch file ("must be a top-level YAML array"), and a
+* missing file means "no layer". A managed-section migration that strips the
+* last row therefore deletes the file instead of writing ''.
+* @param filePath - target patch file.
+* @param next - full next content ('' or whitespace removes the file).
+*/
+function writePatchOrRemove(filePath, next) {
+	if (next.trim() === "") {
+		try {
+			unlinkSync(filePath);
+		} catch {}
+		return;
+	}
+	writePatchAtomic(filePath, next);
+}
+/** Whether a patch text contains at least one top-level list row. The boot
+* parser requires a top-level YAML array; a comment-only file parses as null
+* and is rejected, so empty sections must fall back to the template's flow
+* form instead of leaving a comment-only file behind. */
+function hasAnyListRow(patch) {
+	return patch.split(/\r?\n/).some((line) => /^\s*-\s/.test(line) && !/^\s*#/.test(line));
+}
+/**
+* Reconcile the managed skin section against the live registry and the
+* resolvable installed state — the boot-time self-heal for issue #495.
+*
+* The managed section is rendered from the registry and rewritten only by
+* skin switches, so when a skin package stops being resolvable (dropped from
+* the family bundle's dependencies and pruned by pnpm, or the whole plugin
+* removed) the stale insert row survives and the next boot dies on
+* ERR_MODULE_NOT_FOUND. Re-rendering the section from the current registry
+* at boot, with the active skin validated against the registry AND the
+* resolvable installed state, makes the section self-healing:
+*  - a legacy harness-wide block (pre-issue-#290) is migrated into the active
+*    profile, or removed when it carried no usable state — at boot, not only
+*    on the next explicit switch;
+*  - an active skin that is unknown to the registry, or whose package is not
+*    resolvable from the profile, falls back to the official stock look
+*    (every skin disabled) instead of leaving a dangling insert row;
+*  - a healthy section re-renders byte-identically and no file is written.
+* Idempotent. Never throws on a malformed user patch (the boot must not fail
+* over skin-center's own bookkeeping) — such a patch is left untouched for
+* the next explicit switch, whose error then names the problem.
+* @param opts - injectable HOME/profile/registry (tests use a throwaway HOME).
+* @returns whether any file changed and which skin is active afterwards.
+*/
+function reconcileSkinPatches(opts = {}) {
+	const paths = resolvePaths(opts.home, opts.profile);
+	const registry = opts.registry ?? loadRegistry();
+	const renderRegistry = registryWithProfileWiring(registry, paths.profileModulesDir, paths.profileManifestPath);
+	const legacyPatch = readPatch(paths.legacyPatchPath);
+	const profilePatch = readPatch(paths.patchPath);
+	if (!legacyPatch.includes("# --- dsh-skin managed (auto-generated; do not edit) ---") && !profilePatch.includes("# --- dsh-skin managed (auto-generated; do not edit) ---")) return {
+		changed: false,
+		activeAfter: null,
+		notes: []
+	};
+	const activeNow = currentActive(profilePatch.includes("# --- dsh-skin managed (auto-generated; do not edit) ---") ? profilePatch : legacyPatch, renderRegistry);
+	const notes = [];
+	let activeAfter = activeNow;
+	if (activeAfter !== null) {
+		const entry = registry[activeAfter];
+		if (entry === void 0) {
+			notes.push(`skin "${activeAfter}" is no longer in the skin registry — falling back to the official stock look (issue #495)`);
+			activeAfter = null;
+		} else if (!renderRegistry[activeAfter].bundleWired) {
+			if (checkResolvable(entry, paths.profileModulesDir) !== null) {
+				notes.push(`skin "${activeAfter}" (${entry.pkg}) is not resolvable from the profile — falling back to the official stock look (issue #495)`);
+				activeAfter = null;
+			}
+		}
+	}
+	let changed = false;
+	const strippedLegacy = stripEmptyPatchList(stripLegacySkinRows(stripManaged(legacyPatch)));
+	if (strippedLegacy !== legacyPatch) {
+		writePatchOrRemove(paths.legacyPatchPath, strippedLegacy);
+		changed = true;
+	}
+	const base = stripEmptyPatchList(stripLegacySkinRows(stripManaged(profilePatch)));
+	let next;
+	try {
+		next = normalizePatchForManagedAppend(appendManagedPatch(base, renderManaged(activeAfter, renderRegistry)));
+	} catch (error) {
+		notes.push(`managed-section rewrite skipped (${String(error)})`);
+		return {
+			changed,
+			activeAfter,
+			notes
+		};
+	}
+	if (!hasAnyListRow(next)) {
+		notes.push("no skins are installed — removed the managed skin section");
+		next = `${base.replace(/\s+$/, "")}${base.trim() === "" ? "" : "\n\n"}[]\n`;
+	}
+	if (next !== profilePatch) {
+		writePatchAtomic(paths.patchPath, next);
+		changed = true;
+	}
+	return {
+		changed,
+		activeAfter,
+		notes
+	};
 }
 //#endregion
 //#region src/routes.ts
@@ -2171,6 +2277,12 @@ const SkinWallpaperConfigSchema = z.object({
 */
 const apply = mountOnce("@linxin666/dsh-client-ui-skin-center", applyImpl);
 function applyImpl(ctx) {
+	try {
+		const { notes } = reconcileSkinPatches();
+		for (const note of notes) console.warn("[ui-skin-center] " + note);
+	} catch (error) {
+		console.error("[ui-skin-center] managed-section reconciliation failed:", error);
+	}
 	installSettingsSection(ctx, SKIN_BACKGROUND_NAMESPACE, SkinBackgroundConfigSchema, {}, {
 		setSource: () => {},
 		onChange: () => {}

--- a/packages/skins/skin-center/src/index.ts
+++ b/packages/skins/skin-center/src/index.ts
@@ -16,7 +16,7 @@ import type {} from '@deepseek-ai/dsh-host-webserver'
 import { makeSkinCenterRoutes, SKIN_CENTER_API_PREFIX } from './routes.ts'
 import { makeWeRoutes, WE_API_PREFIX } from './we-routes.ts'
 import { defaultWallpapersStoreDir } from './we-library.ts'
-import { resolveHarnessHome } from './skin-switch.ts'
+import { reconcileSkinPatches, resolveHarnessHome } from './skin-switch.ts'
 import { mountOnce } from './mount-once.ts'
 
 export { makeSkinCenterRoutes, SKIN_CENTER_API_PREFIX } from './routes.ts'
@@ -126,6 +126,18 @@ export const SkinWallpaperConfigSchema: z<SkinWallpaperConfig> = z.object({
 export const apply = mountOnce('@linxin666/dsh-client-ui-skin-center', applyImpl)
 
 function applyImpl(ctx: Context): void {
+  // Boot-time self-heal of the managed skin section (issue #495): re-render it
+  // from the live registry so insert rows referencing packages that pnpm
+  // pruned (a skin dropped from the family bundle, or the whole plugin
+  // removed) cannot leave a stale boot-breaking patch behind. Idempotent;
+  // logs, never throws — the skin center must not take the GUI down.
+  try {
+    const { notes } = reconcileSkinPatches()
+    for (const note of notes) console.warn('[ui-skin-center] ' + note)
+  } catch (error) {
+    console.error('[ui-skin-center] managed-section reconciliation failed:', error)
+  }
+
   // Optional-settings wiring for the background scrim namespace. The browser
   // half binds the scope and applies the value to the body CSS variable;
   // this side just declares the namespace + schema so the value persists and

--- a/packages/skins/skin-center/src/skin-switch.ts
+++ b/packages/skins/skin-center/src/skin-switch.ts
@@ -1093,7 +1093,7 @@ export function useSkin(name: string, opts: { home?: string; profile?: string; r
   const legacyPatch = readPatch(paths.legacyPatchPath)
   const migratedLegacyPatch = stripLegacySkinRows(stripManaged(legacyPatch))
   if (migratedLegacyPatch !== legacyPatch) {
-    writePatchAtomic(paths.legacyPatchPath, migratedLegacyPatch)
+    writePatchOrRemove(paths.legacyPatchPath, migratedLegacyPatch)
   }
 
   const patch = normalizePatchForManagedAppend(stripEmptyPatchList(stripLegacySkinRows(stripManaged(readPatch(paths.patchPath)))))
@@ -1143,4 +1143,125 @@ export function currentSkin(patch: string | undefined, opts: { home?: string; pr
     activePatch = readPatch(paths.legacyPatchPath)
   }
   return currentActive(activePatch, registryWithProfileWiring(registry, paths.profileModulesDir, paths.profileManifestPath)) ?? 'none'
+}
+
+/**
+ * Write a patch file, or remove it when the new content is empty — the boot
+ * parser rejects an empty patch file ("must be a top-level YAML array"), and a
+ * missing file means "no layer". A managed-section migration that strips the
+ * last row therefore deletes the file instead of writing ''.
+ * @param filePath - target patch file.
+ * @param next - full next content ('' or whitespace removes the file).
+ */
+function writePatchOrRemove(filePath: string, next: string): void {
+  if (next.trim() === '') {
+    try {
+      unlinkSync(filePath)
+    } catch {
+      // Absent already — nothing to remove.
+    }
+    return
+  }
+  writePatchAtomic(filePath, next)
+}
+
+/** Whether a patch text contains at least one top-level list row. The boot
+ * parser requires a top-level YAML array; a comment-only file parses as null
+ * and is rejected, so empty sections must fall back to the template's flow
+ * form instead of leaving a comment-only file behind. */
+function hasAnyListRow(patch: string): boolean {
+  return patch.split(/\r?\n/).some(line => /^\s*-\s/.test(line) && !/^\s*#/.test(line))
+}
+
+/**
+ * Reconcile the managed skin section against the live registry and the
+ * resolvable installed state — the boot-time self-heal for issue #495.
+ *
+ * The managed section is rendered from the registry and rewritten only by
+ * skin switches, so when a skin package stops being resolvable (dropped from
+ * the family bundle's dependencies and pruned by pnpm, or the whole plugin
+ * removed) the stale insert row survives and the next boot dies on
+ * ERR_MODULE_NOT_FOUND. Re-rendering the section from the current registry
+ * at boot, with the active skin validated against the registry AND the
+ * resolvable installed state, makes the section self-healing:
+ *  - a legacy harness-wide block (pre-issue-#290) is migrated into the active
+ *    profile, or removed when it carried no usable state — at boot, not only
+ *    on the next explicit switch;
+ *  - an active skin that is unknown to the registry, or whose package is not
+ *    resolvable from the profile, falls back to the official stock look
+ *    (every skin disabled) instead of leaving a dangling insert row;
+ *  - a healthy section re-renders byte-identically and no file is written.
+ * Idempotent. Never throws on a malformed user patch (the boot must not fail
+ * over skin-center's own bookkeeping) — such a patch is left untouched for
+ * the next explicit switch, whose error then names the problem.
+ * @param opts - injectable HOME/profile/registry (tests use a throwaway HOME).
+ * @returns whether any file changed and which skin is active afterwards.
+ */
+export function reconcileSkinPatches(opts: { home?: string; profile?: string; registry?: Record<string, SkinSwitchEntry> } = {}): { changed: boolean; activeAfter: string | null; notes: string[] } {
+  const paths = resolvePaths(opts.home, opts.profile)
+  const registry = opts.registry ?? loadRegistry()
+  const renderRegistry = registryWithProfileWiring(registry, paths.profileModulesDir, paths.profileManifestPath)
+  const legacyPatch = readPatch(paths.legacyPatchPath)
+  const profilePatch = readPatch(paths.patchPath)
+  // No managed section anywhere: nothing dsh-skin ever wrote can be stale,
+  // and appending one would mutate a patch the user never asked to touch.
+  if (!legacyPatch.includes(MANAGED_START) && !profilePatch.includes(MANAGED_START)) {
+    return { changed: false, activeAfter: null, notes: [] }
+  }
+  // The active skin: the profile patch when it carries the managed section,
+  // else the legacy harness-wide patch (pre-#290 state).
+  const activeNow = currentActive(profilePatch.includes(MANAGED_START) ? profilePatch : legacyPatch, renderRegistry)
+  const notes: string[] = []
+  let activeAfter = activeNow
+  if (activeAfter !== null) {
+    const entry = registry[activeAfter]
+    if (entry === undefined) {
+      notes.push(`skin "${activeAfter}" is no longer in the skin registry — falling back to the official stock look (issue #495)`)
+      activeAfter = null
+    } else if (!renderRegistry[activeAfter].bundleWired) {
+      // A bundle-wired skin is imported through its own installed bundle row,
+      // so only a non-wired insert row needs the resolvability gate.
+      const problem = checkResolvable(entry, paths.profileModulesDir)
+      if (problem !== null) {
+        notes.push(`skin "${activeAfter}" (${entry.pkg}) is not resolvable from the profile — falling back to the official stock look (issue #495)`)
+        activeAfter = null
+      }
+    }
+  }
+  let changed = false
+  // Migrate (or drop) the legacy harness-wide managed block: a Web-only
+  // insert there would make a non-Web profile resolve a Web-only package
+  // (issue #290).
+  const strippedLegacy = stripEmptyPatchList(stripLegacySkinRows(stripManaged(legacyPatch)))
+  if (strippedLegacy !== legacyPatch) {
+    writePatchOrRemove(paths.legacyPatchPath, strippedLegacy)
+    changed = true
+  }
+  // Re-render the profile managed section from the registry: insert rows for
+  // skins that no longer exist or are no longer resolvable cannot survive a
+  // boot (issue #495).
+  const base = stripEmptyPatchList(stripLegacySkinRows(stripManaged(profilePatch)))
+  let next: string
+  try {
+    next = normalizePatchForManagedAppend(appendManagedPatch(base, renderManaged(activeAfter, renderRegistry)))
+  } catch (error) {
+    // A malformed user patch is the user's to fix; never take the boot down
+    // over skin-center's own bookkeeping. Leave it for the next explicit
+    // switch, which reports the same problem as a normal useSkin error.
+    notes.push(`managed-section rewrite skipped (${String(error)})`)
+    return { changed, activeAfter, notes }
+  }
+  if (!hasAnyListRow(next)) {
+    // The managed section referenced skins that are all gone (registry empty)
+    // and the user layer carries no rows: a comment-only patch parses as null
+    // and the boot parser rejects it. Fall back to the template's empty-flow
+    // form so the file stays bootable.
+    notes.push('no skins are installed — removed the managed skin section')
+    next = `${base.replace(/\s+$/, '')}${base.trim() === '' ? '' : '\n\n'}[]\n`
+  }
+  if (next !== profilePatch) {
+    writePatchAtomic(paths.patchPath, next)
+    changed = true
+  }
+  return { changed, activeAfter, notes }
 }

--- a/packages/skins/skin-center/tests/skin-switch.spec.ts
+++ b/packages/skins/skin-center/tests/skin-switch.spec.ts
@@ -32,6 +32,7 @@ import {
   wiredNames,
   useSkin,
   currentSkin,
+  reconcileSkinPatches,
   resolvePaths,
   resolveHarnessHome,
   resolveInstallLayout,
@@ -532,7 +533,9 @@ describe('useSkin / currentSkin against a throwaway HOME', () => {
 
     useSkin('official', { home: h, registry })
 
-    expect(readFileSync(legacyPatchPath(h), 'utf8')).not.toContain(MANAGED_START)
+    // The legacy file held only the managed block: removed, never emptied —
+    // the boot parser rejects an empty patch file.
+    expect(existsSync(legacyPatchPath(h))).toBe(false)
     expect(readFileSync(patchPath(h), 'utf8')).toContain(MANAGED_START)
     expect(currentSkin(undefined, { home: h, registry })).toBe('none')
   })
@@ -1145,5 +1148,117 @@ describe('self-referential symlink defense (issue #43: ELOOP on second skin swit
     expect(readlinkSync(target)).toBe(realDir)
     // And it still resolves (no ELOOP on realpath).
     expect(realpathSync(target)).toBe(realpathSync(realDir))
+  })
+})
+
+describe('reconcileSkinPatches (boot-time self-heal, issue #495)', () => {
+  it('drops an insert row whose skin package is no longer resolvable from the profile', () => {
+    const h = fakeHome()
+    const registry = loadRegistry()
+    // The patch names xp as active, but no package sits under the profile —
+    // exactly the post-upgrade state where pnpm pruned the orphan package.
+    writeFileSync(patchPath(h), `${renderManaged('xp', registry)}\n`)
+
+    const result = reconcileSkinPatches({ home: h, registry })
+
+    expect(result.changed).toBe(true)
+    expect(result.activeAfter).toBeNull()
+    expect(result.notes.some(note => note.includes('xp'))).toBe(true)
+    const after = readFileSync(patchPath(h), 'utf8')
+    expect(after).not.toContain('- insert:')
+    expect(after).toContain(`- id: ${registry.xp.id}\n  disabled: true`)
+    expect(currentSkin(after, { home: h, registry })).toBe('none')
+  })
+
+  it('keeps a resolvable active skin and rewrites nothing (idempotent)', () => {
+    const h = fakeHome()
+    const registry = loadRegistry()
+    const xp = registry.xp
+    // npm layout: the skin package physically sits under the profile modules.
+    const installed = join(resolvePaths(h).profileModulesDir, xp.pkg)
+    makeSkinPackage(installed, xp)
+    const fakeRegistry: Record<string, SkinSwitchEntry> = { ...registry, xp: { ...xp, dir: installed } }
+    writeFileSync(patchPath(h), `${renderManaged('xp', fakeRegistry)}\n`)
+
+    const result = reconcileSkinPatches({ home: h, registry: fakeRegistry })
+
+    expect(result.changed).toBe(false)
+    expect(result.activeAfter).toBe('xp')
+    expect(result.notes).toEqual([])
+    expect(readFileSync(patchPath(h), 'utf8')).toBe(`${renderManaged('xp', fakeRegistry)}\n`)
+  })
+
+  it('migrates a legacy harness-wide managed block and drops its unresolvable insert (the uninstall scenario)', () => {
+    const h = fakeHome()
+    const registry = loadRegistry()
+    // Pre-#290 state: the managed section lives at harness-home scope with
+    // whale-song active — what a skin switch on an old release leaves behind
+    // after the package stops being resolvable.
+    writeFileSync(legacyPatchPath(h), `${renderManaged('whale-song', registry)}\n`)
+    writeFileSync(patchPath(h), '# profile patch\n[]\n')
+
+    const result = reconcileSkinPatches({ home: h, registry })
+
+    expect(result.changed).toBe(true)
+    expect(result.activeAfter).toBeNull()
+    // The legacy file held only the managed block: it must be removed, not
+    // emptied — the boot parser rejects an empty patch file.
+    expect(existsSync(legacyPatchPath(h))).toBe(false)
+    const after = readFileSync(patchPath(h), 'utf8')
+    expect(after).not.toContain('- insert:')
+    expect(after).toContain(MANAGED_START)
+    expect(currentSkin(after, { home: h, registry })).toBe('none')
+  })
+
+  it('drops an active skin the registry no longer knows', () => {
+    const h = fakeHome()
+    const registry = loadRegistry()
+    const ghost = { pkg: '@linxin666/dsh-client-ui-skin-ghost', id: 'ui-skin-ghost', dir: '/tmp/ghost', bundleWired: false }
+    const ghostRegistry: Record<string, SkinSwitchEntry> = { ...registry, ghost }
+    writeFileSync(patchPath(h), `${renderManaged('ghost', ghostRegistry)}\n`)
+
+    const result = reconcileSkinPatches({ home: h, registry })
+
+    expect(result.changed).toBe(true)
+    expect(result.activeAfter).toBeNull()
+    const after = readFileSync(patchPath(h), 'utf8')
+    expect(after).not.toContain('ghost')
+    expect(after).not.toContain('- insert:')
+  })
+
+  it('leaves a patch without a managed section untouched', () => {
+    const h = fakeHome()
+    writeFileSync(patchPath(h), '# user rows\n- id: custom\n  config: 1\n')
+
+    const result = reconcileSkinPatches({ home: h })
+
+    expect(result.changed).toBe(false)
+    expect(result.activeAfter).toBeNull()
+    expect(result.notes).toEqual([])
+    expect(readFileSync(patchPath(h), 'utf8')).toBe('# user rows\n- id: custom\n  config: 1\n')
+  })
+
+  it('a second run on a reconciled patch is a no-op (converges after one write)', () => {
+    const h = fakeHome()
+    const registry = loadRegistry()
+    writeFileSync(patchPath(h), `${renderManaged('xp', registry)}\n`)
+    const first = reconcileSkinPatches({ home: h, registry })
+    expect(first.changed).toBe(true)
+    const second = reconcileSkinPatches({ home: h, registry })
+    expect(second.changed).toBe(false)
+    expect(second.activeAfter).toBeNull()
+  })
+
+  it('writes the template empty-flow form when the registry is empty (comment-only patch would not parse)', () => {
+    const h = fakeHome()
+    // A stale managed section survives a full uninstall; the registry no
+    // longer knows any skin (every skin package is gone).
+    writeFileSync(patchPath(h), `${MANAGED_START}\n- insert:\n    - id: ui-skin-whale-song\n      name: '@linxin666/dsh-client-ui-skin-whale-song'\n${MANAGED_END}\n`)
+
+    const result = reconcileSkinPatches({ home: h, registry: {} })
+
+    expect(result.changed).toBe(true)
+    expect(readFileSync(patchPath(h), 'utf8').trim()).toBe('[]')
+    expect(result.notes.some(note => note.includes('no skins'))).toBe(true)
   })
 })

--- a/scripts/dsh-skin
+++ b/scripts/dsh-skin
@@ -312,7 +312,15 @@ function cmdUse(name) {
   // active insert there makes dsh-tui resolve a Web-only package (issue #290).
   const legacyPatch = readPatch(LEGACY_PATCH)
   const migratedLegacyPatch = stripLegacySkinRows(stripManaged(legacyPatch))
-  if (migratedLegacyPatch !== legacyPatch) writePatch(LEGACY_PATCH, migratedLegacyPatch)
+  if (migratedLegacyPatch !== legacyPatch) {
+    // The boot parser rejects an empty patch file; a missing file means
+    // "no layer", so strip the last row by removing the file, not emptying it.
+    if (migratedLegacyPatch.trim() === '') {
+      try { fs.unlinkSync(LEGACY_PATCH) } catch { /* already absent */ }
+    } else {
+      writePatch(LEGACY_PATCH, migratedLegacyPatch)
+    }
+  }
 
   const patch = normalizePatchForManagedAppend(stripEmptyPatchList(stripLegacySkinRows(stripManaged(readPatch()))))
   const next = appendManagedPatch(patch, renderManaged(official ? null : name))
@@ -349,6 +357,92 @@ function cmdCurrent() {
   console.log(active ?? 'none')
 }
 
+/**
+ * Whether a skin package is resolvable from the web profile — the same
+ * directory contract the boot graph relies on when it loads the insert row:
+ * the profile-target package dir must carry a package.json whose name is this
+ * skin's package and a host entry (main, else index.js) that exists. A
+ * package pnpm pruned (dropped from the family bundle, or the whole plugin
+ * removed) fails this check, mirroring checkResolvable in skin-switch.ts.
+ * @param name - skin id.
+ */
+function skinResolvable(name) {
+  const target = path.join(DSH_HOME, 'profiles', DEFAULT_PROFILE, 'node_modules', SKINS[name].pkg)
+  try {
+    if (!fs.statSync(target).isDirectory()) return false
+    const manifest = JSON.parse(fs.readFileSync(path.join(target, 'package.json'), 'utf8'))
+    if (manifest.name !== SKINS[name].pkg) return false
+    const main = typeof manifest.main === 'string' ? manifest.main : 'index.js'
+    return fs.statSync(path.join(target, main)).isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The active skin a repair keeps: null when it must fall back to the stock
+ * look — unknown to the registry (dropped from the family bundle), or not
+ * resolvable from the profile (a package pnpm pruned, issue #495). A
+ * bundle-wired active skin is imported through its own installed bundle row
+ * and needs no insert row, so it survives without the package-dir probe.
+ * @param active - the skin currentActive read from the patches.
+ */
+function reconcilableActive(active) {
+  if (active === null) return null
+  if (!SKINS[active]) return null
+  if (bundleWiredFromProfile().has(active)) return active
+  return skinResolvable(active) ? active : null
+}
+
+/** Whether a patch text contains at least one top-level list row (the boot
+ * parser requires a YAML array; a comment-only file parses as null). */
+function hasListRow(patch) {
+  return patch.split(/\r?\n/).some(line => /^\s*-\s/.test(line) && !/^\s*#/.test(line))
+}
+
+/**
+ * Reconcile the managed skin section against the live registry and the
+ * resolvable installed state (issue #495): migrate the legacy harness-wide
+ * block into the active profile, drop insert rows for skins that are gone or
+ * unresolvable (falling back to the official stock look), and leave a
+ * healthy section untouched. The offline counterpart of the skin-center
+ * plugin's boot-time reconcileSkinPatches, runnable when a dangling insert
+ * has already broken the boot.
+ */
+function cmdRepair() {
+  const legacyPatch = readPatch(LEGACY_PATCH)
+  const profilePatch = readPatch()
+  // Read the active skin before migrating, so a legacy-only managed block
+  // still reports its choice (the resolve step decides whether it survives).
+  const active = reconcilableActive(currentActive(profilePatch.includes(MANAGED_START) ? profilePatch : legacyPatch))
+  let changed = false
+  const migratedLegacyPatch = stripEmptyPatchList(stripLegacySkinRows(stripManaged(legacyPatch)))
+  if (migratedLegacyPatch !== legacyPatch) {
+    if (migratedLegacyPatch.trim() === '') {
+      try { fs.unlinkSync(LEGACY_PATCH) } catch { /* already absent */ }
+    } else {
+      writePatch(LEGACY_PATCH, migratedLegacyPatch)
+    }
+    changed = true
+  }
+  const patch = normalizePatchForManagedAppend(stripEmptyPatchList(stripLegacySkinRows(stripManaged(profilePatch))))
+  let next = appendManagedPatch(patch, renderManaged(active))
+  if (!hasListRow(next)) {
+    // The managed section referenced skins that are all gone and the user
+    // layer carries no rows: a comment-only patch parses as null and the boot
+    // parser rejects it. Fall back to the template's empty-flow form so the
+    // file stays bootable.
+    next = `${patch.replace(/\s+$/, '')}${patch.trim() === '' ? '' : '\n\n'}[]\n`
+  }
+  if (next !== profilePatch) {
+    writePatch(PATCH, next)
+    changed = true
+  }
+  console.log(changed
+    ? `repaired the managed skin section (active: ${active ?? 'none'}) — the config watcher applies it within seconds; refresh the page to see it.`
+    : 'managed skin section is already consistent — nothing to repair.')
+}
+
 // Pure helpers exported so tests can assert the managed-section rendering
 // and parsing without touching the real ~/.dsh (the entry-script guard below
 // keeps an import side-effect free).
@@ -363,6 +457,7 @@ module.exports = {
   stripEmptyPatchList,
   stripLegacySkinRows,
   currentActive,
+  reconcilableActive,
 }
 
 // Run only when invoked as the entry script (as a CLI), so the module can be
@@ -374,6 +469,7 @@ if (require.main === module) {
     case 'install': cmdInstall(arg); break
     case 'list': cmdList(); break
     case 'current': cmdCurrent(); break
+    case 'repair': cmdRepair(); break
     default:
       console.log('dsh-skin — one-command skin switching for the DSH web GUI')
       console.log('')
@@ -383,6 +479,7 @@ if (require.main === module) {
       console.log('  dsh-skin use official     restore the official stock look (disable every skin)')
       console.log('  dsh-skin list             show skins, the active one, and symlink state')
       console.log('  dsh-skin current          print the active skin name (or "none")')
+      console.log('  dsh-skin repair           reconcile the managed patch section against the installed skins (fixes a stale insert row)')
       console.log('')
       console.log(`skins: ${Object.keys(SKINS).join(', ')}`)
       process.exit(cmd ? 1 : 0)

--- a/scripts/dsh-skin.test.mjs
+++ b/scripts/dsh-skin.test.mjs
@@ -6,7 +6,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { chmodSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -235,10 +235,111 @@ test('use migrates the global managed skin row into the web profile', () => {
       env: { ...process.env, DSH_HOME: join(home, '.dsh'), DSH_SKIN_REPO: repo },
     })
 
-    assert.ok(!readFileSync(legacyPatchPath(home), 'utf8').includes(MANAGED_START))
+    // The legacy file held only the managed block: removed, never emptied —
+    // the boot parser rejects an empty patch file.
+    assert.ok(!existsSync(legacyPatchPath(home)))
     const scoped = readFileSync(patchPath(home), 'utf8')
     assert.ok(scoped.includes(MANAGED_START))
     assert.ok(scoped.includes(`- id: ${SKINS.xp.id}`))
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+/** Install a resolvable skin package under a profile's node_modules (the npm
+ * layout the boot graph imports): package.json named after the skin, main
+ * entry that exists. */
+function fakeSkinPackage(modulesDir, name) {
+  const dir = join(modulesDir, '@linxin666', `dsh-client-ui-skin-${name}`)
+  mkdirSync(join(dir, 'lib'), { recursive: true })
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({
+    name: `@linxin666/dsh-client-ui-skin-${name}`,
+    version: '0.2.0',
+    type: 'module',
+    main: 'lib/index.js',
+  }))
+  writeFileSync(join(dir, 'lib', 'index.js'), 'export function apply() {}\n')
+  return dir
+}
+
+test('repair drops an insert row whose skin package is no longer resolvable (issue #495)', () => {
+  const home = fakeHome()
+  try {
+    const repo = join(home, 'code', 'dsh-web-ui')
+    for (const name of Object.keys(SKINS)) fakeSkinDir(repo, name)
+    // The patch names xp as active; no package sits under the profile
+    // node_modules — the state a pnpm prune leaves behind.
+    writeFileSync(patchPath(home), `${renderManaged('xp')}\n`)
+    const out = execFileSync(process.execPath, [SCRIPT, 'repair'], {
+      env: { ...process.env, DSH_HOME: join(home, '.dsh'), DSH_SKIN_REPO: repo },
+      encoding: 'utf8',
+    })
+    assert.ok(out.includes('repaired'))
+    const after = readFileSync(patchPath(home), 'utf8')
+    assert.ok(!after.includes('- insert:'), 'dangling insert row must be dropped')
+    assert.ok(after.includes(`- id: ${SKINS.xp.id}\n  disabled: true`), 'xp falls back to disabled')
+    const current = execFileSync(process.execPath, [SCRIPT, 'current'], {
+      env: { ...process.env, DSH_HOME: join(home, '.dsh'), DSH_SKIN_REPO: repo },
+      encoding: 'utf8',
+    })
+    assert.equal(current.trim(), 'none')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('repair keeps a resolvable active skin and reports nothing to repair', () => {
+  const home = fakeHome()
+  try {
+    const repo = join(home, 'code', 'dsh-web-ui')
+    for (const name of Object.keys(SKINS)) fakeSkinDir(repo, name)
+    fakeSkinPackage(join(home, '.dsh', 'profiles', 'web', 'node_modules'), 'xp')
+    writeFileSync(patchPath(home), `${renderManaged('xp')}\n`)
+    const out = execFileSync(process.execPath, [SCRIPT, 'repair'], {
+      env: { ...process.env, DSH_HOME: join(home, '.dsh'), DSH_SKIN_REPO: repo },
+      encoding: 'utf8',
+    })
+    assert.ok(out.includes('already consistent'))
+    assert.equal(readFileSync(patchPath(home), 'utf8'), `${renderManaged('xp')}\n`)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('repair migrates a legacy harness-wide managed block and removes the emptied file', () => {
+  const home = fakeHome()
+  try {
+    const repo = join(home, 'code', 'dsh-web-ui')
+    for (const name of Object.keys(SKINS)) fakeSkinDir(repo, name)
+    // Pre-#290 state: the managed section lives at harness-home scope with an
+    // unresolvable active skin; the profile patch is the stock template.
+    writeFileSync(legacyPatchPath(home), `${renderManaged('whale-song')}\n`)
+    writeFileSync(patchPath(home), '# profile patch\n[]\n')
+    execFileSync(process.execPath, [SCRIPT, 'repair'], {
+      env: { ...process.env, DSH_HOME: join(home, '.dsh'), DSH_SKIN_REPO: repo },
+    })
+    // The legacy file held only the managed block: removed, not emptied —
+    // the boot parser rejects an empty patch file.
+    assert.ok(!existsSync(legacyPatchPath(home)))
+    const after = readFileSync(patchPath(home), 'utf8')
+    assert.ok(!after.includes('- insert:'))
+    assert.ok(after.includes(MANAGED_START))
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('repair falls back to the template empty-flow form when no skins are installed', () => {
+  const home = fakeHome()
+  try {
+    // The fake repo has no skin dirs, so the subprocess registry is empty.
+    const repo = join(home, 'code', 'dsh-web-ui')
+    writeFileSync(patchPath(home), `${MANAGED_START}\n- insert:\n    - id: ui-skin-whale-song\n      name: '@linxin666/dsh-client-ui-skin-whale-song'\n${MANAGED_END}\n`)
+    execFileSync(process.execPath, [SCRIPT, 'repair'], {
+      env: { ...process.env, DSH_HOME: join(home, '.dsh'), DSH_SKIN_REPO: repo },
+    })
+    // A comment-only patch would not parse; the template's empty-flow form is bootable.
+    assert.equal(readFileSync(patchPath(home), 'utf8').trim(), '[]')
   } finally {
     rmSync(home, { recursive: true, force: true })
   }


### PR DESCRIPTION
## 摘要（Summary）

修复 issue #495：自 0.1.19 起 `@linxin666/dsh-client-ui-skin-whale-song` 不再是全家桶正式依赖，但 dsh-skin 维护的 managed patch 段仍保留 insert 行引用它；任何 pnpm install / 升级 / 卸载清理掉该包后，`dsh web` 启动即 `ERR_MODULE_NOT_FOUND`，无法对话。

修复分三层：

1. **启动自愈（skin-center）**：web 启动时用当前注册表 + 可解析性重新渲染 managed 段——皮肤包从全家桶移除或不可解析时自动回退官方默认外观（全部 skin disabled），不再留下悬空 insert；旧版遗留的 harness-home 级 managed 块在启动时即迁移进 profile（此前只在下次显式切换时迁移，issue #290）。
2. **离线修复命令（`dsh-skin repair`）**：boot 已被悬空 insert 打断时，GUI 自愈无法运行；`repair` 在命令行完成同一套对账，一条命令恢复启动。
3. **补丁文件健全性**：legacy 迁移后若文件为空则删除而非写 `''`（boot 解析器拒绝空 patch 文件）；注册表为空时回退模板 `[]` 形式（纯注释文件解析为 null 同样会炸 boot）。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch origin && git rebase origin/main`（克隆自 main @ 30caa3a，提交前已确认最新）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：pi（DeepSeek Harness）

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本次无新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改 README）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm test                      # 全仓单测全绿（含 skin-center 188 项）
pnpm test:scripts              # scripts 测试 103 项，0 失败
pnpm typecheck                 # 全绿
pnpm docs:check                # passed
pnpm skin-center:check         # check OK (11 skins, generated file in sync)
pnpm aggregate:check           # done
pnpm --filter @linxin666/dsh-client-ui-skin-center build  # lib/ 已重建并提交
```

结果摘要：全部通过。新增测试覆盖：悬空 insert（包不可解析）被清除并回退官方外观、legacy 块启动迁移、注册表未知皮肤清除、健康状态幂等（不写盘）、空注册表回退 `[]`、二次运行收敛（无重复写入）。

## 用户可见变更证据（Local Feature Evidence）

复现现场（issue #495 同类）：`~/.dsh/cordis.patch.yml` 的 `dsh-skin managed` 段残留 `insert ui-skin-whale-song` → `@linxin666/dsh-client-ui-skin-whale-song`，包已随卸载移除：

```
Error: dsh: plugin tree failed to load: failed to apply loader entry include (cordis:include):
failed to import loader entry ui-skin-whale-song (@linxin666/dsh-client-ui-skin-whale-song):
Cannot find package '@linxin666/dsh-client-ui-skin-whale-song' imported from /Users/ron/.dsh/profiles/web/
```

修复后（本 PR 的 `dsh-skin repair` 等价操作）：insert 行移除，`dsh --profile web --dump-config` exit 0，`dsh web` 正常启动到 `http://127.0.0.1:3080`。本次改动不改变健康状态下任何行为（幂等，不写盘）。

已知边界（建议在 DSH 侧跟进，见 issue #495 附注）：插件被**完整卸载**且注册表为空时，GUI 启动自愈无法运行（loader 在插件挂载前即失败），恢复路径为 `dsh-skin repair` 或手动移除 insert 行；DSH loader 对悬空 include 的报错可进一步提示来源 patch 文件与修复方式。
