### PR TITLE
fix(remote-web-ui): drop a stale tunnel handle from an earlier start attempt

### DIFF
--- a/packages/dsh-remote-web-ui/src/tunnel.ts
+++ b/packages/dsh-remote-web-ui/src/tunnel.ts
@@ -86,6 +86,9 @@ export class TunnelManager {
   private urlTimer: unknown | undefined
   private restartTimer: unknown | undefined
   private attempts = 0
+  // Generation counter: a stale ensureBinary resolution from an earlier
+  // start() must not spawn a second handle after a stop/start cycle.
+  private generation = 0
   private stopping = false
   private readonly urlListeners = new Set<(url: string) => void>()
   private readonly phaseListeners = new Set<(info: TunnelInfo) => void>()
@@ -123,6 +126,7 @@ export class TunnelManager {
     this.stopping = false
     this.targetUrl = targetUrl
     this.attempts = 0
+    this.generation += 1
     this.attempt()
   }
 
@@ -153,12 +157,13 @@ export class TunnelManager {
 
   private attempt(): void {
     if (this.stopping || this.targetUrl === undefined) return
+    const gen = this.generation
     this.setPhase('starting')
     this.handle = undefined
     this.url = undefined
     this.error = undefined
     void this.ensureBinary().then(() => {
-      if (this.stopping || this.targetUrl === undefined) return
+      if (this.stopping || this.targetUrl === undefined || gen !== this.generation) return
       const handle = this.factory(this.targetUrl)
       this.handle = handle
       this.urlTimer = this.timer.setTimeout(() => {
@@ -181,7 +186,7 @@ export class TunnelManager {
       })
     }).catch((value: unknown) => {
       // Binary install failed (no network, no platform build): report it.
-      if (this.stopping || this.targetUrl === undefined) return
+      if (this.stopping || this.targetUrl === undefined || gen !== this.generation) return
       const message = value instanceof Error ? value.message : String(value)
       this.fail(`could not obtain the cloudflared binary: ${message}`)
     })

--- a/packages/dsh-remote-web-ui/tests/tunnel.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/tunnel.spec.ts
@@ -129,6 +129,40 @@ describe('TunnelManager', () => {
     expect(h.manager.info.phase).toBe('starting')
   })
 
+  it('drops a stale ensureBinary resolution after stop/start (no double handle)', async () => {
+    const releases: Array<() => void> = []
+    const ensure = vi.fn(() => new Promise<void>((resolve) => { releases.push(resolve) }))
+    const tunnels: FakeTunnel[] = []
+    const { timer } = makeTimers()
+    const manager = new TunnelManager({
+      factory: () => {
+        const tunnel = new FakeTunnel()
+        tunnels.push(tunnel)
+        return tunnel
+      },
+      ensureBinary: ensure,
+      timer,
+      urlTimeoutMs: 30_000,
+      restartBaseMs: 5_000,
+      restartMaxMs: 60_000,
+    })
+
+    manager.start('http://127.0.0.1:3080')
+    expect(releases.length).toBe(1)
+    manager.stop()
+    manager.start('http://127.0.0.1:3081')
+    expect(releases.length).toBe(2)
+
+    // The first (stale) resolution must NOT spawn a handle — a second start
+    // superseded it.
+    releases[0]!()
+    await vi.waitFor(() => { expect(tunnels.length).toBe(0) })
+
+    // The current attempt's resolution spawns exactly one handle.
+    releases[1]!()
+    await vi.waitFor(() => { expect(tunnels.length).toBe(1) })
+  })
+
   it('restarts after an unexpected exit and recovers to running', async () => {
     const h = makeHarness({ restartBaseMs: 10 })
     h.manager.start('http://127.0.0.1:3080')


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-remote-web-ui` 自动隧道在 stop/start 循环后可能泄漏一个多余的隧道进程句柄的问题。

根因：`attempt()` 的 `ensureBinary()` 异步解析只以 `stopping` / `targetUrl` 为守卫，而 `stop()` 会清空二者、`start()` 会重设，所以第一次 attempt 的过期 promise 在 stop→start 后能通过守卫，生成第二个 handle 覆盖 `this.handle` / `this.urlTimer`，泄漏第一个进程。

修复：引入 generation 计数器——`start()` 递增，`attempt()` 记录当前值并在 `ensureBinary` 解析后校验；过期 promise 解析时直接丢弃。补一个测试：stop/start 后旧的解析不再生成 handle。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-remote-web-ui test`：24 个测试文件 249 个用例全部通过（含新增 tunnel generation 测试 1 个）。
- `pnpm --filter @linxin666/dsh-remote-web-ui typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：stop/start 循环后不再泄漏多余的 cloudflared 进程）。
