### PR TITLE
perf(task-board): replace the minute-scan parity oracles with a day-granular reference (#543)

### DIFF
--- a/packages/dsh-task-board/tests/schedule-dst.spec.ts
+++ b/packages/dsh-task-board/tests/schedule-dst.spec.ts
@@ -23,7 +23,7 @@ describe('Host-local cron across daylight-saving transitions', () => {
     expect(nextRunAtMs('30 1 * * *', afterFirstOccurrence)).toBe(new Date(2026, 10, 2, 1, 30).getTime())
   })
 
-  it('matches the legacy minute scan around both transitions', () => {
+  it('matches an independent day-granular reference around both transitions', () => {
     const froms = [
       new Date(2026, 2, 7, 23, 0).getTime(),
       new Date(2026, 2, 8, 1, 59).getTime(),
@@ -40,22 +40,40 @@ describe('Host-local cron across daylight-saving transitions', () => {
   })
 })
 
-/** Legacy minute scan reference (wall-clock field stepping). */
+/**
+ * Independent fast behavioural reference: walks calendar days inside the
+ * same five-year horizon (never scanning minutes), and for each matching day
+ * picks the earliest matching hour/minute strictly after `fromMs`. Wall-clock
+ * field construction plus the hour/minute re-check reproduce the production
+ * implementation's DST semantics without sharing its control flow.
+ */
 function referenceScan(expr: string, fromMs: number): number | undefined {
   const schedule = parseCron(expr)
   if (schedule === null) return undefined
   const from = new Date(fromMs)
-  const scan = new Date(from.getFullYear(), from.getMonth(), from.getDate(), from.getHours(), from.getMinutes() + 1, 0, 0)
   const limitMs = fromMs + 5 * 366 * 24 * 60 * 60 * 1000
-  while (scan.getTime() <= limitMs) {
-    const dayMatches = schedule.days.has(scan.getDate())
-    const weekdayMatches = schedule.weekdays.has(scan.getDay())
+  const hours = [...schedule.hours].sort((a, b) => a - b)
+  const minutes = [...schedule.minutes].sort((a, b) => a - b)
+  const start = new Date(from.getFullYear(), from.getMonth(), from.getDate(), 0, 0, 0, 0)
+  for (let offset = 0; ; offset += 1) {
+    const day = new Date(start.getFullYear(), start.getMonth(), start.getDate() + offset, 0, 0, 0, 0)
+    if (day.getTime() > limitMs) return undefined
+    if (!schedule.months.has(day.getMonth() + 1)) continue
+    const dayMatches = schedule.days.has(day.getDate())
+    const weekdayMatches = schedule.weekdays.has(day.getDay())
     const matchesDay = schedule.dayWildcard ? weekdayMatches : schedule.weekdayWildcard ? dayMatches : dayMatches || weekdayMatches
-    if (schedule.minutes.has(scan.getMinutes()) && schedule.hours.has(scan.getHours())
-      && schedule.months.has(scan.getMonth() + 1) && matchesDay) {
-      return scan.getTime()
+    if (!matchesDay) continue
+    for (const hour of hours) {
+      for (const minute of minutes) {
+        const candidate = new Date(day.getFullYear(), day.getMonth(), day.getDate(), hour, minute, 0, 0)
+        // Wall-clock re-check: a nonexistent spring-forward time normalizes
+        // forward, so the constructed fields must equal the intended ones.
+        if (candidate.getHours() !== hour || candidate.getMinutes() !== minute) continue
+        const time = candidate.getTime()
+        if (time <= fromMs) continue
+        if (time > limitMs) return undefined
+        return time
+      }
     }
-    scan.setMinutes(scan.getMinutes() + 1)
   }
-  return undefined
 }

--- a/packages/dsh-task-board/tests/schedule.spec.ts
+++ b/packages/dsh-task-board/tests/schedule.spec.ts
@@ -133,7 +133,7 @@ describe('nextRunAtMs', () => {
     expect(nextRunAtMs('not a cron', at(2026, 1, 1, 0, 0))).toBeUndefined()
   })
 
-  it('matches the legacy minute scan across sparse and dense schedules', () => {
+  it('matches an independent day-granular reference across sparse and dense schedules', () => {
     const crons = [
       '* * * * *',
       '*/5 * * * *',
@@ -163,12 +163,17 @@ describe('nextRunAtMs', () => {
         expect(nextRunAtMs(expr, fromMs), `${expr} from ${new Date(fromMs).toISOString()}`).toBe(referenceNextRunAtMs(expr, fromMs))
       }
     }
-    // The minute-scan reference walks up to ~1.5 years of minutes per case;
-    // slow CI runners need headroom beyond vitest's 5s default.
-  }, 30000)
+  })
 })
 
-/** The pre-jump minute scan, kept verbatim as the behavioural reference. */
+/**
+ * Independent fast behavioural reference: walks calendar days inside the
+ * same five-year horizon (never scanning minutes), and for each matching day
+ * picks the earliest matching hour/minute strictly after `fromMs`. Wall-clock
+ * field construction plus the hour/minute re-check reproduce the production
+ * implementation's DST semantics without sharing its control flow, so the
+ * two implementations still cross-check each other.
+ */
 function referenceNextRunAtMs(expr: string, fromMs: number): number | undefined {
   const schedule = parseCron(expr)
   if (schedule === null) return undefined
@@ -181,17 +186,29 @@ function referenceNextRunAtMs(expr: string, fromMs: number): number | undefined 
     if (!possible) return undefined
   }
   const from = new Date(fromMs)
-  const scan = new Date(from.getFullYear(), from.getMonth(), from.getDate(), from.getHours(), from.getMinutes() + 1, 0, 0)
   const limitMs = fromMs + 5 * 366 * 24 * 60 * 60 * 1000
-  while (scan.getTime() <= limitMs) {
-    const dayMatches = schedule.days.has(scan.getDate())
-    const weekdayMatches = schedule.weekdays.has(scan.getDay())
+  const hours = [...schedule.hours].sort((a, b) => a - b)
+  const minutes = [...schedule.minutes].sort((a, b) => a - b)
+  const start = new Date(from.getFullYear(), from.getMonth(), from.getDate(), 0, 0, 0, 0)
+  for (let offset = 0; ; offset += 1) {
+    const day = new Date(start.getFullYear(), start.getMonth(), start.getDate() + offset, 0, 0, 0, 0)
+    if (day.getTime() > limitMs) return undefined
+    if (!schedule.months.has(day.getMonth() + 1)) continue
+    const dayMatches = schedule.days.has(day.getDate())
+    const weekdayMatches = schedule.weekdays.has(day.getDay())
     const matchesDay = schedule.dayWildcard ? weekdayMatches : schedule.weekdayWildcard ? dayMatches : dayMatches || weekdayMatches
-    if (schedule.minutes.has(scan.getMinutes()) && schedule.hours.has(scan.getHours())
-      && schedule.months.has(scan.getMonth() + 1) && matchesDay) {
-      return scan.getTime()
+    if (!matchesDay) continue
+    for (const hour of hours) {
+      for (const minute of minutes) {
+        const candidate = new Date(day.getFullYear(), day.getMonth(), day.getDate(), hour, minute, 0, 0)
+        // Wall-clock re-check: a nonexistent spring-forward time normalizes
+        // forward, so the constructed fields must equal the intended ones.
+        if (candidate.getHours() !== hour || candidate.getMinutes() !== minute) continue
+        const time = candidate.getTime()
+        if (time <= fromMs) continue
+        if (time > limitMs) return undefined
+        return time
+      }
     }
-    scan.setMinutes(scan.getMinutes() + 1)
   }
-  return undefined
 }


### PR DESCRIPTION
## 摘要（Summary）

维护者在 Issue #543 认可方案 1（O(1) 字段计算替换逐分钟暴力扫描）并邀请按仓库规范提 PR。核查后的事实：生产 `nextRunAtMs` 已由维护者在 `f79eda9`（随一期重构 #550 合入）改为字段跳跃，仓库内最后一处「逐分钟暴力扫描」只剩两个对拍测试里的 verbatim oracle——这正是 CI 上该用例耗时 6.7s、超 5s 默认超时的根源。

本 PR 完成根治收尾：

1. 把 `tests/schedule.spec.ts` 与 `tests/schedule-dst.spec.ts` 的逐分钟 oracle 替换为**独立的按天粒度参考实现**：只按日历天行走（≤5×366 天），对每个匹配日取最早的匹配时/分；墙钟字段构造 + 时/分复检，DST 语义与生产实现等价但控制流完全不同，仍构成两套独立实现的交叉验证。
2. 撤销 `17b4d5f` 为旧 oracle 加的 30s 超时与说明注释——根治后不再需要（保留原对拍矩阵不变）。

零新依赖；生产 `nextRunAtMs` 与全部对拍用例语义不变，全部继续全绿。

## 涉及包（Affected Packages）

- [x] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）：测试基建性能根治，无行为变化
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch upstream && git checkout -b perf/task-board-parity-oracle upstream/main`（基于 upstream main 4f5eea4）

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-task-board test
pnpm --filter @linxin666/dsh-client-ui-task-board typecheck
```

结果摘要：测试 22 个文件 230 用例全部通过（1 跳过）；typecheck 通过。原对拍用例从约 2s（慢 runner 实测 6.7s）降到 16ms（`schedule.spec.ts` 18 用例 16ms，`schedule-dst.spec.ts` 3 用例 6ms）。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（纯测试基建优化，无用户可见变更；耗时对比见上）。