### PR TITLE
fix(web-ui-settings): route atomic settings batches through the bridge on the official-scope path (#516)

### DIFF
--- a/packages/dsh-web-ui-settings/src/client/compat-settings-scope.ts
+++ b/packages/dsh-web-ui-settings/src/client/compat-settings-scope.ts
@@ -5,9 +5,15 @@
  * namespace on rc.6 hosts (the apiproxy allowlist is hard-coded), which turns
  * every family plugin card into a read-only explanation. This binder wraps
  * the official scope: when it reports the namespace ready, the wrapper is a
- * pass-through; when it reports unavailable, a same-origin
- * bridge controller takes over and serves the same SettingsScope contract
- * from this package's host-side bridge routes (/api/dsh-web-ui-settings).
+ * pass-through for reads and single-field writes; when it reports
+ * unavailable, a same-origin bridge controller takes over and serves the
+ * same SettingsScope contract from this package's host-side bridge routes
+ * (/api/dsh-web-ui-settings). The bridge is described once on bind either
+ * way, because the official controller carries no batched mutate: cards
+ * whose cross-field validate hooks must judge several fields together (the
+ * describe-image baseURL+model pair, issue #516) route their atomic batch
+ * through the bridge whenever it serves the namespace, even while the
+ * official scope stays the read authority.
  * The Host keeps the bridge loopback-only by default and may explicitly admit
  * an authenticated same-host reverse proxy. Family plugins opt in through
  * ctx.get('webUiSettings') without a hard service dependency, so a deployment
@@ -345,7 +351,11 @@ export function createCompatScope<T>(options: CompatScopeOptions<T>): SettingsSc
     if (primary.getSnapshot().status === 'unavailable') startFallback()
   }))
   if (fallback !== undefined) unsubscribes.push(fallback.subscribe(publish))
-  if (primary.getSnapshot().status === 'unavailable') startFallback()
+  // Describe the bridge once on bind even while the official scope is ready:
+  // its snapshot is what the batch-mutate getter below gates on, so the
+  // verdict "bridge reachable and serving this namespace" is reached up front
+  // instead of only after the official scope turns unavailable.
+  startFallback()
   return {
     dispose: () => {
       for (const unsubscribe of unsubscribes.splice(0)) unsubscribe()
@@ -359,14 +369,22 @@ export function createCompatScope<T>(options: CompatScopeOptions<T>): SettingsSc
       fallbackStarted = true
       await fallback?.load()
     },
-    // The batch surface exists only while the bridge controller is the active
-    // transport; the official scope path still writes per-field (its writes
-    // are out of our reach, so the card's duck-typed detection falls back to
-    // the per-field loop there). A getter keeps the capability decision at
-    // call time instead of freezing it when the wrapper is built.
+    // The batch surface exists while the bridge controller is the active
+    // transport. A ready official scope still has no batched mutate (its
+    // controller exposes set/unset only), so an atomic batch is routed
+    // through the bridge whenever the bridge serves the namespace: the
+    // describe-image card's baseURL+model pair must land together (issue
+    // #516), and per-field writes deadlock on the host validate hook. The
+    // gate is the bridge's own snapshot — a remote browser (bridge 403) or an
+    // allowlisted-out namespace keeps this getter undefined and the card's
+    // per-field loop runs exactly as before. A getter keeps the capability
+    // decision at call time instead of freezing it when the wrapper is built.
     get mutate() {
       const backend = active()
       if (fallback !== undefined && backend === fallback && typeof fallback.mutate === 'function') return fallback.mutate.bind(fallback)
+      if (fallback !== undefined && typeof fallback.mutate === 'function' && fallback.getSnapshot().status === 'ready') {
+        return fallback.mutate.bind(fallback)
+      }
       return undefined
     },
   }

--- a/packages/dsh-web-ui-settings/src/index.ts
+++ b/packages/dsh-web-ui-settings/src/index.ts
@@ -5,9 +5,10 @@
  * user's web_settings_namespaces allowlist from settings.yaml (with the
  * built-in family fallback list). An explicit authenticated-proxy config may
  * admit exact same-origin Hosts without changing the default. The browser
- * half uses it only when the official settings scope reports the namespace
- * unavailable, so hosts whose apiproxy already exposes the namespaces never
- * touch the bridge.
+ * half uses it for reads and writes only when the official settings scope
+ * reports the namespace unavailable; on hosts whose apiproxy already exposes
+ * the namespaces it still answers the atomic batch mutate the official scope
+ * lacks (issue #516).
  */
 
 import { readFileSync } from 'node:fs'

--- a/packages/dsh-web-ui-settings/src/protocol.ts
+++ b/packages/dsh-web-ui-settings/src/protocol.ts
@@ -10,7 +10,9 @@
  * HTTP pair, gated by the user's web_settings_namespaces allowlist from
  * settings.yaml with a built-in family fallback list. On hosts whose
  * apiproxy already exposes the namespaces, the official settings scope stays
- * the primary transport and this bridge never activates.
+ * the primary read and single-field transport; atomic batched writes (the
+ * describe-image baseURL+model pair, issue #516) still ride the bridge while
+ * it serves the namespace.
  */
 
 /** Bridge route prefix (same-origin, loopback-only). */

--- a/packages/dsh-web-ui-settings/tests/compat-scope.spec.ts
+++ b/packages/dsh-web-ui-settings/tests/compat-scope.spec.ts
@@ -2,9 +2,11 @@
 
 /**
  * Compatibility scope state machine: the official scope stays authoritative
- * while it serves the namespace; the bridge controller takes over its
- * unavailable state over same-origin fetch; writes route to the active
- * transport; and a missing fetch keeps the official unavailable behavior.
+ * for reads and single-field writes while it serves the namespace; the bridge
+ * controller takes over its unavailable state over same-origin fetch and also
+ * answers the batched mutate the official scope lacks whenever it serves the
+ * namespace (the describe-image baseURL+model pair, issue #516). A missing
+ * fetch keeps the official unavailable behavior.
  */
 
 import { describe, expect, it, vi } from 'vitest'
@@ -103,13 +105,16 @@ const unavailable = (): SettingsScopeSnapshot<never> => ({
 })
 
 describe('createCompatScope', () => {
-  it('passes the official scope through while it serves the namespace', () => {
+  it('passes the official scope through while it serves the namespace', async () => {
     const primary = fakePrimary<{ enabled: boolean }>(ready({ enabled: true }))
     const { fetchFn, handler } = fakeFetch(async () => describeResult([]))
     const scope = createCompatScope<{ enabled: boolean }>({ namespace: 'task-board', primary: primary.scope, fetchFn })
     expect(scope.getSnapshot().status).toBe('ready')
     expect(scope.getSnapshot().value).toEqual({ enabled: true })
-    expect(handler).not.toHaveBeenCalled()
+    // The bridge is described once on bind even while the official scope is
+    // ready, so the batch-mutate getter can judge bridge reachability up
+    // front instead of only after the official scope turns unavailable.
+    await vi.waitFor(() => { expect(handler).toHaveBeenCalledTimes(1) })
   })
 
   it('bridges the namespace when the official scope reports unavailable', async () => {
@@ -185,12 +190,58 @@ function batchView(ns: string, value: unknown, revision: number, extra: { user?:
 }
 
 describe('createCompatScope batch mutate', () => {
-  it('exposes no mutate while the official scope serves the namespace', async () => {
+  it('exposes no mutate while the official scope serves the namespace but the bridge does not', async () => {
     const primary = fakePrimary<{ enabled: boolean }>(ready({ enabled: true }))
-    const { fetchFn } = fakeFetch(async () => describeResult([]))
+    const { fetchFn, handler } = fakeFetch(async () => describeResult([]))
     const scope = createCompatScope<{ enabled: boolean }>({ namespace: 'task-board', primary: primary.scope, fetchFn })
     expect(scope.getSnapshot().status).toBe('ready')
+    await vi.waitFor(() => { expect(handler).toHaveBeenCalledTimes(1) })
     expect(typeof (scope as unknown as { mutate?: unknown }).mutate).not.toBe('function')
+  })
+
+  it('exposes the bridge batch surface while the official scope is ready, for atomic multi-field saves', async () => {
+    const primary = fakePrimary<{ baseURL: string; model: string }>(ready({ baseURL: 'https://old/v1', model: 'old' }))
+    const calls: Array<{ body: Record<string, unknown> }> = []
+    const { fetchFn } = fakeFetch(async (url, init) => {
+      if (url === WEB_UI_SETTINGS_BRIDGE_PREFIX + '/describe') {
+        return describeResult([batchView('describe-image', { baseURL: 'https://old/v1', model: 'old' }, 3, { user: { baseURL: 'https://old/v1', model: 'old' } })])
+      }
+      calls.push({ body: JSON.parse(String(init.body)) as Record<string, unknown> })
+      return { ok: true, value: batchView('describe-image', { baseURL: 'https://a/v1', model: 'm' }, 4, { user: { baseURL: 'https://a/v1', model: 'm' } }) }
+    })
+    const scope = createCompatScope<{ baseURL: string; model: string }>({ namespace: 'describe-image', primary: primary.scope, fetchFn })
+    expect(scope.getSnapshot().status).toBe('ready')
+    // Reads still project the official scope.
+    expect(scope.getSnapshot().value).toEqual({ baseURL: 'https://old/v1', model: 'old' })
+    // The getter turns on once the bridge describe settles ready.
+    await vi.waitFor(() => { expect(typeof (scope as unknown as { mutate?: unknown }).mutate).toBe('function') })
+    const mutate = (scope as unknown as { mutate: (writes: { field: string; op: 'set'; value: unknown }[]) => Promise<{ ok: boolean; fields: { field: string; landed: boolean }[] }> }).mutate
+    const result = await mutate([
+      { field: 'baseURL', op: 'set', value: 'https://a/v1' },
+      { field: 'model', op: 'set', value: 'm' },
+    ])
+    expect(calls).toHaveLength(1)
+    const body = calls[0].body
+    expect(body.ns).toBe('describe-image')
+    expect(body.expectedRevision).toBe(3)
+    expect(body.ops).toEqual([
+      { op: 'set', path: ['baseURL'], value: 'https://a/v1' },
+      { op: 'set', path: ['model'], value: 'm' },
+    ])
+    expect(result.ok).toBe(true)
+    expect(result.fields).toEqual([
+      { field: 'baseURL', landed: true },
+      { field: 'model', landed: true },
+    ])
+  })
+
+  it('keeps single-field writes on the official scope while the bridge is ready for batches', async () => {
+    const primary = fakePrimary<{ enabled: boolean }>(ready({ enabled: true }))
+    const { fetchFn } = fakeFetch(async () => describeResult([bridgeView('task-board', { enabled: true }, 3)]))
+    const scope = createCompatScope<{ enabled: boolean }>({ namespace: 'task-board', primary: primary.scope, fetchFn })
+    await vi.waitFor(() => { expect(typeof (scope as unknown as { mutate?: unknown }).mutate).toBe('function') })
+    await scope.set('enabled', false)
+    expect(primary.sets).toEqual([['enabled', false]])
   })
 
   it('posts every op in one /mutate and reports per-field success', async () => {


### PR DESCRIPTION
## 摘要（Summary）

修复 #516：「图像理解」设置卡片在 DSH 0.1.0-rc.7（官方 settings scope 可用、apiproxy 直连）下保存 baseURL / model 仍提示「保存失败」，`~/.dsh/settings.yaml` 不落盘。

根因：官方 settings scope 没有批量 mutate，compat scope 原先只在官方 scope unavailable（bridge 接管）时暴露 mutate；官方 scope ready 时卡片回落逐字段写入，而宿主校验要求 baseURL 与 model 同时存在，逐字段写入互相被拒，形成死锁。

本次改动让批量保存走 compat bridge 的一次 `/mutate`：宿主的 validate 钩子把 baseURL + model 作为整体校验，原子通过。

## 涉及包（Affected Packages）

- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`

（仅改 `dsh-web-ui-settings`，聚合包无需重新生成。）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream
git switch -c fix/issue-516-describe-image-batch-save upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README）。

## 具体改动

`packages/dsh-web-ui-settings/src/client/compat-settings-scope.ts`：

- bind 时即使官方 scope 是 ready 也 describe 一次 bridge，提前得出「bridge 可达且服务该 namespace」的判定；
- `mutate` getter 在官方 scope ready 但 bridge 快照 ready 时返回 bridge 的批量 mutate，卡片保存改为一次 `/mutate`，跨字段校验原子通过；
- 单字段 `set` / `unset` 仍走官方 scope；bridge 不可达（远程浏览器 403）或被 `web_settings_namespaces` 排除时维持原逐字段行为，避免对远程浏览器场景引入回归。

`packages/dsh-web-ui-settings/src/protocol.ts`、`src/index.ts`：同步更新 bridge 行为说明注释。

`packages/dsh-web-ui-settings/tests/compat-scope.spec.ts`：

- 新增用例：官方 scope ready 且 bridge 服务该 namespace 时，批量保存走一次 bridge `/mutate` 并报告逐字段落盘结果；
- 新增回归用例：官方 scope ready 时单字段写入仍路由到官方 scope；
- 更新既有用例以匹配「bind 时总是 describe 一次 bridge」的新行为。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-web-ui-settings
node node_modules/vitest/dist/cli.js run
node node_modules/typescript/bin/tsc --noEmit
cd ../dsh-tool-describe-image
node node_modules/vitest/dist/cli.js run
cd ../..
node scripts/sync-shared.mjs --check
node scripts/verify-docs.mjs
```

结果摘要：

- `dsh-web-ui-settings`：56/56 测试通过；`tsc --noEmit` 通过；
- `dsh-tool-describe-image`：205/205 测试通过（确认无回归）；
- `sync-shared --check` 与 `docs:check` 通过。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A。

本环境未运行 `dsh web` 图形界面做截图验收；保存路径行为由新增的 compat-scope 单测覆盖，复现环境与手动落盘对照见 issue #516 的冒烟测试描述。
