### PR TITLE
fix(skin-center): normalize comment-only patch after migration

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -1714,7 +1714,7 @@ function migrateLegacySelection(options) {
 			} else notes.push("legacy state resolves to the stock look; selection store left unset");
 		} else notes.push("v2 selection already present; skipped id migration");
 		let cleaned = stripLegacySkinState(patch);
-		if (cleaned.trim() === "") cleaned = "[]\n";
+		if (cleaned.split(/\r?\n/).every((line) => line.trim() === "" || line.trimStart().startsWith("#"))) cleaned = "[]\n";
 		if (cleaned !== patch) {
 			(options.writePatch ?? writePatchAtomic)(patchPath, cleaned);
 			result.patchCleaned = true;

--- a/packages/skins/skin-center/src/legacy-bridge.ts
+++ b/packages/skins/skin-center/src/legacy-bridge.ts
@@ -227,7 +227,9 @@ export function migrateLegacySelection(options: {
     // A patch whose only content was the managed section would be left
     // empty — and an empty cordis.patch.yml is not a valid patch list (the
     // next boot fails on it). Normalize to the stock empty-sequence root.
-    if (cleaned.trim() === '') cleaned = '[]\n'
+    const isCommentOnly = cleaned.split(/\r?\n/)
+      .every(line => line.trim() === '' || line.trimStart().startsWith('#'))
+    if (isCommentOnly) cleaned = '[]\n'
     if (cleaned !== patch) {
       const write = options.writePatch ?? writePatchAtomic
       write(patchPath, cleaned)

--- a/packages/skins/skin-center/tests/legacy-bridge.spec.ts
+++ b/packages/skins/skin-center/tests/legacy-bridge.spec.ts
@@ -167,6 +167,12 @@ describe('migrateLegacySelection', () => {
     expect(after.trim()).toBe('[]')
   })
 
+  it('a comment-only patch after cleanup normalizes to []', () => {
+    writeFileSync(patchPath, '# User patch layer.\n\n' + STOCK_PATCH)
+    migrateLegacySelection({ knownIds: KNOWN, activeStatePath: statePath, patchPath })
+    expect(readFileSync(patchPath, 'utf8')).toBe('[]\n')
+  })
+
   it('stock-look legacy state migrates no id and still cleans', () => {
     writeFileSync(patchPath, STOCK_PATCH)
     const result = migrateLegacySelection({ knownIds: KNOWN, activeStatePath: statePath, patchPath })


### PR DESCRIPTION
## 摘要（Summary）

修复皮肤中心旧配置迁移后可能生成无效 `cordis.patch.yml`、导致 `dsh web` 无法启动的问题。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream --prune
git switch -c fix/skin-center-comment-only-patch upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5.6 Sol

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未修改 README）；`pnpm docs:check` 已通过。

## 贡献者版权声明（Contributor Copyright）

N/A

## 新皮肤收录（New Skin）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
packages/skins/skin-center/node_modules/.bin/vitest run packages/skins/skin-center/tests/legacy-bridge.spec.ts
pnpm --filter @linxin666/dsh-client-ui-skin-center test
pnpm --filter @linxin666/dsh-client-ui-skin-center build
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm aggregate:check
pnpm gallery:check
pnpm skin-center:check
git diff --check
```

结果摘要：

- 皮肤中心回归测试 15/15、包测试 218/218、构建和类型检查通过。
- 脚本测试、文档检查及 aggregate / gallery / skin-center 一致性检查通过。
- 全仓 `pnpm test` 中仅未改动的 git-graph 既有 tag 断言失败；本 PR 涉及的 skin-center 测试全部通过。
- `git diff --check` 通过。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（Bug 修复，无新增用户界面。）