### PR TITLE
fix(web-ui-settings): keep describe-image settings save atomic (#516)

### DIFF
--- a/packages/dsh-web-ui-settings/src/client/compat-settings-scope.ts
+++ b/packages/dsh-web-ui-settings/src/client/compat-settings-scope.ts
@@ -359,14 +359,14 @@ export function createCompatScope<T>(options: CompatScopeOptions<T>): SettingsSc
       fallbackStarted = true
       await fallback?.load()
     },
-    // The batch surface exists only while the bridge controller is the active
-    // transport; the official scope path still writes per-field (its writes
-    // are out of our reach, so the card's duck-typed detection falls back to
-    // the per-field loop there). A getter keeps the capability decision at
-    // call time instead of freezing it when the wrapper is built.
+    // The batch surface is exposed whenever the bridge exists: the family
+    // cards use it to keep cross-field host validation atomic even when the
+    // official scope already serves the namespace.
     get mutate() {
-      const backend = active()
-      if (fallback !== undefined && backend === fallback && typeof fallback.mutate === 'function') return fallback.mutate.bind(fallback)
+      if (fallback !== undefined && typeof fallback.mutate === 'function') {
+        startFallback()
+        return fallback.mutate.bind(fallback)
+      }
       return undefined
     },
   }

--- a/packages/dsh-web-ui-settings/tests/compat-scope.spec.ts
+++ b/packages/dsh-web-ui-settings/tests/compat-scope.spec.ts
@@ -185,12 +185,31 @@ function batchView(ns: string, value: unknown, revision: number, extra: { user?:
 }
 
 describe('createCompatScope batch mutate', () => {
-  it('exposes no mutate while the official scope serves the namespace', async () => {
-    const primary = fakePrimary<{ enabled: boolean }>(ready({ enabled: true }))
-    const { fetchFn } = fakeFetch(async () => describeResult([]))
-    const scope = createCompatScope<{ enabled: boolean }>({ namespace: 'task-board', primary: primary.scope, fetchFn })
+  it('exposes batch mutate while the official scope serves the namespace', async () => {
+    const primary = fakePrimary<{ baseURL: string; model: string }>(ready({ baseURL: '', model: '' }))
+    const calls: Array<{ body: Record<string, unknown> }> = []
+    const { fetchFn } = fakeFetch(async (url, init) => {
+      if (url === WEB_UI_SETTINGS_BRIDGE_PREFIX + '/describe') {
+        return describeResult([batchView('describe-image', { baseURL: '', model: '' }, 3, { user: {} })])
+      }
+      calls.push({ body: JSON.parse(String(init.body)) as Record<string, unknown> })
+      return { ok: true, value: batchView('describe-image', { baseURL: 'https://a/v1', model: 'm' }, 4, { user: { baseURL: 'https://a/v1', model: 'm' } }) }
+    })
+    const scope = createCompatScope<{ baseURL: string; model: string }>({ namespace: 'describe-image', primary: primary.scope, fetchFn })
     expect(scope.getSnapshot().status).toBe('ready')
-    expect(typeof (scope as unknown as { mutate?: unknown }).mutate).not.toBe('function')
+    const mutate = (scope as unknown as { mutate?: (writes: unknown[]) => Promise<{ ok: boolean; fields: { field: string; landed: boolean }[] }> }).mutate
+    expect(typeof mutate).toBe('function')
+    const result = await mutate!([
+      { field: 'baseURL', op: 'set', value: 'https://a/v1' },
+      { field: 'model', op: 'set', value: 'm' },
+    ])
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.expectedRevision).toBe(3)
+    expect(result.ok).toBe(true)
+    expect(result.fields).toEqual([
+      { field: 'baseURL', landed: true },
+      { field: 'model', landed: true },
+    ])
   })
 
   it('posts every op in one /mutate and reports per-field success', async () => {


### PR DESCRIPTION
## 摘要（Summary）

Fixes #516 by keeping Web UI plugin settings saves atomic when the official settings scope is ready but lacks a batch mutate surface. The compatibility scope now exposes the bridge batch mutate whenever the bridge is available, so describe-image baseURL/model writes are validated together instead of failing one field at a time.

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git worktree add -b fix/dsh-web-ui-settings-batch-save D:\Code\dsh-web-ui-issue-516 origin/main
git branch -m codex/fix-dsh-web-ui-settings-batch-save
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5 Codex

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

N/A

## 新皮肤收录（New Skin）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
corepack pnpm@11.22.0 --filter @linxin666/dsh-client-ui-web-ui-settings exec vitest run tests/compat-scope.spec.ts
corepack pnpm@11.22.0 --filter @linxin666/dsh-client-ui-web-ui-settings test
corepack pnpm@11.22.0 --filter @linxin666/dsh-client-ui-web-ui-settings typecheck
corepack pnpm@11.22.0 --filter @linxin666/dsh-client-ui-web-ui-settings build
git diff --check
```

结果摘要：

All commands passed. The targeted compat-scope regression passed 11/11 tests; the full web-ui-settings package test suite passed 53/53 tests; typecheck and build completed successfully.

## 用户可见变更证据（Local Feature Evidence）

证据：

![describe-image settings save failure screenshot](https://github.com/user-attachments/assets/308996ef-3516-473c-a799-bcd5348976c3)

Unit-level regression coverage added for the rc.7 path where the official settings scope is ready and the compatibility bridge supplies atomic batch mutation.