### PR TITLE
fix(web-ui-settings): pin the settings.section registration and document the keyed-slot upgrade path (#513)

### DIFF
--- a/packages/dsh-remote-web-ui/src/client/RemoteSettingsCard.tsx
+++ b/packages/dsh-remote-web-ui/src/client/RemoteSettingsCard.tsx
@@ -1,7 +1,7 @@
 /**
  * The remote-control settings card: pairing security and device limits.
- * Registers into the `settings.plugin.item` slot the plugin-configuration
- * section renders, bound to the `remote-web-ui` settings namespace.
+ * Registers into the `web-ui.plugin.item` child slot the Web UI plugin group
+ * renders, bound to the `remote-web-ui` settings namespace.
  */
 
 import type { InjectFace, PropsLocale, PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'

--- a/packages/dsh-task-board/src/client/TaskBoardSettingsCard.tsx
+++ b/packages/dsh-task-board/src/client/TaskBoardSettingsCard.tsx
@@ -1,7 +1,7 @@
 /**
  * Task-board settings for availability, agent announcement, and optional Host
- * idle-sleep protection. Registers into the `settings.plugin.item` slot the
- * plugin-configuration section renders, bound to the `task-board` namespace.
+ * idle-sleep protection. Registers into the `web-ui.plugin.item` child slot
+ * the Web UI plugin group renders, bound to the `task-board` namespace.
  */
 
 import type { InjectFace, PropsLocale, PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'

--- a/packages/dsh-web-ui-all/README.i18n.yaml
+++ b/packages/dsh-web-ui-all/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 7d25bafc39148eca0d043a174d7aa800d391adcb
-README.zh.md: c790cba6a2aa1f63aa0b9fb8e1096463bcd6b240
+README.md: 3c5e18a262a4bf305b60cdbec97d0b7526fca98c
+README.zh.md: 07324e3d6a211d840df73bd591534ea41309b6f8

--- a/packages/dsh-web-ui-all/README.md
+++ b/packages/dsh-web-ui-all/README.md
@@ -34,6 +34,20 @@ Restart `dsh web` for the plugins to take effect.
 
 When you upgrade by bumping the version in the profile `package.json` and running `pnpm install`, the top-level `node_modules/@linxin666/*` entries are not always refreshed: they can stay linked to the previous version's store directory until recreated. After upgrading, verify the links resolve to the new version (on Windows: `cmd /c rmdir <link>` then `cmd /c mklink /J <link> <target>`), then restart `dsh web`.
 
+## Troubleshooting
+
+### "Failed to load plugins ... keyed slot `settings.plugin.item` requires options.key" (DSH 0.1.0-rc.6+)
+
+Versions up to 0.1.17 of the bundled `dsh-client-ui-web-ui-settings` registered its card in the keyed `settings.plugin.item` slot with an `id` instead of the required `key` (the other family plugins already registered their cards in the group's list slot). DSH 0.1.0-rc.6 and later reject such entries while the loader entry applies, so the web GUI fails to boot with "Failed to load plugins".
+
+The group moved to a first-level `settings.section` registration in 0.1.18 and ships in 0.2.0; the code on `main` is compatible with rc.6 and rc.7. A profile that still fails carries a frozen older install:
+
+1. Bump every `@linxin666/*` dependency in the profile `package.json` to `^0.2.0` (at least `^0.1.18`).
+2. Reinstall the profile dependencies (`pnpm install`) and recreate the stale `node_modules/@linxin666/*` links as described in Manual upgrade above.
+3. Restart `dsh web`.
+
+See [issue #513](https://github.com/zhu1090093659/dsh-web-ui/issues/513).
+
 ## Known limitations
 
 - Every sub-plugin activates together. For only a subset, install that sub-plugin package directly.

--- a/packages/dsh-web-ui-all/README.zh.md
+++ b/packages/dsh-web-ui-all/README.zh.md
@@ -34,6 +34,20 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-web-ui-all
 
 在 profile 的 `package.json` 中改版本后执行 `pnpm install`，顶层 `node_modules/@linxin666/*` 条目不会总是被刷新：它们可能仍链接到旧版本的 store 目录，直到手动重建。升级后请确认这些链接已指向新版本目录（Windows 下：先 `cmd /c rmdir <链接>` 再 `cmd /c mklink /J <链接> <目标>`），然后重启 `dsh web`。
 
+## 故障排查
+
+### "Failed to load plugins ... keyed slot `settings.plugin.item` requires options.key"（DSH 0.1.0-rc.6+）
+
+聚合包内置的 `dsh-client-ui-web-ui-settings` 0.1.17 及更早版本把组卡片注册进 keyed 槽 `settings.plugin.item` 时传的是 `id` 而不是必填的 `key`（其他全家桶插件此前已注册进该组的 list 槽）；DSH 0.1.0-rc.6 起在 loader entry 应用阶段直接拒绝这种注册，Web GUI 因此以 "Failed to load plugins" 启动失败。
+
+0.1.18 起该组改为一级 `settings.section` 注册，0.2.0 已发布；`main` 上的代码与 rc.6 / rc.7 兼容。仍在报错的 profile 带的是冻结的旧安装：
+
+1. 把 profile `package.json` 里所有 `@linxin666/*` 依赖升到 `^0.2.0`（至少 `^0.1.18`）。
+2. 重装 profile 依赖（`pnpm install`），并按上文「手工升级」重建陈旧的 `node_modules/@linxin666/*` 链接。
+3. 重启 `dsh web`。
+
+参见 [issue #513](https://github.com/zhu1090093659/dsh-web-ui/issues/513)。
+
 ## 已知限制
 
 - 各子插件随本包一起激活；若只需要其中一部分，请直接安装对应子插件包。

--- a/packages/dsh-web-ui-settings/README.i18n.yaml
+++ b/packages/dsh-web-ui-settings/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 26ae1433be6da87139734faf4b1770eff0ba8b96
-README.zh.md: 20ce8352f2639ceace111b297fad74ad53db10c0
+README.md: 34fea38e5fc4fd6c9afb242182ec9328352c69f7
+README.zh.md: 356d98b2f4c8956f8d7a643c2f92cda193954863

--- a/packages/dsh-web-ui-settings/README.md
+++ b/packages/dsh-web-ui-settings/README.md
@@ -59,6 +59,20 @@ reverse_proxy 127.0.0.1:3080 {
 - The reverse proxy is the authentication boundary: keep DSH bound to loopback, run authentication before `reverse_proxy`, and replace rather than forward the client-supplied internal header.
 - The bridge exposes only the intersection of registered family namespaces and `web_settings_namespaces`. It does not expose credentials, native paths, or any other privileged DSH API.
 
+## Troubleshooting
+
+### "Failed to load plugins ... keyed slot `settings.plugin.item` requires options.key" (DSH 0.1.0-rc.6+)
+
+Plugin versions up to 0.1.17 registered the group card in the keyed `settings.plugin.item` slot with an `id` instead of the required `key`. DSH 0.1.0-rc.6 and later reject such entries while the loader entry applies, so the web GUI fails to boot with "Failed to load plugins".
+
+The registration moved to the first-level `settings.section` slot (a list slot addressed by `id`) in 0.1.18 and ships in 0.2.0; the code on `main` is compatible with rc.6 and rc.7. A profile that still fails carries a frozen older install:
+
+1. Bump every `@linxin666/*` dependency in the profile `package.json` to `^0.2.0` (at least `^0.1.18`).
+2. Reinstall the profile dependencies (`pnpm install`), and on Windows recreate stale `node_modules/@linxin666/*` junction links (`cmd /c rmdir <link>` then `cmd /c mklink /J <link> <target>`).
+3. Restart `dsh web`.
+
+See [issue #513](https://github.com/zhu1090093659/dsh-web-ui/issues/513).
+
 ## Known limitations
 
 - The section shows on the dsh settings page only when its prerequisite (`@deepseek-ai/dsh-client-ui-settings`) is present.

--- a/packages/dsh-web-ui-settings/README.zh.md
+++ b/packages/dsh-web-ui-settings/README.zh.md
@@ -59,6 +59,20 @@ reverse_proxy 127.0.0.1:3080 {
 - 反向代理是认证边界：DSH 必须只监听 loopback，认证必须排在 `reverse_proxy` 之前，内部请求头必须由代理替换而不能透传客户端值。
 - 桥接只开放已注册全家桶命名空间与 `web_settings_namespaces` 的交集，不开放凭据、本机路径或其他 DSH 特权 API。
 
+## 故障排查
+
+### "Failed to load plugins ... keyed slot `settings.plugin.item` requires options.key"（DSH 0.1.0-rc.6+）
+
+0.1.17 及更早版本把组卡片注册进 keyed 槽 `settings.plugin.item` 时传的是 `id` 而不是必填的 `key`；DSH 0.1.0-rc.6 起在 loader entry 应用阶段直接拒绝这种注册，Web GUI 因此以 "Failed to load plugins" 启动失败。
+
+0.1.18 起注册改到一级 `settings.section` 槽（list 槽，用 `id` 定位），0.2.0 已发布；`main` 上的代码与 rc.6 / rc.7 兼容。仍在报错的 profile 带的是冻结的旧安装：
+
+1. 把 profile `package.json` 里所有 `@linxin666/*` 依赖升到 `^0.2.0`（至少 `^0.1.18`）。
+2. 重装 profile 依赖（`pnpm install`）；Windows 下重建陈旧的 `node_modules/@linxin666/*` junction 链接（先 `cmd /c rmdir <链接>` 再 `cmd /c mklink /J <链接> <目标>`）。
+3. 重启 `dsh web`。
+
+参见 [issue #513](https://github.com/zhu1090093659/dsh-web-ui/issues/513)。
+
 ## 已知限制
 
 - 仅当依赖的 `@deepseek-ai/dsh-client-ui-settings` 存在时，该菜单项才会出现在 dsh 设置页。

--- a/packages/dsh-web-ui-settings/tests/client-apply.spec.tsx
+++ b/packages/dsh-web-ui-settings/tests/client-apply.spec.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+/**
+ * Client-half registration test for the web-ui-settings browser bundle:
+ * asserts that apply() contributes the Web UI Plugins group as a first-level
+ * settings section ("settings.section", a list slot keyed by id) rather than
+ * as a plugin-configuration card ("settings.plugin.item", a keyed slot).
+ *
+ * Regression guard for issue #513: DSH 0.1.0-rc.6+ rejects keyed-slot
+ * registrations without options.key, and the pre-0.1.18 bundles registered
+ * the group card into "settings.plugin.item" with an id - which made the web
+ * GUI fail to boot with "Failed to load plugins".
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/client/compat-settings-scope.ts', () => ({
+  WebUiSettingsBinder: class {
+    constructor(_ctx: unknown) {}
+  },
+}))
+
+import { apply } from '../src/client/index.ts'
+
+describe('web-ui-settings client registration', () => {
+  it('registers into settings.section with an id, not the keyed settings.plugin.item slot', () => {
+    const injected: string[] = []
+    const registered: Array<Record<string, unknown>> = []
+    const fakeCtx = {
+      effect: (fn: () => unknown) => {
+        fn()
+        return () => {}
+      },
+      locale: {
+        register: () => {},
+        bind: () => (key: string) => key,
+      },
+      get: () => undefined,
+      slots: {
+        inject: (name: string, fn: () => unknown) => {
+          injected.push(name)
+          fn()
+          return () => {}
+        },
+        register: (options: Record<string, unknown>) => {
+          registered.push(options)
+          return () => {}
+        },
+      },
+    }
+
+    apply(fakeCtx as never)
+
+    expect(injected).toEqual(['settings.section'])
+    expect(injected).not.toContain('settings.plugin.item')
+
+    const section = registered.find((entry) => entry.name === 'settings.section')
+    expect(section).toBeDefined()
+    expect(section?.id).toBe('web-ui-plugins')
+    expect(section?.children).toEqual({ 'web-ui.plugin.item': { kind: 'list', scope: 'root' } })
+
+    // The keyed slot must stay untouched: the host rejects entries without
+    // options.key and the group has no reason to contribute one there.
+    expect(registered.some((entry) => entry.name === 'settings.plugin.item')).toBe(false)
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

Close #513。DSH 0.1.0-rc.6+ 的 slot 运行时要求 keyed 槽注册必须带 `options.key`；0.1.17 及更早的 `@linxin666/dsh-client-ui-web-ui-settings` 把组卡片注册进 keyed 槽 `settings.plugin.item` 时只传了 `id`，于是 loader entry 应用阶段抛错，Web GUI 显示 Failed to load plugins。

该注册在 0.1.18 已改为一级 `settings.section`（list 槽，用 `id` 定位），0.2.0 已发布；`main` 代码与 rc.6/rc.7 兼容。本 PR 把修复固化并补上用户恢复路径：

- 新增 `packages/dsh-web-ui-settings/tests/client-apply.spec.tsx` 回归测试：断言 apply() 只注入 `settings.section`（带 `id: web-ui-plugins` 与 `web-ui.plugin.item` 子槽声明），绝不触碰 keyed 槽 `settings.plugin.item`。
- 修正 `dsh-task-board` / `dsh-remote-web-ui` 卡片头部注释：实际注册的是 `web-ui.plugin.item` 子槽，不再是 `settings.plugin.item`。
- `dsh-web-ui-all` 与 `dsh-web-ui-settings` 双语 README 新增故障排查节：报错含义、修复版本边界（0.1.17 及更早损坏，0.1.18+ 修复）、以及冻结 profile 的升级步骤（依赖升到 `^0.2.0`（至少 `^0.1.18`）、重装、重建 `node_modules/@linxin666/*` junction 链接、重启 `dsh web`），并已重录 README.i18n.yaml 配对。

## 涉及包（Affected Packages）

- [x] 任务看板 `packages/dsh-task-board`（仅注释）
- [x] 远程 Web UI `packages/dsh-remote-web-ui`（仅注释）
- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`

## PR 类型（PR Type）

- [x] Bug 修复
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch upstream && git checkout -B fix/issue-513-plugin-load-failure upstream/main`

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-web-ui-settings test
pnpm --filter @linxin666/dsh-client-ui-task-board test
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-client-ui-web-ui-settings typecheck
pnpm --filter @linxin666/dsh-client-ui-task-board typecheck
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
```

结果摘要：

- settings 测试 7 个文件 54 用例全过（含新增 client-apply 回归测试）。
- task-board 测试 226 用例通过（1 个原生电源 smoke 按预期跳过）。
- remote-web-ui 测试本机 2 个既有环境性用例失败（SDK 包缺失 `*.js.map` 的 sourcemap 警告 + mobile bundle 503），与本次仅注释改动无关，请以 CI 为准。
- 三个受影响包的 typecheck 全部通过。
- README.i18n.yaml 配对 hash 已按 `scripts/verify-docs.mjs` 逻辑重录（本机 Node 22.15.1 不支持 `import.meta.main`，脚本主体未执行；结构镜像与 hash 已对齐，CI 会复核）。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（纯 bug 修复与文档，无新增用户可见功能）。
