### PR TITLE
fix(ssh): make the web terminal font configurable (#577)

### DIFF
--- a/packages/dsh-ssh/README.i18n.yaml
+++ b/packages/dsh-ssh/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 4f2f068da6af190caeadf8deeffce24d138c6b37
-README.zh.md: d0090dd49663cf397e4980b70127659cb041fea9
+README.md: f9476df50bac571b567512cfa5272b5a64a1c3d6
+README.zh.md: ec991222c0a38f2376acdd21ae52fe185facd0c2

--- a/packages/dsh-ssh/README.md
+++ b/packages/dsh-ssh/README.md
@@ -48,7 +48,7 @@ After installing, **restart `dsh web`**: a "SSH" entry appears in the sidebar; t
 
 ## Configuration
 
-The settings panel (plugin config) toggles `announceToAgent` (whether to announce the plugin to the Agent) and `enabled` (master switch).
+The settings panel (plugin config) toggles `announceToAgent` (whether to announce the plugin to the Agent) and `enabled` (master switch), and sets `terminalFontFamily` (the web terminal font; empty defers to the CSS chain: `--dsh-ssh-terminal-font` → the official `--ds-font-family-code` token → the built-in monospace stack). The terminal font is fixed in the xterm constructor, so a plain stylesheet cannot override it; to render powerline / Nerd Font glyphs, enter a Nerd Font stack here (e.g. `"SauceCodePro Nerd Font", monospace`). Changes re-apply to open terminals live, no reconnect needed.
 
 ## Data
 

--- a/packages/dsh-ssh/README.zh.md
+++ b/packages/dsh-ssh/README.zh.md
@@ -48,7 +48,7 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-ssh
 
 ## 配置
 
-设置面板（插件配置）可开关 `announceToAgent`（是否向 Agent 宣告插件）与 `enabled`（总开关）。
+设置面板（插件配置）可开关 `announceToAgent`（是否向 Agent 宣告插件）与 `enabled`（总开关），并可设置 `terminalFontFamily`（Web 终端字体，留空则按 CSS 链解析：`--dsh-ssh-terminal-font` → 官方 `--ds-font-family-code` token → 内置 monospace 栈）。终端字体写死在 xterm 构造参数里，CSS 无法直接覆盖；要渲染 powerline / Nerd Font 图标，请在此填入对应 Nerd Font 栈（如 `"SauceCodePro Nerd Font", monospace`），修改对已打开的终端即时生效，无需重连。
 
 ## 数据
 

--- a/packages/dsh-ssh/src/client/index.ts
+++ b/packages/dsh-ssh/src/client/index.ts
@@ -10,19 +10,42 @@
  * Export discipline (packages/client rule): the /client surface carries what
  * cordis loading needs plus types only — all value exports stay internal.
  */
-import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+import type { ClientContext, SettingsScope, SettingsScopeSpec } from '@deepseek-ai/dsh-client-runtime/client'
 // Type-only: pulls the locale plugin's Context merge (ctx.locale).
 import type {} from '@deepseek-ai/dsh-client-locale/client'
+// Type-only: pulls the settings-surface Context merge (ctx.settingsScope).
+import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
 // Type-only: pulls the LocaleNamespaceMap merge table.
 import type {} from '@deepseek-ai/dsh-client-ui-slots'
 import { SshApi } from './api.ts'
 import { en, zh, type SshKey } from './locales.ts'
 import { mountPanel } from './mount.tsx'
 import { PanelController } from './panel/controller.ts'
+import type { TerminalFontSource } from './panel/helpers.ts'
 import { mountSidebarEntry } from './sidebar-entry.ts'
 
 /** Locale namespace this plugin owns. */
 const NS = 'dsh-ssh'
+
+/** Settings namespace the terminal-font preference lives in (issue #577). */
+const SETTINGS_NS = 'dsh-ssh'
+
+/** The dsh-ssh settings surface the browser half reads. */
+interface SshClientSettings {
+  /** User-configured xterm fontFamily; empty/undefined means the CSS chain. */
+  terminalFontFamily?: string
+}
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    /**
+     * Optional rc.6 compatibility binder provided by dsh-web-ui-settings;
+     * absent when that group plugin is not installed, so callers fall back to
+     * the official settings scope.
+     */
+    webUiSettings?: { bind<S>(spec: SettingsScopeSpec<S>): SettingsScope<S> }
+  }
+}
 
 declare module '@deepseek-ai/dsh-client-ui-slots' {
   interface LocaleNamespaceMap {
@@ -32,7 +55,7 @@ declare module '@deepseek-ai/dsh-client-ui-slots' {
 }
 
 /** Required services (fiber inject waiting — the runtime must be up first). */
-export const inject = ['slots', 'locale']
+export const inject = ['slots', 'locale', 'settingsScope']
 
 /** Type-only surface (export discipline: no value exports beyond the plugin contract). */
 export type { PanelControllerSnapshot } from './panel/controller.ts'
@@ -54,10 +77,22 @@ export function apply(ctx: ClientContext): void {
 
   const controller = new PanelController()
   const api = new SshApi()
+  // Live terminal-font preference (issue #577): the settings namespace is
+  // edited by the host-registered GUI section; the panel re-applies changes
+  // to open terminals without a reconnect.
+  const binder = ctx.get('webUiSettings') ?? ctx.settingsScope
+  const scope = binder.bind<SshClientSettings>({ namespace: SETTINGS_NS })
+  const terminalFont: TerminalFontSource = {
+    get: () => {
+      const snapshot = scope.getSnapshot()
+      return snapshot.status === 'ready' ? snapshot.value?.terminalFontFamily : undefined
+    },
+    subscribe: (listener) => scope.subscribe(listener),
+  }
   const disposers: Array<() => void> = []
   try {
     disposers.push(mountSidebarEntry(controller))
-    disposers.push(mountPanel(controller, api))
+    disposers.push(mountPanel(controller, api, terminalFont))
   } catch (error) {
     // DOM failures degrade the panel, never the GUI.
     console.warn('[dsh-ssh] mount failed:', error)

--- a/packages/dsh-ssh/src/client/mount.tsx
+++ b/packages/dsh-ssh/src/client/mount.tsx
@@ -14,6 +14,7 @@
 import { createRoot, type Root } from 'react-dom/client'
 import type { SshApi } from './api.ts'
 import type { PanelController } from './panel/controller.ts'
+import type { TerminalFontSource } from './panel/helpers.ts'
 import { SshPanel } from './panel/SshPanel.tsx'
 import css from './panel/panel.module.css'
 
@@ -38,9 +39,10 @@ function conversationColumn(): HTMLElement | undefined {
  * to the controller's panelOpen state.
  * @param controller - the panel controller driving the view.
  * @param api - the SSH API client the tabs operate through.
+ * @param terminalFont - live terminal-font setting source (issue #577).
  * @returns disposer unmounting the tree and restoring the column.
  */
-export function mountPanel(controller: PanelController, api: SshApi): () => void {
+export function mountPanel(controller: PanelController, api: SshApi, terminalFont?: TerminalFontSource): () => void {
   let root: Root | undefined
   let container: HTMLDivElement | undefined
 
@@ -61,7 +63,7 @@ export function mountPanel(controller: PanelController, api: SshApi): () => void
     container.className = css.view
     column.appendChild(container)
     root = createRoot(container)
-    root.render(<SshPanel controller={controller} api={api} />)
+    root.render(<SshPanel controller={controller} api={api} terminalFont={terminalFont} />)
   }
 
   // The frame mounts after boot settlement; watch for the column's arrival.

--- a/packages/dsh-ssh/src/client/panel/SshPanel.tsx
+++ b/packages/dsh-ssh/src/client/panel/SshPanel.tsx
@@ -8,7 +8,7 @@
 import { useState } from 'react'
 import type { SshApi } from '../api.ts'
 import type { PanelController } from './controller.ts'
-import { tt } from './helpers.ts'
+import { tt, type TerminalFontSource } from './helpers.ts'
 import { ClusterTab } from './ClusterTab.tsx'
 import { HostsTab } from './HostsTab.tsx'
 import { TerminalTab } from './TerminalTab.tsx'
@@ -25,6 +25,8 @@ export interface SshPanelProps {
   controller: PanelController
   /** The SSH API client every tab operates through. */
   api: SshApi
+  /** Live terminal-font setting source handed to the terminal tab (issue #577). */
+  terminalFont?: TerminalFontSource
 }
 
 /** The tab bar definition (labels resolved at render time). */
@@ -43,7 +45,7 @@ interface ConnectRequest {
 }
 
 /** The tabbed SSH panel. */
-export function SshPanel({ controller, api }: SshPanelProps) {
+export function SshPanel({ controller, api, terminalFont }: SshPanelProps) {
   const [activeTab, setActiveTab] = useState<SshTab>('hosts')
   const [connectRequest, setConnectRequest] = useState<ConnectRequest | null>(null)
 
@@ -75,7 +77,7 @@ export function SshPanel({ controller, api }: SshPanelProps) {
       </div>
       <div className={css.panelContent}>
         {activeTab === 'hosts' && <HostsTab api={api} onConnect={handleConnect} />}
-        {activeTab === 'terminal' && <TerminalTab api={api} presetAlias={connectRequest?.alias} requestId={connectRequest?.nonce} />}
+        {activeTab === 'terminal' && <TerminalTab api={api} presetAlias={connectRequest?.alias} requestId={connectRequest?.nonce} terminalFont={terminalFont} />}
         {activeTab === 'transfer' && <TransferTab api={api} />}
         {activeTab === 'tunnels' && <TunnelsTab api={api} />}
         {activeTab === 'cluster' && <ClusterTab api={api} />}

--- a/packages/dsh-ssh/src/client/panel/TerminalTab.tsx
+++ b/packages/dsh-ssh/src/client/panel/TerminalTab.tsx
@@ -5,13 +5,13 @@
  * output stays visible and input is disabled. xterm's stylesheet is injected
  * once per page load (module-level guard).
  */
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { Terminal, type IDisposable } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import type { SshApi, TerminalConnection } from '../api.ts'
 import type { SshHostSummary } from '../../protocol.ts'
 import { XTERM_CSS } from './xterm.css.ts'
-import { errorMessage, tt } from './helpers.ts'
+import { errorMessage, resolveTerminalFontFamily, tt, type TerminalFontSource } from './helpers.ts'
 import css from './panel.module.css'
 
 /** Terminal tab props. */
@@ -21,6 +21,11 @@ export interface TerminalTabProps {
   presetAlias?: string
   /** Monotonic id of the connect request (re-applies presetAlias). */
   requestId?: number
+  /**
+   * Live terminal-font setting source (issue #577). Absent in tests and
+   * legacy mounts: the font then comes from the CSS custom-property chain.
+   */
+  terminalFont?: TerminalFontSource
 }
 
 /** The terminal session lifecycle state shown in the status banner. */
@@ -44,8 +49,14 @@ function ensureXtermCss(): void {
   document.head.appendChild(style)
 }
 
+/** No-op source stand-in so the hook order stays stable without the prop. */
+const NO_FONT_SOURCE: TerminalFontSource = {
+  get: () => undefined,
+  subscribe: () => () => undefined,
+}
+
 /** The xterm terminal view. */
-export function TerminalTab({ api, presetAlias, requestId }: TerminalTabProps) {
+export function TerminalTab({ api, presetAlias, requestId, terminalFont }: TerminalTabProps) {
   const [hosts, setHosts] = useState<SshHostSummary[]>([])
   const [alias, setAlias] = useState(presetAlias ?? '')
   const [status, setStatus] = useState<TerminalStatus>({ kind: 'idle' })
@@ -54,8 +65,23 @@ export function TerminalTab({ api, presetAlias, requestId }: TerminalTabProps) {
   const fitRef = useRef<FitAddon | null>(null)
   const connRef = useRef<TerminalConnection | null>(null)
   const dataSubRef = useRef<IDisposable | null>(null)
+  const fontSource = terminalFont ?? NO_FONT_SOURCE
+  const fontOverride = useSyncExternalStore(fontSource.subscribe, fontSource.get)
 
   useEffect(() => { ensureXtermCss() }, [])
+
+  // Live re-apply a terminal-font change (issue #577): xterm re-measures
+  // and repaints on the options write; a refit keeps cols/rows aligned with
+  // the new metrics and the remote PTY learns the new size.
+  useEffect(() => {
+    const term = termRef.current
+    if (term === null) return
+    const next = resolveTerminalFontFamily(fontOverride)
+    if (term.options.fontFamily === next) return
+    term.options.fontFamily = next
+    fitRef.current?.fit()
+    connRef.current?.resize(term.cols, term.rows)
+  }, [fontOverride])
 
   // Fetch the host list on tab activation.
   useEffect(() => {
@@ -122,7 +148,7 @@ export function TerminalTab({ api, presetAlias, requestId }: TerminalTabProps) {
       convertEol: false,
       cursorBlink: true,
       fontSize: 13,
-      fontFamily: 'Menlo, Consolas, "Liberation Mono", monospace',
+      fontFamily: resolveTerminalFontFamily(fontOverride),
       theme: { background: '#0b0e14', foreground: '#d8dee9', cursor: '#a3b8d0' },
     })
     const fit = new FitAddon()

--- a/packages/dsh-ssh/src/client/panel/helpers.ts
+++ b/packages/dsh-ssh/src/client/panel/helpers.ts
@@ -24,3 +24,47 @@ export function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message
   return String(error)
 }
+
+/**
+ * The terminal font stack used before issue #577, kept as the last resort
+ * when neither the plugin setting nor a CSS custom property names a font.
+ */
+export const TERMINAL_FONT_FALLBACK = 'Menlo, Consolas, "Liberation Mono", monospace'
+
+/**
+ * Live source of the user's configured terminal font family: the client
+ * entry binds the dsh-ssh settings namespace into one of these and hands it
+ * to the panel, so a settings change re-applies without a remount.
+ */
+export interface TerminalFontSource {
+  /** Current configured family, or undefined when unset / not yet loaded. */
+  get(): string | undefined
+  /** Subscribe to changes; the returned function unsubscribes. */
+  subscribe(listener: () => void): () => void
+}
+
+/**
+ * Resolve the xterm `fontFamily` (issue #577). xterm's DOM renderer takes
+ * the font only from constructor/options, so a plain stylesheet rule cannot
+ * retarget it — the value must be read back into the options. The chain,
+ * first non-empty value wins:
+ *   1. `override` — the `terminalFontFamily` plugin setting;
+ *   2. `--dsh-ssh-terminal-font` — dedicated hook for skins and user CSS
+ *      (e.g. a Nerd Font for powerline glyphs);
+ *   3. `--ds-font-family-code` — the official code-font token several skins
+ *      already remap;
+ *   4. {@link TERMINAL_FONT_FALLBACK}.
+ */
+export function resolveTerminalFontFamily(override?: string): string {
+  const trimmed = override?.trim()
+  if (trimmed !== undefined && trimmed !== '') return trimmed
+  if (typeof getComputedStyle === 'function' && typeof document !== 'undefined') {
+    const target = document.body ?? document.documentElement
+    const style = getComputedStyle(target)
+    for (const name of ['--dsh-ssh-terminal-font', '--ds-font-family-code']) {
+      const value = style.getPropertyValue(name).trim()
+      if (value !== '') return value
+    }
+  }
+  return TERMINAL_FONT_FALLBACK
+}

--- a/packages/dsh-ssh/src/index.ts
+++ b/packages/dsh-ssh/src/index.ts
@@ -42,11 +42,19 @@ export interface Config {
   announceToAgent?: boolean
   /** Master switch for the plugin (routes, tools, prompt section). */
   enabled?: boolean
+  /**
+   * xterm `fontFamily` for the web terminal (issue #577). Empty (default)
+   * defers to the CSS chain: `--dsh-ssh-terminal-font`, then the official
+   * `--ds-font-family-code` token, then the built-in monospace stack. Set a
+   * Nerd Font stack here to render powerline/Nerd glyphs.
+   */
+  terminalFontFamily?: string
 }
 
 export const Config: z<Config> = z.object({
   announceToAgent: z.boolean().default(true),
   enabled: z.boolean().default(true),
+  terminalFontFamily: z.string().default(''),
 })
 
 /** Schema default, re-read for hand-built test contexts (the loader applies them normally). */

--- a/packages/dsh-ssh/tests/panel-terminal-font.test.tsx
+++ b/packages/dsh-ssh/tests/panel-terminal-font.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+/**
+ * TerminalTab font wiring (issue #577): the constructed xterm receives the
+ * resolved font family, and a live settings change re-applies it (options
+ * write + refit + PTY resize) without a reconnect.
+ */
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalFontSource } from '../src/client/panel/helpers.ts'
+
+const { terminalInstances, fitSpy } = vi.hoisted(() => ({
+  terminalInstances: [] as Array<{ options: Record<string, unknown> }>,
+  fitSpy: vi.fn(),
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    options: Record<string, unknown>
+    cols = 80
+    rows = 24
+    constructor(options: Record<string, unknown>) {
+      this.options = { ...options }
+      terminalInstances.push(this as { options: Record<string, unknown> })
+    }
+    loadAddon(): void {}
+    open(): void {}
+    dispose(): void {}
+    onData(): { dispose(): void } { return { dispose: () => undefined } }
+  },
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class { fit = fitSpy },
+}))
+
+import { TerminalTab } from '../src/client/panel/TerminalTab.tsx'
+import type { SshApi, TerminalConnection } from '../src/client/api.ts'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  terminalInstances.length = 0
+  fitSpy.mockClear()
+  document.body.replaceChildren()
+})
+
+type FakeConnection = TerminalConnection & { resize: ReturnType<typeof vi.fn> }
+
+function fakeApi(): { api: SshApi, connection: FakeConnection } {
+  const connection = {
+    onReady: undefined,
+    onOutput: undefined,
+    onExit: undefined,
+    send: () => undefined,
+    resize: vi.fn(),
+    close: () => undefined,
+  }
+  return {
+    api: {
+      listHosts: vi.fn(async () => [{ alias: 'demo', host: 'example.com' }]),
+      openTerminal: vi.fn(() => connection),
+    } as unknown as SshApi,
+    connection: connection as unknown as FakeConnection,
+  }
+}
+
+function fontSource(initial?: string): TerminalFontSource & { set(value: string | undefined): void } {
+  let current = initial
+  const listeners = new Set<() => void>()
+  return {
+    get: () => current,
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => { listeners.delete(listener) }
+    },
+    set: (value) => {
+      current = value
+      for (const listener of listeners) listener()
+    },
+  }
+}
+
+describe('TerminalTab terminal font (#577)', () => {
+  it('constructs xterm with the resolved font and re-applies live changes', async () => {
+    const source = fontSource('"SauceCodePro Nerd Font", monospace')
+    const { api, connection } = fakeApi()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    await act(async () => { root.render(<TerminalTab api={api} presetAlias="demo" terminalFont={source} />) })
+    await act(async () => { await Promise.resolve() })
+
+    // presetAlias preselects the host; the first control button is Connect.
+    const connect = container.querySelectorAll('button')[0] as HTMLButtonElement
+    expect(connect.disabled).toBe(false)
+    const fitsAfterConnect = fitSpy.mock.calls.length
+    await act(async () => { connect.click() })
+    expect(terminalInstances).toHaveLength(1)
+    expect(terminalInstances[0]!.options.fontFamily).toBe('"SauceCodePro Nerd Font", monospace')
+
+    // A live settings change re-applies without a reconnect: options write,
+    // one extra refit, and a PTY resize with the current geometry.
+    const resizesBefore = connection.resize.mock.calls.length
+    await act(async () => { source.set('User Mono, monospace') })
+    expect(terminalInstances[0]!.options.fontFamily).toBe('User Mono, monospace')
+    expect(fitSpy.mock.calls.length).toBeGreaterThan(fitsAfterConnect)
+    expect(connection.resize.mock.calls.length).toBeGreaterThan(resizesBefore)
+    expect(connection.resize).toHaveBeenLastCalledWith(80, 24)
+
+    // Clearing the setting drops back to the CSS chain (no custom properties
+    // set in this environment, so the built-in fallback wins).
+    await act(async () => { source.set(undefined) })
+    expect(terminalInstances[0]!.options.fontFamily).toBe('Menlo, Consolas, "Liberation Mono", monospace')
+
+    await act(async () => { root.unmount() })
+  })
+})

--- a/packages/dsh-ssh/tests/terminal-font.test.ts
+++ b/packages/dsh-ssh/tests/terminal-font.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+/**
+ * resolveTerminalFontFamily unit tests (issue #577): the settings override
+ * wins, then --dsh-ssh-terminal-font, then the official --ds-font-family-code
+ * token, then the built-in fallback stack; blank values never win.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveTerminalFontFamily, TERMINAL_FONT_FALLBACK } from '../src/client/panel/helpers.ts'
+
+afterEach(() => {
+  document.body.removeAttribute('style')
+  document.head.replaceChildren()
+})
+
+describe('resolveTerminalFontFamily (#577)', () => {
+  it('falls back to the built-in stack when nothing is configured', () => {
+    expect(resolveTerminalFontFamily()).toBe(TERMINAL_FONT_FALLBACK)
+    expect(resolveTerminalFontFamily('')).toBe(TERMINAL_FONT_FALLBACK)
+    expect(resolveTerminalFontFamily('   ')).toBe(TERMINAL_FONT_FALLBACK)
+  })
+
+  it('lets the settings override win over any CSS custom property', () => {
+    document.body.style.setProperty('--dsh-ssh-terminal-font', '"SauceCodePro Nerd Font", monospace')
+    expect(resolveTerminalFontFamily('User Mono, monospace')).toBe('User Mono, monospace')
+  })
+
+  it('reads --dsh-ssh-terminal-font before --ds-font-family-code', () => {
+    document.body.style.setProperty('--ds-font-family-code', 'Code Mono, monospace')
+    document.body.style.setProperty('--dsh-ssh-terminal-font', '"SauceCodePro Nerd Font", monospace')
+    expect(resolveTerminalFontFamily()).toBe('"SauceCodePro Nerd Font", monospace')
+  })
+
+  it('falls back to the official code-font token when the dedicated hook is unset', () => {
+    document.body.style.setProperty('--ds-font-family-code', 'Code Mono, monospace')
+    expect(resolveTerminalFontFamily()).toBe('Code Mono, monospace')
+  })
+
+  it('resolves custom properties from a stylesheet, not only inline style', () => {
+    const style = document.createElement('style')
+    style.textContent = 'body { --dsh-ssh-terminal-font: "JetBrainsMono Nerd Font", monospace; }'
+    document.head.appendChild(style)
+    expect(resolveTerminalFontFamily()).toBe('"JetBrainsMono Nerd Font", monospace')
+  })
+
+  it('ignores a custom property that is only whitespace', () => {
+    document.body.style.setProperty('--dsh-ssh-terminal-font', '  ')
+    expect(resolveTerminalFontFamily()).toBe(TERMINAL_FONT_FALLBACK)
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 #577：dsh-ssh Web 终端的 xterm `fontFamily` 在构造时写死（`Menlo, Consolas, "Liberation Mono", monospace`），powerline / Nerd Font 图标渲染为方框，且没有任何可配置入口。xterm DOM renderer 只从 options 取字体，纯 CSS 覆盖不到。

修复（与报告者建议的链路一致并补上真正的配置入口）：
- `resolveTerminalFontFamily()`：设置覆盖 → `--dsh-ssh-terminal-font` → 官方 `--ds-font-family-code` token（5 款皮肤已重映射）→ 原内置栈；
- 新增 `terminalFontFamily` 插件设置项（复用既有 settings section 的 GUI 文本框），客户端经 settings scope 绑定，改动对已打开终端即时生效（options 写入 + refit + PTY resize），无需重连；
- 回归测试：解析链路单测（含内联与 stylesheet 两种自定义属性来源）+ 组件级测试（构造参数断言 + 实时重应用 + 清空回退）。

## 涉及包（Affected Packages）

- [x] SSH 远程运维 `packages/dsh-ssh`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化
- [ ] 新皮肤收录
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek；使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK 开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```sh
cd packages/dsh-ssh && pnpm build && pnpm test
npx vitest run tests/terminal-font.test.ts tests/panel-terminal-font.test.tsx
pnpm typecheck && pnpm test:scripts && pnpm docs:check
node scripts/verify-docs.mjs --write packages/dsh-ssh
```

结果摘要：dsh-ssh 全量 110 用例通过（含 7 个新增字体用例：解析链路 6 + 组件 1）；typecheck / test:scripts（107）/ docs:check 全绿；README.i18n.yaml 已重录；构建产物 lib/ 不入库（该包不提交 lib）。

## 关联 Issue

Fixes #577
