### PR TITLE
fix(git-graph): clamp the graph limit and stop resetting the dialog on re-render

### DIFF
--- a/packages/dsh-git-graph/src/client/graph/GraphDialog.tsx
+++ b/packages/dsh-git-graph/src/client/graph/GraphDialog.tsx
@@ -87,7 +87,13 @@ export function GraphDialog({ graph, onClose, t }: GraphDialogProps) {
     })
   }, [graph, t])
 
-  useEffect(() => { load(INITIAL_LIMIT) }, [load])
+  // Initial load exactly once on mount. The parent passes a fresh inline
+  // `graph` arrow on every BranchChip render, which changes `load`'s identity
+  // and would re-run the initial fetch (resetting any loaded pages) if it
+  // were a dependency — so read the latest `load` through a ref instead.
+  const loadRef = useRef(load)
+  loadRef.current = load
+  useEffect(() => { loadRef.current(INITIAL_LIMIT) }, [])
 
   const lanes = useMemo(() => {
     if (view === null) return []

--- a/packages/dsh-git-graph/src/host/routes.ts
+++ b/packages/dsh-git-graph/src/host/routes.ts
@@ -248,7 +248,9 @@ export function registerGitRoutes(ctx: Context, service: GitService): () => void
         const rawLimit = typeof payload === 'object' && payload !== null
           ? (payload as Record<string, unknown>).limit
           : undefined
-        const limit = typeof rawLimit === 'number' && rawLimit > 0 && rawLimit <= 1000 ? rawLimit : undefined
+        // Clamp rather than reset: a limit above 1000 must not silently fall
+        // back to the 200 default (the client's load-more grows past 1000).
+        const limit = typeof rawLimit === 'number' && rawLimit > 0 ? Math.min(rawLimit, 1000) : undefined
         okView(res, await service.graph(path, limit), isGraphView)
         return
       }

--- a/packages/dsh-git-graph/tests/client.spec.tsx
+++ b/packages/dsh-git-graph/tests/client.spec.tsx
@@ -450,4 +450,45 @@ describe('GraphDialog', () => {
     expect(dialog.getAttribute('data-dsh-part')).toBe('dialog')
     expect(await screen.findByText('root commit')).toBeTruthy()
   })
+
+  it('does not re-run the initial load when the graph prop identity changes', async () => {
+    const calls: number[] = []
+    const graph = async (limit?: number) => {
+      calls.push(limit ?? 0)
+      return {
+        root: '/ws/proj', branch: 'main',
+        commits: [
+          { oid: 'aabbcc', parents: [], subject: 'root commit', author: 'Bob', authorTime: 1690000000, refs: [] },
+        ],
+        hasMore: false,
+      }
+    }
+    const { rerender } = render(
+      <GraphDialog graph={graph} onClose={() => {}} t={makeTranslate()} />,
+    )
+    await screen.findByText('root commit')
+    const callsAfterMount = calls.length
+    // The initial load ran with the page size.
+    expect(calls).toEqual([200])
+
+    // A parent re-render passes a fresh inline arrow → graph identity changes.
+    rerender(
+      <GraphDialog
+        graph={async (limit?: number) => {
+          calls.push(limit ?? 0)
+          return {
+            root: '/ws/proj', branch: 'main',
+            commits: [
+              { oid: 'aabbcc', parents: [], subject: 'root commit', author: 'Bob', authorTime: 1690000000, refs: [] },
+            ],
+            hasMore: false,
+          }
+        }}
+        onClose={() => {}}
+        t={makeTranslate()}
+      />,
+    )
+    // No new initial fetch: the effect is mount-only.
+    expect(calls.length).toBe(callsAfterMount)
+  })
 })

--- a/packages/dsh-git-graph/tests/routes.spec.ts
+++ b/packages/dsh-git-graph/tests/routes.spec.ts
@@ -163,6 +163,24 @@ describe('/git loopback fence', () => {
     expect(status).toHaveBeenCalledWith('/w', expect.any(AbortSignal))
   })
 
+  it('clamps a graph limit above 1000 instead of resetting to the default', async () => {
+    const graph = vi.fn(async () => ({ root: '/w', branch: 'main', commits: [], hasMore: false }))
+    const { ctx, registrations } = fakeCtx()
+    registerGitRoutes(ctx as never, { graph } as never)
+    const prefix = registrations.find((row) => row.kind === 'prefix')!
+
+    const result = await drive(prefix.handler, '/git/graph', {
+      body: JSON.stringify({ path: '/w', limit: 1100 }),
+    })
+
+    expect(result.status).toBe(200)
+    expect(graph).toHaveBeenCalledWith('/w', 1000)
+    expect(JSON.parse(result.body)).toEqual({
+      ok: true,
+      value: { root: '/w', branch: 'main', commits: [], hasMore: false },
+    })
+  })
+
   it('rejects non-loopback JSON operations with 403 before touching the service', async () => {
     const status = vi.fn(async () => null)
     const { ctx, registrations } = fakeCtx()


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-git-graph` 的两个问题：

1. `/git/graph` 路由把超过 1000 的 limit 映射为 `undefined`（回退到 200 默认），导致 load-more 超过 1000 个提交时图谱缩回 200。改为 clamp 到 1000。
2. `GraphDialog` 的初始加载 effect 依赖 `load`，而 `load` 的 identity 会随父组件（BranchChip）每次渲染传入的新内联 `graph` 箭头变化——窗口聚焦 refetch / SSE push 触发父组件重渲染时，图谱被重置回第一页、丢失已加载的页。改为通过 ref 在 mount 时加载一次。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [x] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-git-graph test
pnpm --filter @linxin666/dsh-client-ui-git-graph typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-client-ui-git-graph test`：6 个测试文件 86 个用例全部通过（含新增 graph limit clamp 路由测试 1 个、GraphDialog 不重置测试 1 个）。
- `pnpm --filter @linxin666/dsh-client-ui-git-graph typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：图谱 load-more 超过 1000 不再缩回 200；窗口聚焦/SSE push 不再把已加载的图谱重置回第一页）。
