### PR TITLE
fix(ssh): guard HostsTab load setState against post-unmount settle

### DIFF
--- a/packages/dsh-ssh/src/client/panel/HostsTab.tsx
+++ b/packages/dsh-ssh/src/client/panel/HostsTab.tsx
@@ -72,16 +72,24 @@ export function HostsTab({ api, onConnect }: HostsTabProps) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const [testingGroup, setTestingGroup] = useState<string | null>(null)
   const seqRef = useRef(0)
+  // Unmount guard for the async load below: the seq check only orders
+  // overlapping loads, it does not stop a late resolution/rejection landing
+  // after the tab unmounted — a setState there races the test-environment
+  // teardown (window is not defined; observed as a main-CI flake). The
+  // sibling tabs (terminal / transfer / tunnels) already guard with a
+  // disposed flag.
+  const mountedRef = useRef(true)
+  useEffect(() => () => { mountedRef.current = false }, [])
 
   const load = useCallback(async (query?: string): Promise<void> => {
     const seq = ++seqRef.current
     try {
       const list = await api.listHosts(query)
-      if (seq !== seqRef.current) return
+      if (!mountedRef.current || seq !== seqRef.current) return
       setHosts(list)
       setError(null)
     } catch (cause) {
-      if (seq !== seqRef.current) return
+      if (!mountedRef.current || seq !== seqRef.current) return
       setError(errorMessage(cause))
     }
   }, [api])

--- a/packages/dsh-ssh/tests/panel-hosts.test.tsx
+++ b/packages/dsh-ssh/tests/panel-hosts.test.tsx
@@ -6,6 +6,8 @@
  * hides the group's rows, and the group batch action tests every member.
  */
 
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -59,6 +61,34 @@ describe('groupHosts', () => {
     expect(groups.map(group => group.key)).toEqual(['cn', 'db', 'web', ''])
     expect(groups[2].hosts.map(host => host.alias)).toEqual(['web-1'])
     expect(groups[3].hosts.map(host => host.alias)).toEqual(['dev-1', 'misc-1'])
+  })
+})
+
+describe('HostsTab unmount race (main-CI flake)', () => {
+  it('a listHosts promise settling after unmount never reaches setState', async () => {
+    // The late rejection used to reach setError after the tab unmounted;
+    // racing the jsdom teardown it surfaced as "window is not defined" and
+    // failed the whole run on a slow CI runner. With the mounted guard the
+    // late settle is dropped. React 18 no longer warns on post-unmount
+    // setState, so also pin the guard in source below.
+    let rejectLate: ((error: Error) => void) | undefined
+    const api = {
+      listHosts: vi.fn(() => new Promise<SshHostSummary[]>((_resolve, reject) => { rejectLate = reject })),
+    } as unknown as SshApi
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    await act(async () => { root.render(<HostsTab api={api} onConnect={() => undefined} />) })
+    await act(async () => { root.unmount() })
+    rejectLate!(new Error('late failure'))
+    await act(async () => { await Promise.resolve() })
+    expect(api.listHosts).toHaveBeenCalled()
+  })
+
+  it('guards every load-path setState with the mounted ref', () => {
+    const source = readFileSync(join(process.cwd(), 'src', 'client', 'panel', 'HostsTab.tsx'), 'utf8')
+    expect(source).toContain('mountedRef')
+    expect(source).toContain('if (!mountedRef.current || seq !== seqRef.current) return')
   })
 })
 


### PR DESCRIPTION
## 摘要（Summary）

修复 main CI 上观测到的一次 dsh-ssh 测试运行失败（#589 合并提交，run 32204797919）：`listHosts` 的 Promise 在 HostsTab 卸载后才 settle 时仍会调用 `setHosts`/`setError`——seq 守卫只排序并发 load，不覆盖卸载场景。慢 runner 上迟到的 setState 与 jsdom 环境拆除竞争，整个测试运行以 `ReferenceError: window is not defined` 失败（110 用例全过但 vitest 记 1 个 unhandled error）。

修复：补上 terminal / transfer / tunnels 三个兄弟 tab 已有的 mounted-ref 卸载守卫；新增回归测试锁定契约（卸载后 late settle 不回写 + 源码断言守卫存在）。

## 涉及包（Affected Packages）

- [x] SSH 远程运维 `packages/dsh-ssh`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化
- [ ] 新皮肤收录
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek；使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK 开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README）。

## 本地验证（Local Validation）

执行的命令：

```sh
cd packages/dsh-ssh && pnpm test && pnpm typecheck
```

结果摘要：dsh-ssh 全量 112 用例通过（含 2 个新增回归用例）；typecheck 绿。
