### PR TITLE
fix(skin-center): resolve scene wallpapers to the real container and render frames (#521)

### DIFF
--- a/packages/skins/skin-center/src/client/skin-center.module.css
+++ b/packages/skins/skin-center/src/client/skin-center.module.css
@@ -7,6 +7,21 @@
    is themed by the active (or tried-on) skin automatically. Never use bare
    hex here: a token-less rule is a light-theme-only bug. */
 
+/* While a wallpaper is mounted the fixed media/scrim layers live behind
+   the shell's grid; the shell's own opaque frame + sidebar backgrounds would
+   otherwise cover them. The controller flags document.body with
+   data-dsh-wallpaper-active and these rules punch the backgrounds through.
+   The data-dsh-frame / data-pane attributes are stamped by the dsh-web-ui-all
+   compat shim; the :has() rule covers standalone installs without the shim. */
+body[data-dsh-skin-center][data-dsh-wallpaper-active] [data-dsh-frame],
+body[data-dsh-skin-center][data-dsh-wallpaper-active] :has(> [class*="sidebarCol"]) {
+  background: transparent;
+}
+body[data-dsh-skin-center][data-dsh-wallpaper-active] [data-pane="sidebar"],
+body[data-dsh-skin-center][data-dsh-wallpaper-active] [class*="sidebarCol"] {
+  background: transparent;
+}
+
 /* The section wrapper: one list that stacks the skin-center card rows. */
 body[data-dsh-skin-center] .sectionList {
   list-style: none;

--- a/packages/skins/skin-center/src/client/wallpaper.ts
+++ b/packages/skins/skin-center/src/client/wallpaper.ts
@@ -315,6 +315,11 @@ export class WallpaperController implements WallpaperHandle {
       styleLayer(this.scrimLayer, -2)
       document.body.appendChild(this.scrimLayer)
     }
+    // While a wallpaper is mounted the shell's own opaque frame/column
+    // backgrounds would hide the fixed layers behind them; the body flag
+    // switches those backgrounds to transparent (skin-center.module.css) and
+    // is removed again on teardown.
+    document.body.setAttribute('data-dsh-wallpaper-active', '')
     const mediaKey = descriptor.id + ':' + this.modeValue
     if (this.mediaLayer.dataset.mediaKey !== mediaKey) {
       this.mediaLayer.dataset.mediaKey = mediaKey
@@ -431,6 +436,7 @@ export class WallpaperController implements WallpaperHandle {
       this.scrimLayer.remove()
       this.scrimLayer = null
     }
+    document.body.removeAttribute('data-dsh-wallpaper-active')
   }
 
   private publish(): void {

--- a/packages/skins/skin-center/src/pkg-extract.ts
+++ b/packages/skins/skin-center/src/pkg-extract.ts
@@ -31,11 +31,16 @@
  *
  * LZ4 block decoding follows the official lz4 block format specification;
  * BC1/BC2/BC3 follow the standard public algorithms. No npm dependencies.
+ * `extractSceneMainImageFromDir` additionally handles loose scene projects
+ * (scene.json + materials/*.tex on disk, as WE's bundled defaultprojects
+ * ship them) so local scenes without a .pkg still yield a static frame.
  *
  * @module @linxin666/dsh-client-ui-skin-center/pkg-extract
  */
 
 import { Buffer } from 'node:buffer'
+import { readFileSync } from 'node:fs'
+import { isAbsolute, join as joinPath, relative, resolve as resolvePath } from 'node:path'
 import { deflateSync } from 'node:zlib'
 
 /** One file inside a PKG container. */
@@ -139,6 +144,11 @@ export interface SceneMainImage {
 }
 
 const textDecoder = new TextDecoder('utf-8')
+
+/** Package paths may use backslashes; normalize to '/' for lookups. */
+function normalizePkgPath(path: string): string {
+  return path.replace(/\\/g, '/')
+}
 
 /**
  * Bounds-checked little-endian binary reader. Every failed read throws an
@@ -331,14 +341,15 @@ export function parsePkg(data: Uint8Array): PkgEntry[] {
   }
   const dataStart = r.pos
   return index.map(({ path, offset, length }) => {
+    const normalized = normalizePkgPath(path)
     const abs = dataStart + offset
     if (abs + length > data.byteLength) {
-      throw new Error("pkg: entry '" + path + "' out of bounds")
+      throw new Error("pkg: entry '" + normalized + "' out of bounds")
     }
     const originalSize = probeCompressedEntry(data, abs, length)
     return originalSize === null
-      ? { path, offset: abs, compressedSize: length, size: length, flags: 0 }
-      : { path, offset: abs, compressedSize: length, size: originalSize, flags: PKG_ENTRY_FLAG_LZ4 }
+      ? { path: normalized, offset: abs, compressedSize: length, size: length, flags: 0 }
+      : { path: normalized, offset: abs, compressedSize: length, size: originalSize, flags: PKG_ENTRY_FLAG_LZ4 }
   })
 }
 
@@ -687,10 +698,35 @@ function decodeDxt5(src: Uint8Array, width: number, height: number): Uint8Array 
   return out
 }
 
+/** IEEE 754 half float to number; NaN/Infinity propagate to callers. */
+function halfFloatToNumber(half: number): number {
+  const sign = (half & 0x8000) !== 0 ? -1 : 1
+  const exponent = (half >> 10) & 0x1f
+  const mantissa = half & 0x3ff
+  if (exponent === 0) return sign * mantissa * 2 ** -24
+  if (exponent === 31) return mantissa === 0 ? sign * Infinity : NaN
+  return sign * (1 + mantissa / 1024) * 2 ** (exponent - 15)
+}
+
+/** Half float to 8-bit channel: NaN to 0, out-of-range values clipped. */
+function halfFloatToByte(half: number): number {
+  const value = halfFloatToNumber(half)
+  if (Number.isNaN(value)) return 0
+  if (!Number.isFinite(value)) return value > 0 ? 255 : 0
+  return Math.max(0, Math.min(255, Math.round(value * 255)))
+}
+
+/** 10-bit channel to 8-bit (rounds, then clips). */
+function channel10To8(value: number): number {
+  return Math.max(0, Math.min(255, Math.round((value * 255) / 1023)))
+}
+
 /**
  * Decode the first (largest) mipmap of a TEX container to RGBA8888.
- * Supports RGBA8888, R8, RG88 and DXT1/DXT3/DXT5; embedded MP4 textures and
- * unknown formats throw a descriptive error instead of failing silently.
+ * Supports RGBA8888, RGB888, RGB565, R8, RG88, RG1616F, R16F,
+ * RGBA1010102, RGBA16161616F, RGB161616F and DXT1/DXT3/DXT5; embedded MP4
+ * textures and unknown formats throw a descriptive error instead of failing
+ * silently.
  */
 export function decodeTex(data: Uint8Array): DecodedImage {
   const parsed = parseTexInternal(data)
@@ -742,6 +778,103 @@ export function decodeTex(data: Uint8Array): DecodedImage {
       const expected = Math.ceil(width / 4) * Math.ceil(height / 4) * 16
       if (bytes.length < expected) throw new Error('tex: mipmap size mismatch for DXT5')
       return { width, height, rgba: decodeDxt5(bytes, width, height) }
+    }
+    case TexFormat.RGB888: {
+      if (bytes.length < width * height * 3) throw new Error('tex: mipmap size mismatch for RGB888')
+      const rgba = new Uint8Array(width * height * 4)
+      for (let i = 0; i < width * height; i++) {
+        const source = i * 3
+        const target = i * 4
+        rgba[target] = bytes[source]
+        rgba[target + 1] = bytes[source + 1]
+        rgba[target + 2] = bytes[source + 2]
+        rgba[target + 3] = 255
+      }
+      return { width, height, rgba }
+    }
+    case TexFormat.RGB565: {
+      if (bytes.length < width * height * 2) throw new Error('tex: mipmap size mismatch for RGB565')
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      const rgba = new Uint8Array(width * height * 4)
+      for (let i = 0; i < width * height; i++) {
+        const [r, g, b] = rgb565(view.getUint16(i * 2, true))
+        const target = i * 4
+        rgba[target] = r
+        rgba[target + 1] = g
+        rgba[target + 2] = b
+        rgba[target + 3] = 255
+      }
+      return { width, height, rgba }
+    }
+    case TexFormat.RG1616F: {
+      if (bytes.length < width * height * 4) throw new Error('tex: mipmap size mismatch for RG1616F')
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      const rgba = new Uint8Array(width * height * 4)
+      for (let i = 0; i < width * height; i++) {
+        const source = i * 4
+        const target = i * 4
+        rgba[target] = halfFloatToByte(view.getUint16(source, true))
+        rgba[target + 1] = halfFloatToByte(view.getUint16(source + 2, true))
+        rgba[target + 2] = 0
+        rgba[target + 3] = 255
+      }
+      return { width, height, rgba }
+    }
+    case TexFormat.R16F: {
+      if (bytes.length < width * height * 2) throw new Error('tex: mipmap size mismatch for R16F')
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      const rgba = new Uint8Array(width * height * 4)
+      for (let i = 0; i < width * height; i++) {
+        const value = halfFloatToByte(view.getUint16(i * 2, true))
+        const target = i * 4
+        rgba[target] = value
+        rgba[target + 1] = value
+        rgba[target + 2] = value
+        rgba[target + 3] = 255
+      }
+      return { width, height, rgba }
+    }
+    case TexFormat.RGBA1010102: {
+      if (bytes.length < width * height * 4) throw new Error('tex: mipmap size mismatch for RGBA1010102')
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      const rgba = new Uint8Array(width * height * 4)
+      for (let i = 0; i < width * height; i++) {
+        const value = view.getUint32(i * 4, true)
+        const target = i * 4
+        rgba[target] = channel10To8((value >>> 20) & 0x3ff)
+        rgba[target + 1] = channel10To8((value >>> 10) & 0x3ff)
+        rgba[target + 2] = channel10To8(value & 0x3ff)
+        rgba[target + 3] = (value >>> 30) * 85
+      }
+      return { width, height, rgba }
+    }
+    case TexFormat.RGBA16161616F: {
+      if (bytes.length < width * height * 8) throw new Error('tex: mipmap size mismatch for RGBA16161616F')
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      const rgba = new Uint8Array(width * height * 4)
+      for (let i = 0; i < width * height; i++) {
+        const source = i * 8
+        const target = i * 4
+        rgba[target] = halfFloatToByte(view.getUint16(source, true))
+        rgba[target + 1] = halfFloatToByte(view.getUint16(source + 2, true))
+        rgba[target + 2] = halfFloatToByte(view.getUint16(source + 4, true))
+        rgba[target + 3] = halfFloatToByte(view.getUint16(source + 6, true))
+      }
+      return { width, height, rgba }
+    }
+    case TexFormat.RGB161616F: {
+      if (bytes.length < width * height * 6) throw new Error('tex: mipmap size mismatch for RGB161616F')
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      const rgba = new Uint8Array(width * height * 4)
+      for (let i = 0; i < width * height; i++) {
+        const source = i * 6
+        const target = i * 4
+        rgba[target] = halfFloatToByte(view.getUint16(source, true))
+        rgba[target + 1] = halfFloatToByte(view.getUint16(source + 2, true))
+        rgba[target + 2] = halfFloatToByte(view.getUint16(source + 4, true))
+        rgba[target + 3] = 255
+      }
+      return { width, height, rgba }
     }
     default:
       throw new Error('tex: unsupported format ' + parsed.format)
@@ -804,38 +937,60 @@ export function encodePng(width: number, height: number, rgba: Uint8Array): Buff
   ])
 }
 
-/** Extract .tex candidate paths referenced by one scene.json image object. */
+/** Push one texture reference, normalized to '/'. */
+function pushTextureRef(ref: unknown, out: string[]): void {
+  if (typeof ref !== 'string') return
+  const name = normalizePkgPath(ref)
+  if (name.toLowerCase().endsWith('.tex')) out.push(name)
+}
+
+/** Walk arbitrary JSON, pushing every string that references a .tex file. */
+function walkTextureRefs(value: unknown, out: string[]): void {
+  if (typeof value === 'string') {
+    pushTextureRef(value, out)
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) walkTextureRefs(item, out)
+    return
+  }
+  if (value !== null && typeof value === 'object') {
+    for (const child of Object.values(value)) walkTextureRefs(child, out)
+  }
+}
+
+/**
+ * Extract .tex candidate paths referenced by one scene.json image object.
+ * The `image` reference normally names a material json whose passes carry
+ * the texture paths (RePKG scene model); shader scenes can also inline
+ * texture lists in other fields, so every non-image field is walked
+ * recursively for `.tex` references.
+ */
 function collectImageObjectTextures(
   imageObject: Record<string, unknown>,
   readJson: (path: string) => unknown | null,
 ): string[] {
   const out: string[] = []
-  const pushTextureList = (list: unknown): void => {
-    if (!Array.isArray(list)) return
-    for (const item of list) {
-      const name =
-        typeof item === 'string'
-          ? item
-          : item && typeof item === 'object' && typeof (item as { name?: unknown }).name === 'string'
-            ? (item as { name: string }).name
-            : null
-      if (name && name.toLowerCase().endsWith('.tex')) out.push(name)
+  const image = imageObject.image
+  if (typeof image === 'string') {
+    const ref = normalizePkgPath(image)
+    if (ref.toLowerCase().endsWith('.tex')) {
+      out.push(ref)
+    } else {
+      const material = readJson(ref) as { passes?: { textures?: unknown }[] } | null
+      if (material && Array.isArray(material.passes)) {
+        for (const pass of material.passes) {
+          if (pass && typeof pass === 'object' && Array.isArray(pass.textures)) {
+            for (const texture of pass.textures) pushTextureRef(texture, out)
+          }
+        }
+      }
     }
   }
-  const ref = imageObject.image as string
-  if (ref.toLowerCase().endsWith('.tex')) {
-    out.push(ref)
-  } else {
-    // the image reference normally points at a material json whose passes
-    // carry the actual texture paths (RePKG scene model)
-    const material = readJson(ref) as { passes?: { textures?: unknown }[] } | null
-    if (material && Array.isArray(material.passes)) {
-      for (const pass of material.passes) pushTextureList(pass?.textures)
-    }
+  for (const [key, value] of Object.entries(imageObject)) {
+    if (key === 'image') continue
+    walkTextureRefs(value, out)
   }
-  // per-instance texture overrides
-  const instance = imageObject.instance as { textures?: unknown } | undefined
-  if (instance && typeof instance === 'object') pushTextureList(instance.textures)
   return out
 }
 
@@ -851,7 +1006,7 @@ export function extractSceneMainImage(pkgData: Uint8Array): SceneMainImage {
   const entries = parsePkg(pkgData)
   const byPath = new Map(entries.map((entry) => [entry.path.toLowerCase(), entry]))
   const readJson = (path: string): unknown | null => {
-    const entry = byPath.get(path.toLowerCase())
+    const entry = byPath.get(normalizePkgPath(path).toLowerCase())
     if (!entry) return null
     try {
       return JSON.parse(textDecoder.decode(readPkgEntry(pkgData, entry)))
@@ -859,17 +1014,18 @@ export function extractSceneMainImage(pkgData: Uint8Array): SceneMainImage {
       return null
     }
   }
-  const scene = readJson('scene.json') as { objects?: unknown } | null
-  if (!scene || !Array.isArray(scene.objects)) {
-    throw new Error('pkg: scene.json not found or invalid')
-  }
   const candidates: string[] = []
-  const imageObject = (scene.objects as unknown[]).find(
-    (o): o is Record<string, unknown> =>
-      !!o && typeof o === 'object' && typeof (o as { image?: unknown }).image === 'string',
-  )
-  if (imageObject) candidates.push(...collectImageObjectTextures(imageObject, readJson))
-  // fallback: every .tex in the package, largest pixel area first
+  const scene = readJson('scene.json') as { objects?: unknown } | null
+  if (scene && Array.isArray(scene.objects)) {
+    for (const object of scene.objects as unknown[]) {
+      if (object !== null && typeof object === 'object') {
+        candidates.push(...collectImageObjectTextures(object as Record<string, unknown>, readJson))
+      }
+    }
+  }
+  // Fallback: every .tex in the package, largest pixel area first. This also
+  // covers packages without a (readable) scene.json, shader-only scenes and
+  // scene.json files whose image objects never materialize a texture path.
   const texEntries = entries.filter((entry) => entry.path.toLowerCase().endsWith('.tex'))
   const ranked: { path: string; area: number }[] = []
   for (const entry of texEntries) {
@@ -889,7 +1045,7 @@ export function extractSceneMainImage(pkgData: Uint8Array): SceneMainImage {
   }
   let lastError: unknown = null
   for (const path of candidates) {
-    const entry = byPath.get(path.toLowerCase())
+    const entry = byPath.get(normalizePkgPath(path).toLowerCase())
     if (!entry) {
       lastError = new Error("pkg: texture '" + path + "' not found in package")
       continue
@@ -898,8 +1054,87 @@ export function extractSceneMainImage(pkgData: Uint8Array): SceneMainImage {
       const { width, height, rgba } = decodeTex(readPkgEntry(pkgData, entry))
       return { width, height, png: encodePng(width, height, rgba), texturePath: entry.path }
     } catch (err) {
-      lastError = err
+      // Wrap with the failing texture path and format name so the route's
+      // 422 payload explains exactly which scene asset could not decode.
+      const detail = err instanceof Error ? err.message : String(err)
+      const formatName = (() => {
+        try {
+          return parseTex(readPkgEntry(pkgData, entry)).formatName
+        } catch {
+          return null
+        }
+      })()
+      lastError = new Error(
+        "pkg: cannot decode texture '" + entry.path + "'" +
+        (formatName !== null ? ' (' + formatName + ')' : '') + ': ' + detail,
+      )
     }
   }
   throw lastError instanceof Error ? lastError : new Error('pkg: no decodable texture found')
+}
+
+/**
+ * A scene-dir json reader: resolves material paths against `sceneDir` and
+ * refuses anything that escapes it. Local wallpaper content is trusted
+ * input, but a stray `../` must never read outside the project.
+ */
+function dirReadJson(sceneDir: string): (path: string) => unknown | null {
+  const root = resolvePath(sceneDir)
+  return (path: string): unknown | null => {
+    const abs = resolvePath(root, normalizePkgPath(path))
+    const rel = relative(root, abs)
+    if (rel.startsWith('..') || isAbsolute(rel)) return null
+    try {
+      return JSON.parse(readFileSync(abs, 'utf8'))
+    } catch {
+      return null
+    }
+  }
+}
+
+/**
+ * Extract a static frame from a loose scene project (scene.json sitting
+ * next to its materials/*.tex files on disk, the layout of Wallpaper
+ * Engine's bundled defaultprojects). Only textures referenced by scene.json
+ * image objects are considered: model / particle scenes carry no usable
+ * static texture, so they return null and the caller falls back to the
+ * project's preview image.
+ * @param sceneDir - absolute project directory holding scene.json.
+ */
+export function extractSceneMainImageFromDir(sceneDir: string): SceneMainImage | null {
+  let scene: unknown
+  try {
+    scene = JSON.parse(readFileSync(joinPath(sceneDir, 'scene.json'), 'utf8'))
+  } catch {
+    return null
+  }
+  if (scene === null || typeof scene !== 'object') return null
+  const objects = (scene as { objects?: unknown }).objects
+  if (!Array.isArray(objects)) return null
+  const readJson = dirReadJson(sceneDir)
+  const root = resolvePath(sceneDir)
+  const candidates: string[] = []
+  for (const object of objects) {
+    if (object === null || typeof object !== 'object') continue
+    candidates.push(...collectImageObjectTextures(object as Record<string, unknown>, readJson))
+  }
+  for (const path of candidates) {
+    const abs = resolvePath(root, normalizePkgPath(path))
+    const rel = relative(root, abs)
+    if (rel.startsWith('..') || isAbsolute(rel)) continue
+    let data: Uint8Array
+    try {
+      data = new Uint8Array(readFileSync(abs))
+    } catch {
+      continue
+    }
+    try {
+      const { width, height, rgba } = decodeTex(data)
+      return { width, height, png: encodePng(width, height, rgba), texturePath: normalizePkgPath(path) }
+    } catch {
+      // Try the next candidate; a model scene with no image textures ends
+      // up returning null below.
+    }
+  }
+  return null
 }

--- a/packages/skins/skin-center/src/we-library.ts
+++ b/packages/skins/skin-center/src/we-library.ts
@@ -60,7 +60,7 @@ export interface WallpaperEntry {
   previewAbs: string | null
   /** Discovery source. */
   source: WallpaperSource
-  /** Main file exists and the type is renderable in the browser (video/web). */
+  /** Main file exists and the entry is renderable (video/web directly, scene via the host-decoded frame). */
   playable: boolean
   /** Main-file mtime (ms) and size (bytes); 0 when the file is missing. */
   srcMtime: number
@@ -98,7 +98,7 @@ export interface WeInventory {
   /** Steam library roots that own app 431960. */
   libraryDirs: string[]
   total: number
-  /** Entries playable in the browser (video/web with an existing main file). */
+  /** Entries renderable in the browser (video/web/scene with an existing main file). */
   portableCount: number
   wallpapers: WallpaperEntry[]
 }
@@ -249,6 +249,75 @@ const VIDEO_FILE_RE = /\.(mp4|webm|mkv|avi|mov)$/i
 /** Web entry files. */
 const WEB_FILE_RE = /\.html?$/i
 
+/** Scene containers tried when project.json's declared main file is absent. */
+const SCENE_FILE_FALLBACKS = ['scene.pkg', 'scene.json']
+
+/** Normalize project.json paths to forward slashes (portable join/display). */
+export function normalizeSlashes(path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
+/** True when `path` names an existing regular file. */
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Pick a scene container from a project directory: `scene.pkg` first, then
+ * `scene.json`, then the single `*.pkg` file present (stable sorted order
+ * when several remain). Workshop scenes ship their assets inside scene.pkg
+ * while project.json often declares a `project\scene.json` path that does
+ * not exist on disk.
+ */
+function findSceneFallback(dir: string): string | null {
+  let names: string[] = []
+  try {
+    names = readdirSync(dir)
+  } catch {
+    return null
+  }
+  const files = names.filter((name) => isFile(joinPath(dir, name)))
+  const byLower = new Map(files.map((name) => [name.toLowerCase(), name]))
+  for (const candidate of SCENE_FILE_FALLBACKS) {
+    const hit = byLower.get(candidate)
+    if (hit !== undefined) return hit
+  }
+  const pkgs = files.filter((name) => name.toLowerCase().endsWith('.pkg')).sort((a, b) => a.localeCompare(b))
+  return pkgs[0] ?? null
+}
+
+/**
+ * Resolve a project's main file. The project.json `file` field is
+ * authoritative while it exists; scene projects frequently declare a path
+ * their published files do not contain (scene.json vs the actual scene.pkg),
+ * so scenes fall back to the container actually present. Returns the path
+ * relative to `dir` plus its absolute form.
+ */
+export function resolveMainFile(
+  dir: string,
+  declared: string,
+  type: WallpaperType,
+): { file: string; fileAbs: string; exists: boolean } {
+  const file = normalizeSlashes(declared)
+  // Scenes resolve through the container actually present, even when the
+  // declared scene.json also exists on disk: the frame route can only
+  // decode a scene.pkg, and a loose scene.json next to the real package
+  // must never win over it.
+  if (type === 'scene') {
+    const fallback = findSceneFallback(dir)
+    if (fallback !== null) {
+      return { file: fallback, fileAbs: resolvePath(dir, fallback), exists: true }
+    }
+  }
+  const direct = resolvePath(dir, file)
+  if (isFile(direct)) return { file, fileAbs: direct, exists: true }
+  return { file, fileAbs: direct, exists: false }
+}
+
 interface ProjectJson {
   title: string | null
   type: WallpaperType
@@ -272,8 +341,8 @@ export function readProjectJson(dir: string): ProjectJson | null {
     return {
       title: typeof record.title === 'string' && record.title !== '' ? record.title : null,
       type,
-      file: record.file,
-      preview: typeof record.preview === 'string' && record.preview !== '' ? record.preview : null,
+      file: normalizeSlashes(record.file),
+      preview: typeof record.preview === 'string' && record.preview !== '' ? normalizeSlashes(record.preview) : null,
     }
   } catch {
     return null
@@ -307,32 +376,30 @@ function synthesizeMediaEntries(dir: string, source: WallpaperSource): Wallpaper
 
 /** Build one entry from a project directory. */
 function entryFromDir(dir: string, source: WallpaperSource, project: ProjectJson, id?: string): WallpaperEntry {
-  const fileAbs = resolvePath(dir, project.file)
+  const main = resolveMainFile(dir, project.file, project.type)
   const previewAbs = project.preview ? resolvePath(dir, project.preview) : null
   let mtime = 0
   let size = 0
-  let fileExists = false
-  try {
-    const stat = statSync(fileAbs)
-    if (stat.isFile()) {
-      fileExists = true
+  if (main.exists) {
+    try {
+      const stat = statSync(main.fileAbs)
       mtime = stat.mtimeMs
       size = stat.size
+    } catch {
+      // Vanished between the existence check and the stat: keep zeros.
     }
-  } catch {
-    // Missing main file: keep zeros.
   }
   return {
     id: id ?? basename(dir),
     title: project.title ?? basename(dir),
     type: project.type,
-    file: project.file,
+    file: main.file,
     preview: project.preview,
     dir,
-    fileAbs,
+    fileAbs: main.fileAbs,
     previewAbs: previewAbs && existsSync(previewAbs) ? previewAbs : null,
     source,
-    playable: fileExists && (project.type === 'video' || project.type === 'web'),
+    playable: main.exists && (project.type === 'video' || project.type === 'web' || project.type === 'scene'),
     srcMtime: mtime,
     srcSize: size,
     updateAvailable: false,
@@ -391,8 +458,8 @@ export function readImportedManifest(entryDir: string): ImportedManifest | null 
       srcMtime: typeof record.srcMtime === 'number' ? record.srcMtime : 0,
       srcSize: typeof record.srcSize === 'number' ? record.srcSize : 0,
       importedAt: typeof record.importedAt === 'number' ? record.importedAt : 0,
-      file: record.file,
-      preview: typeof record.preview === 'string' && record.preview !== '' ? record.preview : null,
+      file: normalizeSlashes(record.file),
+      preview: typeof record.preview === 'string' && record.preview !== '' ? normalizeSlashes(record.preview) : null,
     }
   } catch {
     return null
@@ -418,35 +485,48 @@ export function scanImportStore(storeDir: string): WallpaperEntry[] {
     const manifest = readImportedManifest(dir)
     if (!manifest) continue
     const projectDir = joinPath(dir, 'project')
-    const fileAbs = resolvePath(dir, manifest.file)
+    // The manifest records the copied main file relative to the store entry
+    // dir ('project/<file>'). Manifests written before the scene fallback
+    // kept the declared-but-never-copied path (scene.json vs the actual
+    // scene.pkg); re-find the scene container inside the copied project dir.
+    let file = manifest.file
+    let fileAbs = resolvePath(dir, manifest.file)
+    if (!isFile(fileAbs) && manifest.type === 'scene') {
+      const fallback = findSceneFallback(projectDir)
+      if (fallback !== null) {
+        file = fallback
+        fileAbs = resolvePath(projectDir, fallback)
+      }
+    }
+    if (file.startsWith('project/')) file = file.slice('project/'.length)
     const previewAbs = manifest.preview ? resolvePath(dir, manifest.preview) : null
+    const preview = manifest.preview && manifest.preview.startsWith('project/')
+      ? manifest.preview.slice('project/'.length)
+      : manifest.preview
     let mtime = 0
     let size = 0
     let fileExists = false
-    try {
-      const stat = statSync(fileAbs)
-      if (stat.isFile()) {
-        fileExists = true
+    if (isFile(fileAbs)) {
+      fileExists = true
+      try {
+        const stat = statSync(fileAbs)
         mtime = stat.mtimeMs
         size = stat.size
+      } catch {
+        // Vanished between the existence check and the stat: keep zeros.
       }
-    } catch {
-      // Missing copy: keep zeros.
     }
-    // A scene import is playable through the extracted frame route even
-    // though the raw .pkg is not browser-renderable; the routes layer
-    // decides. Here 'playable' stays the video/web definition.
     entries.push({
       id: `imported/${manifest.sourceId}`,
       title: manifest.title,
       type: manifest.type,
-      file: manifest.file,
-      preview: manifest.preview,
+      file,
+      preview,
       dir: projectDir,
       fileAbs,
       previewAbs: previewAbs && existsSync(previewAbs) ? previewAbs : null,
       source: 'imported',
-      playable: fileExists && (manifest.type === 'video' || manifest.type === 'web'),
+      playable: fileExists && (manifest.type === 'video' || manifest.type === 'web' || manifest.type === 'scene'),
       srcMtime: mtime,
       srcSize: size,
       updateAvailable: false,

--- a/packages/skins/skin-center/src/we-routes.ts
+++ b/packages/skins/skin-center/src/we-routes.ts
@@ -54,6 +54,8 @@ export interface WeRouteDeps {
   getConfig: () => WeRouteConfig
   /** Import-store root (<harnessHome>/skin-center/wallpapers). */
   storeDir: string
+  /** Disable Wallpaper Engine auto-detection (tests inject a synthetic library). */
+  autoDetect?: boolean
 }
 
 /** Sanitize a wallpaper id into a safe store directory name. */
@@ -128,6 +130,8 @@ interface WallpaperJson {
 export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
   // token -> absolute path, issued by the inventory handler only.
   const mediaMap = new Map<string, string>()
+  /** frame token -> preview path to serve when the frame cannot be decoded. */
+  const frameFallback = new Map<string, string | null>()
   const tokenFor = (absPath: string): string => {
     const token = Buffer.from(absPath, 'utf8').toString('base64url')
     mediaMap.set(token, absPath)
@@ -137,10 +141,20 @@ export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
   const freshInventory = () => buildInventory({
     manualDirs: deps.getConfig().weLibraryDirs ?? [],
     storeDir: deps.storeDir,
+    autoDetect: deps.autoDetect ?? true,
   })
 
   const entryToJson = (entry: WallpaperEntry): WallpaperJson => {
     const hasFile = existsSync(entry.fileAbs)
+    let frameUrl: string | null = null
+    if (entry.type === 'scene' && hasFile) {
+      const token = tokenFor(entry.fileAbs)
+      frameUrl = WE_API_PREFIX + '/scene-frame/' + token
+      // A scene whose frame cannot be decoded (model-only loose scenes, an
+      // unsupported texture format) falls back to the preview image instead
+      // of a broken <img>.
+      frameFallback.set(token, entry.previewAbs)
+    }
     return {
       id: entry.id,
       title: entry.title,
@@ -150,7 +164,7 @@ export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
       updateAvailable: entry.updateAvailable,
       videoUrl: entry.type === 'video' && hasFile ? WE_API_PREFIX + '/media/' + tokenFor(entry.fileAbs) : null,
       webUrl: entry.type === 'web' && hasFile ? WE_API_PREFIX + '/web/' + tokenFor(entry.fileAbs) + '/' : null,
-      frameUrl: entry.type === 'scene' && hasFile ? WE_API_PREFIX + '/scene-frame/' + tokenFor(entry.fileAbs) : null,
+      frameUrl,
       previewUrl: entry.previewAbs ? WE_API_PREFIX + '/preview/' + tokenFor(entry.previewAbs) : null,
     }
   }
@@ -252,14 +266,20 @@ export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
     },
   })
 
-  // GET /scene-frame/<token> — decode the scene pkg's main texture to PNG,
-  // cached under <store>/.cache/frames (keyed by path + mtime).
+  // GET /scene-frame/<token> — decode the scene's main texture to PNG,
+  // cached under <store>/.cache/frames (keyed by path + mtime). A packed
+  // scene.pkg goes through the pkg decoder; a loose scene.json resolves its
+  // materials from the same directory. When no static frame can be produced
+  // (model/particle scenes, unsupported formats) the entry preview is served
+  // instead of a broken image.
   const framePrefix = WE_API_PREFIX + '/scene-frame/'
   routes.push({
     kind: 'prefix',
     path: WE_API_PREFIX + '/scene-frame',
     handler: (req, res) => {
       if (req.method !== 'GET') { json(res, 405, { ok: false, error: 'method-not-allowed' }); return }
+      const pathname = new URL(req.url || '/', 'http://localhost').pathname
+      const token = decodeURIComponent(pathname.slice(framePrefix.length).split('/')[0] ?? '')
       const abs = resolveToken(req, res, framePrefix)
       if (!abs) return
       void (async () => {
@@ -269,10 +289,23 @@ export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
         const key = Buffer.from(abs, 'utf8').toString('base64url') + '_' + String(Math.round(mtime)) + '.png'
         const cachePath = joinPath(cacheDir, key)
         if (!existsSync(cachePath)) {
-          const { extractSceneMainImage } = await import('./pkg-extract.ts')
-          const frame = extractSceneMainImage(new Uint8Array(readFileSync(abs)))
-          mkdirSync(cacheDir, { recursive: true })
-          writeFileSync(cachePath, frame.png)
+          try {
+            const { extractSceneMainImage, extractSceneMainImageFromDir } = await import('./pkg-extract.ts')
+            const frame = /\.pkg$/i.test(abs)
+              ? extractSceneMainImage(new Uint8Array(readFileSync(abs)))
+              : extractSceneMainImageFromDir(dirname(abs))
+            if (frame === null) throw new Error('scene-frame-unavailable')
+            mkdirSync(cacheDir, { recursive: true })
+            writeFileSync(cachePath, frame.png)
+          } catch (error) {
+            const preview = frameFallback.get(token) ?? null
+            if (preview !== null && existsSync(preview)) {
+              serveFile(preview, req, res)
+              return
+            }
+            json(res, 422, { ok: false, error: error instanceof Error ? error.message : String(error) })
+            return
+          }
         }
         res.setHeader('Content-Type', 'image/png')
         res.setHeader('Cache-Control', 'no-store')
@@ -294,6 +327,9 @@ export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
   const copyIntoStore = (entry: WallpaperEntry, dest: string): void => {
     mkdirSync(dest, { recursive: true })
     cpSync(entry.dir, joinPath(dest, 'project'), { recursive: true })
+    // entry.file is the main file actually present in entry.dir: scene
+    // entries fall back to scene.pkg in we-library before this point, so the
+    // manifest never records a declared-but-missing scene.json path.
     const manifest = {
       sourceId: entry.id,
       title: entry.title,

--- a/packages/skins/skin-center/tests/pkg-extract.spec.ts
+++ b/packages/skins/skin-center/tests/pkg-extract.spec.ts
@@ -10,6 +10,9 @@
  */
 
 import { Buffer } from 'node:buffer'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { inflateSync } from 'node:zlib'
 import { describe, expect, it } from 'vitest'
 
@@ -19,6 +22,7 @@ import {
   decodeTex,
   encodePng,
   extractSceneMainImage,
+  extractSceneMainImageFromDir,
   lz4DecompressBlock,
   parsePkg,
   parseTex,
@@ -361,6 +365,11 @@ describe('parsePkg', () => {
     expect(readPkgEntry(pkg, one)).toEqual(compressedSingle)
     expect(readPkgEntry(pkg, two)).toEqual(concat(chunkA, chunkB))
   })
+
+  it('normalizes backslash entry paths to forward slashes', () => {
+    const pkg = buildPkg([{ path: 'materials\\bg.tex', data: bgTex }])
+    expect(parsePkg(pkg)[0].path).toBe('materials/bg.tex')
+  })
 })
 
 describe('lz4DecompressBlock', () => {
@@ -509,6 +518,67 @@ describe('decodeTex', () => {
       mipmaps: [{ width: 1, height: 1, data: Uint8Array.of(7, 9) }],
     })
     expect(decodeTex(rg88).rgba).toEqual(Uint8Array.of(7, 9, 0, 255))
+  })
+
+  it('converts RGB888 and RGB565 to RGBA', () => {
+    const rgb888 = buildTex({
+      width: 2,
+      height: 1,
+      format: TexFormat.RGB888,
+      mipmaps: [{ width: 2, height: 1, data: Uint8Array.of(10, 20, 30, 200, 100, 50) }],
+    })
+    expect(decodeTex(rgb888).rgba).toEqual(Uint8Array.of(10, 20, 30, 255, 200, 100, 50, 255))
+    const rgb565 = buildTex({
+      width: 2,
+      height: 1,
+      format: TexFormat.RGB565,
+      mipmaps: [{ width: 2, height: 1, data: concat(u16le(0xf800), u16le(0x07e0)) }],
+    })
+    expect(decodeTex(rgb565).rgba).toEqual(Uint8Array.of(255, 0, 0, 255, 0, 255, 0, 255))
+  })
+
+  it('converts packed RGBA1010102 to RGBA', () => {
+    // r=1023 (255), g=0, b=0, alpha=2 (170)
+    const tex = buildTex({
+      width: 1,
+      height: 1,
+      format: TexFormat.RGBA1010102,
+      mipmaps: [{ width: 1, height: 1, data: u32le((2 << 30) | (1023 << 20)) }],
+    })
+    expect(decodeTex(tex).rgba).toEqual(Uint8Array.of(255, 0, 0, 170))
+  })
+
+  it('converts half-float formats to RGBA', () => {
+    const one = 0x3c00 // 1.0
+    const half = 0x3800 // 0.5 -> 128
+    const r16f = buildTex({
+      width: 2,
+      height: 1,
+      format: TexFormat.R16F,
+      mipmaps: [{ width: 2, height: 1, data: concat(u16le(one), u16le(half)) }],
+    })
+    expect(decodeTex(r16f).rgba).toEqual(Uint8Array.of(255, 255, 255, 255, 128, 128, 128, 255))
+    const rg1616f = buildTex({
+      width: 1,
+      height: 1,
+      format: TexFormat.RG1616F,
+      mipmaps: [{ width: 1, height: 1, data: concat(u16le(one), u16le(half)) }],
+    })
+    expect(decodeTex(rg1616f).rgba).toEqual(Uint8Array.of(255, 128, 0, 255))
+    const rgba16161616f = buildTex({
+      width: 1,
+      height: 1,
+      format: TexFormat.RGBA16161616F,
+      mipmaps: [{ width: 1, height: 1, data: concat(u16le(one), u16le(half), u16le(0), u16le(one)) }],
+    })
+    expect(decodeTex(rgba16161616f).rgba).toEqual(Uint8Array.of(255, 128, 0, 255))
+    const rgb161616f = buildTex({
+      width: 1,
+      height: 1,
+      format: TexFormat.RGB161616F,
+      mipmaps: [{ width: 1, height: 1, data: concat(u16le(half), u16le(one), u16le(0)) }],
+    })
+    expect(decodeTex(rgb161616f).rgba).toEqual(Uint8Array.of(128, 255, 0, 255))
   })
 
   it('decodes a DXT1 single block with known endpoints', () => {
@@ -692,8 +762,90 @@ describe('extractSceneMainImage', () => {
     expect(decodePng(result.png).rgba).toEqual(bgPixels)
   })
 
-  it('throws when scene.json is absent', () => {
+  it('falls back to the largest texture when scene.json is absent', () => {
     const pkg = buildPkg([{ path: 'materials/bg.tex', data: bgTex }])
-    expect(() => extractSceneMainImage(pkg)).toThrow(/pkg: scene.json not found or invalid/)
+    const result = extractSceneMainImage(pkg)
+    expect(result.texturePath).toBe('materials/bg.tex')
+    expect(decodePng(result.png).rgba).toEqual(bgPixels)
+  })
+
+  it('collects inline texture refs from shader-style scene objects', () => {
+    const shaderScene = encoder.encode(JSON.stringify({
+      objects: [{ id: 1, name: 'shader bg', shader: 'background', textures: ['materials/bg.tex'] }],
+    }))
+    const pkg = buildPkg([
+      { path: 'scene.json', data: shaderScene },
+      { path: 'materials/bg.tex', data: bgTex },
+    ])
+    const result = extractSceneMainImage(pkg)
+    expect(result.texturePath).toBe('materials/bg.tex')
+    expect(decodePng(result.png).rgba).toEqual(bgPixels)
+  })
+
+  it('resolves backslash material and texture references', () => {
+    const scene = sceneJson('materials\\bg.json')
+    const pkg = buildPkg([
+      { path: 'scene.json', data: scene },
+      { path: 'materials\\bg.json', data: materialJson },
+      { path: 'materials\\bg.tex', data: bgTex },
+    ])
+    const result = extractSceneMainImage(pkg)
+    expect(result.texturePath).toBe('materials/bg.tex')
+    expect(decodePng(result.png).rgba).toEqual(bgPixels)
+  })
+
+  it('throws a readable error for an undecodable candidate texture', () => {
+    const badTex = buildTex({
+      width: 4,
+      height: 4,
+      format: TexFormat.BC7,
+      mipmaps: [{ width: 4, height: 4, data: new Uint8Array(16) }],
+    })
+    const pkg = buildPkg([
+      { path: 'scene.json', data: sceneJson('materials/bad.tex') },
+      { path: 'materials/bad.tex', data: badTex },
+    ])
+    expect(() => extractSceneMainImage(pkg)).toThrow(/cannot decode texture 'materials\/bad\.tex' \(BC7\)/)
+  })
+
+  it('throws when the package has no texture candidates at all', () => {
+    const pkg = buildPkg([{ path: 'scene.json', data: sceneJson('materials/missing.json') }])
+    expect(() => extractSceneMainImage(pkg)).toThrow(/pkg: no texture candidates found/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loose scene project extraction (scene.json + materials on disk)
+// ---------------------------------------------------------------------------
+
+describe('extractSceneMainImageFromDir', () => {
+  it('decodes the material texture of a loose image scene', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pkg-extract-scene-'))
+    try {
+      writeFileSync(join(dir, 'scene.json'), encoder.encode(JSON.stringify({
+        objects: [{ id: 1, name: 'bg', image: 'materials/bg.json' }],
+      })))
+      mkdirSync(join(dir, 'materials'))
+      writeFileSync(join(dir, 'materials', 'bg.json'), materialJson)
+      writeFileSync(join(dir, 'materials', 'bg.tex'), bgTex)
+      const result = extractSceneMainImageFromDir(dir)
+      expect(result).not.toBeNull()
+      expect(result!.texturePath).toBe('materials/bg.tex')
+      expect(decodePng(result!.png).rgba).toEqual(bgPixels)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns null for a model-only scene with no static texture', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pkg-extract-scene-'))
+    try {
+      writeFileSync(join(dir, 'scene.json'), encoder.encode(JSON.stringify({
+        objects: [{ id: 1, name: 'pistols', model: 'models/pistols.mdl' }],
+      })))
+      expect(extractSceneMainImageFromDir(dir)).toBeNull()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/skins/skin-center/tests/wallpaper.spec.ts
+++ b/packages/skins/skin-center/tests/wallpaper.spec.ts
@@ -123,6 +123,17 @@ describe('WallpaperController', () => {
     controller.dispose()
   })
 
+  it('flags the body while a wallpaper layer is mounted and clears it on teardown', () => {
+    const { scope } = fakeScope()
+    const controller = new WallpaperController(scope)
+    expect(document.body.hasAttribute('data-dsh-wallpaper-active')).toBe(false)
+    controller.applySelection(scene)
+    expect(document.body.hasAttribute('data-dsh-wallpaper-active')).toBe(true)
+    controller.clearSelection()
+    expect(document.body.hasAttribute('data-dsh-wallpaper-active')).toBe(false)
+    controller.dispose()
+  })
+
   it('frame mode renders the video preview instead of the video element', () => {
     const { scope } = fakeScope({ mode: 'frame' })
     const controller = new WallpaperController(scope)

--- a/packages/skins/skin-center/tests/we-library.spec.ts
+++ b/packages/skins/skin-center/tests/we-library.spec.ts
@@ -5,7 +5,7 @@
  * synthetic fixture trees in a temp dir; nothing real is ever touched.
  */
 import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
@@ -67,9 +67,10 @@ describe('librariesFromVdf', () => {
 
 describe('expandUser', () => {
   it('expands a leading tilde to the home directory and leaves other paths alone', () => {
-    const home = process.env.HOME ?? ''
+    // expandUser resolves through os.homedir(), not the HOME env var.
+    const home = homedir()
     expect(expandUser('~')).toBe(home)
-    expect(expandUser('~/Movies/wallpapers')).toBe(home + '/Movies/wallpapers')
+    expect(expandUser('~/Movies/wallpapers')).toBe(join(home, 'Movies', 'wallpapers'))
     expect(expandUser('/abs/path')).toBe('/abs/path')
     expect(expandUser('relative/path')).toBe('relative/path')
     expect(expandUser('~user/x')).toBe('~user/x')
@@ -99,6 +100,14 @@ describe('readProjectJson', () => {
     writeFileSync(join(dir, 'project.json'), '{ not json', 'utf8')
     expect(readProjectJson(dir)).toBeNull()
   })
+
+  it('normalizes backslash paths to forward slashes', () => {
+    const dir = join(root, 'slashed')
+    makeProject(dir, { title: 'S', type: 'scene', file: 'project\\scene.json', preview: 'preview\\p.jpg' })
+    expect(readProjectJson(dir)).toEqual({
+      title: 'S', type: 'scene', file: 'project/scene.json', preview: 'preview/p.jpg',
+    })
+  })
 })
 
 describe('scanProjectsRoot', () => {
@@ -112,7 +121,23 @@ describe('scanProjectsRoot', () => {
     expect(video?.playable).toBe(true)
     expect(video?.source).toBe('workshop')
     const scene = entries.find(e => e.id === '222')
-    expect(scene?.playable).toBe(false)
+    expect(scene?.playable).toBe(true)
+  })
+
+  it('falls back to the actual scene container when the declared file is absent', () => {
+    const ws = join(root, 'workshop')
+    makeProject(join(ws, '444'), { title: 'Scenery', type: 'scene', file: 'project\\scene.json' }, ['scene.pkg'])
+    const scene = scanProjectsRoot(ws, 'workshop')[0]
+    expect(scene?.file).toBe('scene.pkg')
+    expect(scene?.playable).toBe(true)
+    expect(scene?.srcSize).toBe(1)
+  })
+
+  it('prefers scene.pkg over scene.json when both exist', () => {
+    const ws = join(root, 'workshop')
+    makeProject(join(ws, '555'), { title: 'Packed', type: 'scene', file: 'scene.json' }, ['scene.json', 'scene.pkg'])
+    const scene = scanProjectsRoot(ws, 'workshop')[0]
+    expect(scene?.file).toBe('scene.pkg')
   })
 
   it('accepts a root that is itself a single project', () => {
@@ -170,6 +195,24 @@ describe('scanImportStore', () => {
     const store = join(root, 'store')
     mkdirSync(join(store, 'junk'), { recursive: true })
     expect(scanImportStore(store)).toHaveLength(0)
+  })
+
+  it('re-finds the scene container for legacy scene manifests', () => {
+    const store = join(root, 'store')
+    const entryDir = join(store, '111')
+    mkdirSync(join(entryDir, 'project'), { recursive: true })
+    writeFileSync(join(entryDir, 'project', 'scene.pkg'), 'pkg', 'utf8')
+    // A pre-fix manifest recorded the declared project\scene.json path.
+    writeFileSync(join(entryDir, 'manifest.json'), JSON.stringify({
+      sourceId: '111', title: 'Imported Scene', type: 'scene',
+      srcMtime: 1, srcSize: 3, importedAt: 20,
+      file: join('project', 'project', 'scene.json'), preview: null,
+    }), 'utf8')
+    const entries = scanImportStore(store)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].file).toBe('scene.pkg')
+    expect(entries[0].playable).toBe(true)
+    expect(entries[0].srcSize).toBe(3)
   })
 })
 

--- a/packages/skins/skin-center/tests/we-routes.spec.ts
+++ b/packages/skins/skin-center/tests/we-routes.spec.ts
@@ -91,7 +91,14 @@ beforeEach(async () => {
   makeProject(join(library, '333'), { title: 'Scene', type: 'scene', file: 'scene.pkg' }, {
     'scene.pkg': 'NOT-A-REAL-PKG',
   })
-  const routes = makeWeRoutes({ getConfig: () => ({ weLibraryDirs: [library] }), storeDir: store })
+  makeProject(join(library, '444'), { title: 'Packed scene', type: 'scene', file: 'project\\scene.json' }, {
+    'scene.pkg': 'NOT-A-REAL-PKG',
+  })
+  makeProject(join(library, '555'), { title: 'Model scene', type: 'scene', file: 'scene.json', preview: 'preview.jpg' }, {
+    'scene.json': JSON.stringify({ objects: [{ id: 1, model: 'models/x.mdl' }] }),
+    'preview.jpg': 'FAKE-PREVIEW-555',
+  })
+  const routes = makeWeRoutes({ getConfig: () => ({ weLibraryDirs: [library] }), storeDir: store, autoDetect: false })
   await serve(routes)
 })
 
@@ -106,7 +113,7 @@ describe('inventory', () => {
     expect(res.status).toBe(200)
     expect(res.body.ok).toBe(true)
     const wallpapers = res.body.wallpapers as Array<Record<string, unknown>>
-    expect(wallpapers).toHaveLength(3)
+    expect(wallpapers).toHaveLength(5)
     const video = wallpapers.find(w => w.id === '111')
     expect(video?.type).toBe('video')
     expect(video?.playable).toBe(true)
@@ -114,8 +121,16 @@ describe('inventory', () => {
     const web = wallpapers.find(w => w.id === '222')
     expect(String(web?.webUrl)).toContain(WE_API_PREFIX + '/web/')
     const scene = wallpapers.find(w => w.id === '333')
-    expect(scene?.playable).toBe(false)
+    expect(scene?.playable).toBe(true)
     expect(String(scene?.frameUrl)).toContain(WE_API_PREFIX + '/scene-frame/')
+    // The declared project\scene.json is absent; the entry resolves the
+    // actual scene.pkg and still gets a frame url.
+    const packed = wallpapers.find(w => w.id === '444')
+    expect(packed?.playable).toBe(true)
+    expect(String(packed?.frameUrl)).toContain(WE_API_PREFIX + '/scene-frame/')
+    const modelScene = wallpapers.find(w => w.id === '555')
+    expect(modelScene?.playable).toBe(true)
+    expect(String(modelScene?.frameUrl)).toContain(WE_API_PREFIX + '/scene-frame/')
   })
 
   it('rejects cross-site requests', async () => {
@@ -181,6 +196,14 @@ describe('scene-frame', () => {
     expect(res.status).toBe(422)
     expect(res.body.ok).toBe(false)
   })
+
+  it('serves the preview when a loose scene has no static frame', async () => {
+    const inventory = await call('GET', WE_API_PREFIX + '/inventory')
+    const scene = (inventory.body.wallpapers as Array<Record<string, unknown>>).find(w => w.id === '555')
+    const res = await call('GET', String(scene?.frameUrl))
+    expect(res.status).toBe(200)
+    expect(res.raw).toBe('FAKE-PREVIEW-555')
+  })
 })
 
 describe('import lifecycle', () => {
@@ -211,6 +234,14 @@ describe('import lifecycle', () => {
     expect(removed.status).toBe(200)
     expect(existsSync(join(store, '111'))).toBe(false)
     expect(existsSync(join(library, '111'))).toBe(true)
+  })
+
+  it('records the actual scene container in the import manifest', async () => {
+    const imported = await call('POST', WE_API_PREFIX + '/import', { body: { id: '444' } })
+    expect(imported.status).toBe(200)
+    const manifest = JSON.parse(readFileSync(join(store, '444', 'manifest.json'), 'utf8')) as Record<string, unknown>
+    expect(String(manifest.file)).toContain('scene.pkg')
+    expect(String(manifest.file)).not.toContain('scene.json')
   })
 
   it('rejects bad ids and cross-site posts', async () => {


### PR DESCRIPTION
> 关联 Issue：https://github.com/zhu1090093659/dsh-web-ui/issues/521
> 分支：fix/issue-521-scene-wallpaper-save（基于 upstream/main 878a66b）

## 摘要（Summary）

修复皮肤中心 Wallpaper Engine bridge 的 scene（场景）类型壁纸：project.json 声明的
主文件（project\scene.json）与实际发布文件（scene.pkg）不一致，导致 scene 壁纸永远
playable=false、frameUrl=null，导入 manifest 也记录了不存在的路径。本次改动按实际存在的
容器解析主文件、让 scene-frame 能解码 scene.pkg 与 loose scene.json、解码失败时回退到
预览图，并在壁纸挂载期间打穿 shell 自身的不透明 frame/sidebar 背景，使应用后立即可见。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream && git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改 README）

## 贡献者版权声明（Contributor Copyright）

<!-- 可选。若本 PR 贡献的是插件或皮肤，可在项目 README 末尾「来源与版权」的版权表中追加一行声明你自己的版权（包 / 来源 / 版权三列，格式参考表中现有行）；不声明则维持现有版权归属。 -->

## 新皮肤收录（New Skin）

<!-- 仅当本 PR 新增皮肤时必填；其余改动可跳过本节。 -->

## 社区插件索引登记（Community Plugin Index）

<!-- 仅当本 PR 新增接入一个社区插件时必填；其余改动可跳过本节。 -->

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/skins/skin-center
pnpm typecheck
pnpm test
```

结果摘要：

- typecheck：通过。
- vitest：197/198 通过；唯一失败项是 tests/skin-switch.spec.ts 的
  「0600 stays 0600」权限位断言，仅 Windows 本地环境出现（与本次改动无关，
  Linux CI 无此问题）。
- 真实库验证（本机 Wallpaper Engine 库）：workshop 场景 2973440020 / 3021850803
  的 scene.pkg 分别解出 1920x1080 与 3008x1440 静态帧；默认场景 arsenal /
  beach（loose scene.json）无可用静态纹理时回退到 preview.jpg，不再 422。

## 用户可见变更证据（Local Feature Evidence）

证据：

![issue-521 合成场景帧（修复后的 scene-frame 提取管线输出）](https://gist.githubusercontent.com/QIU0826/cb4fcfc45c56ae45810c0235a1a4e1cb/raw/f7ff6202e5d7e387912218901e715ce2c45b58fb/issue-521-scene-frame-pipeline.png)

说明：上图是本次修复后的 scene-frame 提取管线（decodeTex -> encodePng）输出的合成
场景静态帧快照（托管在 gist）。真实 workshop 场景（2973440020 / 3021850803）
已在本机验证可解出 1920x1080 / 3008x1440 静态帧；因这些帧属于壁纸作者内容，
按合规要求不上传，GUI 应用后的截图后续补充。
