### PR TITLE
refactor(pet): 建立与呈现端无关的宠物核心契约

### DIFF
--- a/packages/dsh-pet/src/adapters/embedded/embedded-host.ts
+++ b/packages/dsh-pet/src/adapters/embedded/embedded-host.ts
@@ -1,0 +1,89 @@
+import type {
+  PetDesktopHost,
+  PetSurfaceHandle,
+  PetSurfaceRequest,
+} from '../../contracts/desktop-host.ts'
+import { PET_DESKTOP_HOST_API_VERSION } from '../../contracts/desktop-host.ts'
+import type {
+  PetPresentationAdapter,
+  PetPresentationContext,
+  PetPresentationHostView,
+} from '../../presentation/controller.ts'
+
+export interface EmbeddedPetHostOptions {
+  host: PetDesktopHost
+  surfaceRequest(context: PetPresentationContext): PetSurfaceRequest
+}
+
+/** Adapts a capability-only embedded host without exposing raw Electron objects. */
+export class EmbeddedPetHost implements PetPresentationAdapter {
+  readonly kind = 'embedded' as const
+  readonly host: PetPresentationHostView
+  private surface: PetSurfaceHandle | undefined
+  private disposeClosed: (() => void | Promise<void>) | undefined
+  private disposeTray: (() => void | Promise<void>) | undefined
+
+  constructor(private readonly options: EmbeddedPetHostOptions) {
+    this.host = {
+      id: options.host.descriptor.id,
+      name: options.host.descriptor.name,
+      embedded: true,
+      ownsTray: options.host.descriptor.ownsTray,
+    }
+  }
+
+  async start(context: PetPresentationContext): Promise<void> {
+    if (this.surface !== undefined) return
+    if (this.options.host.descriptor.apiVersion !== PET_DESKTOP_HOST_API_VERSION) {
+      throw new Error('embedded host API version is incompatible')
+    }
+    if (!this.options.host.descriptor.capabilities.floatingSurface) {
+      throw new Error('embedded host has no floating surface capability')
+    }
+    const surface = await this.options.host.createPetSurface(this.options.surfaceRequest(context))
+    this.surface = surface
+    const closed = surface.onClosed(() => {
+      if (this.surface === surface) this.surface = undefined
+    })
+    this.disposeClosed = () => closed.dispose()
+    if (this.options.host.descriptor.capabilities.contributesTrayAction
+      && this.options.host.contributeTrayAction !== undefined) {
+      const tray = await this.options.host.contributeTrayAction({
+        id: 'dsh-pet:show',
+        label: '显示桌宠',
+        onInvoke: () => { void surface.show().catch(() => undefined) },
+      })
+      this.disposeTray = () => tray.dispose()
+    }
+  }
+
+  async show(): Promise<void> {
+    await this.surface?.show()
+  }
+
+  async hide(): Promise<void> {
+    await this.surface?.hide()
+  }
+
+  update(_snapshot: unknown): void {
+    // The embedded renderer consumes the same native bridge as Standalone.
+  }
+
+  async stop(_reason?: string): Promise<void> {
+    const surface = this.surface
+    this.surface = undefined
+    const disposeClosed = this.disposeClosed
+    this.disposeClosed = undefined
+    const disposeTray = this.disposeTray
+    this.disposeTray = undefined
+    try {
+      await disposeTray?.()
+    } finally {
+      try {
+        await disposeClosed?.()
+      } finally {
+        await surface?.close()
+      }
+    }
+  }
+}

--- a/packages/dsh-pet/src/adapters/standalone/standalone-host.ts
+++ b/packages/dsh-pet/src/adapters/standalone/standalone-host.ts
@@ -1,0 +1,48 @@
+import type {
+  PetPresentationAdapter,
+  PetPresentationContext,
+  PetPresentationHostView,
+} from '../../presentation/controller.ts'
+
+export interface StandalonePetHostOptions {
+  launch(origin: string, nativeToken: string): () => void
+}
+
+/** Controller adapter around the current managed standalone Electron runtime. */
+export class StandalonePetHost implements PetPresentationAdapter {
+  readonly kind = 'standalone' as const
+  readonly host: PetPresentationHostView = {
+    id: 'standalone',
+    name: 'Standalone dsh-pet',
+    embedded: false,
+    ownsTray: true,
+  }
+  private disposeProcess: (() => void) | undefined
+
+  constructor(private readonly options: StandalonePetHostOptions) {}
+
+  async start(context: PetPresentationContext): Promise<void> {
+    if (this.disposeProcess !== undefined) return
+    if (context.bridgeOrigin === undefined || context.nativeToken === undefined) {
+      throw new Error('standalone bridge is unavailable')
+    }
+    this.disposeProcess = this.options.launch(context.bridgeOrigin, context.nativeToken)
+  }
+
+  async show(): Promise<void> {
+    // Visibility is mirrored through Host settings and the native state stream.
+  }
+
+  async hide(): Promise<void> {
+    // Visibility is mirrored through Host settings and the native state stream.
+  }
+
+  update(_snapshot: unknown): void {
+    // Standalone consumes the authenticated SSE stream directly.
+  }
+
+  async stop(_reason?: string): Promise<void> {
+    this.disposeProcess?.()
+    this.disposeProcess = undefined
+  }
+}

--- a/packages/dsh-pet/src/contracts/desktop-host.ts
+++ b/packages/dsh-pet/src/contracts/desktop-host.ts
@@ -1,0 +1,130 @@
+/** Stable capability contract implemented by embedded DSH desktop shells. */
+
+import type {} from '@deepseek-ai/cordis'
+import type { PetDisposable } from './disposable.ts'
+import type { PetRendererKind } from './renderer.ts'
+
+export type { PetDisposable } from './disposable.ts'
+export type { PetRendererKind } from './renderer.ts'
+
+export const PET_DESKTOP_HOST_API_VERSION = 1 as const
+export const PET_DESKTOP_SCALE_MIN = 1
+export const PET_DESKTOP_SCALE_MAX = 2
+
+export interface PetDesktopHostDescriptor {
+  apiVersion: typeof PET_DESKTOP_HOST_API_VERSION
+  id: string
+  name: string
+  version?: string
+  capabilities: {
+    floatingSurface: boolean
+    focusMainWindow: boolean
+    openRoute: boolean
+    contributesTrayAction: boolean
+    rendererKinds: readonly PetRendererKind[]
+  }
+  /** Embedded hosts own their existing tray; dsh-pet must not create another. */
+  ownsTray: boolean
+}
+
+export type PetHostRoute =
+  | { kind: 'home' }
+  | { kind: 'session'; sessionId: string }
+  | { kind: 'settings'; section?: 'plugins' | 'pet' }
+
+export type PetReturnTarget =
+  | { kind: 'web'; id: string; label: string; url: string }
+  | {
+      kind: 'desktop-host'
+      id: string
+      label: string
+      hostId: string
+      route?: PetHostRoute
+    }
+  | { kind: 'none' }
+
+export interface PetSurfaceBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface PetNativeSurfaceState {
+  bounds: PetSurfaceBounds
+  visible: boolean
+  alwaysOnTop: boolean
+  returnTarget: PetReturnTarget
+}
+
+export interface PetNativeSurfaceDragResult {
+  state: PetNativeSurfaceState
+  moved: boolean
+}
+
+/** Sandboxed preload API implemented by every native Presentation Host. */
+export interface PetNativeSurfaceApi {
+  readonly apiVersion: typeof PET_DESKTOP_HOST_API_VERSION
+  getState(): Promise<PetNativeSurfaceState>
+  show(): Promise<PetNativeSurfaceState>
+  hide(): Promise<PetNativeSurfaceState>
+  setBounds(bounds: PetSurfaceBounds): Promise<PetNativeSurfaceState>
+  setAlwaysOnTop(value: boolean): Promise<PetNativeSurfaceState>
+  beginDrag(): Promise<PetNativeSurfaceState>
+  endDrag(): Promise<PetNativeSurfaceDragResult>
+  openReturnTarget(): Promise<void>
+  onStateChanged(listener: (state: PetNativeSurfaceState) => void): PetDisposable
+}
+
+export interface PetSurfaceRequest {
+  surfaceId: string
+  content: {
+    kind: 'loopback-url'
+    url: string
+    allowedOrigin: string
+  }
+  initial: {
+    width: number
+    height: number
+    alwaysOnTop: boolean
+    visible: boolean
+  }
+  auth: {
+    token: string
+  }
+  returnTarget: PetReturnTarget
+}
+
+export interface PetSurfaceHandle {
+  readonly id: string
+  show(): Promise<void>
+  hide(): Promise<void>
+  focus?(): Promise<void>
+  setBounds(bounds: PetSurfaceBounds): Promise<void>
+  getBounds(): Promise<PetSurfaceBounds>
+  setAlwaysOnTop(value: boolean): Promise<void>
+  setIgnoreMouseEvents?(value: boolean): Promise<void>
+  close(): Promise<void>
+  onClosed(listener: () => void): PetDisposable
+}
+
+export interface PetTrayContribution {
+  id: string
+  label: string
+  checked?: boolean
+  onInvoke(): void
+}
+
+export interface PetDesktopHost {
+  readonly descriptor: PetDesktopHostDescriptor
+  createPetSurface(request: PetSurfaceRequest): Promise<PetSurfaceHandle>
+  focusMainWindow(): Promise<void>
+  openRoute?(route: PetHostRoute): Promise<void>
+  contributeTrayAction?(action: PetTrayContribution): Promise<PetDisposable>
+}
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    petDesktopHost: PetDesktopHost
+  }
+}

--- a/packages/dsh-pet/src/contracts/disposable.ts
+++ b/packages/dsh-pet/src/contracts/disposable.ts
@@ -1,0 +1,4 @@
+/** Minimal lifecycle handle shared by public contracts. */
+export interface PetDisposable {
+  dispose(): void | Promise<void>
+}

--- a/packages/dsh-pet/src/contracts/model.ts
+++ b/packages/dsh-pet/src/contracts/model.ts
@@ -1,0 +1,53 @@
+/** Stable, renderer-neutral model and asset boundary. */
+
+import type { PetExpression, PetMotion } from '../core/intent.ts'
+
+export const PET_MODEL_SCHEMA_VERSION = 1 as const
+
+export type PetModelSourceKind = 'builtin' | 'local' | 'imported' | 'extension'
+
+export interface PetModelDescriptor {
+  schemaVersion: typeof PET_MODEL_SCHEMA_VERSION
+  id: string
+  displayName: string
+  description?: string
+  rendererId: string
+  format: string
+  entry: string
+  source: {
+    kind: PetModelSourceKind
+    providerId?: string
+  }
+  capabilities: {
+    motions: PetMotion[]
+    expressions: PetExpression[]
+    lookAt: boolean
+    lipSync: boolean
+    hitAreas: string[]
+  }
+  bindings: {
+    motions: Partial<Record<PetMotion, string | string[]>>
+    expressions: Partial<Record<PetExpression, string>>
+  }
+  fallback: {
+    motion: PetMotion
+    expression: PetExpression
+  }
+  license?: {
+    name?: string
+    url?: string
+    author?: string
+  }
+}
+
+export interface PetAssetRef {
+  modelId: string
+  path: string
+}
+
+/** Renderers receive assets through this boundary and never read the filesystem. */
+export interface PetAssetResolver {
+  fetch(asset: PetAssetRef, signal?: AbortSignal): Promise<ArrayBuffer>
+  createObjectUrl?(asset: PetAssetRef, signal?: AbortSignal): Promise<string>
+  revokeObjectUrl?(url: string): void
+}

--- a/packages/dsh-pet/src/contracts/renderer.ts
+++ b/packages/dsh-pet/src/contracts/renderer.ts
@@ -1,0 +1,91 @@
+/** Stable renderer and model boundary shared by every presentation host. */
+
+import type { PetDisposable } from './disposable.ts'
+import type {
+  PetIntent,
+  PetIntentSpeech,
+} from '../core/intent.ts'
+import type { PetAssetResolver, PetModelDescriptor } from './model.ts'
+import type { PetErrorCode } from '../errors.ts'
+
+export { PET_MODEL_SCHEMA_VERSION } from './model.ts'
+export type {
+  PetAssetRef,
+  PetAssetResolver,
+  PetModelDescriptor,
+  PetModelSourceKind,
+} from './model.ts'
+
+export const PET_RENDERER_API_VERSION = 1 as const
+
+export type PetRendererKind = 'sprite2d' | 'live2d' | 'model3d'
+export type PetRenderQuality = 'low' | 'balanced' | 'high'
+
+export interface PetRendererCapabilities {
+  expressions: boolean
+  motions: boolean
+  lookAt: boolean
+  lipSync: boolean
+  hitAreas: boolean
+  transparentBackground: boolean
+}
+
+export interface PetRendererDescriptor {
+  apiVersion: typeof PET_RENDERER_API_VERSION
+  id: string
+  displayName: string
+  kind: PetRendererKind
+  version: string
+  capabilities: PetRendererCapabilities
+  supportedModelFormats: readonly string[]
+}
+
+export interface PetRenderSurface {
+  element: HTMLElement
+  width: number
+  height: number
+  devicePixelRatio: number
+}
+
+export interface PetRenderSize {
+  width: number
+  height: number
+  devicePixelRatio: number
+}
+
+export interface PetRendererEvents {
+  ready: { rendererId: string, modelId: string }
+  motionComplete: { intentId: string }
+  hit: { area?: string, x: number, y: number }
+  error: { code: PetErrorCode, recoverable: boolean, message: string }
+  contextLost: Record<never, never>
+}
+
+export interface PetRendererCreateContext {
+  signal: AbortSignal
+  emit<K extends keyof PetRendererEvents>(type: K, event: PetRendererEvents[K]): void
+}
+
+export interface PetRenderer {
+  readonly descriptor: PetRendererDescriptor
+  mount(surface: PetRenderSurface): Promise<void>
+  loadModel(model: PetModelDescriptor, assets: PetAssetResolver): Promise<void>
+  applyIntent(intent: PetIntent): void | Promise<void>
+  applySpeech?(speech: PetIntentSpeech): void | Promise<void>
+  resize(size: PetRenderSize): void
+  setVisible(visible: boolean): void
+  setQuality(quality: PetRenderQuality): void
+  dispose(): void | Promise<void>
+}
+
+export interface PetRendererProvider {
+  readonly descriptor: PetRendererDescriptor
+  create(context: PetRendererCreateContext): Promise<PetRenderer>
+}
+
+export interface PetRendererRegistryContract {
+  register(provider: PetRendererProvider): PetDisposable
+  get(id: string): PetRendererProvider | undefined
+  list(): readonly PetRendererDescriptor[]
+  supports(rendererId: string, model: PetModelDescriptor): boolean
+}

--- a/packages/dsh-pet/src/core/activity-projection.ts
+++ b/packages/dsh-pet/src/core/activity-projection.ts
@@ -1,0 +1,146 @@
+/** Pure projection of official DSH session events into task activity facts. */
+
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import type { PetTaskPhase, PetTaskToolSnapshot } from './protocol.ts'
+
+/** Per-session mutable facts required to understand an event stream. */
+export interface ActivityProjectionRuntime {
+  activeTools: Map<string, string>
+  completedTools: number
+  failedTools: number
+  officialEventsSeen: boolean
+  stepHadFailure: boolean
+}
+
+/** One projected activity update, optionally carrying a turn reward. */
+export interface ProjectedActivity {
+  phase: PetTaskPhase
+  statusLine?: string
+  narration?: string
+  tool?: PetTaskToolSnapshot
+  completedTurn?: number
+}
+
+/** Create clean projection state for one session. */
+export function createActivityProjectionRuntime(): ActivityProjectionRuntime {
+  return {
+    activeTools: new Map(),
+    completedTools: 0,
+    failedTools: 0,
+    officialEventsSeen: false,
+    stepHadFailure: false,
+  }
+}
+
+/** Keep tool names readable inside compact status surfaces. */
+export function displayToolName(name: string): string {
+  const compact = name.replace(/\s+/g, ' ').trim() || '工具'
+  return compact.length <= 24 ? compact : `${compact.slice(0, 21)}...`
+}
+
+function toolSnapshot(
+  runtime: ActivityProjectionRuntime,
+  fallbackName: string,
+): PetTaskToolSnapshot {
+  const activeName = runtime.activeTools.values().next().value as string | undefined
+  return {
+    name: activeName ?? fallbackName,
+    activeCount: runtime.activeTools.size,
+    completedCount: runtime.completedTools,
+    ...(runtime.failedTools === 0 ? {} : { failedCount: runtime.failedTools }),
+  }
+}
+
+/**
+ * Project the durable session vocabulary. Unknown and log-only events return
+ * undefined so they cannot overwrite the last meaningful task state.
+ */
+export function projectOfficialEvent(
+  event: SessionEvent,
+  runtime: ActivityProjectionRuntime,
+): ProjectedActivity | undefined {
+  switch (event.type) {
+    case 'turn/start':
+      runtime.activeTools.clear()
+      runtime.completedTools = 0
+      runtime.failedTools = 0
+      runtime.stepHadFailure = false
+      return { phase: 'waiting', statusLine: '准备开始' }
+    case 'step/start':
+      runtime.activeTools.clear()
+      runtime.stepHadFailure = false
+      return { phase: 'waiting', statusLine: '等待模型响应' }
+    case 'assistant/chunk': {
+      const { chunk } = event.data
+      if (chunk.type === 'reasoning-delta' && chunk.text.length > 0) {
+        return { phase: 'thinking', statusLine: '正在思考' }
+      }
+      if (chunk.type === 'text-delta' && chunk.text.length > 0) {
+        return { phase: 'review', statusLine: '整理回复中' }
+      }
+      return undefined
+    }
+    case 'assistant/message':
+      return { phase: 'review', statusLine: '整理回复中' }
+    case 'tool/call': {
+      const name = displayToolName(event.data.name)
+      runtime.activeTools.set(String(event.data.callId), name)
+      return {
+        phase: 'tool',
+        statusLine: `正在使用 ${name}`,
+        tool: toolSnapshot(runtime, name),
+      }
+    }
+    case 'tool/result': {
+      const callId = String(event.data.message.source.callId)
+      const completedName = runtime.activeTools.get(callId) ?? '工具'
+      if (runtime.activeTools.delete(callId)) runtime.completedTools += 1
+      const block = event.data.message.content[0]
+      runtime.stepHadFailure ||= event.data.error !== undefined || block?.isError === true
+      if (event.data.error !== undefined || block?.isError === true) runtime.failedTools += 1
+      if (runtime.activeTools.size > 0) {
+        return {
+          phase: 'tool',
+          statusLine: `还有 ${runtime.activeTools.size} 个工具运行中`,
+          tool: toolSnapshot(runtime, completedName),
+        }
+      }
+      return runtime.stepHadFailure
+        ? {
+            phase: 'failed',
+            statusLine: '工具执行失败',
+            tool: toolSnapshot(runtime, completedName),
+          }
+        : {
+            phase: 'thinking',
+            statusLine: '处理工具结果',
+            tool: toolSnapshot(runtime, completedName),
+          }
+    }
+    case 'turn/end': {
+      runtime.activeTools.clear()
+      switch (event.data.reason.kind) {
+        case 'completed':
+          return {
+            phase: 'done',
+            statusLine: '完成啦',
+            completedTurn: event.data.turn,
+          }
+        case 'error':
+          return { phase: 'failed', statusLine: '执行失败' }
+        case 'max-tokens':
+          return { phase: 'failed', statusLine: '达到输出上限' }
+        case 'interrupted':
+          return { phase: 'failed', statusLine: '执行意外中断' }
+        case 'blocked':
+          return { phase: 'blocked', statusLine: '任务受阻，等待继续' }
+        case 'aborted':
+          return { phase: 'idle', statusLine: '已停止' }
+        default:
+          return { phase: 'idle' }
+      }
+    }
+    default:
+      return undefined
+  }
+}

--- a/packages/dsh-pet/src/core/activity-registry.ts
+++ b/packages/dsh-pet/src/core/activity-registry.ts
@@ -1,0 +1,220 @@
+/** Process-local registry retaining one immutable activity view per session. */
+
+import { selectPrimaryTask } from './primary-task.ts'
+import { sanitizeActivityText } from './sanitize.ts'
+import {
+  PET_ACTIVITY_PROTOCOL_VERSION,
+  petTaskId,
+  type PetAggregateSnapshot,
+  type PetTaskIdentity,
+  type PetTaskPhase,
+  type PetTaskProgress,
+  type PetTaskSnapshot,
+  type PetTaskTokenUsage,
+  type PetTaskToolSnapshot,
+} from './protocol.ts'
+
+/** Facts accepted when one session emits meaningful activity. */
+export interface PetTaskUpdate extends PetTaskIdentity {
+  profile?: string
+  workspaceLabel?: string
+  title?: string
+  phase: PetTaskPhase
+  statusLine?: string
+  narration?: string
+  tool?: PetTaskToolSnapshot
+  startedAt?: number
+  phaseStartedAt?: number
+  updatedAt?: number
+  finishedAt?: number
+  tokenUsage?: PetTaskTokenUsage
+  progress?: PetTaskProgress
+}
+
+/** Registry retention and clock controls. */
+export interface ActivityRegistryOptions {
+  completedRecentlyMs?: number
+  failedPriorityMs?: number
+  now?: () => number
+}
+
+const DEFAULT_COMPLETED_RECENTLY_MS = 30_000
+
+function cloneTask(task: PetTaskSnapshot): PetTaskSnapshot {
+  return {
+    ...task,
+    ...(task.tool === undefined ? {} : { tool: { ...task.tool } }),
+    ...(task.tokenUsage === undefined ? {} : { tokenUsage: { ...task.tokenUsage } }),
+    ...(task.progress === undefined ? {} : { progress: { ...task.progress } }),
+  }
+}
+
+function isActive(phase: PetTaskPhase): boolean {
+  return !['idle', 'done', 'failed'].includes(phase)
+}
+
+function safeOptional(value: string | undefined, maxChars: number): string | undefined {
+  if (value === undefined) return undefined
+  const safe = sanitizeActivityText(value, { maxChars })
+  return safe === '' ? undefined : safe
+}
+
+function safeTool(tool: PetTaskToolSnapshot | undefined): PetTaskToolSnapshot | undefined {
+  if (tool === undefined) return undefined
+  const name = sanitizeActivityText(tool.name, { maxChars: 24 }) || '工具'
+  const label = safeOptional(tool.label, 32)
+  const detail = safeOptional(tool.detail, 48)
+  return {
+    name,
+    ...(label === undefined ? {} : { label }),
+    ...(detail === undefined ? {} : { detail }),
+    activeCount: Math.max(0, Math.trunc(tool.activeCount)),
+    completedCount: Math.max(0, Math.trunc(tool.completedCount)),
+    ...(tool.failedCount === undefined ? {} : { failedCount: Math.max(0, Math.trunc(tool.failedCount)) }),
+  }
+}
+
+function safeProgress(progress: PetTaskProgress | undefined): PetTaskProgress | undefined {
+  if (progress === undefined || !Number.isFinite(progress.current) || !Number.isFinite(progress.total)
+    || progress.current < 0 || progress.total <= 0 || progress.current > progress.total) return undefined
+  const unit = safeOptional(progress.unit, 16)
+  return {
+    current: progress.current,
+    total: progress.total,
+    ...(unit === undefined ? {} : { unit }),
+  }
+}
+
+/** Mutable owner of session activity; every public snapshot is copied. */
+export class ActivityRegistry {
+  private readonly tasks = new Map<string, PetTaskSnapshot>()
+  private readonly now: () => number
+  private readonly completedRecentlyMs: number
+  private readonly failedPriorityMs: number | undefined
+  private sequence = 0
+  private pinnedTaskId: string | undefined
+  private focusedTaskId: string | undefined
+  private recentTaskId: string | undefined
+
+  constructor(options: ActivityRegistryOptions = {}) {
+    this.now = options.now ?? Date.now
+    this.completedRecentlyMs = options.completedRecentlyMs ?? DEFAULT_COMPLETED_RECENTLY_MS
+    this.failedPriorityMs = options.failedPriorityMs
+  }
+
+  /** Insert or replace the latest meaningful state for one task. */
+  update(update: PetTaskUpdate): PetTaskSnapshot {
+    const taskId = petTaskId(update)
+    const previous = this.tasks.get(taskId)
+    const updatedAt = update.updatedAt ?? this.now()
+    const phaseChanged = previous === undefined || previous.phase !== update.phase
+    const terminal = update.phase === 'done' || update.phase === 'failed'
+    const tokenUsage = update.tokenUsage ?? previous?.tokenUsage
+    const profile = safeOptional(update.profile ?? previous?.profile, 32)
+    const workspaceLabel = safeOptional(update.workspaceLabel ?? previous?.workspaceLabel, 48)
+    const title = safeOptional(update.title ?? previous?.title, 48)
+    const statusLine = safeOptional(update.statusLine, 48)
+    const narration = safeOptional(update.narration, 48)
+    const tool = safeTool(update.tool)
+    const progress = safeProgress(update.progress ?? previous?.progress)
+    const next: PetTaskSnapshot = {
+      taskId,
+      instanceId: update.instanceId,
+      bootId: update.bootId,
+      sessionId: update.sessionId,
+      ...(profile === undefined ? {} : { profile }),
+      ...(workspaceLabel === undefined ? {} : { workspaceLabel }),
+      ...(title === undefined ? {} : { title }),
+      phase: update.phase,
+      ...(statusLine === undefined ? {} : { statusLine }),
+      ...(narration === undefined ? {} : { narration }),
+      ...(tool === undefined ? {} : { tool }),
+      startedAt: previous?.startedAt ?? update.startedAt ?? updatedAt,
+      phaseStartedAt: phaseChanged
+        ? update.phaseStartedAt ?? updatedAt
+        : previous.phaseStartedAt,
+      updatedAt,
+      ...(terminal
+        ? { finishedAt: update.finishedAt ?? (phaseChanged ? updatedAt : previous?.finishedAt ?? updatedAt) }
+        : {}),
+      ...(tokenUsage === undefined ? {} : { tokenUsage: { ...tokenUsage } }),
+      ...(progress === undefined ? {} : { progress }),
+    }
+    this.tasks.set(taskId, next)
+    this.recentTaskId = taskId
+    this.sequence += 1
+    return cloneTask(next)
+  }
+
+  /** Remove a task after its owning session is disposed. */
+  remove(identity: PetTaskIdentity): boolean {
+    const taskId = petTaskId(identity)
+    const removed = this.tasks.delete(taskId)
+    if (!removed) return false
+    if (this.pinnedTaskId === taskId) this.pinnedTaskId = undefined
+    if (this.focusedTaskId === taskId) this.focusedTaskId = undefined
+    if (this.recentTaskId === taskId) this.recentTaskId = undefined
+    this.sequence += 1
+    return true
+  }
+
+  /** Drop every task, for example when activity collection is disabled. */
+  clear(): void {
+    if (this.tasks.size === 0 && this.pinnedTaskId === undefined && this.focusedTaskId === undefined) return
+    this.tasks.clear()
+    this.pinnedTaskId = undefined
+    this.focusedTaskId = undefined
+    this.recentTaskId = undefined
+    this.sequence += 1
+  }
+
+  /** Set the user-pinned primary task hint. Unknown IDs clear the pin. */
+  pin(taskId?: string): void {
+    const next = taskId !== undefined && this.tasks.has(taskId) ? taskId : undefined
+    if (next === this.pinnedTaskId) return
+    this.pinnedTaskId = next
+    this.sequence += 1
+  }
+
+  /** Set the foreground web-session hint. Unknown IDs clear focus. */
+  focus(taskId?: string): void {
+    const next = taskId !== undefined && this.tasks.has(taskId) ? taskId : undefined
+    if (next === this.focusedTaskId) return
+    this.focusedTaskId = next
+    this.sequence += 1
+  }
+
+  /** Return a deterministic full snapshot suitable for REST or a bridge. */
+  snapshot(): PetAggregateSnapshot {
+    const emittedAt = this.now()
+    const tasks = [...this.tasks.values()]
+      .map(cloneTask)
+      .sort((left, right) => right.updatedAt - left.updatedAt || left.taskId.localeCompare(right.taskId))
+    const primary = selectPrimaryTask(tasks, {
+      nowMs: emittedAt,
+      ...(this.pinnedTaskId === undefined ? {} : { pinnedTaskId: this.pinnedTaskId }),
+      ...(this.focusedTaskId === undefined ? {} : { focusedTaskId: this.focusedTaskId }),
+      ...(this.recentTaskId === undefined ? {} : { recentTaskId: this.recentTaskId }),
+      ...(this.failedPriorityMs === undefined ? {} : { failedPriorityMs: this.failedPriorityMs }),
+    })
+    const summary = {
+      active: tasks.filter(task => isActive(task.phase)).length,
+      waiting: tasks.filter(task => task.phase === 'waiting' || task.phase === 'waiting_input').length,
+      blocked: tasks.filter(task => task.phase === 'blocked').length,
+      failed: tasks.filter(task => task.phase === 'failed').length,
+      completedRecently: tasks.filter(task => (
+        task.phase === 'done'
+        && task.finishedAt !== undefined
+        && emittedAt - task.finishedAt <= this.completedRecentlyMs
+      )).length,
+    }
+    return {
+      protocolVersion: PET_ACTIVITY_PROTOCOL_VERSION,
+      sequence: this.sequence,
+      emittedAt,
+      ...(primary === undefined ? {} : { primaryTaskId: primary.taskId }),
+      tasks,
+      summary,
+    }
+  }
+}

--- a/packages/dsh-pet/src/core/intent-scheduler.ts
+++ b/packages/dsh-pet/src/core/intent-scheduler.ts
@@ -1,0 +1,119 @@
+/** Deterministic motion scheduler shared by current and future renderers. */
+
+import type { PetIntent } from './intent.ts'
+
+export interface PetIntentSchedulerState {
+  current?: PetIntent
+  queued: PetIntent[]
+}
+
+function copyIntent(intent: PetIntent): PetIntent {
+  return {
+    ...intent,
+    ...(intent.speech === undefined ? {} : { speech: { ...intent.speech } }),
+    sourceTaskIds: [...intent.sourceTaskIds],
+  }
+}
+
+function expired(intent: PetIntent, nowMs: number): boolean {
+  return intent.expiresAt !== undefined && intent.expiresAt <= nowMs
+}
+
+/** Priority scheduler whose queue contains motions only; speech remains out-of-band. */
+export class PetIntentScheduler {
+  private current: PetIntent | undefined
+  private queued: PetIntent[] = []
+  private nowMs = 0
+
+  /** Submit one semantic motion without replaying an already-known ID. */
+  submit(intent: PetIntent): PetIntentSchedulerState {
+    this.nowMs = Math.max(this.nowMs, intent.createdAt)
+    this.prune()
+    if (expired(intent, this.nowMs)
+      || this.current?.id === intent.id
+      || this.queued.some(candidate => candidate.id === intent.id)) {
+      return this.state()
+    }
+
+    const next = copyIntent(intent)
+    if (this.current === undefined) {
+      this.current = next
+      return this.state()
+    }
+
+    // Activity is state, not an effect: a later semantic activity always
+    // replaces an older activity even when its numeric priority decreases.
+    if (next.source === 'activity' && this.current.source === 'activity') {
+      this.current = next
+      this.queued = this.queued.filter(candidate => candidate.source !== 'activity')
+      return this.state()
+    }
+
+    if (next.priority > this.current.priority && this.current.interruptible) {
+      if (this.current.playback !== 'once') this.enqueue(this.current)
+      this.current = next
+      return this.state()
+    }
+
+    this.enqueue(next)
+    return this.state()
+  }
+
+  /** Complete an emitted motion and promote the highest-priority valid fallback. */
+  complete(intentId: string): PetIntentSchedulerState {
+    if (this.current?.id === intentId) this.current = undefined
+    else this.queued = this.queued.filter(intent => intent.id !== intentId)
+    this.prune()
+    this.promote()
+    return this.state()
+  }
+
+  /** Remove expired motions at a caller-controlled time. */
+  tick(nowMs: number): PetIntentSchedulerState {
+    if (!Number.isFinite(nowMs)) throw new TypeError('pet intent scheduler requires a finite clock')
+    this.nowMs = Math.max(this.nowMs, nowMs)
+    this.prune()
+    this.promote()
+    return this.state()
+  }
+
+  /** Forget all renderer state, for example after renderer disposal. */
+  reset(): void {
+    this.current = undefined
+    this.queued = []
+    this.nowMs = 0
+  }
+
+  private enqueue(intent: PetIntent): void {
+    if (intent.source === 'activity') {
+      this.queued = this.queued.filter(candidate => candidate.source !== 'activity')
+    }
+    this.queued.push(copyIntent(intent))
+  }
+
+  private prune(): void {
+    if (this.current !== undefined && expired(this.current, this.nowMs)) this.current = undefined
+    this.queued = this.queued.filter(intent => !expired(intent, this.nowMs))
+  }
+
+  private promote(): void {
+    if (this.current !== undefined || this.queued.length === 0) return
+    let selected = 0
+    for (let index = 1; index < this.queued.length; index += 1) {
+      const candidate = this.queued[index]!
+      const current = this.queued[selected]!
+      if (candidate.priority > current.priority
+        || (candidate.priority === current.priority && candidate.createdAt > current.createdAt)) {
+        selected = index
+      }
+    }
+    this.current = this.queued.splice(selected, 1)[0]
+  }
+
+  private state(): PetIntentSchedulerState {
+    return {
+      ...(this.current === undefined ? {} : { current: copyIntent(this.current) }),
+      queued: this.queued.map(copyIntent),
+    }
+  }
+}

--- a/packages/dsh-pet/src/core/intent.ts
+++ b/packages/dsh-pet/src/core/intent.ts
@@ -1,0 +1,188 @@
+/** Renderer-neutral semantic intents derived from activity and interaction facts. */
+
+import { narrateActivity, type NarrationDecision } from './narration.ts'
+import type { PetAggregateSnapshot, PetTaskPhase, PetTaskSnapshot } from './protocol.ts'
+
+/** Stable intent contract version consumed by every renderer family. */
+export const PET_INTENT_VERSION = 2 as const
+
+export type PetExpression =
+  | 'neutral'
+  | 'curious'
+  | 'focused'
+  | 'happy'
+  | 'worried'
+  | 'questioning'
+
+export type PetMotion =
+  | 'idle'
+  | 'waiting'
+  | 'thinking'
+  | 'working'
+  | 'reviewing'
+  | 'request-input'
+  | 'celebrate'
+  | 'failure'
+  | 'pet'
+  | 'feed'
+
+export type PetIntentSource = 'activity' | 'interaction' | 'system'
+export type PetMotionPlayback = 'loop' | 'once' | 'hold'
+
+/** Speech is a separate event and never participates in motion deduplication. */
+export interface PetIntentSpeech {
+  id: string
+  text: string
+  createdAt: number
+}
+
+/** A bounded semantic command understood by sprite, Live2D, or another renderer. */
+export interface PetIntent {
+  version: typeof PET_INTENT_VERSION
+  id: string
+  source: PetIntentSource
+  createdAt: number
+  expiresAt?: number
+  priority: number
+  interruptible: boolean
+  expression: PetExpression
+  motion: PetMotion
+  playback: PetMotionPlayback
+  speech?: PetIntentSpeech
+  sourceTaskIds: string[]
+}
+
+interface PhaseIntent {
+  expression: PetExpression
+  motion: PetMotion
+  playback: PetMotionPlayback
+  priority: number
+  interruptible: boolean
+}
+
+function forPhase(phase: PetTaskPhase): PhaseIntent {
+  switch (phase) {
+    case 'waiting_input':
+      return {
+        expression: 'questioning', motion: 'request-input', playback: 'hold', priority: 80, interruptible: false,
+      }
+    case 'blocked':
+      return {
+        expression: 'worried', motion: 'request-input', playback: 'hold', priority: 75, interruptible: false,
+      }
+    case 'failed':
+      return {
+        expression: 'worried', motion: 'failure', playback: 'hold', priority: 70, interruptible: false,
+      }
+    case 'done':
+      return {
+        expression: 'happy', motion: 'celebrate', playback: 'once', priority: 60, interruptible: false,
+      }
+    case 'tool':
+      return {
+        expression: 'focused', motion: 'working', playback: 'loop', priority: 40, interruptible: true,
+      }
+    case 'thinking':
+      return {
+        expression: 'focused', motion: 'thinking', playback: 'loop', priority: 30, interruptible: true,
+      }
+    case 'review':
+      return {
+        expression: 'neutral', motion: 'reviewing', playback: 'loop', priority: 25, interruptible: true,
+      }
+    case 'waiting':
+      return {
+        expression: 'curious', motion: 'waiting', playback: 'loop', priority: 15, interruptible: true,
+      }
+    case 'idle':
+      return {
+        expression: 'neutral', motion: 'idle', playback: 'loop', priority: 0, interruptible: true,
+      }
+  }
+}
+
+/** Runtime-neutral FNV-1a hash used only to keep semantic IDs short and bounded. */
+function semanticHash(value: string): string {
+  let hash = 0xcbf29ce484222325n
+  for (const character of value) {
+    hash ^= BigInt(character.codePointAt(0) ?? 0)
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n)
+  }
+  return hash.toString(16).padStart(16, '0')
+}
+
+/** Motion identity changes only when the renderer-relevant task semantics change. */
+export function activityIntentId(task: PetTaskSnapshot | undefined): string {
+  if (task === undefined) return 'activity:idle'
+  return `activity:${semanticHash([
+    task.taskId,
+    task.phase,
+    String(task.phaseStartedAt),
+    task.tool?.name ?? '',
+  ].join('|'))}`
+}
+
+function speechFor(
+  snapshot: PetAggregateSnapshot,
+  narration: NarrationDecision | undefined,
+): PetIntentSpeech | undefined {
+  const text = narration?.text ?? narrateActivity(snapshot)
+  if (text === undefined) return undefined
+  const createdAt = narration?.createdAt ?? snapshot.emittedAt
+  return {
+    id: `speech:${narration?.reason ?? 'snapshot'}:${String(createdAt)}`,
+    text,
+    createdAt,
+  }
+}
+
+/** Map only the selected primary task; renderers never consume session events. */
+export function mapActivityToIntent(
+  snapshot: PetAggregateSnapshot,
+  narration?: NarrationDecision,
+): PetIntent {
+  const primary = snapshot.tasks.find(task => task.taskId === snapshot.primaryTaskId)
+  const phase = primary?.phase ?? 'idle'
+  const mapped = forPhase(phase)
+  const speech = speechFor(snapshot, narration)
+  return {
+    version: PET_INTENT_VERSION,
+    id: activityIntentId(primary),
+    source: 'activity',
+    createdAt: primary?.phaseStartedAt ?? 0,
+    priority: mapped.priority,
+    interruptible: mapped.interruptible,
+    expression: mapped.expression,
+    motion: mapped.motion,
+    playback: mapped.playback,
+    ...(speech === undefined ? {} : { speech }),
+    sourceTaskIds: primary === undefined ? [] : [primary.taskId],
+  }
+}
+
+/** Create one short interaction Intent without replacing the underlying task state. */
+export function createInteractionIntent(
+  kind: 'pet' | 'feed',
+  text: string,
+  createdAt: number,
+  accepted: boolean,
+): PetIntent {
+  return {
+    version: PET_INTENT_VERSION,
+    id: `interaction:${kind}:${String(createdAt)}`,
+    source: 'interaction',
+    createdAt,
+    expiresAt: createdAt + 1_600,
+    priority: 65,
+    interruptible: false,
+    expression: accepted ? 'happy' : 'questioning',
+    motion: kind,
+    playback: 'once',
+    speech: {
+      id: `speech:interaction-${kind}:${String(createdAt)}`,
+      text,
+      createdAt,
+    },
+    sourceTaskIds: [],
+  }
+}

--- a/packages/dsh-pet/src/core/narration.ts
+++ b/packages/dsh-pet/src/core/narration.ts
@@ -1,0 +1,286 @@
+/** Deterministic, privacy-safe activity narration and emission scheduling. */
+
+import { sanitizeActivityText } from './sanitize.ts'
+import type { PetAggregateSnapshot, PetTaskSnapshot } from './protocol.ts'
+
+export type NarrationReason =
+  | 'initial'
+  | 'waiting-input'
+  | 'failure'
+  | 'completion'
+  | 'primary-task'
+  | 'phase'
+  | 'tool'
+  | 'aggregate'
+  | 'long-running'
+
+export interface NarrationContext {
+  reason?: NarrationReason
+  longRunningMs?: number
+  maxChars?: number
+}
+
+export interface NarrationDecision {
+  text?: string
+  emitted: boolean
+  reason?: NarrationReason
+  /** Stable creation time of the currently displayed speech event. */
+  createdAt?: number
+}
+
+export interface NarrationEngineOptions {
+  minIntervalMs?: number
+  duplicateWindowMs?: number
+  completionMergeMs?: number
+  longRunningThresholdsMs?: number[]
+  maxChars?: number
+}
+
+interface Trigger {
+  reason: NarrationReason
+  urgent: boolean
+  longRunningMs?: number
+}
+
+const DEFAULT_MIN_INTERVAL_MS = 8_000
+const DEFAULT_DUPLICATE_WINDOW_MS = 60_000
+const DEFAULT_COMPLETION_MERGE_MS = 3_000
+const DEFAULT_LONG_THRESHOLDS_MS = [30_000, 60_000, 300_000]
+
+function primaryTask(snapshot: PetAggregateSnapshot): PetTaskSnapshot | undefined {
+  return snapshot.tasks.find(task => task.taskId === snapshot.primaryTaskId)
+}
+
+function phaseFallback(task: PetTaskSnapshot): string | undefined {
+  switch (task.phase) {
+    case 'waiting': return '正在等待响应'
+    case 'thinking': return '正在思考'
+    case 'tool': return task.tool === undefined ? '正在使用工具' : `正在使用 ${task.tool.name}`
+    case 'review': return '正在整理回复'
+    case 'waiting_input': return '正在等你确认'
+    case 'blocked': return '任务受阻，正在等待继续'
+    case 'done': return '完成啦'
+    case 'failed': return '任务遇到问题了'
+    case 'idle': return undefined
+  }
+}
+
+function taskLine(task: PetTaskSnapshot, maxChars = 16): string {
+  const action = task.narration ?? task.statusLine ?? phaseFallback(task) ?? '暂时待机'
+  const safeAction = sanitizeActivityText(action, { maxChars })
+  if (task.title === undefined) return safeAction
+  const title = sanitizeActivityText(task.title, { maxChars: 8 })
+  if (title === '') return safeAction
+  const actionWithoutPrefix = safeAction.replace(/^正在/u, '')
+  return sanitizeActivityText(`${title}正在${actionWithoutPrefix}`, { maxChars })
+}
+
+function longRunningLine(task: PetTaskSnapshot, elapsedMs: number): string {
+  if (elapsedMs >= 300_000) return '这个任务运行较久，仍在继续。'
+  if (elapsedMs >= 60_000) return '任务还在继续，我会帮你盯着。'
+  if (task.phase === 'tool') return '这个工具还在运行，我继续等结果。'
+  return '这个任务忙了一会儿，我还在盯着。'
+}
+
+/** Build one bounded line from known facts only; no percentage is inferred. */
+export function narrateActivity(
+  snapshot: PetAggregateSnapshot,
+  context: NarrationContext = {},
+): string | undefined {
+  const primary = primaryTask(snapshot)
+  if (primary === undefined) return undefined
+
+  const maxChars = context.maxChars ?? 32
+  let text: string
+  if (context.reason === 'long-running' && context.longRunningMs !== undefined) {
+    text = longRunningLine(primary, context.longRunningMs)
+  } else if (context.reason === 'completion' && snapshot.summary.completedRecently > 0) {
+    text = snapshot.summary.active > 0
+      ? `有 ${snapshot.summary.completedRecently} 个任务刚完成，另外 ${snapshot.summary.active} 个还在继续。`
+      : snapshot.summary.completedRecently === 1
+        ? '刚刚完成了一个任务。'
+        : `刚刚完成了 ${snapshot.summary.completedRecently} 个任务。`
+  } else {
+    const freshFailures = snapshot.tasks.filter(task => (
+      task.phase === 'failed' && snapshot.emittedAt - task.updatedAt <= 30_000
+    )).length
+    if (freshFailures > 0) {
+      text = `有 ${freshFailures} 个任务遇到问题，我先盯着最急的。`
+    } else if (primary.phase === 'waiting_input') {
+      text = snapshot.summary.active > 1
+        ? `主任务正在等你确认，另外 ${snapshot.summary.active - 1} 个还在继续。`
+        : '这个任务正在等你确认。'
+    } else if (primary.phase === 'blocked') {
+      text = snapshot.summary.blocked > 1
+        ? `有 ${snapshot.summary.blocked} 个任务受阻，我先盯着主任务。`
+        : '这个任务暂时受阻，正在等待继续。'
+    } else if (snapshot.summary.active > 2) {
+      text = `现在有 ${snapshot.summary.active} 个任务在跑，主任务${taskLine(primary, 13)}。`
+    } else if (snapshot.summary.active === 2) {
+      const other = snapshot.tasks.find(task => (
+        task.taskId !== primary.taskId && !['idle', 'done', 'failed'].includes(task.phase)
+      ))
+      text = other === undefined
+        ? taskLine(primary, maxChars)
+        : `主任务${taskLine(primary, 12)}，另一个任务${taskLine(other, 12)}。`
+    } else {
+      text = taskLine(primary, maxChars)
+    }
+  }
+  const safe = sanitizeActivityText(text, { maxChars })
+  return safe === '' ? undefined : safe
+}
+
+function taskById(snapshot: PetAggregateSnapshot | undefined, taskId: string | undefined): PetTaskSnapshot | undefined {
+  if (snapshot === undefined || taskId === undefined) return undefined
+  return snapshot.tasks.find(task => task.taskId === taskId)
+}
+
+function newlyCompleted(previous: PetAggregateSnapshot | undefined, current: PetAggregateSnapshot): boolean {
+  if (previous === undefined) return current.tasks.some(task => task.phase === 'done')
+  const previousPhases = new Map(previous.tasks.map(task => [task.taskId, task.phase]))
+  return current.tasks.some(task => task.phase === 'done' && previousPhases.get(task.taskId) !== 'done')
+}
+
+/** Stateful scheduler enforcing narration priority, cooldown, and deduplication. */
+export class NarrationEngine {
+  private readonly minIntervalMs: number
+  private readonly duplicateWindowMs: number
+  private readonly completionMergeMs: number
+  private readonly longThresholds: number[]
+  private readonly maxChars: number
+  private previous: PetAggregateSnapshot | undefined
+  private currentText: string | undefined
+  private currentReason: NarrationReason | undefined
+  private currentCreatedAt: number | undefined
+  private lastEmittedAt = Number.NEGATIVE_INFINITY
+  private lastCompletionAt = Number.NEGATIVE_INFINITY
+  private readonly recentTexts = new Map<string, number>()
+  private readonly longSeen = new Map<string, number>()
+  private pending: Trigger | undefined
+
+  constructor(options: NarrationEngineOptions = {}) {
+    this.minIntervalMs = options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS
+    this.duplicateWindowMs = options.duplicateWindowMs ?? DEFAULT_DUPLICATE_WINDOW_MS
+    this.completionMergeMs = options.completionMergeMs ?? DEFAULT_COMPLETION_MERGE_MS
+    this.longThresholds = [...(options.longRunningThresholdsMs ?? DEFAULT_LONG_THRESHOLDS_MS)]
+      .filter(value => Number.isFinite(value) && value >= 0)
+      .sort((left, right) => left - right)
+    this.maxChars = options.maxChars ?? 32
+  }
+
+  /** Clear all history when activity collection is disabled or restarted. */
+  reset(): void {
+    this.previous = undefined
+    this.currentText = undefined
+    this.currentReason = undefined
+    this.currentCreatedAt = undefined
+    this.lastEmittedAt = Number.NEGATIVE_INFINITY
+    this.lastCompletionAt = Number.NEGATIVE_INFINITY
+    this.recentTexts.clear()
+    this.longSeen.clear()
+    this.pending = undefined
+  }
+
+  /** Evaluate one full snapshot and return the currently displayable line. */
+  next(snapshot: PetAggregateSnapshot): NarrationDecision {
+    if (snapshot.tasks.length === 0) {
+      this.reset()
+      this.previous = snapshot
+      return { emitted: false }
+    }
+
+    const trigger = this.detectTrigger(snapshot)
+    if (trigger !== undefined) this.pending = trigger
+    const emitted = this.tryEmit(snapshot)
+    this.previous = snapshot
+    return emitted ?? {
+      ...(this.currentText === undefined ? {} : { text: this.currentText }),
+      emitted: false,
+      ...(this.currentReason === undefined ? {} : { reason: this.currentReason }),
+      ...(this.currentCreatedAt === undefined ? {} : { createdAt: this.currentCreatedAt }),
+    }
+  }
+
+  private detectTrigger(snapshot: PetAggregateSnapshot): Trigger | undefined {
+    const current = primaryTask(snapshot)
+    const previousPrimary = taskById(this.previous, this.previous?.primaryTaskId)
+    if (current?.phase === 'waiting_input'
+      && (previousPrimary?.phase !== 'waiting_input' || previousPrimary.taskId !== current.taskId)) {
+      return { reason: 'waiting-input', urgent: true }
+    }
+    if (current?.phase === 'failed'
+      && (previousPrimary?.phase !== 'failed' || previousPrimary.taskId !== current.taskId)) {
+      return { reason: 'failure', urgent: true }
+    }
+    if (newlyCompleted(this.previous, snapshot)) {
+      return { reason: 'completion', urgent: true }
+    }
+    if (this.previous === undefined) return { reason: 'initial', urgent: false }
+    if (this.previous.tasks.length !== snapshot.tasks.length
+      || this.previous.summary.active !== snapshot.summary.active) {
+      return { reason: 'aggregate', urgent: true }
+    }
+    if (this.previous.primaryTaskId !== snapshot.primaryTaskId) {
+      return { reason: 'primary-task', urgent: false }
+    }
+    if (current !== undefined && previousPrimary?.phase !== current.phase) {
+      return { reason: 'phase', urgent: false }
+    }
+    if (current !== undefined && (
+      previousPrimary?.tool?.name !== current.tool?.name
+      || previousPrimary?.tool?.activeCount !== current.tool?.activeCount
+    )) {
+      return { reason: 'tool', urgent: false }
+    }
+    if (current?.narration !== previousPrimary?.narration) {
+      return { reason: 'phase', urgent: false }
+    }
+    return this.longRunningTrigger(snapshot, current)
+  }
+
+  private longRunningTrigger(
+    snapshot: PetAggregateSnapshot,
+    task: PetTaskSnapshot | undefined,
+  ): Trigger | undefined {
+    if (task === undefined || ['idle', 'done', 'failed', 'waiting_input'].includes(task.phase)) return undefined
+    const elapsed = Math.max(0, snapshot.emittedAt - task.phaseStartedAt)
+    const crossed = this.longThresholds.filter(value => elapsed >= value).at(-1)
+    if (crossed === undefined) return undefined
+    const key = `${task.taskId}:${task.phaseStartedAt}`
+    const seen = this.longSeen.get(key) ?? Number.NEGATIVE_INFINITY
+    if (crossed <= seen) return undefined
+    this.longSeen.set(key, crossed)
+    return { reason: 'long-running', urgent: false, longRunningMs: crossed }
+  }
+
+  private tryEmit(snapshot: PetAggregateSnapshot): NarrationDecision | undefined {
+    const trigger = this.pending
+    if (trigger === undefined) return undefined
+    const nowMs = snapshot.emittedAt
+    if (!trigger.urgent && nowMs - this.lastEmittedAt < this.minIntervalMs) return undefined
+    if (trigger.reason === 'completion' && nowMs - this.lastCompletionAt < this.completionMergeMs) {
+      return undefined
+    }
+    const text = narrateActivity(snapshot, {
+      reason: trigger.reason,
+      ...(trigger.longRunningMs === undefined ? {} : { longRunningMs: trigger.longRunningMs }),
+      maxChars: this.maxChars,
+    })
+    this.pending = undefined
+    if (text === undefined || text === this.currentText) return undefined
+    const previousAt = this.recentTexts.get(text)
+    if (previousAt !== undefined && nowMs - previousAt < this.duplicateWindowMs) return undefined
+
+    for (const [recentText, emittedAt] of this.recentTexts) {
+      if (nowMs - emittedAt >= this.duplicateWindowMs) this.recentTexts.delete(recentText)
+    }
+    this.currentText = text
+    this.currentReason = trigger.reason
+    this.currentCreatedAt = nowMs
+    this.lastEmittedAt = nowMs
+    if (trigger.reason === 'completion') this.lastCompletionAt = nowMs
+    this.recentTexts.set(text, nowMs)
+    return { text, emitted: true, reason: trigger.reason, createdAt: nowMs }
+  }
+}

--- a/packages/dsh-pet/src/core/primary-task.ts
+++ b/packages/dsh-pet/src/core/primary-task.ts
@@ -1,0 +1,77 @@
+/** Deterministic primary-task selection for multi-session pet snapshots. */
+
+import type { PetTaskSnapshot } from './protocol.ts'
+
+/** External hints that can raise a task without mutating its snapshot. */
+export interface PrimaryTaskSelection {
+  nowMs: number
+  pinnedTaskId?: string
+  focusedTaskId?: string
+  /** Registry-owned hint for the most recently updated active task. */
+  recentTaskId?: string
+  /** How long a failed task receives urgent priority. */
+  failedPriorityMs?: number
+}
+
+const DEFAULT_FAILED_PRIORITY_MS = 30_000
+
+function byRecentActivity(left: PetTaskSnapshot, right: PetTaskSnapshot): number {
+  return right.updatedAt - left.updatedAt
+    || left.startedAt - right.startedAt
+    || left.taskId.localeCompare(right.taskId)
+}
+
+function mostRecent(tasks: PetTaskSnapshot[]): PetTaskSnapshot | undefined {
+  return [...tasks].sort(byRecentActivity)[0]
+}
+
+function isActive(task: PetTaskSnapshot): boolean {
+  return !['idle', 'done', 'failed'].includes(task.phase)
+}
+
+/**
+ * Choose the task the companion should foreground. Priority is waiting for
+ * user, a fresh failure, an explicit pin, foreground focus, recent active
+ * work, recent completion, then an idle task. Ties are stable by task ID.
+ */
+export function selectPrimaryTask(
+  tasks: PetTaskSnapshot[],
+  options: PrimaryTaskSelection,
+): PetTaskSnapshot | undefined {
+  if (tasks.length === 0) return undefined
+
+  const waitingInput = mostRecent(tasks.filter(task => task.phase === 'waiting_input'))
+  if (waitingInput !== undefined) return waitingInput
+
+  const blocked = mostRecent(tasks.filter(task => task.phase === 'blocked'))
+  if (blocked !== undefined) return blocked
+
+  const failedPriorityMs = options.failedPriorityMs ?? DEFAULT_FAILED_PRIORITY_MS
+  const failed = mostRecent(tasks.filter(task => (
+    task.phase === 'failed' && options.nowMs - task.updatedAt <= failedPriorityMs
+  )))
+  if (failed !== undefined) return failed
+
+  const pinned = options.pinnedTaskId === undefined
+    ? undefined
+    : tasks.find(task => task.taskId === options.pinnedTaskId)
+  if (pinned !== undefined) return pinned
+
+  const focused = options.focusedTaskId === undefined
+    ? undefined
+    : tasks.find(task => task.taskId === options.focusedTaskId)
+  if (focused !== undefined) return focused
+
+  const recent = options.recentTaskId === undefined
+    ? undefined
+    : tasks.find(task => task.taskId === options.recentTaskId && isActive(task))
+  if (recent !== undefined) return recent
+
+  const active = mostRecent(tasks.filter(isActive))
+  if (active !== undefined) return active
+
+  const completed = mostRecent(tasks.filter(task => task.phase === 'done'))
+  if (completed !== undefined) return completed
+
+  return mostRecent(tasks)
+}

--- a/packages/dsh-pet/src/core/protocol.ts
+++ b/packages/dsh-pet/src/core/protocol.ts
@@ -1,0 +1,137 @@
+/**
+ * Versioned, transport-neutral activity types shared by the host, web pet,
+ * and future desktop companion. This module must stay free of runtime SDK,
+ * DOM, WebServer, and Electron dependencies.
+ * @module @linxin666/dsh-pet/core/protocol
+ */
+
+/** Stable pre-extension activity protocol version. */
+export const PET_ACTIVITY_PROTOCOL_VERSION = 2 as const
+
+/** Task phases emitted by a live DSH instance. Offline is receiver-derived. */
+export type PetTaskPhase =
+  | 'idle'
+  | 'waiting'
+  | 'thinking'
+  | 'tool'
+  | 'review'
+  | 'waiting_input'
+  | 'blocked'
+  | 'done'
+  | 'failed'
+
+/** Identity fields that prevent collisions across instances and restarts. */
+export interface PetTaskIdentity {
+  instanceId: string
+  bootId: string
+  sessionId: string
+}
+
+/** Safe, bounded facts about the current tool activity. */
+export interface PetTaskToolSnapshot {
+  name: string
+  label?: string
+  detail?: string
+  activeCount: number
+  completedCount: number
+  failedCount?: number
+}
+
+/** Token usage is included only when the official source provides it. */
+export interface PetTaskTokenUsage {
+  input?: number
+  output?: number
+}
+
+/** Progress exists only when an official source provides exact facts. */
+export interface PetTaskProgress {
+  current: number
+  total: number
+  unit?: string
+}
+
+/** One session task retained by the process-local activity registry. */
+export interface PetTaskSnapshot extends PetTaskIdentity {
+  taskId: string
+  profile?: string
+  workspaceLabel?: string
+  title?: string
+  phase: PetTaskPhase
+  statusLine?: string
+  narration?: string
+  tool?: PetTaskToolSnapshot
+  startedAt: number
+  phaseStartedAt: number
+  updatedAt: number
+  finishedAt?: number
+  tokenUsage?: PetTaskTokenUsage
+  progress?: PetTaskProgress
+}
+
+/** Counts used by compact web and desktop summaries. */
+export interface PetAggregateSummary {
+  active: number
+  waiting: number
+  blocked: number
+  failed: number
+  completedRecently: number
+}
+
+/** Full process-local snapshot. V2 deliberately does not use deltas. */
+export interface PetAggregateSnapshot {
+  protocolVersion: typeof PET_ACTIVITY_PROTOCOL_VERSION
+  sequence: number
+  emittedAt: number
+  primaryTaskId?: string
+  tasks: PetTaskSnapshot[]
+  summary: PetAggregateSummary
+}
+
+/** Metadata sent when one host connects to a desktop bridge. */
+export interface PetInstanceDescriptor {
+  instanceId: string
+  bootId: string
+  profile?: string
+  workspaceLabel?: string
+  startedAt: number
+}
+
+/** Message envelope shared by full snapshots and lifecycle signals. */
+export interface PetActivityEnvelope<TType extends string, TPayload> {
+  protocolVersion: typeof PET_ACTIVITY_PROTOCOL_VERSION
+  type: TType
+  instanceId: string
+  bootId: string
+  sequence: number
+  emittedAt: number
+  payload: TPayload
+}
+
+/** Version 2 bridge vocabulary. */
+export type PetActivityMessage =
+  | PetActivityEnvelope<'hello', { instance: PetInstanceDescriptor }>
+  | PetActivityEnvelope<'snapshot', PetAggregateSnapshot>
+  | PetActivityEnvelope<'heartbeat', { activeTasks: number }>
+  | PetActivityEnvelope<'goodbye', { reason?: string }>
+
+/** Create an unambiguous task ID from the protocol's composite identity. */
+export function petTaskId(identity: PetTaskIdentity): string {
+  const parts = [identity.instanceId, identity.bootId, identity.sessionId]
+    .map(part => encodeURIComponent(part))
+  return `v2:${parts.join(':')}`
+}
+
+/** Whether a value belongs to the task phase vocabulary. */
+export function isPetTaskPhase(value: string): value is PetTaskPhase {
+  return [
+    'idle',
+    'waiting',
+    'thinking',
+    'tool',
+    'review',
+    'waiting_input',
+    'blocked',
+    'done',
+    'failed',
+  ].includes(value)
+}

--- a/packages/dsh-pet/src/core/sanitize.ts
+++ b/packages/dsh-pet/src/core/sanitize.ts
@@ -1,0 +1,69 @@
+/** Privacy-safe text normalization for every activity transport boundary. */
+
+export interface ActivityTextOptions {
+  /** Maximum Unicode code points in the returned text. */
+  maxChars?: number
+}
+
+const DEFAULT_MAX_CHARS = 48
+const REDACTED = '[已脱敏]'
+
+function truncate(text: string, maxChars: number): string {
+  const chars = [...text]
+  if (chars.length <= maxChars) return text
+  if (maxChars <= 3) return chars.slice(0, maxChars).join('')
+  return `${chars.slice(0, maxChars - 3).join('')}...`
+}
+
+function stripUrlSecrets(text: string): string {
+  return text.replace(/\bhttps?:\/\/[^\s<>"']+/giu, (raw) => {
+    const suffix = raw.match(/[),.;!?，。！？]+$/u)?.[0] ?? ''
+    const source = suffix === '' ? raw : raw.slice(0, -suffix.length)
+    try {
+      const url = new URL(source)
+      return `${url.origin}${url.pathname}${suffix}`
+    } catch {
+      return raw
+    }
+  })
+}
+
+function shortenPaths(text: string): string {
+  const windows = text.replace(
+    /\b[A-Za-z]:\\(?:[^\\\s"'<>|]+\\){2,}[^\\\s"'<>|]*/gu,
+    (path) => `.../${path.split('\\').at(-1) ?? 'path'}`,
+  )
+  return windows.replace(
+    /(^|[\s(])\/(?:[^/\s"'<>]+\/){2,}[^/\s"'<>),.;!?]*/gu,
+    (_path, prefix: string) => {
+      const source = _path.slice(prefix.length)
+      return `${prefix}.../${source.split('/').at(-1) ?? 'path'}`
+    },
+  )
+}
+
+function redactCredentials(text: string): string {
+  return text
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{8,}\b/giu, `Bearer ${REDACTED}`)
+    .replace(/\b(?:sk|ghp|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{8,}\b/giu, REDACTED)
+    .replace(
+      /\b(token|api[-_ ]?key|secret|password)\s*[:=]\s*[^\s,;]+/giu,
+      (_match, label: string) => `${label}=${REDACTED}`,
+    )
+}
+
+/**
+ * Remove transport-unsafe and sensitive fragments, normalize whitespace,
+ * shorten absolute paths, strip URL queries/fragments, and enforce a bound.
+ */
+export function sanitizeActivityText(
+  input: string,
+  options: ActivityTextOptions = {},
+): string {
+  const withoutControls = input.replace(/[\u0000-\u001f\u007f-\u009f]/gu, ' ')
+  const withoutUrlSecrets = stripUrlSecrets(withoutControls)
+  const withoutCredentials = redactCredentials(withoutUrlSecrets)
+  const withoutPaths = shortenPaths(withoutCredentials)
+  const compact = withoutPaths.replace(/\s+/gu, ' ').trim()
+  return truncate(compact, Math.max(0, options.maxChars ?? DEFAULT_MAX_CHARS))
+}

--- a/packages/dsh-pet/src/errors.ts
+++ b/packages/dsh-pet/src/errors.ts
@@ -1,0 +1,22 @@
+/** Stable, log-safe error codes. UI surfaces localized copy instead. */
+export const PET_ERROR_CODES = Object.freeze({
+  disabled: 'PET_DISABLED',
+  presentationHeadless: 'PRESENTATION_HEADLESS',
+  presentationRuntimeMissing: 'PRESENTATION_RUNTIME_MISSING',
+  presentationHostUnavailable: 'PRESENTATION_HOST_UNAVAILABLE',
+  presentationBridgeUnavailable: 'PRESENTATION_BRIDGE_UNAVAILABLE',
+  presentationStartFailed: 'PRESENTATION_START_FAILED',
+  nativeAuthRequired: 'NATIVE_AUTH_REQUIRED',
+  nativeAuthInvalid: 'NATIVE_AUTH_INVALID',
+  nativeLoopbackRequired: 'NATIVE_LOOPBACK_REQUIRED',
+  rendererNotFound: 'RENDERER_NOT_FOUND',
+  rendererIncompatible: 'RENDERER_INCOMPATIBLE',
+  rendererLoadFailed: 'RENDERER_LOAD_FAILED',
+  rendererContextLost: 'RENDERER_CONTEXT_LOST',
+  modelNotFound: 'MODEL_NOT_FOUND',
+  modelInvalid: 'MODEL_INVALID',
+  modelImportFailed: 'MODEL_IMPORT_FAILED',
+  returnTargetUnavailable: 'RETURN_TARGET_UNAVAILABLE',
+} as const)
+
+export type PetErrorCode = typeof PET_ERROR_CODES[keyof typeof PET_ERROR_CODES]

--- a/packages/dsh-pet/src/models/builtin-whale.ts
+++ b/packages/dsh-pet/src/models/builtin-whale.ts
@@ -1,0 +1,37 @@
+import { PET_MODEL_SCHEMA_VERSION, type PetModelDescriptor } from '../contracts/model.ts'
+
+export const BUILTIN_SPRITE_MODEL_FORMATS = Object.freeze([
+  'petdex-v1', 'petdex-v2', 'dsh-pet-model-v1',
+] as const)
+
+const builtinWhaleModel: PetModelDescriptor = {
+  schemaVersion: PET_MODEL_SCHEMA_VERSION,
+  id: 'builtin:whale',
+  displayName: '鲸鱼娘',
+  description: 'DSH Pet 内置像素模型',
+  rendererId: 'builtin:sprite2d',
+  format: 'petdex-v1',
+  entry: 'spritesheet.webp',
+  source: { kind: 'builtin' },
+  capabilities: {
+    motions: [
+      'idle', 'waiting', 'thinking', 'working', 'reviewing',
+      'request-input', 'celebrate', 'failure', 'pet', 'feed',
+    ],
+    expressions: [],
+    lookAt: false,
+    lipSync: false,
+    hitAreas: ['body'],
+  },
+  bindings: {
+    motions: {
+      idle: 'idle', waiting: 'waiting', thinking: 'running', working: 'running-right',
+      reviewing: 'review', 'request-input': 'waving', celebrate: 'jumping',
+      failure: 'failed', pet: 'waving', feed: 'jumping',
+    },
+    expressions: {},
+  },
+  fallback: { motion: 'idle', expression: 'neutral' },
+}
+
+export const BUILTIN_WHALE_MODEL: PetModelDescriptor = Object.freeze(builtinWhaleModel)

--- a/packages/dsh-pet/src/models/catalog.test.ts
+++ b/packages/dsh-pet/src/models/catalog.test.ts
@@ -1,0 +1,179 @@
+import { mkdir, mkdtemp, readFile, readdir, symlink, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { FilePetAssetResolver } from './file-asset-resolver.ts'
+import { PetModelCatalog, resolvePetModelSelection } from './catalog.ts'
+import { modelDescriptorToManifest, petDexToModelDescriptor } from './descriptor.ts'
+
+function losslessWebpHeader(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(32)
+  buffer.write('RIFF', 0, 'ascii')
+  buffer.write('WEBP', 8, 'ascii')
+  buffer.write('VP8L', 12, 'ascii')
+  buffer[20] = 0x2f
+  buffer.writeUInt32LE((((height - 1) << 14) | (width - 1)) >>> 0, 21)
+  return buffer
+}
+
+async function writePetDex(directory: string, id = 'boba', version: 1 | 2 = 1): Promise<void> {
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, 'pet.json'), JSON.stringify({
+    id,
+    displayName: 'Boba',
+    description: 'A test pet.',
+    spritesheetPath: 'spritesheet.webp',
+    ...(version === 1 ? {} : { spriteVersionNumber: 2 }),
+  }), 'utf8')
+  await writeFile(join(directory, 'spritesheet.webp'), losslessWebpHeader(1536, version === 1 ? 1872 : 2288))
+}
+
+describe('PetModelCatalog', () => {
+  it('normalizes PetDex imports into declarative manifests and copies no code', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-pet-model-'))
+    const source = join(root, 'source')
+    const managed = join(root, 'managed')
+    await writePetDex(source)
+    await writeFile(join(source, 'untrusted.js'), 'throw new Error("never execute")', 'utf8')
+    const catalog = new PetModelCatalog({ root: managed })
+
+    const first = await catalog.importDirectory(source)
+    const second = await catalog.importDirectory(source)
+
+    expect(first.id).toBe('imported:boba')
+    expect(second.id).toBe('imported:boba-2')
+    expect(JSON.parse(await readFile(join(managed, 'imported', 'boba', 'pet-model.json'), 'utf8'))).toMatchObject({
+      schemaVersion: 1,
+      id: 'boba',
+      rendererId: 'builtin:sprite2d',
+      format: 'petdex-v1',
+      entry: 'spritesheet.webp',
+    })
+    expect(JSON.parse(await readFile(join(managed, 'imported', 'boba', 'pet.json'), 'utf8'))).toMatchObject({
+      id: 'boba',
+      displayName: 'Boba',
+      spritesheetPath: 'spritesheet.webp',
+    })
+    await expect(readFile(join(managed, 'imported', 'boba', 'untrusted.js'))).rejects.toThrow()
+
+    const resolver = new FilePetAssetResolver(catalog)
+    const bytes = await resolver.fetch({ modelId: first.id, path: first.entry })
+    expect(bytes.byteLength).toBe(32)
+  })
+
+  it('copies the old userData directory idempotently without deleting it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-pet-migrate-'))
+    const legacy = join(root, 'pixel-models')
+    await writePetDex(join(legacy, 'boba'))
+    const catalog = new PetModelCatalog({ root: join(root, 'dsh-home-models') })
+
+    await expect(catalog.migrateLegacyImportedRoot(legacy)).resolves.toBe(1)
+    await expect(catalog.migrateLegacyImportedRoot(legacy)).resolves.toBe(0)
+    expect((await catalog.list()).map(model => model.id)).toContain('imported:boba')
+    await expect(readFile(join(legacy, 'boba', 'pet.json'), 'utf8')).resolves.toContain('boba')
+  })
+
+  it('imports a real PetDex V2 package and preserves its renderer format', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-pet-v2-'))
+    const source = join(root, 'source')
+    await writePetDex(source, 'v2-model', 2)
+    const catalog = new PetModelCatalog({ root: join(root, 'managed') })
+
+    await expect(catalog.importDirectory(source)).resolves.toMatchObject({
+      id: 'imported:v2-model',
+      format: 'petdex-v2',
+    })
+  })
+
+  it('rejects oversized manifests and textures before copying model data', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-pet-limits-'))
+    const catalog = new PetModelCatalog({ root: join(root, 'managed') })
+    const hugeManifest = join(root, 'huge-manifest')
+    await mkdir(hugeManifest)
+    await writeFile(join(hugeManifest, 'pet.json'), Buffer.alloc(64 * 1024 + 1, 0x20))
+    await writeFile(join(hugeManifest, 'spritesheet.webp'), losslessWebpHeader(1536, 1872))
+    await expect(catalog.importDirectory(hugeManifest)).rejects.toThrow('大小无效')
+
+    const hugeTexture = join(root, 'huge-texture')
+    await writePetDex(hugeTexture, 'huge-texture')
+    await truncate(join(hugeTexture, 'spritesheet.webp'), 32 * 1024 * 1024 + 1)
+    await expect(catalog.importDirectory(hugeTexture)).rejects.toThrow('模型纹理大小无效')
+    await expect(readdir(join(root, 'managed', 'imported'))).rejects.toThrow()
+  })
+
+  it('rejects a texture symlink that escapes the model directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-pet-symlink-'))
+    const source = join(root, 'source')
+    const external = join(root, 'outside')
+    await mkdir(source)
+    await mkdir(external)
+    await writeFile(join(external, 'spritesheet.webp'), losslessWebpHeader(1536, 1872))
+    const descriptor = petDexToModelDescriptor({
+      id: 'escape', displayName: 'Escape', description: '',
+      spritesheetPath: 'spritesheet.webp', spriteVersionNumber: 1,
+    })
+    await writeFile(join(source, 'pet-model.json'), JSON.stringify({
+      ...modelDescriptorToManifest(descriptor, 'escape'),
+      entry: 'assets/spritesheet.webp',
+    }))
+    await symlink(external, join(source, 'assets'), process.platform === 'win32' ? 'junction' : 'dir')
+    const catalog = new PetModelCatalog({ root: join(root, 'managed') })
+
+    await expect(catalog.importDirectory(source)).rejects.toThrow('模型资产不能位于模型目录之外')
+  })
+
+  it('does not overwrite a colliding non-directory destination during atomic import', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-pet-atomic-'))
+    const source = join(root, 'source')
+    const managed = join(root, 'managed')
+    await writePetDex(source)
+    await mkdir(join(managed, 'imported'), { recursive: true })
+    await writeFile(join(managed, 'imported', 'boba'), 'occupied', 'utf8')
+    const catalog = new PetModelCatalog({ root: managed })
+
+    await expect(catalog.importDirectory(source)).resolves.toMatchObject({ id: 'imported:boba-2' })
+    expect(await readFile(join(managed, 'imported', 'boba'), 'utf8')).toBe('occupied')
+    expect((await readdir(join(managed, 'imported'))).filter(name => name.startsWith('.boba-2.import-'))).toEqual([])
+  })
+
+  it('removes only a managed import and lets runtime selection fall back without deleting the preference', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-pet-remove-'))
+    const source = join(root, 'source')
+    await writePetDex(source)
+    const catalog = new PetModelCatalog({ root: join(root, 'managed') })
+    const imported = await catalog.importDirectory(source)
+
+    await catalog.remove(imported.id)
+    const models = await catalog.list()
+    expect(models.map(model => model.id)).not.toContain(imported.id)
+    expect(resolvePetModelSelection('builtin:sprite2d', imported.id, models)).toBe('builtin:whale')
+    await expect(catalog.remove('local:boba')).rejects.toThrow('only imported models')
+  })
+
+  it('removes an import when the configured model root resolves through a filesystem alias', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-pet-remove-alias-'))
+    const source = join(root, 'source')
+    const actualRoot = join(root, 'actual')
+    const aliasRoot = join(root, 'alias')
+    await writePetDex(source)
+    await mkdir(actualRoot)
+    await symlink(actualRoot, aliasRoot, process.platform === 'win32' ? 'junction' : 'dir')
+    const catalog = new PetModelCatalog({ root: join(aliasRoot, 'managed') })
+    const imported = await catalog.importDirectory(source)
+
+    await catalog.remove(imported.id)
+
+    expect((await catalog.list()).map(model => model.id)).not.toContain(imported.id)
+  })
+
+  it('keeps missing or renderer-incompatible preferences but resolves the whale at runtime', async () => {
+    const catalog = new PetModelCatalog({ root: await mkdtemp(join(tmpdir(), 'dsh-pet-empty-')) })
+    const models = await catalog.list()
+
+    expect(resolvePetModelSelection('builtin:sprite2d', 'local:removed', models)).toBe('builtin:whale')
+    expect(resolvePetModelSelection('extension:live2d', 'builtin:whale', models)).toBe('builtin:whale')
+    await expect(catalog.supports('builtin:sprite2d', 'builtin:whale', ['petdex-v1'])).resolves.toBe(true)
+    await expect(catalog.supports('extension:live2d', 'builtin:whale', ['petdex-v1'])).resolves.toBe(false)
+  })
+})

--- a/packages/dsh-pet/src/models/catalog.ts
+++ b/packages/dsh-pet/src/models/catalog.ts
@@ -1,0 +1,59 @@
+import type { PetModelDescriptor } from '../contracts/model.ts'
+import { BUILTIN_SPRITE_MODEL_FORMATS, BUILTIN_WHALE_MODEL } from './builtin-whale.ts'
+import { PetModelStore, type PetModelStoreOptions } from './store.ts'
+
+export interface PetModelCatalogOptions extends PetModelStoreOptions {
+  store?: PetModelStore
+}
+
+export function resolvePetModelSelection(
+  rendererId: string,
+  modelId: string,
+  models: readonly Pick<PetModelDescriptor, 'id' | 'rendererId' | 'format'>[],
+): string {
+  const selected = models.find(model => model.id === modelId)
+  return selected?.rendererId === rendererId
+    && (rendererId !== 'builtin:sprite2d' || BUILTIN_SPRITE_MODEL_FORMATS.some(format => format === selected.format))
+    ? selected.id
+    : BUILTIN_WHALE_MODEL.id
+}
+
+export class PetModelCatalog {
+  readonly #store: PetModelStore
+
+  constructor(options: PetModelCatalogOptions = {}) {
+    this.#store = options.store ?? new PetModelStore(options)
+  }
+
+  async list(): Promise<PetModelDescriptor[]> {
+    return [structuredClone(BUILTIN_WHALE_MODEL), ...(await this.#store.records()).map(record => structuredClone(record.descriptor))]
+  }
+
+  async get(modelId: string): Promise<PetModelDescriptor | undefined> {
+    if (modelId === BUILTIN_WHALE_MODEL.id) return structuredClone(BUILTIN_WHALE_MODEL)
+    const record = await this.#store.record(modelId)
+    return record === undefined ? undefined : structuredClone(record.descriptor)
+  }
+
+  async importDirectory(path: string): Promise<PetModelDescriptor> {
+    return structuredClone((await this.#store.importDirectory(path)).descriptor)
+  }
+
+  remove(modelId: string): Promise<void> {
+    return this.#store.remove(modelId)
+  }
+
+  migrateLegacyImportedRoot(path: string): Promise<number> {
+    return this.#store.migrateLegacyImportedRoot(path)
+  }
+
+  async assetPath(modelId: string, path: string): Promise<string | undefined> {
+    const record = await this.#store.record(modelId)
+    return record?.descriptor.entry === path ? record.entryPath : undefined
+  }
+
+  async supports(rendererId: string, modelId: string, formats: readonly string[]): Promise<boolean> {
+    const model = await this.get(modelId)
+    return model !== undefined && model.rendererId === rendererId && formats.includes(model.format)
+  }
+}

--- a/packages/dsh-pet/src/models/descriptor.test.ts
+++ b/packages/dsh-pet/src/models/descriptor.test.ts
@@ -1,0 +1,61 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+import { PET_MODEL_SCHEMA_VERSION } from '../contracts/model.ts'
+import {
+  modelDescriptorToManifest,
+  parsePetDexManifest,
+  parsePetModelDescriptor,
+  parsePetModelManifest,
+  petDexToModelDescriptor,
+} from './descriptor.ts'
+
+describe('Pet Model Descriptor V1', () => {
+  it('adapts frozen PetDex V1 and V2 without changing their files', async () => {
+    const fixtureRoot = new URL('../../tests/fixtures/', import.meta.url)
+    const v1 = parsePetDexManifest(JSON.parse(await readFile(new URL('petdex-v1/pet.json', fixtureRoot), 'utf8')))
+    const v2 = parsePetDexManifest(JSON.parse(await readFile(new URL('petdex-v2/pet.json', fixtureRoot), 'utf8')))
+
+    expect(petDexToModelDescriptor(v1)).toMatchObject({
+      schemaVersion: 1,
+      id: 'local:fixture-v1',
+      rendererId: 'builtin:sprite2d',
+      format: 'petdex-v1',
+      entry: 'spritesheet.webp',
+    })
+    expect(petDexToModelDescriptor(v2, 'imported')).toMatchObject({
+      id: 'imported:fixture-v2',
+      format: 'petdex-v2',
+    })
+  })
+
+  it('round-trips one declarative pet-model.json manifest and runtime source', () => {
+    const descriptor = petDexToModelDescriptor({
+      id: 'lian',
+      displayName: '小狮子',
+      description: 'Test',
+      spritesheetPath: 'spritesheet.webp',
+      spriteVersionNumber: 2,
+    })
+    const manifest = modelDescriptorToManifest(descriptor, 'lian')
+
+    expect(parsePetModelManifest(manifest)).toEqual(manifest)
+    expect(parsePetModelDescriptor({ ...manifest, id: 'local:lian', source: { kind: 'local' } })).toEqual({
+      ...manifest,
+      id: 'local:lian',
+      source: { kind: 'local' },
+    })
+  })
+
+  it('rejects executable, remote, escaping, and unversioned model entries', () => {
+    const safe = modelDescriptorToManifest(petDexToModelDescriptor({
+      id: 'safe', displayName: 'Safe', description: '', spritesheetPath: 'sprite.webp', spriteVersionNumber: 1,
+    }), 'safe')
+
+    expect(() => parsePetModelManifest({ ...safe, entry: '../pet.js' })).toThrow('entry')
+    expect(() => parsePetModelManifest({ ...safe, entry: 'https://example.com/model.webp' })).toThrow('entry')
+    expect(() => parsePetModelManifest({ ...safe, entry: 'run.ps1' })).toThrow('仅允许')
+    expect(() => parsePetModelManifest({ ...safe, schemaVersion: 2 })).toThrow('schemaVersion')
+    expect(PET_MODEL_SCHEMA_VERSION).toBe(1)
+  })
+})

--- a/packages/dsh-pet/src/models/descriptor.ts
+++ b/packages/dsh-pet/src/models/descriptor.ts
@@ -1,0 +1,242 @@
+import {
+  PET_MODEL_SCHEMA_VERSION,
+  type PetModelDescriptor,
+  type PetModelSourceKind,
+} from '../contracts/model.ts'
+import type { PetExpression, PetMotion } from '../core/intent.ts'
+
+const MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/
+const NAMESPACED_ID_PATTERN = /^(?:builtin|local|imported|extension):[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/
+const PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9._-]*:[a-z0-9][a-z0-9._-]*$/
+const FORMAT_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/
+const MOTIONS = [
+  'idle', 'waiting', 'thinking', 'working', 'reviewing',
+  'request-input', 'celebrate', 'failure', 'pet', 'feed',
+] as const satisfies readonly PetMotion[]
+const EXPRESSIONS = [
+  'neutral', 'curious', 'focused', 'happy', 'worried', 'questioning',
+] as const satisfies readonly PetExpression[]
+const motionSet = new Set<string>(MOTIONS)
+const expressionSet = new Set<string>(EXPRESSIONS)
+
+export interface PetDexManifest {
+  id: string
+  displayName: string
+  description: string
+  spritesheetPath: string
+  spriteVersionNumber: 1 | 2
+}
+
+export type PetModelManifest = Omit<PetModelDescriptor, 'source'>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function boundedText(value: unknown, field: string, min: number, max: number): string {
+  if (typeof value !== 'string') throw new Error(`${field} 必须是字符串`)
+  const text = value.trim()
+  if (text.length < min || text.length > max) throw new Error(`${field} 长度必须为 ${min} 到 ${max} 个字符`)
+  return text
+}
+
+function optionalText(value: unknown, field: string, max: number): string | undefined {
+  if (value === undefined) return undefined
+  const text = boundedText(value, field, 1, max)
+  return text
+}
+
+function safeEntry(value: unknown): string {
+  const entry = boundedText(value, 'entry', 1, 240)
+  if (entry.startsWith('/') || entry.includes('\\') || /^[a-z][a-z0-9+.-]*:/i.test(entry)) {
+    throw new Error('entry 必须是模型目录内的相对路径')
+  }
+  const parts = entry.split('/')
+  if (parts.some(part => part === '' || part === '.' || part === '..')) {
+    throw new Error('entry 必须是模型目录内的相对路径')
+  }
+  if (!/\.(?:webp|png)$/i.test(entry)) {
+    throw new Error('entry 当前仅允许 WebP 或 PNG 数据资产')
+  }
+  return entry
+}
+
+function enumList<T extends string>(
+  value: unknown,
+  field: string,
+  allowed: ReadonlySet<string>,
+): T[] {
+  if (!Array.isArray(value) || value.length > 64 || value.some(item => typeof item !== 'string' || !allowed.has(item))) {
+    throw new Error(`${field} 无效`)
+  }
+  return [...new Set(value)] as T[]
+}
+
+function stringList(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.length > 64) throw new Error(`${field} 无效`)
+  const result = value.map(item => boundedText(item, field, 1, 64))
+  return [...new Set(result)]
+}
+
+function parseBindings<T extends string>(
+  value: unknown,
+  field: string,
+  allowed: ReadonlySet<string>,
+): Partial<Record<T, string | string[]>> {
+  if (!isRecord(value)) throw new Error(`${field} 无效`)
+  const result: Partial<Record<T, string | string[]>> = {}
+  for (const [key, raw] of Object.entries(value)) {
+    if (!allowed.has(key)) throw new Error(`${field}.${key} 无效`)
+    const values = Array.isArray(raw) ? raw : [raw]
+    if (values.length < 1 || values.length > 16) throw new Error(`${field}.${key} 无效`)
+    const parsed = values.map(item => boundedText(item, `${field}.${key}`, 1, 128))
+    result[key as T] = Array.isArray(raw) ? parsed : parsed[0]
+  }
+  return result
+}
+
+function parseExpressionBindings(value: unknown): Partial<Record<PetExpression, string>> {
+  const parsed = parseBindings<PetExpression>(value, 'bindings.expressions', expressionSet)
+  const result: Partial<Record<PetExpression, string>> = {}
+  for (const [key, binding] of Object.entries(parsed)) {
+    if (Array.isArray(binding)) throw new Error(`bindings.expressions.${key} 无效`)
+    result[key as PetExpression] = binding
+  }
+  return result
+}
+
+function parseSource(value: unknown): PetModelDescriptor['source'] {
+  if (!isRecord(value) || !['builtin', 'local', 'imported', 'extension'].includes(String(value.kind))) {
+    throw new Error('source 无效')
+  }
+  const kind = value.kind as PetModelSourceKind
+  const providerId = optionalText(value.providerId, 'source.providerId', 128)
+  if (providerId !== undefined && !PROVIDER_ID_PATTERN.test(providerId)) throw new Error('source.providerId 无效')
+  if (kind === 'extension' && providerId === undefined) throw new Error('extension 模型必须声明 providerId')
+  return { kind, ...(providerId === undefined ? {} : { providerId }) }
+}
+
+function parseCommon(value: unknown, manifest: boolean): PetModelDescriptor {
+  if (!isRecord(value) || value.schemaVersion !== PET_MODEL_SCHEMA_VERSION) throw new Error('pet-model.json schemaVersion 无效')
+  const id = boundedText(value.id, 'id', 1, 80)
+  if (!(manifest ? MODEL_ID_PATTERN : NAMESPACED_ID_PATTERN).test(id)) throw new Error('模型 id 无效')
+  const rendererId = boundedText(value.rendererId, 'rendererId', 3, 128)
+  if (!PROVIDER_ID_PATTERN.test(rendererId)) throw new Error('rendererId 无效')
+  const format = boundedText(value.format, 'format', 1, 64)
+  if (!FORMAT_PATTERN.test(format)) throw new Error('format 无效')
+  if (!isRecord(value.capabilities)) throw new Error('capabilities 无效')
+  if (typeof value.capabilities.lookAt !== 'boolean'
+    || typeof value.capabilities.lipSync !== 'boolean') throw new Error('capabilities 无效')
+  if (!isRecord(value.bindings)) throw new Error('bindings 无效')
+  if (!isRecord(value.fallback)
+    || typeof value.fallback.motion !== 'string' || !motionSet.has(value.fallback.motion)
+    || typeof value.fallback.expression !== 'string' || !expressionSet.has(value.fallback.expression)) {
+    throw new Error('fallback 无效')
+  }
+  let license: PetModelDescriptor['license']
+  if (value.license !== undefined) {
+    if (!isRecord(value.license)) throw new Error('license 无效')
+    const url = optionalText(value.license.url, 'license.url', 500)
+    if (url !== undefined && !/^https?:\/\//i.test(url)) throw new Error('license.url 无效')
+    license = {
+      ...(optionalText(value.license.name, 'license.name', 100) === undefined ? {} : { name: optionalText(value.license.name, 'license.name', 100) }),
+      ...(url === undefined ? {} : { url }),
+      ...(optionalText(value.license.author, 'license.author', 100) === undefined ? {} : { author: optionalText(value.license.author, 'license.author', 100) }),
+    }
+  }
+  const description = typeof value.description === 'string' ? value.description.trim() : undefined
+  if (description !== undefined && description.length > 500) throw new Error('description 不能超过 500 个字符')
+  return {
+    schemaVersion: PET_MODEL_SCHEMA_VERSION,
+    id,
+    displayName: boundedText(value.displayName, 'displayName', 1, 80),
+    ...(description === undefined || description === '' ? {} : { description }),
+    rendererId,
+    format,
+    entry: safeEntry(value.entry),
+    source: manifest ? { kind: 'local' } : parseSource(value.source),
+    capabilities: {
+      motions: enumList<PetMotion>(value.capabilities.motions, 'capabilities.motions', motionSet),
+      expressions: enumList<PetExpression>(value.capabilities.expressions, 'capabilities.expressions', expressionSet),
+      lookAt: value.capabilities.lookAt,
+      lipSync: value.capabilities.lipSync,
+      hitAreas: stringList(value.capabilities.hitAreas, 'capabilities.hitAreas'),
+    },
+    bindings: {
+      motions: parseBindings<PetMotion>(value.bindings.motions, 'bindings.motions', motionSet),
+      expressions: parseExpressionBindings(value.bindings.expressions),
+    },
+    fallback: {
+      motion: value.fallback.motion as PetMotion,
+      expression: value.fallback.expression as PetExpression,
+    },
+    ...(license === undefined ? {} : { license }),
+  }
+}
+
+export function parsePetModelDescriptor(value: unknown): PetModelDescriptor {
+  return parseCommon(value, false)
+}
+
+export function parsePetModelManifest(value: unknown): PetModelManifest {
+  const { source: _source, ...manifest } = parseCommon(value, true)
+  return manifest
+}
+
+export function parsePetDexManifest(value: unknown): PetDexManifest {
+  if (!isRecord(value) || typeof value.id !== 'string' || !MODEL_ID_PATTERN.test(value.id)) {
+    throw new Error('pet.json 中的 id 无效')
+  }
+  const displayName = boundedText(value.displayName, 'displayName', 1, 40)
+  const description = typeof value.description === 'string' ? value.description.trim() : ''
+  if (description.length > 500) throw new Error('description 不能超过 500 个字符')
+  if (typeof value.spritesheetPath !== 'string'
+    || value.spritesheetPath.includes('/')
+    || value.spritesheetPath.includes('\\')
+    || !/\.(?:webp|png)$/i.test(value.spritesheetPath)) {
+    throw new Error('spritesheetPath 必须指向同目录的 WebP 或 PNG 文件')
+  }
+  if (value.spriteVersionNumber !== undefined && value.spriteVersionNumber !== 1 && value.spriteVersionNumber !== 2) {
+    throw new Error('spriteVersionNumber 仅支持 1 或 2')
+  }
+  return {
+    id: value.id,
+    displayName,
+    description,
+    spritesheetPath: value.spritesheetPath,
+    spriteVersionNumber: value.spriteVersionNumber === 2 ? 2 : 1,
+  }
+}
+
+export function petDexToModelDescriptor(
+  manifest: PetDexManifest,
+  source: Exclude<PetModelSourceKind, 'builtin' | 'extension'> = 'local',
+): PetModelDescriptor {
+  return {
+    schemaVersion: PET_MODEL_SCHEMA_VERSION,
+    id: `${source}:${manifest.id}`,
+    displayName: manifest.displayName,
+    ...(manifest.description === '' ? {} : { description: manifest.description }),
+    rendererId: 'builtin:sprite2d',
+    format: manifest.spriteVersionNumber === 2 ? 'petdex-v2' : 'petdex-v1',
+    entry: manifest.spritesheetPath,
+    source: { kind: source },
+    capabilities: {
+      motions: [...MOTIONS], expressions: [], lookAt: false, lipSync: false, hitAreas: ['body'],
+    },
+    bindings: {
+      motions: {
+        idle: 'idle', waiting: 'waiting', thinking: 'running', working: 'running-right',
+        reviewing: 'review', 'request-input': 'waving', celebrate: 'jumping',
+        failure: 'failed', pet: 'waving', feed: 'jumping',
+      },
+      expressions: {},
+    },
+    fallback: { motion: 'idle', expression: 'neutral' },
+  }
+}
+
+export function modelDescriptorToManifest(descriptor: PetModelDescriptor, id: string): PetModelManifest {
+  const { source: _source, ...manifest } = descriptor
+  return { ...structuredClone(manifest), id }
+}

--- a/packages/dsh-pet/src/models/file-asset-resolver.ts
+++ b/packages/dsh-pet/src/models/file-asset-resolver.ts
@@ -1,0 +1,17 @@
+import { readFile } from 'node:fs/promises'
+
+import type { PetAssetRef, PetAssetResolver } from '../contracts/model.ts'
+import type { PetModelCatalog } from './catalog.ts'
+
+/** Host-side resolver; Renderer instances still receive bytes, never paths. */
+export class FilePetAssetResolver implements PetAssetResolver {
+  constructor(private readonly catalog: PetModelCatalog) {}
+
+  async fetch(asset: PetAssetRef, signal?: AbortSignal): Promise<ArrayBuffer> {
+    signal?.throwIfAborted()
+    const path = await this.catalog.assetPath(asset.modelId, asset.path)
+    if (path === undefined) throw new Error(`Unknown pet model asset: ${asset.modelId}/${asset.path}`)
+    const bytes = await readFile(path, { signal })
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+  }
+}

--- a/packages/dsh-pet/src/models/manifest.ts
+++ b/packages/dsh-pet/src/models/manifest.ts
@@ -1,0 +1,122 @@
+import { open, readFile, realpath, stat } from 'node:fs/promises'
+import { extname, isAbsolute, join, relative } from 'node:path'
+
+import type { PetModelManifest } from './descriptor.ts'
+import {
+  modelDescriptorToManifest,
+  parsePetDexManifest,
+  parsePetModelManifest,
+  petDexToModelDescriptor,
+} from './descriptor.ts'
+
+export const PIXEL_FRAME_WIDTH = 192
+export const PIXEL_FRAME_HEIGHT = 208
+export const PIXEL_FRAME_COLUMNS = 8
+export const PET_MODEL_MANIFEST_NAME = 'pet-model.json'
+const PETDEX_MANIFEST_NAME = 'pet.json'
+const MAX_MANIFEST_BYTES = 64 * 1024
+const MAX_ASSET_BYTES = 32 * 1024 * 1024
+const MAX_TEXTURE_DIMENSION = 8192
+
+export interface PetModelPackage {
+  directory: string
+  manifest: PetModelManifest
+  entryPath: string
+  legacyPetDex: boolean
+}
+
+export function pixelImageDimensions(bytes: Uint8Array): { width: number, height: number } {
+  const buffer = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  if (buffer.length >= 24
+    && buffer.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+    && buffer.toString('ascii', 12, 16) === 'IHDR') {
+    return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) }
+  }
+  if (buffer.length < 30 || buffer.toString('ascii', 0, 4) !== 'RIFF' || buffer.toString('ascii', 8, 12) !== 'WEBP') {
+    throw new Error('模型纹理不是有效的 WebP 或 PNG')
+  }
+  const chunk = buffer.toString('ascii', 12, 16)
+  if (chunk === 'VP8X') {
+    return { width: buffer.readUIntLE(24, 3) + 1, height: buffer.readUIntLE(27, 3) + 1 }
+  }
+  if (chunk === 'VP8L' && buffer[20] === 0x2f) {
+    const bits = buffer.readUInt32LE(21)
+    return { width: (bits & 0x3fff) + 1, height: ((bits >>> 14) & 0x3fff) + 1 }
+  }
+  if (chunk === 'VP8 ' && buffer[23] === 0x9d && buffer[24] === 0x01 && buffer[25] === 0x2a) {
+    return { width: buffer.readUInt16LE(26) & 0x3fff, height: buffer.readUInt16LE(28) & 0x3fff }
+  }
+  throw new Error('不支持该 WebP 编码格式')
+}
+
+async function inspectTexture(path: string, manifest: PetModelManifest): Promise<void> {
+  const metadata = await stat(path)
+  if (!metadata.isFile() || metadata.size < 30 || metadata.size > MAX_ASSET_BYTES) {
+    throw new Error('模型纹理大小无效')
+  }
+  const extension = extname(path).toLowerCase()
+  if (extension !== '.webp' && extension !== '.png') throw new Error('模型纹理格式无效')
+  const handle = await open(path, 'r')
+  const header = Buffer.alloc(32)
+  try {
+    const { bytesRead } = await handle.read(header, 0, header.length, 0)
+    const dimensions = pixelImageDimensions(header.subarray(0, bytesRead))
+    if (dimensions.width < 1 || dimensions.height < 1
+      || dimensions.width > MAX_TEXTURE_DIMENSION || dimensions.height > MAX_TEXTURE_DIMENSION) {
+      throw new Error('模型纹理尺寸无效')
+    }
+    if (manifest.rendererId === 'builtin:sprite2d') {
+      const expectedHeight = PIXEL_FRAME_HEIGHT * (manifest.format === 'petdex-v2' ? 11 : 9)
+      if (dimensions.width !== PIXEL_FRAME_WIDTH * PIXEL_FRAME_COLUMNS || dimensions.height !== expectedHeight) {
+        throw new Error(`精灵图必须为 1536×${expectedHeight}`)
+      }
+    }
+  } finally {
+    await handle.close()
+  }
+}
+
+async function readBoundedJson(path: string, label: string): Promise<unknown> {
+  const metadata = await stat(path)
+  if (!metadata.isFile() || metadata.size < 2 || metadata.size > MAX_MANIFEST_BYTES) {
+    throw new Error(`${label} 大小无效`)
+  }
+  return JSON.parse(await readFile(path, 'utf8'))
+}
+
+async function existingManifest(directory: string): Promise<{ path: string, legacy: boolean }> {
+  for (const [name, legacy] of [[PET_MODEL_MANIFEST_NAME, false], [PETDEX_MANIFEST_NAME, true]] as const) {
+    try {
+      const path = await realpath(join(directory, name))
+      const relation = relative(directory, path)
+      if (relation.startsWith('..') || isAbsolute(relation)) throw new Error(`${name} 不能位于模型目录之外`)
+      return { path, legacy }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('模型目录之外')) throw error
+    }
+  }
+  throw new Error('模型文件夹缺少 pet-model.json 或 pet.json')
+}
+
+/** Read only declarative JSON plus its one allow-listed texture entry. */
+export async function readPetModelPackage(path: string): Promise<PetModelPackage> {
+  const directory = await realpath(path)
+  const manifestFile = await existingManifest(directory)
+  const raw = await readBoundedJson(
+    manifestFile.path,
+    manifestFile.legacy ? PETDEX_MANIFEST_NAME : PET_MODEL_MANIFEST_NAME,
+  )
+  const manifest = manifestFile.legacy
+    ? (() => {
+        const legacy = parsePetDexManifest(raw)
+        return modelDescriptorToManifest(petDexToModelDescriptor(legacy), legacy.id)
+      })()
+    : parsePetModelManifest(raw)
+  const entryPath = await realpath(join(directory, manifest.entry))
+  const entryRelation = relative(directory, entryPath)
+  if (entryRelation.startsWith('..') || isAbsolute(entryRelation)) {
+    throw new Error('模型资产不能位于模型目录之外')
+  }
+  await inspectTexture(entryPath, manifest)
+  return { directory, manifest, entryPath, legacyPetDex: manifestFile.legacy }
+}

--- a/packages/dsh-pet/src/models/store.ts
+++ b/packages/dsh-pet/src/models/store.ts
@@ -1,0 +1,198 @@
+import { copyFile, mkdir, readdir, realpath, rename, rm, writeFile } from 'node:fs/promises'
+import { basename, extname, isAbsolute, join, relative } from 'node:path'
+
+import type { PetModelDescriptor, PetModelSourceKind } from '../contracts/model.ts'
+import { dshHome } from '../dsh-home.ts'
+import { modelDescriptorToManifest } from './descriptor.ts'
+import { PET_MODEL_MANIFEST_NAME, readPetModelPackage, type PetModelPackage } from './manifest.ts'
+
+export interface PetModelRecord {
+  descriptor: PetModelDescriptor
+  directory: string
+  entryPath: string
+}
+
+export interface PetModelStoreOptions {
+  root?: string
+  /** Optional shared PetDex directory scanned directly by the Web registry. */
+  importedRoot?: string
+  compatibilityLocalRoots?: readonly string[]
+}
+
+export function petModelRoot(home: string = dshHome()): string {
+  return join(home, 'pet', 'models')
+}
+
+function runtimeDescriptor(
+  model: PetModelPackage,
+  source: Exclude<PetModelSourceKind, 'builtin' | 'extension'>,
+): PetModelDescriptor {
+  return {
+    ...structuredClone(model.manifest),
+    id: `${source}:${model.manifest.id}`,
+    source: { kind: source },
+  }
+}
+
+export class PetModelStore {
+  readonly root: string
+  readonly localRoot: string
+  readonly importedRoot: string
+  readonly #compatibilityLocalRoots: readonly string[]
+
+  constructor(options: PetModelStoreOptions = {}) {
+    this.root = options.root ?? petModelRoot()
+    this.localRoot = join(this.root, 'local')
+    this.importedRoot = options.importedRoot ?? join(this.root, 'imported')
+    this.#compatibilityLocalRoots = options.compatibilityLocalRoots ?? []
+  }
+
+  async records(): Promise<PetModelRecord[]> {
+    const localGroups = await Promise.all([
+      this.localRoot,
+      ...this.#compatibilityLocalRoots,
+    ].map(root => this.#readRoot(root, 'local')))
+    const imported = await this.#readRoot(this.importedRoot, 'imported')
+    const unique = new Map<string, PetModelRecord>()
+    for (const record of [...localGroups.flat(), ...imported]) {
+      if (!unique.has(record.descriptor.id)) unique.set(record.descriptor.id, record)
+    }
+    return [...unique.values()].sort((left, right) =>
+      left.descriptor.displayName.localeCompare(right.descriptor.displayName))
+  }
+
+  async record(modelId: string): Promise<PetModelRecord | undefined> {
+    return (await this.records()).find(record => record.descriptor.id === modelId)
+  }
+
+  async importDirectory(sourceDirectory: string): Promise<PetModelRecord> {
+    const source = await readPetModelPackage(sourceDirectory)
+    await mkdir(this.importedRoot, { recursive: true })
+    const id = await this.#availableImportedId(source.manifest.id)
+    return this.#install(source, id)
+  }
+
+  /** Copy old Electron userData models once; the legacy directory is never deleted. */
+  async migrateLegacyImportedRoot(legacyRoot: string): Promise<number> {
+    let entries
+    try {
+      entries = await readdir(legacyRoot, { withFileTypes: true })
+    } catch {
+      return 0
+    }
+    await mkdir(this.importedRoot, { recursive: true })
+    let migrated = 0
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue
+      const destination = join(this.importedRoot, entry.name)
+      try {
+        await readdir(destination)
+        continue
+      } catch {
+        // A missing destination is eligible for one-way copy migration.
+      }
+      try {
+        const source = await readPetModelPackage(join(legacyRoot, entry.name))
+        await this.#install(source, entry.name)
+        migrated += 1
+      } catch {
+        // One malformed legacy model must not prevent the remaining migration.
+      }
+    }
+    return migrated
+  }
+
+  async remove(modelId: string): Promise<void> {
+    if (!modelId.startsWith('imported:')) throw new Error('only imported models can be removed')
+    const record = await this.record(modelId)
+    if (record === undefined) return
+    const canonicalImportedRoot = await realpath(this.importedRoot)
+    const relation = relative(canonicalImportedRoot, record.directory)
+    if (relation === '' || relation.startsWith('..') || isAbsolute(relation)) throw new Error('unsafe imported model path')
+    await rm(record.directory, { recursive: true, force: true })
+  }
+
+  async #readRoot(
+    root: string,
+    source: Exclude<PetModelSourceKind, 'builtin' | 'extension'>,
+  ): Promise<PetModelRecord[]> {
+    let entries
+    try {
+      entries = await readdir(root, { withFileTypes: true })
+    } catch {
+      return []
+    }
+    const records = await Promise.all(entries
+      .filter(entry => entry.isDirectory() && !entry.name.startsWith('.'))
+      .map(async entry => {
+        try {
+          const model = await readPetModelPackage(join(root, entry.name))
+          return {
+            descriptor: runtimeDescriptor(model, source),
+            directory: model.directory,
+            entryPath: model.entryPath,
+          }
+        } catch {
+          return undefined
+        }
+      }))
+    return records.filter((record): record is PetModelRecord => record !== undefined)
+  }
+
+  async #install(source: PetModelPackage, id: string): Promise<PetModelRecord> {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(id)) throw new Error('无法分配安全的模型 id')
+    const destination = join(this.importedRoot, id)
+    const temporary = join(this.importedRoot, `.${id}.import-${process.pid}-${Date.now()}`)
+    const extension = extname(source.entryPath).toLowerCase()
+    const entryName = source.manifest.rendererId === 'builtin:sprite2d'
+      ? `spritesheet${extension}`
+      : `model${extension}`
+    const descriptor = runtimeDescriptor(source, 'imported')
+    const manifest = modelDescriptorToManifest({
+      ...descriptor,
+      id: `imported:${id}`,
+      entry: entryName,
+    }, id)
+    try {
+      await mkdir(temporary)
+      await copyFile(source.entryPath, join(temporary, entryName))
+      await writeFile(join(temporary, PET_MODEL_MANIFEST_NAME), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+      // Keep a PetDex view beside the renderer-neutral manifest. The Web pet
+      // registry understands this file, so a desktop import becomes available
+      // to both presentations after the documented DSH restart.
+      await writeFile(join(temporary, 'pet.json'), `${JSON.stringify({
+        id,
+        displayName: descriptor.displayName,
+        ...(descriptor.description === undefined ? {} : { description: descriptor.description }),
+        spritesheetPath: entryName,
+        ...(descriptor.format === 'petdex-v2' ? { spriteVersionNumber: 2 } : {}),
+      }, null, 2)}\n`, 'utf8')
+      await rename(temporary, destination)
+    } catch (error) {
+      await rm(temporary, { recursive: true, force: true })
+      throw error
+    }
+    const installed = await readPetModelPackage(destination)
+    return {
+      descriptor: runtimeDescriptor(installed, 'imported'),
+      directory: installed.directory,
+      entryPath: installed.entryPath,
+    }
+  }
+
+  async #availableImportedId(base: string): Promise<string> {
+    let existing = new Set<string>()
+    try {
+      existing = new Set((await readdir(this.importedRoot, { withFileTypes: true }))
+        .map(entry => entry.name))
+    } catch {
+      // The import root is created immediately before this check.
+    }
+    if (!existing.has(base)) return base
+    for (let suffix = 2; suffix < 10_000; suffix += 1) {
+      const candidate = `${base}-${suffix}`
+      if (!existing.has(candidate)) return candidate
+    }
+    throw new Error(`无法为 ${basename(base)} 分配本地模型 id`)
+  }
+}

--- a/packages/dsh-pet/src/presentation/config.ts
+++ b/packages/dsh-pet/src/presentation/config.ts
@@ -1,0 +1,33 @@
+/** Stable Host-side settings that decide whether pet activity and presentation run. */
+
+export type PetPresentationMode = 'auto' | 'standalone' | 'embedded' | 'none'
+
+export interface PetPluginSettings {
+  /** Master switch for the pet domain. */
+  enabled: boolean
+  /** Session activity projection can be disabled without disabling interactions. */
+  activity: {
+    enabled: boolean
+  }
+  /** Presentation policy is independent from activity and surface visibility. */
+  presentation: {
+    mode: PetPresentationMode
+    standaloneAutoStart: boolean
+  }
+}
+
+export const DEFAULT_PET_PLUGIN_SETTINGS: PetPluginSettings = {
+  enabled: true,
+  activity: { enabled: true },
+  presentation: {
+    mode: 'auto',
+    standaloneAutoStart: true,
+  },
+}
+
+/** Parse only the documented environment override vocabulary. */
+export function parsePresentationMode(value: unknown): PetPresentationMode | undefined {
+  return value === 'auto' || value === 'standalone' || value === 'embedded' || value === 'none'
+    ? value
+    : undefined
+}

--- a/packages/dsh-pet/src/presentation/controller.ts
+++ b/packages/dsh-pet/src/presentation/controller.ts
@@ -1,0 +1,245 @@
+import type { PetReturnTarget } from '../contracts/desktop-host.ts'
+import { PET_ERROR_CODES } from '../errors.ts'
+import type { PetPluginSettings } from './config.ts'
+import type { PetPresentationEnvironment } from './environment.ts'
+import {
+  resolvePetPresentation,
+  type PetResolvedPresentation,
+  type PetResolvedPresentationKind,
+} from './resolver.ts'
+import {
+  presentationStateFromResolution,
+  type PetPresentationState,
+} from './status.ts'
+
+export interface PetPresentationContext {
+  settings: PetPluginSettings
+  resolution: PetResolvedPresentation
+  visible: boolean
+  returnTarget: PetReturnTarget
+  bridgeOrigin?: string
+  nativeToken?: string
+}
+
+export interface PetPresentationHostView {
+  id: string
+  name: string
+  embedded: boolean
+  ownsTray: boolean
+}
+
+export interface PetPresentationAdapter {
+  readonly kind: PetResolvedPresentationKind
+  readonly host?: PetPresentationHostView
+  start(context: PetPresentationContext): Promise<void>
+  show(): Promise<void>
+  hide(): Promise<void>
+  update(snapshot: unknown): void
+  stop(reason?: string): Promise<void>
+}
+
+export interface PetPresentationControllerOptions {
+  createAdapter(resolution: PetResolvedPresentation): PetPresentationAdapter | undefined
+  createContext(
+    settings: PetPluginSettings,
+    resolution: PetResolvedPresentation,
+    visible: boolean,
+  ): PetPresentationContext
+  /** Optional runtime identity, used when one logical Host id is rebound. */
+  adapterKey?(resolution: PetResolvedPresentation): string
+  retryDelayMs?: number
+  now?: () => number
+}
+
+type PetPresentationListener = (state: PetPresentationState) => void
+
+/** Serializes adapter switches and owns the externally visible presentation state. */
+export class PetPresentationController {
+  private readonly retryDelayMs: number
+  private readonly now: () => number
+  private currentAdapter: PetPresentationAdapter | undefined
+  private currentKey: string | undefined
+  private currentState: PetPresentationState = {
+    mode: 'auto',
+    resolved: 'none',
+    phase: 'resolving',
+    available: false,
+    visible: false,
+  }
+  private readonly listeners = new Set<PetPresentationListener>()
+  private readonly retryAfter = new Map<string, number>()
+  private queue: Promise<void> = Promise.resolve()
+  private revision = 0
+  private disposed = false
+
+  constructor(private readonly options: PetPresentationControllerOptions) {
+    this.retryDelayMs = options.retryDelayMs ?? 5_000
+    this.now = options.now ?? Date.now
+  }
+
+  state(): PetPresentationState {
+    return {
+      ...this.currentState,
+      ...(this.currentState.host === undefined ? {} : { host: { ...this.currentState.host } }),
+      ...(this.currentState.returnTarget === undefined
+        ? {}
+        : { returnTarget: structuredClone(this.currentState.returnTarget) }),
+    }
+  }
+
+  subscribe(listener: PetPresentationListener): () => void {
+    this.listeners.add(listener)
+    listener(this.state())
+    return () => { this.listeners.delete(listener) }
+  }
+
+  reconcile(
+    settings: PetPluginSettings,
+    environment: PetPresentationEnvironment,
+    visible = true,
+  ): Promise<void> {
+    if (this.disposed) return Promise.resolve()
+    const revision = ++this.revision
+    const resolution = resolvePetPresentation(settings, environment)
+    const next = this.queue.then(async () => {
+      if (revision !== this.revision || this.disposed) return
+      await this.performReconcile(settings, resolution, visible, revision)
+    })
+    this.queue = next.catch(() => undefined)
+    return next
+  }
+
+  update(snapshot: unknown): void {
+    try {
+      this.currentAdapter?.update(snapshot)
+    } catch {
+      // Renderer update failures must not unwind Host session projection.
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return this.queue
+    this.disposed = true
+    this.revision += 1
+    await this.queue
+    const adapter = this.currentAdapter
+    this.currentAdapter = undefined
+    this.currentKey = undefined
+    if (adapter !== undefined) await adapter.stop('controller-disposed').catch(() => undefined)
+    this.listeners.clear()
+  }
+
+  private async performReconcile(
+    settings: PetPluginSettings,
+    resolution: PetResolvedPresentation,
+    visible: boolean,
+    revision: number,
+  ): Promise<void> {
+    const key = this.options.adapterKey?.(resolution)
+      ?? `${resolution.kind}:${resolution.hostId ?? ''}`
+    const baseState = presentationStateFromResolution(settings, resolution, visible)
+    const context = this.options.createContext(settings, resolution, visible)
+
+    if (this.currentAdapter !== undefined && this.currentKey === key) {
+      try {
+        if (visible) await this.currentAdapter.show()
+        else await this.currentAdapter.hide()
+        if (revision !== this.revision || this.disposed) return
+        this.publish(this.withAdapterState(baseState, this.currentAdapter, context.returnTarget))
+      } catch {
+        const failed = this.currentAdapter
+        this.currentAdapter = undefined
+        this.currentKey = undefined
+        await failed.stop('visibility-failed').catch(() => undefined)
+        this.retryAfter.set(key, this.now() + this.retryDelayMs)
+        this.publishFailure(baseState, context.returnTarget)
+      }
+      return
+    }
+
+    const previous = this.currentAdapter
+    this.currentAdapter = undefined
+    this.currentKey = undefined
+    if (previous !== undefined) await previous.stop('presentation-switched').catch(() => undefined)
+    if (revision !== this.revision || this.disposed) return
+
+    const retryAfter = this.retryAfter.get(key) ?? 0
+    if (retryAfter > this.now()) {
+      this.publishFailure(baseState, context.returnTarget)
+      return
+    }
+
+    const adapter = this.options.createAdapter(resolution)
+    if (adapter === undefined) {
+      this.publish({
+        ...baseState,
+        phase: 'unavailable',
+        available: false,
+        visible: false,
+        errorCode: PET_ERROR_CODES.presentationHostUnavailable,
+        returnTarget: context.returnTarget,
+      })
+      return
+    }
+
+    if (resolution.kind !== 'none') {
+      this.publish({
+        ...baseState,
+        phase: 'starting',
+        available: false,
+        visible: false,
+        returnTarget: context.returnTarget,
+      })
+    }
+    try {
+      await adapter.start(context)
+      if (revision !== this.revision || this.disposed) {
+        await adapter.stop('stale-reconcile').catch(() => undefined)
+        return
+      }
+      if (visible) await adapter.show()
+      else await adapter.hide()
+      if (revision !== this.revision || this.disposed) {
+        await adapter.stop('stale-reconcile').catch(() => undefined)
+        return
+      }
+      this.retryAfter.delete(key)
+      this.currentAdapter = adapter
+      this.currentKey = key
+      this.publish(this.withAdapterState(baseState, adapter, context.returnTarget))
+    } catch {
+      await adapter.stop('start-failed').catch(() => undefined)
+      this.retryAfter.set(key, this.now() + this.retryDelayMs)
+      this.publishFailure(baseState, context.returnTarget)
+    }
+  }
+
+  private withAdapterState(
+    state: PetPresentationState,
+    adapter: PetPresentationAdapter,
+    returnTarget: PetReturnTarget,
+  ): PetPresentationState {
+    return {
+      ...state,
+      ...(adapter.host === undefined ? {} : { host: { ...adapter.host } }),
+      returnTarget: structuredClone(returnTarget),
+    }
+  }
+
+  private publishFailure(state: PetPresentationState, returnTarget: PetReturnTarget): void {
+    this.publish({
+      ...state,
+      phase: 'failed',
+      available: false,
+      visible: false,
+      errorCode: PET_ERROR_CODES.presentationStartFailed,
+      returnTarget,
+    })
+  }
+
+  private publish(state: PetPresentationState): void {
+    this.currentState = state
+    const snapshot = this.state()
+    for (const listener of this.listeners) listener(snapshot)
+  }
+}

--- a/packages/dsh-pet/src/presentation/environment.ts
+++ b/packages/dsh-pet/src/presentation/environment.ts
@@ -1,0 +1,110 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { parsePresentationMode, type PetPresentationMode } from './config.ts'
+
+export interface PetPresentationEnvironment {
+  platform: NodeJS.Platform
+  isCi: boolean
+  isContainer: boolean
+  isTest: boolean
+  hasDisplayServer: boolean
+  appearsInteractive: boolean
+  standaloneRuntimeAvailable: boolean
+  webBridgeAvailable: boolean
+  embeddedHostAvailable: boolean
+  embeddedHostHint?: string
+  disabledByEnvironment: boolean
+  /** Validated `DSH_PET_PRESENTATION`; resolver gives it priority over Host settings. */
+  presentationOverride?: PetPresentationMode
+}
+
+export interface PetPresentationEnvironmentInput {
+  platform: NodeJS.Platform
+  env: Readonly<Record<string, string | undefined>>
+  isContainer: boolean
+  standaloneRuntimeAvailable: boolean
+  webBridgeAvailable: boolean
+  embeddedHostAvailable: boolean
+}
+
+function enabledFlag(value: string | undefined): boolean {
+  if (value === undefined) return false
+  return value !== '' && value !== '0' && value.toLowerCase() !== 'false'
+}
+
+function safeHostHint(value: string | undefined): string | undefined {
+  const hint = value?.trim()
+  return hint !== undefined && /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,63}$/.test(hint) ? hint : undefined
+}
+
+/** Convert process/platform facts into resolver input without consulting globals. */
+export function derivePetPresentationEnvironment(
+  input: PetPresentationEnvironmentInput,
+): PetPresentationEnvironment {
+  const { env, platform } = input
+  const isCi = enabledFlag(env.CI)
+    || enabledFlag(env.GITHUB_ACTIONS)
+    || enabledFlag(env.BUILDKITE)
+    || enabledFlag(env.TF_BUILD)
+  const isTest = env.NODE_ENV === 'test' || enabledFlag(env.VITEST)
+  const hasDisplayServer = platform === 'win32' || platform === 'darwin'
+    || (platform === 'linux' && Boolean(env.DISPLAY || env.WAYLAND_DISPLAY || env.MIR_SOCKET))
+  const windowsService = platform === 'win32' && env.SESSIONNAME?.toLowerCase() === 'services'
+  const appearsInteractive = hasDisplayServer
+    && !windowsService
+    && !isCi
+    && !input.isContainer
+    && !isTest
+  const presentationOverride = parsePresentationMode(env.DSH_PET_PRESENTATION)
+  const embeddedHostHint = safeHostHint(env.DSH_PET_DESKTOP_HOST_HINT)
+  return {
+    platform,
+    isCi,
+    isContainer: input.isContainer,
+    isTest,
+    hasDisplayServer,
+    appearsInteractive,
+    standaloneRuntimeAvailable: input.standaloneRuntimeAvailable,
+    webBridgeAvailable: input.webBridgeAvailable,
+    embeddedHostAvailable: input.embeddedHostAvailable,
+    ...(embeddedHostHint === undefined ? {} : { embeddedHostHint }),
+    disabledByEnvironment: env.DSH_PET_DISABLE_DESKTOP === '1',
+    ...(presentationOverride === undefined ? {} : { presentationOverride }),
+  }
+}
+
+function detectCurrentContainer(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): boolean {
+  if (enabledFlag(env.container)) return true
+  if (platform !== 'linux') return false
+  if (existsSync('/.dockerenv')) return true
+  try {
+    return /(?:docker|containerd|kubepods|lxc)/i.test(readFileSync('/proc/1/cgroup', 'utf8'))
+  } catch {
+    return false
+  }
+}
+
+export interface ReadPetPresentationEnvironmentOptions {
+  standaloneRuntimeAvailable: boolean
+  webBridgeAvailable: boolean
+  embeddedHostAvailable?: boolean
+  platform?: NodeJS.Platform
+  env?: NodeJS.ProcessEnv
+  /** Test/host override; omission performs the bounded local container check. */
+  isContainer?: boolean
+}
+
+/** Read process facts once at the adapter boundary; the resolver itself remains pure. */
+export function readPetPresentationEnvironment(
+  options: ReadPetPresentationEnvironmentOptions,
+): PetPresentationEnvironment {
+  const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
+  return derivePetPresentationEnvironment({
+    platform,
+    env,
+    isContainer: options.isContainer ?? detectCurrentContainer(platform, env),
+    standaloneRuntimeAvailable: options.standaloneRuntimeAvailable,
+    webBridgeAvailable: options.webBridgeAvailable,
+    embeddedHostAvailable: options.embeddedHostAvailable ?? false,
+  })
+}

--- a/packages/dsh-pet/src/presentation/null-presentation.ts
+++ b/packages/dsh-pet/src/presentation/null-presentation.ts
@@ -1,0 +1,12 @@
+import type { PetPresentationAdapter, PetPresentationContext } from './controller.ts'
+
+/** No-op adapter used by headless, disabled, CI, and configured-none modes. */
+export class NullPresentation implements PetPresentationAdapter {
+  readonly kind = 'none' as const
+
+  async start(_context: PetPresentationContext): Promise<void> {}
+  async show(): Promise<void> {}
+  async hide(): Promise<void> {}
+  update(_snapshot: unknown): void {}
+  async stop(_reason?: string): Promise<void> {}
+}

--- a/packages/dsh-pet/src/presentation/resolver.ts
+++ b/packages/dsh-pet/src/presentation/resolver.ts
@@ -1,0 +1,72 @@
+import type { PetPluginSettings } from './config.ts'
+import type { PetPresentationEnvironment } from './environment.ts'
+
+export type PetResolvedPresentationKind = 'none' | 'standalone' | 'embedded'
+
+export type PetPresentationReason =
+  | 'disabled'
+  | 'configured-none'
+  | 'embedded-host'
+  | 'embedded-host-pending'
+  | 'forced-standalone'
+  | 'auto-standalone'
+  | 'headless'
+  | 'container'
+  | 'ci'
+  | 'runtime-missing'
+  | 'web-bridge-missing'
+  | 'unsupported-platform'
+
+export interface PetResolvedPresentation {
+  kind: PetResolvedPresentationKind
+  reason: PetPresentationReason
+  hostId?: string
+}
+
+const SUPPORTED_STANDALONE_PLATFORMS = new Set<NodeJS.Platform>(['win32', 'darwin', 'linux'])
+
+function none(reason: PetPresentationReason, hostId?: string): PetResolvedPresentation {
+  return { kind: 'none', reason, ...(hostId === undefined ? {} : { hostId }) }
+}
+
+function standalonePrerequisiteFailure(
+  environment: PetPresentationEnvironment,
+): PetResolvedPresentation | undefined {
+  if (!environment.standaloneRuntimeAvailable) return none('runtime-missing')
+  if (!environment.webBridgeAvailable) return none('web-bridge-missing')
+  return undefined
+}
+
+/** Resolve presentation from settings and captured environment facts only. */
+export function resolvePetPresentation(
+  settings: PetPluginSettings,
+  environment: PetPresentationEnvironment,
+): PetResolvedPresentation {
+  if (!settings.enabled || environment.disabledByEnvironment) return none('disabled')
+  const mode = environment.presentationOverride ?? settings.presentation.mode
+  if (mode === 'none') return none('configured-none')
+
+  if (environment.embeddedHostAvailable) {
+    return {
+      kind: 'embedded',
+      reason: 'embedded-host',
+      ...(environment.embeddedHostHint === undefined ? {} : { hostId: environment.embeddedHostHint }),
+    }
+  }
+  if (mode === 'embedded' || environment.embeddedHostHint !== undefined) {
+    return none('embedded-host-pending', environment.embeddedHostHint)
+  }
+
+  if (mode === 'standalone') {
+    return standalonePrerequisiteFailure(environment)
+      ?? { kind: 'standalone', reason: 'forced-standalone', hostId: 'standalone' }
+  }
+
+  if (!settings.presentation.standaloneAutoStart) return none('configured-none')
+  if (environment.isCi) return none('ci')
+  if (environment.isContainer) return none('container')
+  if (!SUPPORTED_STANDALONE_PLATFORMS.has(environment.platform)) return none('unsupported-platform')
+  if (environment.isTest || !environment.hasDisplayServer || !environment.appearsInteractive) return none('headless')
+  return standalonePrerequisiteFailure(environment)
+    ?? { kind: 'standalone', reason: 'auto-standalone', hostId: 'standalone' }
+}

--- a/packages/dsh-pet/src/presentation/status.ts
+++ b/packages/dsh-pet/src/presentation/status.ts
@@ -1,0 +1,89 @@
+import type { PetPresentationMode, PetPluginSettings } from './config.ts'
+import type { PetResolvedPresentation, PetResolvedPresentationKind } from './resolver.ts'
+import type { PetReturnTarget } from '../contracts/desktop-host.ts'
+import { PET_ERROR_CODES, type PetErrorCode } from '../errors.ts'
+
+export type PetPresentationPhase =
+  | 'disabled'
+  | 'resolving'
+  | 'none'
+  | 'starting'
+  | 'ready'
+  | 'hidden'
+  | 'unavailable'
+  | 'failed'
+
+export interface PetPresentationState {
+  mode: PetPresentationMode
+  resolved: PetResolvedPresentationKind
+  phase: PetPresentationPhase
+  available: boolean
+  visible: boolean
+  reason?: string
+  errorCode?: PetErrorCode
+  host?: {
+    id: string
+    name: string
+    embedded: boolean
+    ownsTray: boolean
+  }
+  returnTarget?: PetReturnTarget
+}
+
+const UNAVAILABLE_REASONS = new Set([
+  'embedded-host-pending',
+  'runtime-missing',
+  'web-bridge-missing',
+  'unsupported-platform',
+])
+
+function errorCodeForResolution(resolution: PetResolvedPresentation): PetErrorCode | undefined {
+  switch (resolution.reason) {
+    case 'disabled': return PET_ERROR_CODES.disabled
+    case 'headless':
+    case 'container':
+    case 'ci':
+    case 'unsupported-platform': return PET_ERROR_CODES.presentationHeadless
+    case 'runtime-missing': return PET_ERROR_CODES.presentationRuntimeMissing
+    case 'embedded-host-pending': return PET_ERROR_CODES.presentationHostUnavailable
+    case 'web-bridge-missing': return PET_ERROR_CODES.presentationBridgeUnavailable
+    default: return undefined
+  }
+}
+
+/** Project one resolved decision onto the diagnostic state consumed by UI and tests. */
+export function presentationStateFromResolution(
+  settings: PetPluginSettings,
+  resolution: PetResolvedPresentation,
+  visible: boolean,
+): PetPresentationState {
+  if (resolution.kind === 'none') {
+    const errorCode = errorCodeForResolution(resolution)
+    return {
+      mode: settings.presentation.mode,
+      resolved: 'none',
+      phase: resolution.reason === 'disabled'
+        ? 'disabled'
+        : UNAVAILABLE_REASONS.has(resolution.reason) ? 'unavailable' : 'none',
+      available: false,
+      visible: false,
+      reason: resolution.reason,
+      ...(errorCode === undefined ? {} : { errorCode }),
+    }
+  }
+  const embedded = resolution.kind === 'embedded'
+  return {
+    mode: settings.presentation.mode,
+    resolved: resolution.kind,
+    phase: visible ? 'ready' : 'hidden',
+    available: true,
+    visible,
+    reason: resolution.reason,
+    host: {
+      id: resolution.hostId ?? resolution.kind,
+      name: embedded ? 'Embedded DSH Host' : 'Standalone dsh-pet',
+      embedded,
+      ownsTray: !embedded,
+    },
+  }
+}

--- a/packages/dsh-pet/src/renderers/registry.test.ts
+++ b/packages/dsh-pet/src/renderers/registry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PET_MODEL_SCHEMA_VERSION,
+  PET_RENDERER_API_VERSION,
+  type PetModelDescriptor,
+  type PetRendererProvider,
+} from '../contracts/renderer.ts'
+import { PetRendererRegistry } from './registry.ts'
+
+const model: PetModelDescriptor = {
+  schemaVersion: PET_MODEL_SCHEMA_VERSION,
+  id: 'builtin:whale',
+  displayName: 'Whale',
+  rendererId: 'builtin:sprite2d',
+  format: 'petdex-v1',
+  entry: 'spritesheet.webp',
+  source: { kind: 'builtin' },
+  capabilities: { motions: ['idle'], expressions: [], lookAt: false, lipSync: false, hitAreas: ['body'] },
+  bindings: { motions: { idle: 'idle' }, expressions: {} },
+  fallback: { motion: 'idle', expression: 'neutral' },
+}
+
+function provider(id = 'builtin:sprite2d'): PetRendererProvider {
+  const descriptor = {
+    apiVersion: PET_RENDERER_API_VERSION,
+    id,
+    displayName: 'Sprite 2D',
+    kind: 'sprite2d' as const,
+    version: '1.0.0',
+    capabilities: {
+      expressions: false,
+      motions: true,
+      lookAt: false,
+      lipSync: false,
+      hitAreas: true,
+      transparentBackground: true,
+    },
+    supportedModelFormats: ['petdex-v1'],
+  }
+  return {
+    descriptor,
+    create: async () => { throw new Error('not used') },
+  }
+}
+
+describe('PetRendererRegistry', () => {
+  it('registers only explicit providers and removes them through the registration', () => {
+    const registry = new PetRendererRegistry()
+    const registration = registry.register(provider())
+
+    expect(registry.get('builtin:sprite2d')?.descriptor.displayName).toBe('Sprite 2D')
+    expect(registry.list().map(descriptor => descriptor.id)).toEqual(['builtin:sprite2d'])
+    expect(registry.supports('builtin:sprite2d', model)).toBe(true)
+
+    registration.dispose()
+    registration.dispose()
+    expect(registry.list()).toEqual([])
+  })
+
+  it('rejects duplicate, malformed, and incompatible registrations', () => {
+    const registry = new PetRendererRegistry()
+    registry.register(provider())
+
+    expect(() => registry.register(provider())).toThrow('already registered')
+    expect(() => registry.register(provider('sprite2d'))).toThrow('Invalid renderer id')
+    expect(registry.supports('builtin:sprite2d', { ...model, format: 'live2d-v3' })).toBe(false)
+    expect(registry.supports('builtin:sprite2d', { ...model, rendererId: 'extension:other' })).toBe(false)
+  })
+})

--- a/packages/dsh-pet/src/renderers/registry.ts
+++ b/packages/dsh-pet/src/renderers/registry.ts
@@ -1,0 +1,76 @@
+import {
+  PET_RENDERER_API_VERSION,
+  type PetModelDescriptor,
+  type PetRendererCreateContext,
+  type PetRendererDescriptor,
+  type PetRendererProvider,
+  type PetRendererRegistryContract,
+} from '../contracts/renderer.ts'
+import type { PetDisposable } from '../contracts/disposable.ts'
+
+const rendererIdPattern = /^[a-z0-9][a-z0-9._-]*:[a-z0-9][a-z0-9._-]*$/
+
+function validatedDescriptor(descriptor: PetRendererDescriptor): PetRendererDescriptor {
+  if (descriptor.apiVersion !== PET_RENDERER_API_VERSION) {
+    throw new Error(`Unsupported renderer API version: ${String(descriptor.apiVersion)}`)
+  }
+  if (!rendererIdPattern.test(descriptor.id)) {
+    throw new Error(`Invalid renderer id: ${descriptor.id}`)
+  }
+  if (descriptor.displayName.trim() === '' || descriptor.version.trim() === '') {
+    throw new Error(`Renderer ${descriptor.id} must declare a display name and version`)
+  }
+  if (descriptor.supportedModelFormats.length === 0) {
+    throw new Error(`Renderer ${descriptor.id} must support at least one model format`)
+  }
+  if (descriptor.supportedModelFormats.some(format => format.trim() === '')) {
+    throw new Error(`Renderer ${descriptor.id} contains an empty model format`)
+  }
+  return Object.freeze({
+    ...descriptor,
+    capabilities: Object.freeze({ ...descriptor.capabilities }),
+    supportedModelFormats: Object.freeze([...new Set(descriptor.supportedModelFormats)]),
+  })
+}
+
+/** Explicit allow-list registry. It never discovers or imports providers itself. */
+export class PetRendererRegistry implements PetRendererRegistryContract {
+  readonly #providers = new Map<string, PetRendererProvider>()
+
+  register(provider: PetRendererProvider): PetDisposable {
+    const descriptor = validatedDescriptor(provider.descriptor)
+    if (this.#providers.has(descriptor.id)) {
+      throw new Error(`Renderer already registered: ${descriptor.id}`)
+    }
+    const registered: PetRendererProvider = Object.freeze({
+      descriptor,
+      create: (context: PetRendererCreateContext) => provider.create(context),
+    })
+    this.#providers.set(descriptor.id, registered)
+    let disposed = false
+    return {
+      dispose: () => {
+        if (disposed) return
+        disposed = true
+        if (this.#providers.get(descriptor.id) === registered) {
+          this.#providers.delete(descriptor.id)
+        }
+      },
+    }
+  }
+
+  get(id: string): PetRendererProvider | undefined {
+    return this.#providers.get(id)
+  }
+
+  list(): readonly PetRendererDescriptor[] {
+    return Object.freeze([...this.#providers.values()].map(provider => provider.descriptor))
+  }
+
+  supports(rendererId: string, model: PetModelDescriptor): boolean {
+    const provider = this.#providers.get(rendererId)
+    return provider !== undefined
+      && model.rendererId === rendererId
+      && provider.descriptor.supportedModelFormats.includes(model.format)
+  }
+}

--- a/packages/dsh-pet/src/renderers/runtime.test.ts
+++ b/packages/dsh-pet/src/renderers/runtime.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PET_INTENT_VERSION, type PetIntent } from '../core/intent.ts'
+import {
+  PET_MODEL_SCHEMA_VERSION,
+  PET_RENDERER_API_VERSION,
+  type PetAssetResolver,
+  type PetModelDescriptor,
+  type PetRenderer,
+  type PetRendererCreateContext,
+  type PetRendererDescriptor,
+  type PetRendererProvider,
+} from '../contracts/renderer.ts'
+import { PetRendererRegistry } from './registry.ts'
+import { PetRendererRuntime, type PetResolvedModel } from './runtime.ts'
+
+const assets: PetAssetResolver = {
+  fetch: async () => new ArrayBuffer(0),
+}
+const surface = {
+  element: {} as HTMLElement,
+  width: 192,
+  height: 208,
+  devicePixelRatio: 1,
+}
+const intent: PetIntent = {
+  version: PET_INTENT_VERSION,
+  id: 'activity:working',
+  source: 'activity',
+  createdAt: 10,
+  priority: 40,
+  interruptible: true,
+  expression: 'focused',
+  motion: 'working',
+  playback: 'loop',
+  speech: { id: 'speech:1', text: 'Working', createdAt: 10 },
+  sourceTaskIds: ['task-1'],
+}
+
+function descriptor(id: string): PetRendererDescriptor {
+  return {
+    apiVersion: PET_RENDERER_API_VERSION,
+    id,
+    displayName: id,
+    kind: 'sprite2d',
+    version: '1.0.0',
+    capabilities: {
+      expressions: false, motions: true, lookAt: false, lipSync: false, hitAreas: true, transparentBackground: true,
+    },
+    supportedModelFormats: ['petdex-v1'],
+  }
+}
+
+function model(id: string, rendererId: string): PetModelDescriptor {
+  return {
+    schemaVersion: PET_MODEL_SCHEMA_VERSION,
+    id,
+    displayName: id,
+    rendererId,
+    format: 'petdex-v1',
+    entry: 'spritesheet.webp',
+    source: { kind: 'builtin' },
+    capabilities: { motions: ['idle', 'working'], expressions: [], lookAt: false, lipSync: false, hitAreas: ['body'] },
+    bindings: { motions: { idle: 'idle', working: 'running-right' }, expressions: {} },
+    fallback: { motion: 'idle', expression: 'neutral' },
+  }
+}
+
+function mockProvider(
+  id: string,
+  log: string[],
+  options: { failLoad?: boolean, onCreate?: (emit: PetRendererCreateContext['emit']) => void } = {},
+): PetRendererProvider {
+  const rendererDescriptor = descriptor(id)
+  return {
+    descriptor: rendererDescriptor,
+    create: async (context) => {
+      options.onCreate?.(context.emit)
+      log.push(`${id}:create:${String(context.signal.aborted)}`)
+      const renderer: PetRenderer = {
+        descriptor: rendererDescriptor,
+        mount: async () => { log.push(`${id}:mount`) },
+        loadModel: async (next) => {
+          log.push(`${id}:load:${next.id}`)
+          if (options.failLoad === true) throw new Error(`${id} load failed`)
+        },
+        applyIntent: async next => { log.push(`${id}:intent:${next.id}`) },
+        applySpeech: async speech => { log.push(`${id}:speech:${speech.id}`) },
+        resize: () => { log.push(`${id}:resize`) },
+        setVisible: visible => { log.push(`${id}:visible:${String(visible)}`) },
+        setQuality: quality => { log.push(`${id}:quality:${quality}`) },
+        dispose: async () => { log.push(`${id}:dispose:${String(context.signal.aborted)}`) },
+      }
+      return renderer
+    },
+  }
+}
+
+function resolved(descriptor: PetModelDescriptor): PetResolvedModel {
+  return { descriptor, assets }
+}
+
+describe('PetRendererRuntime', () => {
+  it('disposes before switching and restores the current intent and speech', async () => {
+    const log: string[] = []
+    const registry = new PetRendererRegistry()
+    registry.register(mockProvider('builtin:sprite2d', log))
+    registry.register(mockProvider('test:alternate', log))
+    const first = model('model:first', 'builtin:sprite2d')
+    const second = model('model:second', 'test:alternate')
+    const models = new Map([
+      [first.id, resolved(first)],
+      [second.id, resolved(second)],
+    ])
+    const runtime = new PetRendererRuntime(registry, surface, {
+      resolveModel: id => models.get(id),
+    })
+
+    await runtime.applyIntent(intent)
+    await runtime.selectModel(first.id)
+    const firstDisposeIndex = log.length
+    await runtime.selectModel(second.id)
+
+    expect(log.slice(firstDisposeIndex, firstDisposeIndex + 4)).toEqual([
+      'builtin:sprite2d:dispose:true',
+      'test:alternate:create:false',
+      'test:alternate:mount',
+      'test:alternate:load:model:second',
+    ])
+    expect(log).toContain('test:alternate:intent:activity:working')
+    expect(log).toContain('test:alternate:speech:speech:1')
+    await runtime.dispose()
+    expect(log.at(-1)).toBe('test:alternate:dispose:true')
+  })
+
+  it('disposes a failed renderer and activates the explicit built-in fallback', async () => {
+    const log: string[] = []
+    const errors: string[] = []
+    const registry = new PetRendererRegistry()
+    registry.register(mockProvider('test:broken', log, { failLoad: true }))
+    registry.register(mockProvider('builtin:sprite2d', log))
+    const broken = model('model:broken', 'test:broken')
+    const whale = model('builtin:whale', 'builtin:sprite2d')
+    const runtime = new PetRendererRuntime(registry, surface, {
+      resolveModel: id => id === broken.id ? resolved(broken) : undefined,
+      fallbackSelections: () => [{ rendererId: 'builtin:sprite2d', ...resolved(whale) }],
+      onEvent: (type, event) => {
+        if (type === 'error' && 'message' in event) errors.push(event.message)
+      },
+    })
+
+    await runtime.selectModel(broken.id)
+
+    expect(log).toContain('test:broken:dispose:true')
+    expect(log).toContain('builtin:sprite2d:load:builtin:whale')
+    expect(runtime.descriptor?.id).toBe('builtin:sprite2d')
+    expect(errors).toEqual(['test:broken load failed'])
+  })
+
+  it('rejects when no target or fallback can be mounted', async () => {
+    const registry = new PetRendererRegistry()
+    const broken = model('model:missing-renderer', 'test:missing')
+    const runtime = new PetRendererRuntime(registry, surface, {
+      resolveModel: () => resolved(broken),
+    })
+
+    await expect(runtime.selectModel(broken.id)).rejects.toThrow('No renderer could load model')
+    expect(runtime.descriptor).toBeUndefined()
+  })
+
+  it('can recover with a later selection after a failed selection', async () => {
+    const log: string[] = []
+    const registry = new PetRendererRegistry()
+    registry.register(mockProvider('builtin:sprite2d', log))
+    const missing = model('model:missing', 'test:missing')
+    const whale = model('builtin:whale', 'builtin:sprite2d')
+    const models = new Map([
+      [missing.id, resolved(missing)],
+      [whale.id, resolved(whale)],
+    ])
+    const runtime = new PetRendererRuntime(registry, surface, {
+      resolveModel: id => models.get(id),
+    })
+
+    await expect(runtime.selectModel(missing.id)).rejects.toThrow('No renderer could load model')
+    await expect(runtime.selectModel(whale.id)).resolves.toBeUndefined()
+    expect(runtime.descriptor?.id).toBe('builtin:sprite2d')
+  })
+
+  it('recreates once after context loss, then activates the explicit fallback', async () => {
+    const log: string[] = []
+    const emitters: PetRendererCreateContext['emit'][] = []
+    const errors: string[] = []
+    const registry = new PetRendererRegistry()
+    registry.register(mockProvider('test:webgl', log, {
+      onCreate: emit => { emitters.push(emit) },
+    }))
+    registry.register(mockProvider('builtin:sprite2d', log))
+    const webgl = model('model:webgl', 'test:webgl')
+    const whale = model('builtin:whale', 'builtin:sprite2d')
+    const runtime = new PetRendererRuntime(registry, surface, {
+      resolveModel: id => id === webgl.id ? resolved(webgl) : undefined,
+      fallbackSelections: () => [{ rendererId: 'builtin:sprite2d', ...resolved(whale) }],
+      onEvent: (type, event) => {
+        if (type === 'error' && 'code' in event) errors.push(event.code)
+      },
+    })
+
+    await runtime.selectModel(webgl.id)
+    emitters[0]?.('contextLost', {})
+    await vi.waitFor(() => expect(log.filter(entry => entry === 'test:webgl:create:false')).toHaveLength(2))
+    expect(runtime.descriptor?.id).toBe('test:webgl')
+
+    emitters[1]?.('contextLost', {})
+    await vi.waitFor(() => expect(runtime.descriptor?.id).toBe('builtin:sprite2d'))
+    expect(log).toContain('builtin:sprite2d:load:builtin:whale')
+    expect(errors.filter(code => code === 'RENDERER_CONTEXT_LOST')).toHaveLength(2)
+    await runtime.dispose()
+  })
+
+  it('disposes every superseded instance during 100 serialized model switches', async () => {
+    const log: string[] = []
+    const registry = new PetRendererRegistry()
+    registry.register(mockProvider('builtin:sprite2d', log))
+    const models = Array.from({ length: 100 }, (_, index) => model(`model:stress-${String(index)}`, 'builtin:sprite2d'))
+    const catalog = new Map(models.map(candidate => [candidate.id, resolved(candidate)]))
+    const runtime = new PetRendererRuntime(registry, surface, {
+      resolveModel: id => catalog.get(id),
+    })
+
+    for (const candidate of models) await runtime.selectModel(candidate.id)
+    expect(log.filter(entry => entry === 'builtin:sprite2d:create:false')).toHaveLength(100)
+    expect(log.filter(entry => entry === 'builtin:sprite2d:dispose:true')).toHaveLength(99)
+    await runtime.dispose()
+    expect(log.filter(entry => entry === 'builtin:sprite2d:dispose:true')).toHaveLength(100)
+  })
+})

--- a/packages/dsh-pet/src/renderers/runtime.ts
+++ b/packages/dsh-pet/src/renderers/runtime.ts
@@ -1,0 +1,274 @@
+import type { PetIntent } from '../core/intent.ts'
+import type {
+  PetAssetResolver,
+  PetModelDescriptor,
+  PetRenderer,
+  PetRendererEvents,
+  PetRendererRegistryContract,
+  PetRenderQuality,
+  PetRenderSize,
+  PetRenderSurface,
+} from '../contracts/renderer.ts'
+import { PET_ERROR_CODES, type PetErrorCode } from '../errors.ts'
+
+export interface PetResolvedModel {
+  descriptor: PetModelDescriptor
+  assets: PetAssetResolver
+}
+
+export interface PetRendererSelection extends PetResolvedModel {
+  rendererId: string
+}
+
+export interface PetRendererRuntimeOptions {
+  resolveModel(modelId: string): Promise<PetResolvedModel | undefined> | PetResolvedModel | undefined
+  fallbackSelections?(failed: PetRendererSelection): Promise<readonly PetRendererSelection[]> | readonly PetRendererSelection[]
+  onEvent?<K extends keyof PetRendererEvents>(type: K, event: PetRendererEvents[K]): void
+}
+
+interface ActiveRenderer {
+  renderer: PetRenderer
+  controller: AbortController
+  selection: PetRendererSelection
+  token: object
+  contextRecoveryQueued: boolean
+  lastSpeechId?: string
+}
+
+/** Owns exactly one renderer instance and serializes every model/renderer switch. */
+export class PetRendererRuntime {
+  readonly #registry: PetRendererRegistryContract
+  readonly #surface: PetRenderSurface
+  readonly #options: PetRendererRuntimeOptions
+  #active?: ActiveRenderer
+  #selectedModelId?: string
+  #selectedRendererId?: string
+  #intent?: PetIntent
+  #visible = true
+  #quality: PetRenderQuality = 'balanced'
+  #size: PetRenderSize
+  #queue: Promise<void> = Promise.resolve()
+  #disposed = false
+  #contextRecoveryKey?: string
+  #contextRecoveryAttempts = 0
+
+  constructor(
+    registry: PetRendererRegistryContract,
+    surface: PetRenderSurface,
+    options: PetRendererRuntimeOptions,
+  ) {
+    this.#registry = registry
+    this.#surface = surface
+    this.#options = options
+    this.#size = {
+      width: surface.width,
+      height: surface.height,
+      devicePixelRatio: surface.devicePixelRatio,
+    }
+  }
+
+  get descriptor() {
+    return this.#active?.renderer.descriptor
+  }
+
+  selectRenderer(rendererId: string): Promise<void> {
+    this.#selectedRendererId = rendererId
+    this.#resetContextRecovery()
+    return this.#enqueueReconcile()
+  }
+
+  selectModel(modelId: string): Promise<void> {
+    this.#selectedModelId = modelId
+    this.#resetContextRecovery()
+    return this.#enqueueReconcile()
+  }
+
+  async applyIntent(intent: PetIntent): Promise<void> {
+    this.#intent = intent
+    const active = this.#active
+    if (active === undefined) return
+    await active.renderer.applyIntent(intent)
+    if (intent.speech !== undefined
+      && intent.speech.id !== active.lastSpeechId
+      && active.renderer.applySpeech !== undefined) {
+      await active.renderer.applySpeech(intent.speech)
+      active.lastSpeechId = intent.speech.id
+    }
+  }
+
+  setVisible(visible: boolean): void {
+    this.#visible = visible
+    this.#active?.renderer.setVisible(visible)
+  }
+
+  setQuality(quality: PetRenderQuality): void {
+    this.#quality = quality
+    this.#active?.renderer.setQuality(quality)
+  }
+
+  resize(size: PetRenderSize): void {
+    this.#size = { ...size }
+    this.#active?.renderer.resize(this.#size)
+  }
+
+  dispose(): Promise<void> {
+    this.#disposed = true
+    const operation = this.#queue.then(() => this.#disposeActive())
+    this.#queue = operation.catch(() => {})
+    return operation
+  }
+
+  #enqueueReconcile(): Promise<void> {
+    if (this.#disposed) return Promise.reject(new Error('Renderer runtime is disposed'))
+    const operation = this.#queue.then(() => this.#reconcile())
+    // A failed selection must not poison later recovery attempts.
+    this.#queue = operation.catch(() => {})
+    return operation
+  }
+
+  async #reconcile(): Promise<void> {
+    const modelId = this.#selectedModelId
+    if (modelId === undefined) return
+    const resolved = await this.#options.resolveModel(modelId)
+    if (resolved === undefined) throw new Error(`Unknown pet model: ${modelId}`)
+    const target: PetRendererSelection = {
+      rendererId: this.#selectedRendererId ?? resolved.descriptor.rendererId,
+      ...resolved,
+    }
+    const fallbacks = await this.#options.fallbackSelections?.(target) ?? []
+    const selections = [target, ...fallbacks].filter((selection, index, all) =>
+      all.findIndex(candidate => candidate.rendererId === selection.rendererId
+        && candidate.descriptor.id === selection.descriptor.id) === index)
+
+    await this.#disposeActive()
+    const errors: unknown[] = []
+    for (const selection of selections) {
+      try {
+        this.#active = await this.#create(selection)
+        return
+      } catch (error) {
+        errors.push(error)
+        this.#emitError(PET_ERROR_CODES.rendererLoadFailed, error)
+      }
+    }
+    this.#emitError(PET_ERROR_CODES.rendererNotFound, new Error(`No renderer could load model ${modelId}`), false)
+    throw new AggregateError(errors, `No renderer could load model ${modelId}`)
+  }
+
+  async #create(selection: PetRendererSelection): Promise<ActiveRenderer> {
+    const provider = this.#registry.get(selection.rendererId)
+    if (provider === undefined) throw new Error(`Unknown renderer: ${selection.rendererId}`)
+    if (!this.#registry.supports(selection.rendererId, selection.descriptor)) {
+      throw new Error(`Renderer ${selection.rendererId} does not support ${selection.descriptor.format}`)
+    }
+    const controller = new AbortController()
+    const token = {}
+    let renderer: PetRenderer | undefined
+    try {
+      renderer = await provider.create({
+        signal: controller.signal,
+        emit: (type, event) => this.#handleProviderEvent(token, type, event),
+      })
+      if (renderer.descriptor.id !== provider.descriptor.id) {
+        throw new Error(`Renderer instance id mismatch: ${renderer.descriptor.id}`)
+      }
+      await renderer.mount(this.#surface)
+      await renderer.loadModel(selection.descriptor, selection.assets)
+      renderer.resize(this.#size)
+      renderer.setQuality(this.#quality)
+      renderer.setVisible(this.#visible)
+      const active: ActiveRenderer = {
+        renderer,
+        controller,
+        selection,
+        token,
+        contextRecoveryQueued: false,
+      }
+      if (this.#intent !== undefined) {
+        await renderer.applyIntent(this.#intent)
+        if (this.#intent.speech !== undefined && renderer.applySpeech !== undefined) {
+          await renderer.applySpeech(this.#intent.speech)
+          active.lastSpeechId = this.#intent.speech.id
+        }
+      }
+      return active
+    } catch (error) {
+      controller.abort()
+      if (renderer !== undefined) await renderer.dispose()
+      throw error
+    }
+  }
+
+  async #disposeActive(): Promise<void> {
+    const active = this.#active
+    this.#active = undefined
+    if (active === undefined) return
+    active.controller.abort()
+    await active.renderer.dispose()
+  }
+
+  #handleProviderEvent<K extends keyof PetRendererEvents>(
+    token: object,
+    type: K,
+    event: PetRendererEvents[K],
+  ): void {
+    this.#options.onEvent?.(type, event)
+    if (type !== 'contextLost' || this.#disposed) return
+    const active = this.#active
+    if (active === undefined || active.token !== token || active.contextRecoveryQueued) return
+    active.contextRecoveryQueued = true
+    const key = `${active.selection.rendererId}\0${active.selection.descriptor.id}`
+    if (this.#contextRecoveryKey !== key) {
+      this.#contextRecoveryKey = key
+      this.#contextRecoveryAttempts = 0
+    }
+    this.#contextRecoveryAttempts += 1
+    const retrySameSelection = this.#contextRecoveryAttempts === 1
+    this.#emitError(
+      PET_ERROR_CODES.rendererContextLost,
+      new Error(`Renderer context lost: ${active.selection.rendererId}`),
+    )
+    const operation = this.#queue.then(() => this.#recoverContext(active, retrySameSelection))
+    this.#queue = operation.catch(() => {})
+    void operation.catch(error => {
+      this.#emitError(PET_ERROR_CODES.rendererLoadFailed, error, false)
+    })
+  }
+
+  async #recoverContext(failed: ActiveRenderer, retrySameSelection: boolean): Promise<void> {
+    if (this.#disposed || this.#active !== failed) return
+    const fallbacks = await this.#options.fallbackSelections?.(failed.selection) ?? []
+    const selections = [
+      ...(retrySameSelection ? [failed.selection] : []),
+      ...fallbacks,
+    ].filter((selection, index, all) => all.findIndex(candidate => (
+      candidate.rendererId === selection.rendererId
+      && candidate.descriptor.id === selection.descriptor.id
+    )) === index)
+    await this.#disposeActive()
+    const errors: unknown[] = []
+    for (const selection of selections) {
+      try {
+        this.#active = await this.#create(selection)
+        return
+      } catch (error) {
+        errors.push(error)
+        this.#emitError(PET_ERROR_CODES.rendererLoadFailed, error)
+      }
+    }
+    throw new AggregateError(errors, 'Renderer context recovery failed')
+  }
+
+  #resetContextRecovery(): void {
+    this.#contextRecoveryKey = undefined
+    this.#contextRecoveryAttempts = 0
+  }
+
+  #emitError(code: PetErrorCode, error: unknown, recoverable = true): void {
+    this.#options.onEvent?.('error', {
+      code,
+      recoverable,
+      message: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/dsh-pet/tests/activity-projection.spec.ts
+++ b/packages/dsh-pet/tests/activity-projection.spec.ts
@@ -1,0 +1,89 @@
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { describe, expect, it } from 'vitest'
+import {
+  createActivityProjectionRuntime,
+  displayToolName,
+  projectOfficialEvent,
+} from '../src/core/activity-projection.ts'
+
+function event(value: object): SessionEvent {
+  return value as SessionEvent
+}
+
+describe('official activity projection', () => {
+  it('projects parallel tools with bounded names and completion counts', () => {
+    const runtime = createActivityProjectionRuntime()
+    const longName = '  search    with a deliberately very long tool name  '
+
+    expect(displayToolName(longName)).toBe('search with a deliber...')
+    expect(projectOfficialEvent(event({
+      type: 'tool/call',
+      data: { callId: 'one', name: longName },
+    }), runtime)).toMatchObject({
+      phase: 'tool',
+      tool: { activeCount: 1, completedCount: 0 },
+    })
+    expect(projectOfficialEvent(event({
+      type: 'tool/call',
+      data: { callId: 'two', name: 'shell' },
+    }), runtime)).toMatchObject({
+      phase: 'tool',
+      statusLine: '正在使用 shell',
+      tool: { activeCount: 2, completedCount: 0 },
+    })
+    expect(projectOfficialEvent(event({
+      type: 'tool/result',
+      data: {
+        message: {
+          source: { callId: 'one' },
+          content: [{ type: 'tool-result', isError: false }],
+        },
+      },
+    }), runtime)).toMatchObject({
+      phase: 'tool',
+      statusLine: '还有 1 个工具运行中',
+      tool: { name: 'shell', activeCount: 1, completedCount: 1 },
+    })
+    expect(projectOfficialEvent(event({
+      type: 'tool/result',
+      data: {
+        error: { code: 'FAILED' },
+        message: {
+          source: { callId: 'two' },
+          content: [{ type: 'tool-result', isError: true }],
+        },
+      },
+    }), runtime)).toMatchObject({
+      phase: 'failed',
+      statusLine: '工具执行失败',
+      tool: { activeCount: 0, completedCount: 2 },
+    })
+  })
+
+  it('keeps compatibility copy for the full official sequence', () => {
+    const runtime = createActivityProjectionRuntime()
+    expect(projectOfficialEvent(event({ type: 'turn/start', data: { turn: 1 } }), runtime))
+      .toMatchObject({ phase: 'waiting', statusLine: '准备开始' })
+    expect(projectOfficialEvent(event({
+      type: 'assistant/chunk',
+      data: { chunk: { type: 'reasoning-delta', text: 'analysis' } },
+    }), runtime)).toMatchObject({ phase: 'thinking', statusLine: '正在思考' })
+    expect(projectOfficialEvent(event({
+      type: 'assistant/chunk',
+      data: { chunk: { type: 'text-delta', text: 'answer' } },
+    }), runtime)).toMatchObject({ phase: 'review', statusLine: '整理回复中' })
+    expect(projectOfficialEvent(event({
+      type: 'turn/end',
+      data: { turn: 1, reason: { kind: 'completed' } },
+    }), runtime)).toEqual({ phase: 'done', statusLine: '完成啦', completedTurn: 1 })
+    expect(projectOfficialEvent(event({
+      type: 'turn/end',
+      data: { turn: 2, reason: { kind: 'blocked' } },
+    }), runtime)).toEqual({ phase: 'blocked', statusLine: '任务受阻，等待继续' })
+  })
+
+  it('ignores unknown events instead of replacing meaningful activity', () => {
+    const runtime = createActivityProjectionRuntime()
+    expect(projectOfficialEvent(event({ type: 'log', data: {} }), runtime)).toBeUndefined()
+  })
+})

--- a/packages/dsh-pet/tests/activity-registry.spec.ts
+++ b/packages/dsh-pet/tests/activity-registry.spec.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import { ActivityRegistry } from '../src/core/activity-registry.ts'
+import { selectPrimaryTask } from '../src/core/primary-task.ts'
+import { petTaskId, type PetTaskSnapshot } from '../src/core/protocol.ts'
+
+const instance = { instanceId: 'web-profile', bootId: 'boot-a' }
+
+function task(
+  sessionId: string,
+  phase: PetTaskSnapshot['phase'],
+  updatedAt: number,
+): PetTaskSnapshot {
+  const identity = { ...instance, sessionId }
+  return {
+    ...identity,
+    taskId: petTaskId(identity),
+    phase,
+    startedAt: 10,
+    phaseStartedAt: updatedAt,
+    updatedAt,
+    ...(phase === 'done' || phase === 'failed' ? { finishedAt: updatedAt } : {}),
+  }
+}
+
+describe('ActivityRegistry', () => {
+  it('retains simultaneous sessions and stable phase timing', () => {
+    let now = 100
+    const registry = new ActivityRegistry({ now: () => now })
+
+    registry.update({ ...instance, sessionId: 'a', phase: 'thinking', statusLine: '分析中' })
+    now = 110
+    registry.update({
+      ...instance,
+      sessionId: 'b',
+      phase: 'tool',
+      statusLine: '正在使用 search',
+      tool: { name: 'search', activeCount: 1, completedCount: 0 },
+    })
+    now = 120
+    registry.update({ ...instance, sessionId: 'a', phase: 'review', statusLine: '整理中' })
+    now = 125
+    registry.update({ ...instance, sessionId: 'a', phase: 'review', statusLine: '继续整理' })
+
+    const snapshot = registry.snapshot()
+    expect(snapshot).toMatchObject({
+      protocolVersion: 2,
+      sequence: 4,
+      emittedAt: 125,
+      summary: { active: 2, waiting: 0, blocked: 0, failed: 0, completedRecently: 0 },
+    })
+    expect(snapshot.tasks).toHaveLength(2)
+    expect(snapshot.tasks.find(item => item.sessionId === 'a')).toMatchObject({
+      phase: 'review',
+      startedAt: 100,
+      phaseStartedAt: 120,
+      updatedAt: 125,
+      statusLine: '继续整理',
+    })
+    expect(snapshot.tasks.find(item => item.sessionId === 'b')?.tool).toEqual({
+      name: 'search', activeCount: 1, completedCount: 0,
+    })
+  })
+
+  it('uses instance and boot identity to prevent session ID collisions', () => {
+    const registry = new ActivityRegistry({ now: () => 100 })
+    registry.update({ instanceId: 'one', bootId: 'boot-a', sessionId: 'same', phase: 'thinking' })
+    registry.update({ instanceId: 'two', bootId: 'boot-a', sessionId: 'same', phase: 'thinking' })
+    registry.update({ instanceId: 'one', bootId: 'boot-b', sessionId: 'same', phase: 'thinking' })
+
+    const ids = registry.snapshot().tasks.map(item => item.taskId)
+    expect(new Set(ids).size).toBe(3)
+    expect(ids).toContain('v2:one:boot-a:same')
+    expect(ids).toContain('v2:two:boot-a:same')
+    expect(ids).toContain('v2:one:boot-b:same')
+  })
+
+  it('uses receive order when concurrent events share a wall-clock millisecond', () => {
+    const registry = new ActivityRegistry({ now: () => 100 })
+    registry.update({ ...instance, sessionId: 'a', phase: 'thinking' })
+    registry.update({ ...instance, sessionId: 'b', phase: 'tool' })
+    expect(registry.snapshot().primaryTaskId).toBe(petTaskId({ ...instance, sessionId: 'b' }))
+
+    registry.update({ ...instance, sessionId: 'a', phase: 'review' })
+    expect(registry.snapshot().primaryTaskId).toBe(petTaskId({ ...instance, sessionId: 'a' }))
+  })
+
+  it('removes disposed tasks and never leaks mutable snapshots', () => {
+    const registry = new ActivityRegistry({ now: () => 100 })
+    const identity = { ...instance, sessionId: 'a' }
+    registry.update({
+      ...identity,
+      phase: 'tool',
+      tool: { name: 'shell', activeCount: 1, completedCount: 0 },
+    })
+    const first = registry.snapshot()
+    const firstTask = first.tasks[0]
+    if (firstTask === undefined || firstTask.tool === undefined) throw new Error('missing task')
+    firstTask.tool.activeCount = 99
+
+    expect(registry.snapshot().tasks[0]?.tool?.activeCount).toBe(1)
+    expect(registry.remove(identity)).toBe(true)
+    expect(registry.snapshot()).toMatchObject({
+      sequence: 2,
+      tasks: [],
+      summary: { active: 0, waiting: 0, blocked: 0, failed: 0, completedRecently: 0 },
+    })
+  })
+
+  it('retains only exact valid progress and reports blocked work separately', () => {
+    const registry = new ActivityRegistry({ now: () => 100 })
+    const identity = { ...instance, sessionId: 'progress' }
+    registry.update({
+      ...identity,
+      phase: 'tool',
+      progress: { current: 3, total: 10, unit: ' files ' },
+      tool: { name: 'build', activeCount: 1, completedCount: 2, failedCount: 1 },
+    })
+
+    expect(registry.snapshot().tasks[0]).toMatchObject({
+      progress: { current: 3, total: 10, unit: 'files' },
+      tool: { failedCount: 1 },
+    })
+    registry.update({ ...identity, phase: 'blocked', progress: { current: 11, total: 10 } })
+    expect(registry.snapshot()).toMatchObject({
+      summary: { active: 1, waiting: 0, blocked: 1, failed: 0, completedRecently: 0 },
+      tasks: [{ phase: 'blocked' }],
+    })
+    expect(registry.snapshot().tasks[0]?.progress).toBeUndefined()
+  })
+
+  it('selects urgent, explicit, active, and completed tasks deterministically', () => {
+    const waitingInput = task('input', 'waiting_input', 80)
+    const failed = task('failed', 'failed', 95)
+    const pinned = task('pinned', 'thinking', 70)
+    const focused = task('focused', 'tool', 90)
+    const done = task('done', 'done', 99)
+    const tasks = [done, focused, pinned, failed, waitingInput]
+
+    expect(selectPrimaryTask(tasks, {
+      nowMs: 100,
+      pinnedTaskId: pinned.taskId,
+      focusedTaskId: focused.taskId,
+    })?.taskId).toBe(waitingInput.taskId)
+
+    expect(selectPrimaryTask(tasks.filter(item => item !== waitingInput), {
+      nowMs: 100,
+      pinnedTaskId: pinned.taskId,
+      focusedTaskId: focused.taskId,
+    })?.taskId).toBe(failed.taskId)
+
+    expect(selectPrimaryTask(tasks.filter(item => item !== waitingInput), {
+      nowMs: 100_000,
+      pinnedTaskId: pinned.taskId,
+      focusedTaskId: focused.taskId,
+    })?.taskId).toBe(pinned.taskId)
+
+    expect(selectPrimaryTask([done, focused, pinned], {
+      nowMs: 100,
+      focusedTaskId: focused.taskId,
+    })?.taskId).toBe(focused.taskId)
+
+    expect(selectPrimaryTask([done, focused, pinned], { nowMs: 100 })?.taskId).toBe(focused.taskId)
+    expect(selectPrimaryTask([done], { nowMs: 100 })?.taskId).toBe(done.taskId)
+  })
+})

--- a/packages/dsh-pet/tests/fixtures/petdex-v1/pet.json
+++ b/packages/dsh-pet/tests/fixtures/petdex-v1/pet.json
@@ -1,0 +1,6 @@
+{
+  "id": "fixture-v1",
+  "displayName": "PetDex V1 Fixture",
+  "description": "Frozen PetDex version 1 manifest used by the stable-baseline tests.",
+  "spritesheetPath": "spritesheet.webp"
+}

--- a/packages/dsh-pet/tests/fixtures/petdex-v2/pet.json
+++ b/packages/dsh-pet/tests/fixtures/petdex-v2/pet.json
@@ -1,0 +1,7 @@
+{
+  "id": "fixture-v2",
+  "displayName": "PetDex V2 Fixture",
+  "description": "Frozen PetDex version 2 manifest used by the stable-baseline tests.",
+  "spritesheetPath": "spritesheet.webp",
+  "spriteVersionNumber": 2
+}

--- a/packages/dsh-pet/tests/intent-scheduler.spec.ts
+++ b/packages/dsh-pet/tests/intent-scheduler.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { PetIntentScheduler } from '../src/core/intent-scheduler.ts'
+import {
+  createInteractionIntent,
+  mapActivityToIntent,
+  type PetIntent,
+} from '../src/core/intent.ts'
+import type { PetAggregateSnapshot, PetTaskPhase } from '../src/core/protocol.ts'
+
+function activity(phase: PetTaskPhase, phaseStartedAt: number, tool?: string): PetIntent {
+  const snapshot: PetAggregateSnapshot = {
+    protocolVersion: 2,
+    sequence: phaseStartedAt,
+    emittedAt: phaseStartedAt,
+    primaryTaskId: 'task',
+    tasks: [{
+      taskId: 'task',
+      instanceId: 'instance',
+      bootId: 'boot',
+      sessionId: 'session',
+      phase,
+      ...(tool === undefined ? {} : { tool: { name: tool, activeCount: 1, completedCount: 0 } }),
+      startedAt: 0,
+      phaseStartedAt,
+      updatedAt: phaseStartedAt,
+    }],
+    summary: { active: 1, waiting: 0, blocked: phase === 'blocked' ? 1 : 0, failed: 0, completedRecently: 0 },
+  }
+  return mapActivityToIntent(snapshot)
+}
+
+describe('PetIntentScheduler', () => {
+  it('deduplicates one semantic motion even when speech changes', () => {
+    const scheduler = new PetIntentScheduler()
+    const first = activity('thinking', 100)
+    const changedSpeech = {
+      ...first,
+      speech: { id: 'speech:later:200', text: '还在继续', createdAt: 200 },
+    }
+
+    scheduler.submit(first)
+    const state = scheduler.submit(changedSpeech)
+    expect(state.current?.id).toBe(first.id)
+    expect(state.current?.speech?.id).not.toBe('speech:later:200')
+    expect(state.queued).toEqual([])
+  })
+
+  it('lets an interaction interrupt activity and returns to the latest activity', () => {
+    const scheduler = new PetIntentScheduler()
+    const thinking = activity('thinking', 100)
+    const interaction = createInteractionIntent('pet', '好呀', 200, true)
+    const tool = activity('tool', 300, 'test')
+
+    scheduler.submit(thinking)
+    expect(scheduler.submit(interaction)).toMatchObject({
+      current: { id: interaction.id },
+      queued: [{ id: thinking.id }],
+    })
+    expect(scheduler.submit(tool)).toMatchObject({
+      current: { id: interaction.id },
+      queued: [{ id: tool.id }],
+    })
+    expect(scheduler.complete(interaction.id)).toMatchObject({
+      current: { id: tool.id },
+      queued: [],
+    })
+  })
+
+  it('does not let lower-priority interaction replace a non-interruptible request', () => {
+    const scheduler = new PetIntentScheduler()
+    const request = activity('waiting_input', 100)
+    const interaction = createInteractionIntent('feed', '好吃', 200, true)
+
+    scheduler.submit(request)
+    expect(scheduler.submit(interaction)).toMatchObject({
+      current: { id: request.id },
+      queued: [{ id: interaction.id }],
+    })
+    expect(scheduler.tick(2_000).queued).toEqual([])
+  })
+
+  it('expires current one-shots and promotes a valid fallback', () => {
+    const scheduler = new PetIntentScheduler()
+    const thinking = activity('thinking', 100)
+    const interaction = createInteractionIntent('pet', '好呀', 200, true)
+    scheduler.submit(thinking)
+    scheduler.submit(interaction)
+
+    expect(scheduler.tick(1_799).current?.id).toBe(interaction.id)
+    expect(scheduler.tick(1_800).current?.id).toBe(thinking.id)
+    scheduler.reset()
+    expect(scheduler.tick(2_000)).toEqual({ queued: [] })
+  })
+})

--- a/packages/dsh-pet/tests/intent.spec.ts
+++ b/packages/dsh-pet/tests/intent.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createInteractionIntent,
+  mapActivityToIntent,
+  PET_INTENT_VERSION,
+} from '../src/core/intent.ts'
+import { narrateActivity, type NarrationDecision } from '../src/core/narration.ts'
+import type { PetAggregateSnapshot, PetTaskPhase } from '../src/core/protocol.ts'
+
+function snapshot(phase?: PetTaskPhase): PetAggregateSnapshot {
+  if (phase === undefined) {
+    return {
+      protocolVersion: 2,
+      sequence: 0,
+      emittedAt: 100,
+      tasks: [],
+      summary: { active: 0, waiting: 0, blocked: 0, failed: 0, completedRecently: 0 },
+    }
+  }
+  return {
+    protocolVersion: 2,
+    sequence: 4,
+    emittedAt: 100,
+    primaryTaskId: 'task',
+    tasks: [{
+      taskId: 'task',
+      instanceId: 'instance',
+      bootId: 'boot',
+      sessionId: 'session',
+      phase,
+      statusLine: phase === 'tool' ? '正在运行测试' : undefined,
+      ...(phase === 'tool'
+        ? { tool: { name: 'test', activeCount: 1, completedCount: 0 } }
+        : {}),
+      startedAt: 10,
+      phaseStartedAt: 90,
+      updatedAt: 90,
+    }],
+    summary: { active: 1, waiting: 0, blocked: phase === 'blocked' ? 1 : 0, failed: 0, completedRecently: 0 },
+  }
+}
+
+describe('pet intent core', () => {
+  it('maps activity into renderer-neutral V2 commands', () => {
+    expect(mapActivityToIntent(snapshot('tool'))).toEqual({
+      version: PET_INTENT_VERSION,
+      id: 'activity:e6041ac9c53fb4cd',
+      source: 'activity',
+      createdAt: 90,
+      priority: 40,
+      interruptible: true,
+      expression: 'focused',
+      motion: 'working',
+      playback: 'loop',
+      speech: {
+        id: 'speech:snapshot:100',
+        text: '正在运行测试',
+        createdAt: 100,
+      },
+      sourceTaskIds: ['task'],
+    })
+    expect(mapActivityToIntent(snapshot('waiting_input'))).toMatchObject({
+      expression: 'questioning',
+      motion: 'request-input',
+      playback: 'hold',
+      priority: 80,
+      interruptible: false,
+    })
+    expect(mapActivityToIntent(snapshot('blocked'))).toMatchObject({
+      expression: 'worried',
+      motion: 'request-input',
+      playback: 'hold',
+      priority: 75,
+      interruptible: false,
+    })
+  })
+
+  it('keeps motion identity stable across transport and speech-only updates', () => {
+    const firstSnapshot = snapshot('thinking')
+    const secondSnapshot = {
+      ...firstSnapshot,
+      sequence: 99,
+      emittedAt: 5_000,
+      tasks: firstSnapshot.tasks.map(task => ({ ...task, statusLine: '仍在思考', updatedAt: 5_000 })),
+    }
+    const firstNarration: NarrationDecision = {
+      text: '正在思考', emitted: true, reason: 'initial', createdAt: 100,
+    }
+    const secondNarration: NarrationDecision = {
+      text: '还在继续思考', emitted: true, reason: 'long-running', createdAt: 5_000,
+    }
+    const first = mapActivityToIntent(firstSnapshot, firstNarration)
+    const second = mapActivityToIntent(secondSnapshot, secondNarration)
+
+    expect(second.id).toBe(first.id)
+    expect(second.speech?.id).not.toBe(first.speech?.id)
+    expect(second.motion).toBe(first.motion)
+  })
+
+  it('changes motion identity when the active tool changes', () => {
+    const first = snapshot('tool')
+    const second = {
+      ...first,
+      sequence: 5,
+      tasks: first.tasks.map(task => ({
+        ...task,
+        tool: { name: 'build', activeCount: 1, completedCount: 0 },
+      })),
+    }
+    expect(mapActivityToIntent(second).id).not.toBe(mapActivityToIntent(first).id)
+  })
+
+  it('creates a bounded one-shot interaction without replacing task identity', () => {
+    expect(createInteractionIntent('feed', '好吃！', 1_000, true)).toEqual({
+      version: PET_INTENT_VERSION,
+      id: 'interaction:feed:1000',
+      source: 'interaction',
+      createdAt: 1_000,
+      expiresAt: 2_600,
+      priority: 65,
+      interruptible: false,
+      expression: 'happy',
+      motion: 'feed',
+      playback: 'once',
+      speech: { id: 'speech:interaction-feed:1000', text: '好吃！', createdAt: 1_000 },
+      sourceTaskIds: [],
+    })
+  })
+
+  it('falls back to idle without inventing task progress', () => {
+    expect(narrateActivity(snapshot())).toBeUndefined()
+    expect(mapActivityToIntent(snapshot())).toMatchObject({
+      id: 'activity:idle',
+      source: 'activity',
+      expression: 'neutral',
+      motion: 'idle',
+      playback: 'loop',
+      sourceTaskIds: [],
+    })
+  })
+})

--- a/packages/dsh-pet/tests/narration.spec.ts
+++ b/packages/dsh-pet/tests/narration.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import { NarrationEngine, narrateActivity } from '../src/core/narration.ts'
+import type {
+  PetAggregateSnapshot,
+  PetTaskPhase,
+  PetTaskSnapshot,
+} from '../src/core/protocol.ts'
+
+function task(
+  id: string,
+  phase: PetTaskPhase,
+  updatedAt: number,
+  statusLine?: string,
+): PetTaskSnapshot {
+  return {
+    taskId: id,
+    instanceId: 'instance',
+    bootId: 'boot',
+    sessionId: id,
+    phase,
+    ...(statusLine === undefined ? {} : { statusLine }),
+    startedAt: 0,
+    phaseStartedAt: phase === 'thinking' || phase === 'tool' ? 0 : updatedAt,
+    updatedAt,
+    ...(phase === 'done' || phase === 'failed' ? { finishedAt: updatedAt } : {}),
+  }
+}
+
+function snapshot(
+  emittedAt: number,
+  tasks: PetTaskSnapshot[],
+  primaryTaskId = tasks[0]?.taskId,
+): PetAggregateSnapshot {
+  const active = tasks.filter(item => !['idle', 'done', 'failed'].includes(item.phase)).length
+  return {
+    protocolVersion: 2,
+    sequence: emittedAt,
+    emittedAt,
+    ...(primaryTaskId === undefined ? {} : { primaryTaskId }),
+    tasks,
+    summary: {
+      active,
+      waiting: tasks.filter(item => item.phase === 'waiting' || item.phase === 'waiting_input').length,
+      blocked: tasks.filter(item => item.phase === 'blocked').length,
+      failed: tasks.filter(item => item.phase === 'failed').length,
+      completedRecently: tasks.filter(item => item.phase === 'done').length,
+    },
+  }
+}
+
+describe('deterministic narration', () => {
+  it('describes two and many active tasks without inventing progress', () => {
+    const two = snapshot(100, [
+      task('a', 'thinking', 100, '正在分析报错'),
+      task('b', 'tool', 90, '正在运行测试'),
+    ], 'a')
+    const many = snapshot(100, [
+      ...two.tasks,
+      task('c', 'review', 80, '正在整理回复'),
+    ], 'a')
+
+    expect(narrateActivity(two)).toContain('主任务正在分析报错')
+    expect(narrateActivity(two)).toContain('另一个任务正在运行测试')
+    expect(narrateActivity(many)).toContain('现在有 3 个任务在跑')
+    expect(narrateActivity(many)).not.toContain('%')
+    expect([...(narrateActivity(many) ?? '')].length).toBeLessThanOrEqual(32)
+  })
+
+  it('prioritizes fresh failures and waiting for user input', () => {
+    const failed = task('failed', 'failed', 95, '执行失败')
+    expect(narrateActivity(snapshot(100, [failed]))).toContain('1 个任务遇到问题')
+
+    const waiting = task('input', 'waiting_input', 100, '等待确认')
+    expect(narrateActivity(snapshot(100, [waiting]))).toBe('这个任务正在等你确认。')
+
+    const blocked = task('blocked', 'blocked', 100, '任务受阻')
+    expect(narrateActivity(snapshot(100, [blocked]))).toBe('这个任务暂时受阻，正在等待继续。')
+  })
+})
+
+describe('NarrationEngine scheduling', () => {
+  it('holds ordinary phase changes until the cooldown ends', () => {
+    const engine = new NarrationEngine()
+    const first = engine.next(snapshot(0, [task('a', 'thinking', 0, '正在思考')]))
+    expect(first).toMatchObject({ text: '正在思考', emitted: true, reason: 'initial', createdAt: 0 })
+
+    const cooling = engine.next(snapshot(1_000, [task('a', 'review', 1_000, '正在整理回复')]))
+    expect(cooling).toMatchObject({ text: '正在思考', emitted: false, createdAt: 0 })
+
+    const ready = engine.next(snapshot(8_000, [task('a', 'review', 1_000, '正在整理回复')]))
+    expect(ready).toMatchObject({
+      text: '正在整理回复', emitted: true, reason: 'phase', createdAt: 8_000,
+    })
+  })
+
+  it('lets urgent input and failure messages bypass ordinary cooldown', () => {
+    const engine = new NarrationEngine()
+    engine.next(snapshot(0, [task('a', 'thinking', 0, '正在思考')]))
+
+    const waiting = engine.next(snapshot(1_000, [task('a', 'waiting_input', 1_000)]))
+    expect(waiting).toMatchObject({
+      text: '这个任务正在等你确认。',
+      emitted: true,
+      reason: 'waiting-input',
+    })
+
+    const failure = engine.next(snapshot(2_000, [task('a', 'failed', 2_000)]))
+    expect(failure).toMatchObject({ emitted: true, reason: 'failure' })
+    expect(failure.text).toContain('1 个任务遇到问题')
+  })
+
+  it('merges rapid completions and emits the aggregate after three seconds', () => {
+    const engine = new NarrationEngine()
+    const firstDone = task('a', 'done', 0)
+    expect(engine.next(snapshot(0, [firstDone]))).toMatchObject({
+      text: '刚刚完成了一个任务。',
+      emitted: true,
+      reason: 'completion',
+    })
+
+    const secondDone = task('b', 'done', 1_000)
+    const merging = engine.next(snapshot(1_000, [firstDone, secondDone]))
+    expect(merging).toMatchObject({ text: '刚刚完成了一个任务。', emitted: false })
+
+    const merged = engine.next(snapshot(3_000, [firstDone, secondDone]))
+    expect(merged).toMatchObject({
+      text: '刚刚完成了 2 个任务。',
+      emitted: true,
+      reason: 'completion',
+    })
+  })
+
+  it('emits long-running thresholds once without per-poll repetition', () => {
+    const engine = new NarrationEngine()
+    const thinking = task('a', 'thinking', 0, '正在思考')
+    engine.next(snapshot(0, [thinking]))
+
+    expect(engine.next(snapshot(30_000, [thinking]))).toMatchObject({
+      emitted: true,
+      reason: 'long-running',
+    })
+    expect(engine.next(snapshot(31_000, [thinking])).emitted).toBe(false)
+    expect(engine.next(snapshot(60_000, [thinking]))).toMatchObject({
+      text: '任务还在继续，我会帮你盯着。',
+      emitted: true,
+      reason: 'long-running',
+    })
+  })
+
+  it('suppresses the same line for sixty seconds', () => {
+    const engine = new NarrationEngine()
+    engine.next(snapshot(0, [task('a', 'thinking', 0, '正在思考')]))
+    engine.next(snapshot(8_000, [task('a', 'review', 8_000, '正在整理回复')]))
+    engine.next(snapshot(16_000, [task('a', 'thinking', 16_000, '正在思考')]))
+
+    const decision = engine.next(snapshot(24_000, [task('a', 'thinking', 16_000, '正在思考')]))
+    expect(decision).toMatchObject({ text: '正在整理回复', emitted: false })
+  })
+})

--- a/packages/dsh-pet/tests/presentation-controller.spec.ts
+++ b/packages/dsh-pet/tests/presentation-controller.spec.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi } from 'vitest'
+import { EmbeddedPetHost } from '../src/adapters/embedded/embedded-host.ts'
+import { StandalonePetHost } from '../src/adapters/standalone/standalone-host.ts'
+import {
+  PET_DESKTOP_HOST_API_VERSION,
+  type PetDesktopHost,
+  type PetReturnTarget,
+  type PetSurfaceHandle,
+  type PetSurfaceRequest,
+} from '../src/contracts/desktop-host.ts'
+import {
+  DEFAULT_PET_PLUGIN_SETTINGS,
+  type PetPluginSettings,
+} from '../src/presentation/config.ts'
+import {
+  PetPresentationController,
+  type PetPresentationAdapter,
+  type PetPresentationContext,
+} from '../src/presentation/controller.ts'
+import type { PetPresentationEnvironment } from '../src/presentation/environment.ts'
+import { NullPresentation } from '../src/presentation/null-presentation.ts'
+
+function settings(patch: Partial<PetPluginSettings> = {}): PetPluginSettings {
+  return {
+    ...DEFAULT_PET_PLUGIN_SETTINGS,
+    ...patch,
+    activity: { ...DEFAULT_PET_PLUGIN_SETTINGS.activity, ...patch.activity },
+    presentation: { ...DEFAULT_PET_PLUGIN_SETTINGS.presentation, ...patch.presentation },
+  }
+}
+
+function environment(patch: Partial<PetPresentationEnvironment> = {}): PetPresentationEnvironment {
+  return {
+    platform: 'win32',
+    isCi: false,
+    isContainer: false,
+    isTest: false,
+    hasDisplayServer: true,
+    appearsInteractive: true,
+    standaloneRuntimeAvailable: true,
+    webBridgeAvailable: true,
+    embeddedHostAvailable: false,
+    disabledByEnvironment: false,
+    ...patch,
+  }
+}
+
+function returnTarget(kind: 'web' | 'desktop-host' | 'none' = 'web'): PetReturnTarget {
+  if (kind === 'none') return { kind: 'none' }
+  if (kind === 'desktop-host') {
+    return {
+      kind,
+      id: 'mock-desktop:main',
+      label: '返回 Mock Desktop',
+      hostId: 'mock-desktop',
+      route: { kind: 'home' },
+    }
+  }
+  return {
+    kind,
+    id: 'dsh-web',
+    label: '打开 DSH Web',
+    url: 'http://127.0.0.1:3080',
+  }
+}
+
+function context(
+  currentSettings: PetPluginSettings,
+  resolution: PetPresentationContext['resolution'],
+  visible: boolean,
+): PetPresentationContext {
+  return {
+    settings: currentSettings,
+    resolution,
+    visible,
+    bridgeOrigin: 'http://127.0.0.1:3080',
+    nativeToken: 't'.repeat(43),
+    returnTarget: resolution.kind === 'embedded'
+      ? returnTarget('desktop-host')
+      : returnTarget('web'),
+  }
+}
+
+function fakeAdapter(kind: PetPresentationAdapter['kind']): PetPresentationAdapter & {
+  start: ReturnType<typeof vi.fn>
+  show: ReturnType<typeof vi.fn>
+  hide: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
+  stop: ReturnType<typeof vi.fn>
+} {
+  return {
+    kind,
+    host: kind === 'none'
+      ? undefined
+      : {
+          id: kind,
+          name: kind,
+          embedded: kind === 'embedded',
+          ownsTray: true,
+        },
+    start: vi.fn(async () => undefined),
+    show: vi.fn(async () => undefined),
+    hide: vi.fn(async () => undefined),
+    update: vi.fn(() => undefined),
+    stop: vi.fn(async () => undefined),
+  }
+}
+
+describe('presentation controller and desktop host contract', () => {
+  it('starts one Standalone adapter for repeated reconciliation and disposes it once', async () => {
+    const launch = vi.fn(() => vi.fn())
+    const adapter = new StandalonePetHost({ launch })
+    const controller = new PetPresentationController({
+      createAdapter: resolution => resolution.kind === 'standalone' ? adapter : new NullPresentation(),
+      createContext: context,
+    })
+
+    await controller.reconcile(settings(), environment())
+    await controller.reconcile(settings(), environment())
+
+    expect(launch).toHaveBeenCalledOnce()
+    expect(controller.state()).toMatchObject({
+      resolved: 'standalone',
+      phase: 'ready',
+      host: { id: 'standalone', embedded: false, ownsTray: true },
+      returnTarget: { kind: 'web' },
+    })
+    await controller.dispose()
+    expect(launch.mock.results[0]?.value).toHaveBeenCalledOnce()
+  })
+
+  it('uses NullPresentation in a headless environment without starting Standalone', async () => {
+    const standalone = fakeAdapter('standalone')
+    const nullPresentation = new NullPresentation()
+    const controller = new PetPresentationController({
+      createAdapter: resolution => resolution.kind === 'none' ? nullPresentation : standalone,
+      createContext: context,
+    })
+
+    await controller.reconcile(settings(), environment({
+      platform: 'linux',
+      hasDisplayServer: false,
+      appearsInteractive: false,
+    }))
+
+    expect(standalone.start).not.toHaveBeenCalled()
+    expect(controller.state()).toMatchObject({
+      resolved: 'none',
+      phase: 'none',
+      reason: 'headless',
+      available: false,
+    })
+    await controller.dispose()
+  })
+
+  it('backs off a failing adapter before retrying the same presentation', async () => {
+    let now = 1_000
+    const failing = fakeAdapter('standalone')
+    failing.start.mockRejectedValue(new Error('launch failed'))
+    const controller = new PetPresentationController({
+      createAdapter: () => failing,
+      createContext: context,
+      now: () => now,
+      retryDelayMs: 500,
+    })
+
+    await expect(controller.reconcile(settings(), environment())).resolves.toBeUndefined()
+    await expect(controller.reconcile(settings(), environment())).resolves.toBeUndefined()
+    expect(failing.start).toHaveBeenCalledOnce()
+    expect(controller.state()).toMatchObject({ phase: 'failed', errorCode: 'PRESENTATION_START_FAILED' })
+
+    now = 1_500
+    await controller.reconcile(settings(), environment())
+    expect(failing.start).toHaveBeenCalledTimes(2)
+    await controller.dispose()
+  })
+
+  it('lets an Embedded Host create and close the surface without contributing another tray', async () => {
+    let onClosed: (() => void) | undefined
+    const disposeClosed = vi.fn()
+    const surface: PetSurfaceHandle = {
+      id: 'mock-pet-surface',
+      show: vi.fn(async () => undefined),
+      hide: vi.fn(async () => undefined),
+      setBounds: vi.fn(async () => undefined),
+      getBounds: vi.fn(async () => ({ x: 0, y: 0, width: 228, height: 304 })),
+      setAlwaysOnTop: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+      onClosed: vi.fn((listener) => {
+        onClosed = listener
+        return { dispose: disposeClosed }
+      }),
+    }
+    const createPetSurface = vi.fn(async (_request: PetSurfaceRequest) => surface)
+    const disposeTrayAction = vi.fn()
+    const contributeTrayAction = vi.fn(async () => ({ dispose: disposeTrayAction }))
+    const host: PetDesktopHost = {
+      descriptor: {
+        apiVersion: PET_DESKTOP_HOST_API_VERSION,
+        id: 'mock-desktop',
+        name: 'Mock Desktop',
+        capabilities: {
+          floatingSurface: true,
+          focusMainWindow: true,
+          openRoute: true,
+          contributesTrayAction: true,
+          rendererKinds: ['sprite2d'],
+        },
+        ownsTray: true,
+      },
+      createPetSurface,
+      focusMainWindow: vi.fn(async () => undefined),
+      contributeTrayAction,
+    }
+    const embedded = new EmbeddedPetHost({
+      host,
+      surfaceRequest: current => ({
+        surfaceId: 'dsh-pet',
+        content: {
+          kind: 'loopback-url',
+          url: `${current.bridgeOrigin}/pet/desktop/index.html`,
+          allowedOrigin: current.bridgeOrigin ?? '',
+        },
+        initial: { width: 228, height: 304, alwaysOnTop: true, visible: true },
+        auth: { token: current.nativeToken ?? '' },
+        returnTarget: current.returnTarget,
+      }),
+    })
+    const controller = new PetPresentationController({
+      createAdapter: resolution => resolution.kind === 'embedded' ? embedded : new NullPresentation(),
+      createContext: context,
+    })
+
+    await controller.reconcile(settings(), environment({
+      embeddedHostAvailable: true,
+      embeddedHostHint: 'mock-desktop',
+    }))
+
+    expect(createPetSurface).toHaveBeenCalledOnce()
+    expect(surface.show).toHaveBeenCalledOnce()
+    expect(contributeTrayAction).toHaveBeenCalledOnce()
+    expect(contributeTrayAction).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'dsh-pet:show',
+      label: '显示桌宠',
+    }))
+    expect(controller.state()).toMatchObject({
+      resolved: 'embedded',
+      host: { id: 'mock-desktop', embedded: true, ownsTray: true },
+      returnTarget: { kind: 'desktop-host', hostId: 'mock-desktop' },
+    })
+
+    await controller.reconcile(
+      settings({ presentation: { mode: 'none', standaloneAutoStart: true } }),
+      environment({ embeddedHostAvailable: false }),
+    )
+    expect(disposeClosed).toHaveBeenCalledOnce()
+    expect(disposeTrayAction).toHaveBeenCalledOnce()
+    expect(surface.close).toHaveBeenCalledOnce()
+    onClosed?.()
+    await controller.dispose()
+  })
+
+  it('uses the adapter identity hook when one Embedded Host id is rebound', async () => {
+    let generation = 1
+    const first = fakeAdapter('embedded')
+    const second = fakeAdapter('embedded')
+    const controller = new PetPresentationController({
+      createAdapter: () => generation === 1 ? first : second,
+      createContext: context,
+      adapterKey: resolution => `${resolution.kind}:${resolution.hostId ?? ''}:${String(generation)}`,
+    })
+    const embeddedEnvironment = environment({
+      embeddedHostAvailable: true,
+      embeddedHostHint: 'same-host-id',
+    })
+
+    await controller.reconcile(settings(), embeddedEnvironment)
+    generation = 2
+    await controller.reconcile(settings(), embeddedEnvironment)
+
+    expect(first.stop).toHaveBeenCalledOnce()
+    expect(second.start).toHaveBeenCalledOnce()
+    await controller.dispose()
+  })
+})

--- a/packages/dsh-pet/tests/presentation-resolver.spec.ts
+++ b/packages/dsh-pet/tests/presentation-resolver.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_PET_PLUGIN_SETTINGS,
+  type PetPluginSettings,
+} from '../src/presentation/config.ts'
+import {
+  derivePetPresentationEnvironment,
+  type PetPresentationEnvironment,
+} from '../src/presentation/environment.ts'
+import { resolvePetPresentation } from '../src/presentation/resolver.ts'
+import { presentationStateFromResolution } from '../src/presentation/status.ts'
+
+function settings(patch: Partial<PetPluginSettings> = {}): PetPluginSettings {
+  return {
+    ...DEFAULT_PET_PLUGIN_SETTINGS,
+    ...patch,
+    activity: { ...DEFAULT_PET_PLUGIN_SETTINGS.activity, ...patch.activity },
+    presentation: { ...DEFAULT_PET_PLUGIN_SETTINGS.presentation, ...patch.presentation },
+  }
+}
+
+function environment(patch: Partial<PetPresentationEnvironment> = {}): PetPresentationEnvironment {
+  return {
+    platform: 'win32',
+    isCi: false,
+    isContainer: false,
+    isTest: false,
+    hasDisplayServer: true,
+    appearsInteractive: true,
+    standaloneRuntimeAvailable: true,
+    webBridgeAvailable: true,
+    embeddedHostAvailable: false,
+    disabledByEnvironment: false,
+    ...patch,
+  }
+}
+
+describe('presentation resolver', () => {
+  it('honors master disable, environment disable, and configured none in order', () => {
+    expect(resolvePetPresentation(settings({ enabled: false }), environment())).toEqual({
+      kind: 'none', reason: 'disabled',
+    })
+    expect(resolvePetPresentation(settings({ presentation: { mode: 'standalone', standaloneAutoStart: true } }), environment({
+      disabledByEnvironment: true,
+    }))).toEqual({ kind: 'none', reason: 'disabled' })
+    expect(resolvePetPresentation(settings({ presentation: { mode: 'none', standaloneAutoStart: true } }), environment())).toEqual({
+      kind: 'none', reason: 'configured-none',
+    })
+  })
+
+  it('selects an embedded host and never falls back while a host is pending', () => {
+    expect(resolvePetPresentation(settings(), environment({
+      embeddedHostAvailable: true,
+      embeddedHostHint: 'dshcode',
+    }))).toEqual({ kind: 'embedded', reason: 'embedded-host', hostId: 'dshcode' })
+    expect(resolvePetPresentation(settings(), environment({ embeddedHostHint: 'dsh-desktop' }))).toEqual({
+      kind: 'none', reason: 'embedded-host-pending', hostId: 'dsh-desktop',
+    })
+    expect(resolvePetPresentation(settings({ presentation: { mode: 'embedded', standaloneAutoStart: true } }), environment())).toEqual({
+      kind: 'none', reason: 'embedded-host-pending',
+    })
+  })
+
+  it('allows explicit standalone in CI but still requires runtime and Web bridge', () => {
+    const forced = settings({ presentation: { mode: 'standalone', standaloneAutoStart: true } })
+    expect(resolvePetPresentation(forced, environment({ isCi: true, appearsInteractive: false }))).toEqual({
+      kind: 'standalone', reason: 'forced-standalone', hostId: 'standalone',
+    })
+    expect(resolvePetPresentation(forced, environment({ standaloneRuntimeAvailable: false }))).toEqual({
+      kind: 'none', reason: 'runtime-missing',
+    })
+    expect(resolvePetPresentation(forced, environment({ webBridgeAvailable: false }))).toEqual({
+      kind: 'none', reason: 'web-bridge-missing',
+    })
+  })
+
+  it('keeps auto mode off in CI, containers, Linux headless, and Windows services', () => {
+    expect(resolvePetPresentation(settings(), environment({ isCi: true }))).toEqual({ kind: 'none', reason: 'ci' })
+    expect(resolvePetPresentation(settings(), environment({ isContainer: true }))).toEqual({ kind: 'none', reason: 'container' })
+
+    const linux = derivePetPresentationEnvironment({
+      platform: 'linux', env: {}, isContainer: false,
+      standaloneRuntimeAvailable: true, webBridgeAvailable: true, embeddedHostAvailable: false,
+    })
+    expect(resolvePetPresentation(settings(), linux)).toEqual({ kind: 'none', reason: 'headless' })
+
+    const service = derivePetPresentationEnvironment({
+      platform: 'win32', env: { SESSIONNAME: 'Services' }, isContainer: false,
+      standaloneRuntimeAvailable: true, webBridgeAvailable: true, embeddedHostAvailable: false,
+    })
+    expect(resolvePetPresentation(settings(), service)).toEqual({ kind: 'none', reason: 'headless' })
+  })
+
+  it('auto-starts on interactive Windows, macOS, and display-backed Linux', () => {
+    for (const [platform, env] of [
+      ['win32', {}],
+      ['darwin', {}],
+      ['linux', { WAYLAND_DISPLAY: 'wayland-0' }],
+    ] as const) {
+      const facts = derivePetPresentationEnvironment({
+        platform,
+        env,
+        isContainer: false,
+        standaloneRuntimeAvailable: true,
+        webBridgeAvailable: true,
+        embeddedHostAvailable: false,
+      })
+      expect(resolvePetPresentation(settings(), facts)).toEqual({
+        kind: 'standalone', reason: 'auto-standalone', hostId: 'standalone',
+      })
+    }
+  })
+
+  it('honors environment mode override and auto-start policy', () => {
+    expect(resolvePetPresentation(settings(), environment({ presentationOverride: 'none' }))).toEqual({
+      kind: 'none', reason: 'configured-none',
+    })
+    expect(resolvePetPresentation(settings({ presentation: { mode: 'auto', standaloneAutoStart: false } }), environment())).toEqual({
+      kind: 'none', reason: 'configured-none',
+    })
+  })
+
+  it('projects headless and visible standalone decisions into diagnostic state', () => {
+    const headless = resolvePetPresentation(settings(), environment({ hasDisplayServer: false, appearsInteractive: false }))
+    expect(presentationStateFromResolution(settings(), headless, true)).toEqual({
+      mode: 'auto', resolved: 'none', phase: 'none', available: false, visible: false, reason: 'headless',
+      errorCode: 'PRESENTATION_HEADLESS',
+    })
+    const standalone = resolvePetPresentation(settings(), environment())
+    expect(presentationStateFromResolution(settings(), standalone, true)).toMatchObject({
+      mode: 'auto', resolved: 'standalone', phase: 'ready', available: true, visible: true,
+      host: { id: 'standalone', embedded: false, ownsTray: true },
+    })
+  })
+})

--- a/packages/dsh-pet/tests/sanitize.spec.ts
+++ b/packages/dsh-pet/tests/sanitize.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { ActivityRegistry } from '../src/core/activity-registry.ts'
+import { sanitizeActivityText } from '../src/core/sanitize.ts'
+
+describe('activity text privacy', () => {
+  it('removes control text, query secrets, credentials, and absolute path prefixes', () => {
+    const source = [
+      '检查 X:\\Users\\demo\\project\\src\\app.ts',
+      '和 /home/demo/project/src/index.ts',
+      'URL https://example.com/task?id=42&token=hidden#result',
+      'api_key=supersecret sk-abcdefghijk Bearer abcdefghijklmnop',
+    ].join('\n')
+
+    const safe = sanitizeActivityText(source, { maxChars: 240 })
+    expect(safe).toContain('.../app.ts')
+    expect(safe).toContain('.../index.ts')
+    expect(safe).toContain('https://example.com/task')
+    expect(safe).toContain('api_key=[已脱敏]')
+    expect(safe).toContain('Bearer [已脱敏]')
+    expect(safe).not.toContain('Users')
+    expect(safe).not.toContain('/home/')
+    expect(safe).not.toContain('supersecret')
+    expect(safe).not.toContain('abcdefghijk')
+    expect(safe).not.toContain('?id=')
+    expect(safe).not.toMatch(/[\u0000-\u001f]/u)
+  })
+
+  it('bounds output by Unicode code points', () => {
+    const safe = sanitizeActivityText('正在整理一个很长很长很长的任务状态说明', { maxChars: 12 })
+    expect([...safe]).toHaveLength(12)
+    expect(safe.endsWith('...')).toBe(true)
+  })
+
+  it('sanitizes registry fields before any adapter can consume them', () => {
+    const registry = new ActivityRegistry({ now: () => 100 })
+    registry.update({
+      instanceId: 'instance',
+      bootId: 'boot',
+      sessionId: 'session',
+      profile: 'web\u0000profile',
+      workspaceLabel: '/home/demo/private/project',
+      title: '修复 https://example.com/a?token=hidden',
+      phase: 'tool',
+      statusLine: '读取 X:\\Users\\demo\\private\\data.json',
+      tool: {
+        name: 'shell\u0007runner',
+        detail: 'password=not-for-display',
+        activeCount: -4,
+        completedCount: 2.9,
+      },
+    })
+
+    expect(registry.snapshot().tasks[0]).toMatchObject({
+      profile: 'web profile',
+      workspaceLabel: '.../project',
+      title: '修复 https://example.com/a',
+      statusLine: '读取 .../data.json',
+      tool: {
+        name: 'shell runner',
+        detail: 'password=[已脱敏]',
+        activeCount: 0,
+        completedCount: 2,
+      },
+    })
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

这是桌面宠物适配的第 1 个拆分 PR。

为 `dsh-pet` 建立与具体呈现端无关的核心基础，包括多会话活动聚合、交互意图调度、状态叙述与脱敏、呈现模式解析与生命周期控制、渲染器切换，以及 PetDex 模型目录和本地存储契约。

本 PR 仅引入内部契约和测试，不接入 Electron 桌面运行时，也不修改现有网页宠物的入口和用户可见行为。后续 PR 将基于这些契约分别接入桌面运行时和 Web UI 控制入口，降低单次审核范围。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [x] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream main
git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5.6 Sol

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

本 PR 未修改 README。

## 贡献者版权声明（Contributor Copyright）

不适用，本 PR 未新增插件包或皮肤。

## 新皮肤收录（New Skin）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm install --frozen-lockfile

pnpm --filter @linxin666/dsh-pet typecheck
pnpm --filter @linxin666/dsh-pet test
pnpm --filter @linxin666/dsh-pet build

pnpm typecheck
pnpm build
pnpm gallery:check
pnpm skin-center:check
pnpm community:check
pnpm aggregate:check
pnpm sync-shared:check
pnpm runtime-deps:check
pnpm docs:check

pnpm test
pnpm test:scripts
```

结果摘要：

- `dsh-pet` 类型检查、构建以及 218 项测试全部通过。
- 仓库级类型检查和构建通过。
- Gallery、皮肤中心、社区索引、聚合包、共享代码同步、运行时依赖和文档检查全部通过。
- `git diff --check` 通过；本 PR 共新增 4,959 行、删除 0 行，未超过仓库规模限制。
- Windows 环境下运行 `pnpm test` 时，`dsh-liangshen` 仍有 2 项既有 POSIX 路径断言失败；该包不在本 PR 差异中。
- Windows 环境下运行 `pnpm test:scripts` 得到 92 项通过、3 项既有环境相关失败、4 项跳过；失败来自路径分隔符、Windows 文件权限位以及本地未纳管皮肤目录，均不涉及本 PR 文件。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A。本 PR 仅增加内部核心契约与自动化测试，不产生用户可见界面或行为变更。