### PR TITLE
fix(aionui-panel): restore shell grid on panel dispose

### DIFF
--- a/packages/dsh-aionui-panel/package.json
+++ b/packages/dsh-aionui-panel/package.json
@@ -34,7 +34,9 @@
   "scripts": {
     "build": "tsc -b && node scripts/copy-mermaid.mjs && tsdown",
     "prepare": "node scripts/copy-mermaid.mjs && tsdown",
-    "watch": "tsdown --watch"
+    "watch": "tsdown --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "peerDependencies": {
     "react": "^18.2.0"
@@ -56,12 +58,14 @@
     "@types/node": "^22.20.0",
     "@types/react": "~18.3.1",
     "@types/react-dom": "^18.3.5",
+    "jsdom": "^25.0.0",
     "lightningcss": "^1.32.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tsdown": "0.22.2",
     "typescript": "~5.7.2",
-    "mermaid": "11.16.1"
+    "mermaid": "11.16.1",
+    "vitest": "^3.0.0"
   },
   "files": [
     "lib",

--- a/packages/dsh-aionui-panel/src/client/layout.ts
+++ b/packages/dsh-aionui-panel/src/client/layout.ts
@@ -547,6 +547,9 @@ export class PanelLayoutController {
     this.styleObserver?.disconnect()
     this.sizeObserver?.disconnect()
     for (const dispose of this.disposers) dispose()
+    if (this.frame !== null && this.shellTracks.length === 3) {
+      this.frame.style.gridTemplateColumns = this.shellTracks.join(' ')
+    }
     this.previewCol?.remove()
     this.explorerCol?.remove()
     this.explorerHandle?.remove()

--- a/packages/dsh-aionui-panel/tests/layout.spec.ts
+++ b/packages/dsh-aionui-panel/tests/layout.spec.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PanelLayoutController } from '../src/client/layout.ts'
+import { createLayoutStore, layoutSetRoot } from '../src/client/store.ts'
+
+class ResizeObserverStub {
+  observe(): void {}
+  disconnect(): void {}
+}
+
+function nextMutationCheckpoint(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('PanelLayoutController', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('restores the shell grid tracks when disposed after mounting panel columns (#499)', async () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+
+    const frame = document.createElement('div')
+    frame.dataset.dshFrame = ''
+    frame.style.display = 'grid'
+    frame.style.gridTemplateColumns = '280px minmax(0, 1fr) 0px'
+    vi.spyOn(frame, 'getBoundingClientRect').mockReturnValue({
+      width: 1000,
+      height: 600,
+      top: 0,
+      right: 1000,
+      bottom: 600,
+      left: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect)
+    document.body.appendChild(frame)
+
+    const layout = createLayoutStore()
+    layoutSetRoot(layout, '/workspace', true)
+    const controller = new PanelLayoutController(layout)
+
+    controller.mount()
+    await nextMutationCheckpoint()
+
+    expect(frame.style.gridTemplateColumns).toBe('280px minmax(0, 1fr) 0px 340px 220px')
+
+    controller.dispose()
+
+    expect(frame.style.gridTemplateColumns).toBe('280px minmax(0, 1fr) 0px')
+    expect(document.querySelector('[data-aionui-preview-col]')).toBeNull()
+    expect(document.querySelector('[data-aionui-explorer-col]')).toBeNull()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.5
         version: 18.3.7(@types/react@18.3.31)
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.1
       lightningcss:
         specifier: ^1.32.0
         version: 1.32.0
@@ -89,6 +92,9 @@ importers:
       typescript:
         specifier: ~5.7.2
         version: 5.7.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jsdom@25.0.1)(lightningcss@1.32.0)
 
   packages/dsh-community-plugins:
     dependencies:


### PR DESCRIPTION
## 摘要（Summary）

Fixes the remaining layout cleanup path for #499: when the legacy AionUI panel layout controller is disposed after extending the shell frame to five grid tracks, it now restores the cached native three shell tracks before removing the panel DOM. This prevents a disabled/unmounted panel from leaving a stale right-side grid track and pushing the conversation off center.

Closes #499.

Note: current `main` has already retired the old panel-column mount path from the client entry, so the settings-sync flicker path described in the issue is no longer present there. This PR covers the still-present defensive cleanup bug in `PanelLayoutController.dispose()`.

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [x] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin main
git worktree add -b fix/aionui-panel-disabled-layout-reset D:\Code\dsh-web-ui-issue-499 origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5 Codex

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

N/A

## 新皮肤收录（New Skin）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
corepack pnpm@11.22.0 install --frozen-lockfile --ignore-scripts
corepack pnpm@11.22.0 --filter @linxin666/dsh-client-ui-aionui-panel exec vitest run tests/layout.spec.ts
corepack pnpm@11.22.0 --filter @linxin666/dsh-client-ui-aionui-panel exec tsc -b
corepack pnpm@11.22.0 --filter @linxin666/dsh-client-ui-aionui-panel test
corepack pnpm@11.22.0 --filter @linxin666/dsh-client-ui-aionui-panel build
```

结果摘要：

- New regression test reproduced the stale 5-track grid before the fix, then passed after the fix.
- `aionui-panel` test passed: 1 test passed.
- `tsc -b` passed.
- `aionui-panel` build passed.

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A - layout cleanup regression covered by jsdom test.