### PR TITLE
fix(liangshen): preserve instruction hint message id

### DIFF
--- a/packages/dsh-liangshen/presets/liangshen/tool-bootstrap.mjs
+++ b/packages/dsh-liangshen/presets/liangshen/tool-bootstrap.mjs
@@ -179,8 +179,11 @@ function extractInstructionPaths(message) {
 }
 
 /** The one-time non-imperative hint replacing the full-text dump (E1.5 wording). */
-function buildInstructionHint(paths) {
+function buildInstructionHint(original, paths) {
   return {
+    id: typeof original?.id === 'string' && original.id !== ''
+      ? original.id
+      : crypto.randomUUID(),
     role: 'user',
     content: [{
       type: 'text',
@@ -214,7 +217,7 @@ function instructionHintMessages(messages, state) {
       continue
     }
     state.instructionHinted = true
-    kept.push(buildInstructionHint(paths))
+    kept.push(buildInstructionHint(message, paths))
   }
   return kept
 }

--- a/packages/dsh-liangshen/tests/tool-bootstrap.test.ts
+++ b/packages/dsh-liangshen/tests/tool-bootstrap.test.ts
@@ -255,6 +255,7 @@ describe('anchored-tool-bootstrap', () => {
     expect(first.messages[0].id).toBe('user')
     const hint = first.messages[1]
     expect(hint.source.kind).toBe('instruction-hint')
+    expect(hint.id).toBe('instructions')
     expect(hint.content[0].text).toContain('Reference documents exist: ~/.dsh/AGENTS.md, AGENTS.md.')
     expect(hint.content[0].text).toContain('not task instructions')
     expect(hint.content[0].text).not.toContain('Global rules.')
@@ -265,6 +266,35 @@ describe('anchored-tool-bootstrap', () => {
       async () => ({ kind: 'enter', messages }),
     )
     expect(second.messages.map((entry: any) => entry.id)).toEqual(['user'])
+  })
+
+  test('instructionHint generates an id when the original instructions message has none (#510)', async () => {
+    const listeners = register({ instructionHint: true })
+    const preStepListener = listener(listeners, 'agent/pre-step')
+    const assembleListener = listener(listeners, 'system-prompt/assemble')
+    const sessionObj = { events: [{ type: 'tool/call' }] }
+    await assembleListener(undefined, { agent: { session: sessionObj } }, async () => ({
+      system: 'minimal persona',
+      tools: [{ name: 'bash' }, { name: 'read' }],
+    }))
+
+    const dump = {
+      role: 'user',
+      content: [{
+        type: 'text',
+        text: '<system-reminder>\n\nInstructions from: AGENTS.md\n\nRepo rules.\n</system-reminder>',
+      }],
+      source: { kind: 'agent-instructions' },
+    }
+    const messages = [message('user', 'user'), dump]
+    const result = await preStepListener(
+      { agent: { session: sessionObj }, messages, turn: 1, step: 1, signal: {} },
+      async () => ({ kind: 'enter', messages }),
+    )
+    const hint = result.messages[1]
+    expect(hint.source.kind).toBe('instruction-hint')
+    expect(hint.id).toEqual(expect.any(String))
+    expect(hint.id).not.toBe('')
   })
 
   test('instructionHint passes an instructions message with no file sections through', async () => {


### PR DESCRIPTION
## 摘要（Summary）

Fixes the liangshen instructionHint replacement message so persisted `user/message` events keep a valid non-empty `id`. This prevents DSH session cold-load validation from rejecting histories with `SessionPersistenceCorruptionError`.

Closes #510.

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）: `packages/dsh-liangshen`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin main
git worktree add -b fix/liangshen-instruction-hint-id D:\Code\dsh-web-ui-issue-510 origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5 Codex

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

N/A

## 新皮肤收录（New Skin）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-liangshen exec vitest run tests/tool-bootstrap.test.ts
pnpm --filter @linxin666/dsh-liangshen typecheck
pnpm --filter @linxin666/dsh-liangshen test
```

结果摘要：

- `tests/tool-bootstrap.test.ts` 回归测试修复前复现失败：hint `id` 为 `undefined`；修复后通过，45 tests passed。
- `pnpm --filter @linxin666/dsh-liangshen typecheck` 通过。
- `pnpm --filter @linxin666/dsh-liangshen test` 在本机 Windows 环境失败于既有 `tests/custom-bash.test.ts` 路径分隔断言：`bashCandidates` 生成 Windows 反斜杠路径，而测试期望 POSIX `/opt/...`。本 PR 改动不经过 custom-bash 逻辑；其余 92/94 tests passed。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A - session persistence shape fix covered by regression tests.