### PR TITLE
fix(describe-image): scale the attach body cap with the configured image bound

### DIFF
--- a/packages/dsh-tool-describe-image/src/attach-routes.ts
+++ b/packages/dsh-tool-describe-image/src/attach-routes.ts
@@ -21,8 +21,19 @@ import { UNKNOWN_CAPABILITY, type CapabilityProbe } from './model-capability.ts'
 
 export { renderAttachmentMarkdown as attachmentMarkdown }
 
-/** Request-body byte cap: base64 of a {@link DEFAULT_MAX_BYTES} image plus envelope slack. */
+/** Request-body byte cap for the default image bound (kept for docs/tests). */
 export const MAX_ATTACH_BODY_BYTES = 16 * 1024 * 1024
+
+/**
+ * JSON request-body cap for one attach: base64 of a `maxBytes` image
+ * inflates to ~4/3 its byte length, plus JSON envelope slack. Scaling it with
+ * the configured image bound (not a fixed 16 MiB) keeps a higher configured
+ * maxBytes usable — a fixed cap silently rejected any image whose base64
+ * exceeded it.
+ */
+export function attachBodyCap(maxBytes: number): number {
+  return Math.ceil(maxBytes / 3) * 4 + 1024
+}
 
 /** Stable error codes the browser half surfaces without leaking internals. */
 export interface AttachError {
@@ -293,12 +304,13 @@ export function registerAttachRoute(ctx: Context, readMaxBytes: () => number = (
         json(res, { ok: false, error: METHOD_NOT_ALLOWED }, 405)
         return
       }
-      const body = await readJsonBody(req, MAX_ATTACH_BODY_BYTES)
+      const maxBytes = readMaxBytes()
+      const body = await readJsonBody(req, attachBodyCap(maxBytes))
       if (body === null) {
-        json(res, { ok: false, error: { code: 'internal', message: 'request body must be JSON within 16 MiB' } }, 400)
+        json(res, { ok: false, error: { code: 'internal', message: 'request body must be JSON within the configured image bound' } }, 400)
         return
       }
-      const outcome = await handleAttach(ctx, readMaxBytes(), body)
+      const outcome = await handleAttach(ctx, maxBytes, body)
       if (outcome.ok) {
         json(res, { ok: true, value: { note: outcome.note, markdown: outcome.markdown, ref: outcome.ref } })
         return

--- a/packages/dsh-tool-describe-image/tests/attach-routes.spec.ts
+++ b/packages/dsh-tool-describe-image/tests/attach-routes.spec.ts
@@ -10,7 +10,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { AttachmentStore } from '@deepseek-ai/dsh-attachment'
 import type { ImageAttachmentLimits, ImageAttachmentRef, SaveImageAttachment, StoredImageAttachment } from '@deepseek-ai/dsh-attachment'
 import { Context } from '@deepseek-ai/cordis'
-import { attachmentMarkdown, attachmentNote, attachmentRefById, handleAttach, registerAttachRoute, registerAttachmentRef, validateAttachPayload, type AttachError } from '../src/attach-routes.ts'
+import { attachBodyCap, attachmentMarkdown, attachmentNote, attachmentRefById, handleAttach, registerAttachRoute, registerAttachmentRef, validateAttachPayload, type AttachError } from '../src/attach-routes.ts'
 import type { AttachPayload } from '../src/attach-routes.ts'
 import { PNG_BYTES } from './mock-server.ts'
 
@@ -71,6 +71,16 @@ function errOf(result: { payload: AttachPayload; bytes: Buffer } | { error: Atta
 }
 
 const PNG_BASE64 = PNG_BYTES.toString('base64')
+
+describe('attachBodyCap', () => {
+  it('stays under the legacy 16 MiB wall for the default 10 MiB bound', () => {
+    expect(attachBodyCap(10 * 1024 * 1024)).toBeLessThan(16 * 1024 * 1024)
+  })
+
+  it('scales above the legacy wall when the image bound is raised', () => {
+    expect(attachBodyCap(20 * 1024 * 1024)).toBeGreaterThan(16 * 1024 * 1024)
+  })
+})
 
 describe('validateAttachPayload', () => {
   it('accepts a well-formed PNG payload', () => {
@@ -279,7 +289,7 @@ describe('registerAttachRoute', () => {
   }
 
   /** Register the route and return the captured prefix row. */
-  const capture = (attachments: AttachmentStore | undefined, webserver: boolean) => {
+  const capture = (attachments: AttachmentStore | undefined, webserver: boolean, readMaxBytes?: () => number) => {
     const registrations: Array<{ kind: string; path: string; handler: (req: unknown, res: unknown) => Promise<void> }> = []
     const webServer = webserver
       ? { register: (row: { kind: string; path: string; handler: (req: unknown, res: unknown) => Promise<void> }) => { registrations.push(row); return () => {} } }
@@ -291,7 +301,7 @@ describe('registerAttachRoute', () => {
         return undefined
       },
     }
-    registerAttachRoute(ctx as unknown as Context)
+    registerAttachRoute(ctx as unknown as Context, readMaxBytes)
     return registrations
   }
 
@@ -318,6 +328,18 @@ describe('registerAttachRoute', () => {
     const { res, status } = makeRes()
     await registrations[0].handler(makeReq('POST', '{not json'), res)
     expect(status()).toBe(400)
+  })
+
+  it('scales the body cap with a higher configured maxBytes (no fixed 16 MiB wall)', async () => {
+    const registrations = capture(undefined, true, () => 20 * 1024 * 1024)
+    // A base64 payload that exceeds the old fixed 16 MiB cap but fits the
+    // scaled cap for a 20 MiB image bound.
+    const payload = JSON.stringify({ data: 'A'.repeat((16 * 1024 * 1024) + 4), mediaType: 'image/png' })
+    const { res, status } = makeRes()
+    await registrations[0].handler(makeReq('POST', payload), res)
+    // The body cap passed; the (fake) image is then rejected by payload
+    // validation (422), not by a fixed body cap (400).
+    expect(status()).toBe(422)
   })
 
   it('stores a valid upload and returns the note with 200', async () => {


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-tool-describe-image` 附件上传的请求体上限被固定 16 MiB 硬编码、覆盖可配置 `maxBytes` 的问题。

根因：attach 路由先用固定 `MAX_ATTACH_BODY_BYTES`（16 MiB）读 JSON 请求体，之后才用可配置的 `maxBytes` 校验解码后的图片字节。base64 膨胀约 4/3，任何 base64 超过 16 MiB（即解码后约 >12 MiB）的图片都会被 400 拒绝，即使 `maxBytes` 配置得更高——静默覆盖了用户配置的上限。

修复：新增 `attachBodyCap(maxBytes)` 从配置的 `maxBytes` 推导请求体上限（base64 4/3 + JSON envelope 余量），路由每次请求先读一次 `maxBytes`，同时用于 body cap 和图片校验。补单测 + 路由测试。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）：`packages/dsh-tool-describe-image`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-tool-describe-image test
pnpm --filter @linxin666/dsh-tool-describe-image typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-tool-describe-image test`：11 个测试文件 208 个用例全部通过（含新增 attachBodyCap 单测 2 个、route body-cap 测试 1 个）。
- `pnpm --filter @linxin666/dsh-tool-describe-image typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：配置的 `maxBytes` 高于约 12 MiB 时，对应大小的图片不再被固定请求体上限提前拒绝）。
