### PR TITLE
fix(ssh): close already-connected hops when a middle ProxyJump hop fails

### DIFF
--- a/packages/dsh-ssh/src/engine/connection-pool.ts
+++ b/packages/dsh-ssh/src/engine/connection-pool.ts
@@ -140,28 +140,34 @@ export async function connectChain(engine: PoolEngine, entry: SshHostEntry): Pro
   const hops: Client[] = []
   let sock: ConnectConfig['sock']
   const chain = entry.proxyJump
-  for (let index = 0; index < chain.length; index += 1) {
-    const hopAlias = chain[index]
-    const hop = engine.store.find(hopAlias)
-    if (hop === undefined) {
-      for (const client of hops) client.end()
-      throw new Error('proxyJump alias \'' + hopAlias + '\' not found — create it first')
-    }
-    const hopClient = await connectClient(buildConnectConfig(hop, sock, engine.opts))
-    hops.push(hopClient)
-    const next = index + 1 < chain.length ? engine.store.find(chain[index + 1]) : undefined
-    const nextHost = next !== undefined ? next.host : entry.host
-    const nextPort = next !== undefined ? next.port : entry.port
-    sock = await new Promise<ConnectConfig['sock']>((resolve, reject) => {
-      hopClient.forwardOut('127.0.0.1', 0, nextHost, nextPort, (error, stream) => {
-        if (error !== undefined) {
-          for (const client of hops) client.end()
-          reject(error)
-        } else {
-          resolve(stream)
-        }
+  try {
+    for (let index = 0; index < chain.length; index += 1) {
+      const hopAlias = chain[index]
+      const hop = engine.store.find(hopAlias)
+      if (hop === undefined) {
+        throw new Error('proxyJump alias \'' + hopAlias + '\' not found — create it first')
+      }
+      const hopClient = await connectClient(buildConnectConfig(hop, sock, engine.opts))
+      hops.push(hopClient)
+      const next = index + 1 < chain.length ? engine.store.find(chain[index + 1]) : undefined
+      const nextHost = next !== undefined ? next.host : entry.host
+      const nextPort = next !== undefined ? next.port : entry.port
+      sock = await new Promise<ConnectConfig['sock']>((resolve, reject) => {
+        hopClient.forwardOut('127.0.0.1', 0, nextHost, nextPort, (error, stream) => {
+          if (error !== undefined) {
+            reject(error)
+          } else {
+            resolve(stream)
+          }
+        })
       })
-    })
+    }
+  } catch (error) {
+    // A missing alias, a failed hop connect, or a failed forwardOut must all
+    // close the hops already connected, so a failed ProxyJump never leaks a
+    // middle-hop connection.
+    for (const client of hops) client.end()
+    throw error
   }
   let target: Client | undefined
   try {

--- a/packages/dsh-ssh/tests/connection-pool.test.ts
+++ b/packages/dsh-ssh/tests/connection-pool.test.ts
@@ -208,4 +208,33 @@ describe('connectChain', () => {
     expect(targetInstance.connectConfig?.readyTimeout).toBe(1)
     expect(targetInstance.connectConfig?.keepaliveInterval).toBe(1)
   })
+
+  it('ends already-connected hops when a middle-hop connect fails', async () => {
+    const hopA = passwordEntry('a', { proxyJump: [] })
+    const hopB = passwordEntry('b', { proxyJump: [] })
+    const target = passwordEntry('target', { proxyJump: ['a', 'b'] })
+    const store = fakeStore([hopA, hopB, target])
+    // Hop A connects and forwards; hop B fails its handshake.
+    sshMock.behaviors.push((client) => { client.emit('ready') })
+    sshMock.behaviors.push((client) => { client.emit('error', new Error('Connection lost before handshake')) })
+
+    const engine = {
+      store,
+      opts: { idleTimeoutMs: 1, connectTimeoutMs: 1, keepaliveIntervalMs: 1, maxOutputBytes: 1, defaultExecTimeoutMs: 1, defaultMaxWorkers: 1, sftpConcurrency: 1 },
+      pool: new Map(),
+      acquireQueue: new Map(),
+    }
+
+    await expect(connectChain(engine as never, target)).rejects.toThrow('Connection lost before handshake')
+
+    const hopAInstance = sshMock.instances[0]
+    const hopBInstance = sshMock.instances[1]
+    expect(hopAInstance).toBeDefined()
+    expect(hopBInstance).toBeDefined()
+    expect(hopAInstance.forwardOutCalls).toBe(1)
+    // The already-connected hop A must be closed so no middle-hop leaks.
+    expect(hopAInstance.endCalls).toBe(1)
+    // The failed hop B is destroyed by connectClient on its own failure.
+    expect(hopBInstance.destroyCalls).toBe(1)
+  })
 })


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-ssh` 的 ProxyJump 中间跳连接失败时泄漏已连接 hop 客户端的问题。

根因：`connectChain` 的 `try/catch` 只包住最后 target 的 `connectClient`；循环里中间 hop 的 `connectClient` 抛错会直接冒出循环，前面已连接的 hop 客户端（及其 forwardOut 的 sock 流）不会被 `end()`，每次失败的 ProxyJump 都泄漏一条 SSH 连接。

修复：把整个 hop 循环包进 `try/catch`，缺 alias、hop 连接失败、forwardOut 失败三种情况统一在 catch 里关闭已累积的 hops 再抛。补一个双 hop 测试：第二个 hop 握手失败时断言第一个 hop 被 `end()`。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [x] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-ssh test
pnpm --filter @linxin666/dsh-ssh typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-ssh test`：11 个测试文件 99 个用例全部通过（含新增 connection-pool 双 hop 测试 1 个）。
- `pnpm --filter @linxin666/dsh-ssh typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：ProxyJump 中间跳失败时不再遗留已连接 hop 的 SSH 会话）。
