### PR TITLE
fix(gallery): deploy the committed styles.js artifact instead of the removed bundles.js

### DIFF
--- a/gallery/_headers
+++ b/gallery/_headers
@@ -4,5 +4,5 @@
 /manifest.js
 	Cache-Control: public, max-age=0, must-revalidate
 
-/bundles.js
+/styles.js
 	Cache-Control: public, max-age=0, must-revalidate

--- a/scripts/deploy-gallery
+++ b/scripts/deploy-gallery
@@ -15,7 +15,7 @@
  * 无需重复配置）。
  *
  * 前置：gallery 产物须已生成并提交 —— `pnpm gallery:build` 生成
- * manifest.js / bundles.js；official-facade.js 由 scripts/export-official-facade
+ * manifest.js / styles.js；official-facade.js 由 scripts/export-official-facade
  * 生成；preview PNG 由 scripts/capture-previews 生成。本脚本只做组装与部署，
  * 不重建产物（重建会嵌入构建机绝对路径，破坏 gallery 产物的确定性）。
  *
@@ -37,7 +37,7 @@ const { spawnSync } = require('node:child_process')
 
 const ROOT = path.resolve(__dirname, '..')
 const GALLERY_DIR = path.join(ROOT, 'gallery')
-const ROOT_FILES = ['index.html', 'preview.html', 'manifest.js', 'bundles.js', 'official-facade.js']
+const ROOT_FILES = ['index.html', 'preview.html', 'manifest.js', 'styles.js', 'official-facade.js']
 
 function opt(name, fallback) {
   const i = process.argv.indexOf(name)

--- a/scripts/deploy-gallery.test.mjs
+++ b/scripts/deploy-gallery.test.mjs
@@ -1,0 +1,36 @@
+/**
+ * deploy-gallery 组装门禁：gallery v2 产物集（manifest.js / styles.js /
+ * official-facade.js + html）变化时，部署脚本的 ROOT_FILES 必须同步，
+ * 否则 Deploy Gallery 工作流在 main 上硬失败而 gallery:check 不变红。
+ * 本测试以 --dry-run 真实跑一遍组装（不触碰 wrangler / 网络），
+ * 复现「产物集漂移 → 组装失败」的回归路径。
+ */
+import { test, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url))
+const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-gallery-test-'))
+
+after(() => { fs.rmSync(outDir, { recursive: true, force: true }) })
+
+test('deploy-gallery --dry-run 能对已提交的 gallery 产物完成组装', () => {
+  const res = spawnSync(process.execPath, ['scripts/deploy-gallery', '--dry-run', '--out', outDir], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  })
+  assert.equal(res.status, 0, 'dry-run 退出码非 0:\n' + res.stderr + '\n' + res.stdout)
+  for (const f of ['index.html', 'preview.html', 'manifest.js', 'styles.js', 'official-facade.js', '_headers']) {
+    assert.ok(fs.existsSync(path.join(outDir, f)), '组装产物缺少 ' + f)
+  }
+})
+
+test('gallery/_headers 的缓存规则覆盖 styles.js 且不再引用 bundles.js', () => {
+  const headers = fs.readFileSync(path.join(ROOT, 'gallery', '_headers'), 'utf8')
+  assert.ok(headers.includes('/styles.js'), '_headers 缺少 /styles.js 规则')
+  assert.ok(!headers.includes('bundles.js'), '_headers 仍引用已删除的 bundles.js')
+})


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；已读。

## 摘要（Summary）

修复 Deploy Gallery 工作流自 PR #550 起在 main 上的持续失败：gallery v2 重建后不再产出 `gallery/bundles.js`，但 `scripts/deploy-gallery` 的 `ROOT_FILES` 仍要求它、`gallery/_headers` 仍保留其缓存规则，导致组装阶段硬失败（`缺少 bundles.js`），而 `pnpm gallery:check` 只校验 manifest.js/styles.js 所以一直绿。

改动：
- `scripts/deploy-gallery`：`ROOT_FILES` 中 `bundles.js` → `styles.js`（`gallery/preview.html:10` 实际加载的就是 styles.js）；同步头部注释。
- `gallery/_headers`：no-cache 规则 `/bundles.js` → `/styles.js`。
- 新增 `scripts/deploy-gallery.test.mjs`：以 `--dry-run` 真实组装已提交的 gallery 产物（不触 wrangler/网络），产物集漂移时 `pnpm test:scripts` 先红，避免再次只在 main 部署时暴露。

## 涉及包（Affected Packages）

仅脚本 / gallery 产物规则改动（维护类），不涉及包。

- [x] 其他（请说明）：`scripts/deploy-gallery`、`scripts/deploy-gallery.test.mjs`、`gallery/_headers`

## PR 类型（PR Type）

- [x] Bug 修复
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch origin && git worktree add ... origin/main`（分支基点 3675750c）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（k3）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/deploy-gallery --dry-run --out /tmp/gallery-stage-verify
pnpm gallery:check
pnpm test:scripts
pnpm docs:check
```

结果摘要：

- dry-run 修复前：`deploy-gallery: 缺少 bundles.js` 退出码 1（与 CI 失败一致）；修复后：`组装完成（6 个根文件 + 24 个 preview PNG）`。
- `pnpm gallery:check`：gallery assets up to date (12 skins)。
- `pnpm test:scripts`：107 pass / 0 fail（含新增 2 条 deploy-gallery 门禁测试）。
- `pnpm docs:check`：all documentation gates passed。

## 用户可见变更证据（Local Feature Evidence）

N/A（纯 CI/部署脚本修复，无用户可见界面变更；验证证据为上方 dry-run 与门禁输出。）
