### PR TITLE
fix(skin-center): resolve skin asset paths with platform separators

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -497,8 +497,9 @@ function findSkin(catalog, id) {
 */
 function resolveInsideSkin(entry, relPath) {
 	const abs = resolve(entry.dir, relPath);
-	const rootWithSep = entry.dir.endsWith("/") ? entry.dir : entry.dir + "/";
-	if (abs !== entry.dir && !abs.startsWith(rootWithSep)) return null;
+	const root = resolve(entry.dir);
+	const rootWithSep = root.endsWith(sep) ? root : root + sep;
+	if (abs !== root && !abs.startsWith(rootWithSep)) return null;
 	return abs;
 }
 //#endregion

--- a/packages/skins/skin-center/src/skin-repo.ts
+++ b/packages/skins/skin-center/src/skin-repo.ts
@@ -21,7 +21,7 @@
  */
 
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
-import { dirname, join, resolve as resolvePath } from 'node:path'
+import { dirname, join, resolve as resolvePath, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { validateSkinManifestV2 } from './core/manifest-v2/validate.ts'
@@ -182,7 +182,8 @@ export function findSkin(catalog: SkinCatalog, id: string): SkinCatalogEntry | n
  */
 export function resolveInsideSkin(entry: SkinCatalogEntry, relPath: string): string | null {
   const abs = resolvePath(entry.dir, relPath)
-  const rootWithSep = entry.dir.endsWith('/') ? entry.dir : entry.dir + '/'
-  if (abs !== entry.dir && !abs.startsWith(rootWithSep)) return null
+  const root = resolvePath(entry.dir)
+  const rootWithSep = root.endsWith(sep) ? root : root + sep
+  if (abs !== root && !abs.startsWith(rootWithSep)) return null
   return abs
 }


### PR DESCRIPTION
## 摘要（Summary）

修复皮肤中心 v2 在 Windows 上试穿 / 应用无反应的问题：`resolveInsideSkin` 的路径越界校验用正斜杠拼接根前缀，Windows 上 `resolvePath` 产出反斜杠路径导致所有合法皮肤资源被判为越界，`/skins/<id>/*` 路由全部 404，客户端切换静默失败。改用平台分隔符 `sep` 并规范化根路径后恢复正常。详见 issue #564。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch github && git rebase github/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本 PR 未新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改动 README）

## 贡献者版权声明（Contributor Copyright）

（不声明，维持现有版权归属。）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-skin-center build
pnpm --filter @linxin666/dsh-client-ui-skin-center exec vitest run tests/skin-repo.spec.ts
```

结果摘要：

Windows 11 上验证通过：构建成功；`tests/skin-repo.spec.ts` 6 个用例全部通过（修复前在 Windows 上会失败）。皮肤中心 v2 接口恢复：`/skins/<id>/stylesheet`、`/hooks.mjs`、`/assets/<file>` 均 200（修复前 404），越界路径 `../` 仍被 `resolveInsideSkin` 拒绝返回 null。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A —— 纯 Bug 修复，无新增用户可见功能；修复效果已通过上述接口验证与单元测试覆盖（Windows 路径分隔符场景）。

Fixes #564