### PR TITLE
test(skill-explorer): wrap the panel render in act to deflake the escape test

### DIFF
--- a/packages/dsh-skill-explorer/tests/panel.spec.tsx
+++ b/packages/dsh-skill-explorer/tests/panel.spec.tsx
@@ -34,7 +34,12 @@ function mount(api: ReturnType<typeof fakeApi>, onClose: () => void): { containe
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
-  root.render(<SkillPanel api={api as never} onClose={onClose} />)
+  // Render inside act so the commit and passive effects (the document
+  // keydown listener) are drained synchronously; an unwrapped render rides
+  // the Scheduler and can lose the race on slow CI runners.
+  act(() => {
+    root.render(<SkillPanel api={api as never} onClose={onClose} />)
+  })
   return {
     container,
     dispose: () => {


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；已读。

## 摘要（Summary）

修复 main 上 CI 间歇性变红的一个来源：`tests/panel.spec.tsx` 的 `mount()` 在 `act` 之外执行 `root.render`，慢 runner 上初始渲染可能让出 Scheduler 帧预算，导致 `Escape dismisses the panel when not typing in a form field` 在 document keydown 监听挂上之前就派发事件，断言 `closed` 为 0（实测失败：run 32152340848，`expected +0 to be 1`）。

改动（仅测试）：把 `mount()` 里的 `root.render(...)` 包进同步 `act()`，提交与 passive effect（document keydown 监听）随 act 队列同步排空；异步 `api.list()` 仍由既有 `flush()` 覆盖。不触碰 `SkillPanel.tsx` 任何源码行为。

依据：`panel.spec.tsx` / `SkillPanel.tsx` 在最近一次全绿（06:46Z run 32108401057）与失败（15:05Z run 32152340848）之间零改动（`git log 45207c9e..c51ffb18` 为空），同代码一次过一次挂，确认为时序 flake 而非回归。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-skill-explorer`（仅 tests/）

## PR 类型（PR Type）

- [x] Bug 修复
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch origin && git worktree add ... origin/main`（分支基点 f1cdce07）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（k3）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-skill-explorer test   # x5 次
pnpm --filter @linxin666/dsh-client-ui-skill-explorer run typecheck
```

结果摘要：5 次全绿（每次 8 个测试文件 / 53 条测试全过）；`tsc --noEmit` 通过。

## 用户可见变更证据（Local Feature Evidence）

N/A（测试-only 修复，无用户可见变更。）
