### PR TITLE
fix(task-board): re-arm reconcile when a session change arrives mid-pass

### DIFF
--- a/packages/dsh-task-board/src/core/controller.ts
+++ b/packages/dsh-task-board/src/core/controller.ts
@@ -509,7 +509,15 @@ export class BoardController {
   /** Settle tasks left 'running' whose sessions already finished. */
   private async reconcileRunningTasks(): Promise<void> {
     if (this.deps.exec === undefined) return
-    if (this.reconcileInFlight) return
+    if (this.reconcileInFlight) {
+      // A session change arrived while a pass was in flight. The in-flight
+      // pass already captured the task list it iterates and will not revisit
+      // this task, so dropping the notification would leave it stuck
+      // 'running'. Re-arm the debounce so the change is reconciled once the
+      // current pass settles.
+      this.scheduleReconcile()
+      return
+    }
     this.reconcileInFlight = true
     try {
       type Settled = Extract<ExecutionEvent, { kind: 'settled' }>

--- a/packages/dsh-task-board/tests/controller.spec.ts
+++ b/packages/dsh-task-board/tests/controller.spec.ts
@@ -562,6 +562,52 @@ describe('external (cross-tab) ledger changes', () => {
     expect(JSON.stringify(store.load())).not.toContain('旧标题')
   })
 
+  it('re-arms a session change that arrives while reconcile is in flight', async () => {
+    let resolveFirst: (() => void) | undefined
+    let reconcileCalls = 0
+    const stub = {
+      reconcile: (task: { id: string }): Promise<ExecutionEvent | undefined> => {
+        reconcileCalls += 1
+        if (task.id === 'task-a') {
+          // The startup pass for A parks; a later pass finds A still running.
+          if (reconcileCalls === 1) return new Promise(resolve => { resolveFirst = () => resolve(undefined) })
+          return Promise.resolve(undefined)
+        }
+        // B's session already finished: settle it.
+        return Promise.resolve({ kind: 'settled', taskId: 'task-b', executionId: 'e2', outcome: 'succeeded', error: undefined })
+      },
+    }
+    const store = new ExternalAwareStore()
+    const sessions = new FakeSessions()
+    const seedA = seedTask(store, { id: 'task-a', title: 'A' })
+    const seedB = seedTask(store, { id: 'task-b', title: 'B' })
+    const runningA = { ...seedA, status: 'running' as const, executions: [{ id: 'e1', sessionId: 's-1', startedAt: NOW, endedAt: undefined, result: undefined, error: undefined }] }
+    const runningB = { ...seedB, status: 'running' as const, executions: [{ id: 'e2', sessionId: 's-2', startedAt: NOW, endedAt: undefined, result: undefined, error: undefined }] }
+    store.save([runningA, runningB])
+    const controller = new BoardController({
+      store, exec: stub as unknown as ExecutionService, sessions, now: () => NOW, uuid, reconcileDebounceMs: 0,
+    })
+    controller.start()
+    await flush()
+    // The startup pass is parked on A.
+    expect(reconcileCalls).toBe(1)
+    expect(resolveFirst).toBeDefined()
+
+    // B's session finishes while A's reconcile is still in flight; the change
+    // must re-arm the debounce, not drop B.
+    sessions.setCurrent('s-other')
+    await flush()
+    resolveFirst!()
+    await flush()
+    await flush()
+    await flush()
+
+    // The re-armed pass settled B instead of dropping the notification.
+    const b = controller.getSnapshot().tasks.find(t => t.id === 'task-b')
+    expect(b?.status).toBe('done')
+    expect(reconcileCalls).toBeGreaterThanOrEqual(3)
+  })
+
   it('stops reacting to external changes after dispose', () => {
     const { controller, store } = makeWithExternalStore()
     let notified = 0


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-task-board` 的会话状态变更在 reconcile 进行中到达时被丢弃的问题。

根因：`reconcileRunningTasks` 在 `reconcileInFlight` 为真时立即返回且不重新调度定时器，所以慢 reconcile 进行中 settle 的会话永远不会被那次通知 settle——任务一直卡在 `running`，直到无关的后续变更才恢复。

修复：in-flight 时重新 arm `scheduleReconcile`，让当前 pass 结束后该变更被重新 reconcile。补测试（在还原修复的情况下该测试失败）。

## 涉及包（Affected Packages）

- [x] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-task-board test
pnpm --filter @linxin666/dsh-client-ui-task-board typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-client-ui-task-board test`：23 个测试文件 231 个用例通过、1 skipped（含新增 reconcile re-arm 测试 1 个；还原修复时该测试失败，证明能捕捉此 bug）。
- `pnpm --filter @linxin666/dsh-client-ui-task-board typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：后台/遗留 running 任务在 reconcile 进行中完成时，能被后续通知正常 settle，不再卡在 running）。
