### PR TITLE
fix(liangshen): allow goal auto-rounds through the phase-1 filter (#578)

### DIFF
--- a/packages/dsh-liangshen/README.i18n.yaml
+++ b/packages/dsh-liangshen/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 5699b2aee7b9cfdec6184e042a48ab359a76b5d7
-README.zh.md: 44295097d6561d0d5db7388b438f4bef8509ff4e
+README.md: 369bb8384a73650063d3d040f1aecc4d7f11f842
+README.zh.md: 96ce3a7db25f7696368b7e0d8440c42df457e571

--- a/packages/dsh-liangshen/README.md
+++ b/packages/dsh-liangshen/README.md
@@ -52,7 +52,7 @@ Fully restart `dsh web`, open a NEW empty session, and pick "梁神模式" as th
 Export the session JSONL and inspect `request/header`:
 
 - The first header should carry only `bash/str_replace_editor` (the persistent shell plus the sandboxed editor);
-- The first turn should contain only the user's own messages — no workspace-instruction baseline, no runtime snapshot, no skill-catalog message — and only the `deployment:persona` prompt section;
+- The first turn should contain only whitelisted source kinds (the user's own messages and `/goal` auto-round messages) — no workspace-instruction baseline, no runtime snapshot, no skill-catalog message — and only the `deployment:persona` prompt section;
 - After the first tool call, the next changed header should carry exactly `run_code` (PTC); the runtime snapshot and all prompt sections arrive with that step (including plan mode's `plan:policy`, and the persona now ends with the selected workspace path), and the workspace instructions and skill catalog arrive one step later;
 - Phase-1 editor writes obey the host file sandbox policy — there is no bare local-filesystem bypass;
 - Later requests keep `run_code`.

--- a/packages/dsh-liangshen/README.zh.md
+++ b/packages/dsh-liangshen/README.zh.md
@@ -8,7 +8,7 @@
 
 DeepSeek V4 Pro 会强烈依赖 API 中可见的**首轮工具目录**选择执行轨迹。社区评测（[xiaobright/modeltest](https://github.com/xiaobright/modeltest)）中，Standard / PTC 只有 91/92 分，Minimal 达到 99/96，但 Minimal 只有两个工具。两阶段方案把「首次轨迹选择」与「后续完整工具能力」拆开：
 
-1. 首轮模型请求只暴露官方 Minimal 精确双工具（持久 `bash` 与 `str_replace_editor`），只保留 `deployment:persona` 一个 prompt section，清空运行时上下文，并且只放行用户自己的消息；
+1. 首轮模型请求只暴露官方 Minimal 精确双工具（持久 `bash` 与 `str_replace_editor`），只保留 `deployment:persona` 一个 prompt section，清空运行时上下文，并且只放行白名单内的消息（用户自己的消息与 `/goal` 自动轮次消息）；
 2. 会话出现首次持久 `tool/call` 后，晋升会等到首个 reasoning 块呈 minimal-like（包含 `we` 且无 `let me`）才发生，四步兜底；随后 wire 切换为 PTC Mode——只暴露一个 `run_code`，完整工具注册表通过生成的 SDK 调用——并恢复全部 prompt section（含 plan mode 的 `plan:policy`）以及 workspace 指令、skill 目录与运行时快照等常规注入；
 3. 阶段从持久化 session events 推导，resume / reload 不丢失状态。
 

--- a/packages/dsh-liangshen/presets/liangshen/agent.cordis.yml
+++ b/packages/dsh-liangshen/presets/liangshen/agent.cordis.yml
@@ -45,7 +45,10 @@
 # Two-phase input bootstrap with the exact Minimal phase-1 tools. Before the
 # first durable tool/call event the model sees only persistent `bash` plus
 # `str_replace_editor`, only the `persona` prompt section, no runtime
-# contexts, and only direct user messages. `anchorGate` holds the promotion
+# contexts, and only whitelisted source kinds (direct user messages plus
+# goal auto-rounds — a filtered-out `/goal` round never reaches the model, so
+# no promotion branch fires and the resume/pause loop deadlocks, issue #578).
+# `anchorGate` holds the promotion
 # open until the first reasoning block is minimal-like (four-step fallback);
 # `promoteAfterFirstResponse` avoids a permanent two-tool session after a
 # tool-less first response, and releases an anchor-gated session once its
@@ -70,7 +73,7 @@
   config:
     shellTools: [bash]
     commonTools: [str_replace_editor]
-    messageSources: [user]
+    messageSources: [user, goal]
     anchorGate: true
     maxBootstrapSteps: 4
     promoteAfterFirstResponse: true

--- a/packages/dsh-liangshen/presets/liangshen/tool-bootstrap.mjs
+++ b/packages/dsh-liangshen/presets/liangshen/tool-bootstrap.mjs
@@ -7,7 +7,8 @@
  * - prompt sections: only the persona section (all other sections,
  *   including plan-mode's `plan:policy`, return after promotion)
  * - runtime contexts: emptied (no sandbox/approval snapshot)
- * - pre-step messages: only explicit user messages pass
+ * - pre-step messages: only whitelisted source kinds pass (direct user
+ *   messages and goal auto-rounds by default)
  *
  * Promotion opens the full tool catalog and restores runtime contexts and all
  * prompt sections. With `anchorGate` the promotion after the first tool call
@@ -73,8 +74,13 @@ const PERSONA_SECTION_NAMES = new Set(['deployment:persona', 'persona'])
  */
 const WORKSPACE_LINE_PREFIX = '\n\nYour working directory is '
 
-/** Message-source kinds the model may see during phase 1. */
-const DEFAULT_MESSAGE_SOURCES = ['user']
+/**
+ * Message-source kinds the model may see during phase 1. Goal auto-rounds
+ * (source kind `goal`, issue #578) must be here: a filtered-out goal round
+ * never produces a response or tool call, so no promotion branch ever fires
+ * and the goal resume/pause loop deadlocks.
+ */
+const DEFAULT_MESSAGE_SOURCES = ['user', 'goal']
 
 /** Message-source kinds delayed after promotion. */
 const DEFAULT_DEFERRED_SOURCES = []
@@ -144,12 +150,15 @@ export function hasAnchoredReasoning(content) {
 }
 
 /**
- * Whether one pre-step message is an explicit user message. Only `kind:
- * 'user'` passes; injected kinds and source-less seed messages never pass.
+ * Whether one pre-step message belongs to a whitelisted source kind. The
+ * configured whitelist alone decides; injected kinds and source-less seed
+ * messages never pass unless explicitly named. (Before issue #578 this also
+ * hardcoded `kind === 'user'`, so no whitelist entry could ever admit a
+ * goal auto-round and `/goal` sessions deadlocked in phase 1.)
  */
 function isAllowedMessage(message, allowedSources) {
   const kind = message.source?.kind
-  return kind === 'user' && allowedSources.has(kind)
+  return kind !== undefined && allowedSources.has(kind)
 }
 
 /** Whether one pre-step message belongs to a deferred injection kind. */

--- a/packages/dsh-liangshen/src/index.ts
+++ b/packages/dsh-liangshen/src/index.ts
@@ -50,7 +50,7 @@ const DEFAULT_ANNOUNCE = true
 const SECTION_ORDER = 150
 
 /** Model-facing announcement: plugin presence, principle, and limits. */
-export const LIANGSHEN_GUIDANCE = '本机已安装 dsh-liangshen 插件（梁神模式 agent preset）：新建会话的预设选择器中可选「梁神模式」。原理：两阶段锚定——首轮模型请求仅暴露官方 Minimal 精确双工具（持久 bash 与 str_replace_editor，文件工具继承宿主沙箱），只保留一行 persona，清空运行时上下文并只放行用户的直接消息，锚定 Minimal 推理轨迹；晋升受首块锚定门控（首块包含 we 且无 let me，四步兜底），无工具首轮会在响应后自动晋升，晋升后 wire 切换为 PTC Mode（单一 run_code）并在 persona 追加所选工作区路径，workspace 指令与 skill 目录在晋升后再延迟一步注入。preset 文件由插件维护于 ~/.dsh/.agent-presets，升级插件时自动更新；默认预设由用户自行选择。用户提到「梁神模式 / 锚定模式 / anchored standard」时即指本插件，请据此协作。'
+export const LIANGSHEN_GUIDANCE = '本机已安装 dsh-liangshen 插件（梁神模式 agent preset）：新建会话的预设选择器中可选「梁神模式」。原理：两阶段锚定——首轮模型请求仅暴露官方 Minimal 精确双工具（持久 bash 与 str_replace_editor，文件工具继承宿主沙箱），只保留一行 persona，清空运行时上下文并只放行白名单消息（用户直接消息与 /goal 自动轮次），锚定 Minimal 推理轨迹；晋升受首块锚定门控（首块包含 we 且无 let me，四步兜底），无工具首轮会在响应后自动晋升，晋升后 wire 切换为 PTC Mode（单一 run_code）并在 persona 追加所选工作区路径，workspace 指令与 skill 目录在晋升后再延迟一步注入。preset 文件由插件维护于 ~/.dsh/.agent-presets，升级插件时自动更新；默认预设由用户自行选择。用户提到「梁神模式 / 锚定模式 / anchored standard」时即指本插件，请据此协作。'
 // The harness-home resolution (DSH_HOME override with the platform-home
 // fallback and ~ expansion) lives in the family-shared copy ./dsh-home.ts.
 // Re-export it so the plugin surface stays stable while the implementation is

--- a/packages/dsh-liangshen/tests/tool-bootstrap.test.ts
+++ b/packages/dsh-liangshen/tests/tool-bootstrap.test.ts
@@ -321,7 +321,7 @@ describe('anchored-tool-bootstrap', () => {
     expect(result.messages).toEqual(messages)
   })
 
-  test('phase 1 only lets explicit user messages through, whatever messageSources names', async () => {
+  test('phase 1 honors the configured messageSources whitelist', async () => {
     const preStepListener = listener(register({ messageSources: ['user', 'agent-instructions'] }), 'agent/pre-step')
     const messages = [
       message('user', 'user'),
@@ -329,7 +329,39 @@ describe('anchored-tool-bootstrap', () => {
       message('skill-catalog', 'skills'),
     ]
     const result = await preStep(preStepListener, [], messages)
-    expect(result.messages.map((entry: any) => entry.id)).toEqual(['user'])
+    expect(result.messages.map((entry: any) => entry.id)).toEqual(['user', 'instructions'])
+  })
+
+  test('phase 1 lets goal auto-round messages through by default (issue #578)', async () => {
+    const preStepListener = listener(register(), 'agent/pre-step')
+    const messages = [
+      message('goal', 'goal-round'),
+      message('agent-instructions', 'instructions'),
+      message(undefined, 'seed'),
+    ]
+    const result = await preStep(preStepListener, [], messages)
+    expect(result.messages.map((entry: any) => entry.id)).toEqual(['goal-round'])
+  })
+
+  test('a tool-less goal auto-round response still promotes (issue #578 deadlock)', async () => {
+    // A goal round that reaches the model can end without any tool call and
+    // without a minimal-like reasoning anchor. Branch (d) must still promote
+    // — otherwise every later goal round is filtered out again and the goal
+    // resume/pause loop deadlocks.
+    const assembleListener = listener(
+      register({ promoteAfterFirstResponse: true, anchorGate: true, maxBootstrapSteps: 4 }),
+      'system-prompt/assemble',
+    )
+    const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }]
+    const events = [
+      {
+        type: 'assistant/message',
+        data: { message: { content: [{ type: 'text', text: 'Continuing the goal this round.' }] } },
+      },
+      turnEndEvent(1),
+    ]
+    const result = await assemble(assembleListener, events, tools)
+    expect(result.tools).toEqual(tools)
   })
 
   test('anchorGate holds promotion after a standard-like first block', async () => {


### PR DESCRIPTION
## 摘要（Summary）

修复 #578：梁神模式下 `/goal` 自动轮次消息（`source.kind: 'goal'`）被阶段一 pre-step 过滤丢弃，永远到不了模型——无响应、无工具调用，`decidePromotion` 四个分支全部不成立，会话永远停在阶段一，每轮都被过滤，goal driver 陷入「恢复即暂停」死循环。

根因：`isAllowedMessage` 无视 `messageSources` 白名单、硬编码 `kind === 'user'`，改配置也无法放行。

修复（最小补丁）：
- `isAllowedMessage` 改为尊重配置白名单（`kind !== undefined && allowedSources.has(kind)`）；
- 默认白名单与 preset 配置（`agent.cordis.yml`）在 `user` 之外放行 `goal`；
- 回归测试：白名单被尊重、goal 轮次默认通过阶段一、无工具调用的 goal 轮次响应仍能经 `promoteAfterFirstResponse` 晋升（死锁回归）。

## 涉及包（Affected Packages）

- [x] 其他：`packages/dsh-liangshen`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化
- [ ] 新皮肤收录
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek；使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK 开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```sh
cd packages/dsh-liangshen && pnpm test
pnpm typecheck && pnpm test && pnpm test:scripts && pnpm docs:check
node scripts/verify-docs.mjs --write packages/dsh-liangshen
```

结果摘要：dsh-liangshen 96 用例全绿（tool-bootstrap 47，含 3 个新增/更新回归用例）；全仓 typecheck / test / test:scripts（107）/ docs:check 全绿；README.i18n.yaml 已重录。

## 关联 Issue

Fixes #578
