### PR TITLE
fix(pet): resolve a composed extra atlas to the real file path

### DIFF
--- a/packages/dsh-pet/src/registry.test.ts
+++ b/packages/dsh-pet/src/registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -7,6 +7,7 @@ import {
   DEFAULT_PET_CELL,
   codexPetsDir,
   loadPetRegistry,
+  petAtlasFile,
   resolvePetManifest,
 } from './registry.ts'
 
@@ -175,6 +176,33 @@ describe('loadPetRegistry', () => {
         extra: [{ id: 'whale-girl', displayName: '替换鲸', spritesheetPath: 'spritesheet.webp' }],
       })
       expect(overridden.byId('whale-girl')!.displayName).toBe('替换鲸')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves a composed extra atlas to the real file (no doubled directory)', () => {
+    const root = tempDir()
+    try {
+      // The atlas sits at <root>/pets/otter/spritesheet.webp.
+      mkdirSync(join(root, 'pets', 'otter'), { recursive: true })
+      writeFileSync(join(root, 'pets', 'otter', 'spritesheet.webp'), 'png', 'utf8')
+
+      const registry = loadPetRegistry({
+        packageRoot: root,
+        petsDir: '',
+        extra: [{ id: 'otter', displayName: '水獭', spritesheetPath: 'pets/otter/spritesheet.webp' }],
+      })
+      const entry = registry.byId('otter')
+      expect(entry).toBeDefined()
+      // dir is the spritesheet's parent; the stored path is its basename, so
+      // joining them resolves to the real file instead of applying the
+      // directory twice.
+      expect(entry!.dir).toBe(join(root, 'pets', 'otter'))
+      expect(entry!.spritesheetPath).toBe('spritesheet.webp')
+      const atlas = petAtlasFile(entry!)
+      expect(atlas).toBe(join(root, 'pets', 'otter', 'spritesheet.webp'))
+      expect(existsSync(atlas)).toBe(true)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/packages/dsh-pet/src/registry.ts
+++ b/packages/dsh-pet/src/registry.ts
@@ -410,10 +410,18 @@ export function loadPetRegistry(options: PetRegistryOptions): PetRegistry {
   }
 
   for (const manifest of options.extra ?? []) {
-    const dir = manifest.spritesheetPath === undefined || isAbsolute(manifest.spritesheetPath)
+    const raw = manifest.spritesheetPath
+    const dir = raw === undefined || isAbsolute(raw)
       ? join(packageRoot, 'assets', 'extra')
-      : dirname(resolve(packageRoot, manifest.spritesheetPath))
-    const entry = resolvePetManifest(manifest, dir, { assetPrefix, warnings })
+      : dirname(resolve(packageRoot, raw))
+    // petAtlasFile joins entry.dir (already the spritesheet's parent when the
+    // path is package-relative) with entry.spritesheetPath, so the stored path
+    // must be the basename only — otherwise the directory segment is applied
+    // twice and the atlas 404s.
+    const source = raw === undefined || isAbsolute(raw)
+      ? manifest
+      : { ...manifest, spritesheetPath: basename(raw) }
+    const entry = resolvePetManifest(source, dir, { assetPrefix, warnings })
     if (entry === undefined) continue
     if (byId.has(entry.id)) warnings.push('composed pet ' + entry.id + ' overrides an earlier registration')
     byId.set(entry.id, entry)


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-pet` 组合（extra）宠物图集解析到错误文件路径的问题。

根因：`loadPetRegistry` 对带包相对 `spritesheetPath`（如 `pets/otter/spritesheet.webp`）的 extra manifest，把 `entry.dir` 推导为 spritesheet 的父目录，却把完整相对路径存进 `entry.spritesheetPath`；`petAtlasFile` 再把两者 `join`，目录段被应用两次（`<root>/pets/otter/pets/otter/spritesheet.webp`），图集 404、宠物渲染空白。

修复：当 dir 是 spritesheet 的父目录时，存 basename 而非完整路径。补一个真实文件系统测试锁定 `petAtlasFile` 解析到实际文件。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [x] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-pet test
pnpm --filter @linxin666/dsh-pet typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-pet test`：16 个测试文件 159 个用例全部通过（含新增 extra 图集路径测试 1 个）。
- `pnpm --filter @linxin666/dsh-pet typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：组合 extra 宠物的图集 URL 能正确解析到真实文件，宠物不再渲染空白）。
