### PR TITLE
fix(shared): keep an in-flight edit to the same field being saved

### DIFF
--- a/packages/dsh-aionui-panel/src/client/settings-form.ts
+++ b/packages/dsh-aionui-panel/src/client/settings-form.ts
@@ -333,9 +333,11 @@ export class CardForm<T> {
     const valid = plan.filter(item => item.run !== undefined)
     if (plan.length === 0 || this.saving || valid.length !== plan.length) return
     const plannedWrites = valid.map(item => item.op)
-    // Snapshot the fields this save writes, so edits staged while it is in
-    // flight survive: only the staged keys this save actually wrote are cleared.
-    const fields = new Set(plan.map(item => item.field))
+    // Snapshot the staged entries this save writes, so an edit staged while it
+    // is in flight (which replaces the same key) survives: only delete the key
+    // when the entry is still the one this save started from.
+    const pending = new Map<string, StagedEdit | undefined>()
+    for (const item of plan) pending.set(item.field, this.staged.get(item.field))
     this.saving = true
     this.failed = false
     this.failedReason = undefined
@@ -356,11 +358,11 @@ export class CardForm<T> {
         if (await item.run!()) landed.add(item.field)
       }
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
+    for (const [field, before] of pending) {
+      if (landed.has(field) && this.staged.get(field) === before) this.staged.delete(field)
     }
     this.saving = false
-    this.failed = landed.size !== fields.size
+    this.failed = landed.size !== pending.size
     this.publish()
   }
 

--- a/packages/dsh-community-plugins/src/client/settings-form.ts
+++ b/packages/dsh-community-plugins/src/client/settings-form.ts
@@ -333,9 +333,11 @@ export class CardForm<T> {
     const valid = plan.filter(item => item.run !== undefined)
     if (plan.length === 0 || this.saving || valid.length !== plan.length) return
     const plannedWrites = valid.map(item => item.op)
-    // Snapshot the fields this save writes, so edits staged while it is in
-    // flight survive: only the staged keys this save actually wrote are cleared.
-    const fields = new Set(plan.map(item => item.field))
+    // Snapshot the staged entries this save writes, so an edit staged while it
+    // is in flight (which replaces the same key) survives: only delete the key
+    // when the entry is still the one this save started from.
+    const pending = new Map<string, StagedEdit | undefined>()
+    for (const item of plan) pending.set(item.field, this.staged.get(item.field))
     this.saving = true
     this.failed = false
     this.failedReason = undefined
@@ -356,11 +358,11 @@ export class CardForm<T> {
         if (await item.run!()) landed.add(item.field)
       }
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
+    for (const [field, before] of pending) {
+      if (landed.has(field) && this.staged.get(field) === before) this.staged.delete(field)
     }
     this.saving = false
-    this.failed = landed.size !== fields.size
+    this.failed = landed.size !== pending.size
     this.publish()
   }
 

--- a/packages/dsh-pet/src/client/settings-form.ts
+++ b/packages/dsh-pet/src/client/settings-form.ts
@@ -333,9 +333,11 @@ export class CardForm<T> {
     const valid = plan.filter(item => item.run !== undefined)
     if (plan.length === 0 || this.saving || valid.length !== plan.length) return
     const plannedWrites = valid.map(item => item.op)
-    // Snapshot the fields this save writes, so edits staged while it is in
-    // flight survive: only the staged keys this save actually wrote are cleared.
-    const fields = new Set(plan.map(item => item.field))
+    // Snapshot the staged entries this save writes, so an edit staged while it
+    // is in flight (which replaces the same key) survives: only delete the key
+    // when the entry is still the one this save started from.
+    const pending = new Map<string, StagedEdit | undefined>()
+    for (const item of plan) pending.set(item.field, this.staged.get(item.field))
     this.saving = true
     this.failed = false
     this.failedReason = undefined
@@ -356,11 +358,11 @@ export class CardForm<T> {
         if (await item.run!()) landed.add(item.field)
       }
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
+    for (const [field, before] of pending) {
+      if (landed.has(field) && this.staged.get(field) === before) this.staged.delete(field)
     }
     this.saving = false
-    this.failed = landed.size !== fields.size
+    this.failed = landed.size !== pending.size
     this.publish()
   }
 

--- a/packages/dsh-remote-web-ui/src/client/settings-form.ts
+++ b/packages/dsh-remote-web-ui/src/client/settings-form.ts
@@ -333,9 +333,11 @@ export class CardForm<T> {
     const valid = plan.filter(item => item.run !== undefined)
     if (plan.length === 0 || this.saving || valid.length !== plan.length) return
     const plannedWrites = valid.map(item => item.op)
-    // Snapshot the fields this save writes, so edits staged while it is in
-    // flight survive: only the staged keys this save actually wrote are cleared.
-    const fields = new Set(plan.map(item => item.field))
+    // Snapshot the staged entries this save writes, so an edit staged while it
+    // is in flight (which replaces the same key) survives: only delete the key
+    // when the entry is still the one this save started from.
+    const pending = new Map<string, StagedEdit | undefined>()
+    for (const item of plan) pending.set(item.field, this.staged.get(item.field))
     this.saving = true
     this.failed = false
     this.failedReason = undefined
@@ -356,11 +358,11 @@ export class CardForm<T> {
         if (await item.run!()) landed.add(item.field)
       }
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
+    for (const [field, before] of pending) {
+      if (landed.has(field) && this.staged.get(field) === before) this.staged.delete(field)
     }
     this.saving = false
-    this.failed = landed.size !== fields.size
+    this.failed = landed.size !== pending.size
     this.publish()
   }
 

--- a/packages/dsh-task-board/src/client/settings-form.ts
+++ b/packages/dsh-task-board/src/client/settings-form.ts
@@ -333,9 +333,11 @@ export class CardForm<T> {
     const valid = plan.filter(item => item.run !== undefined)
     if (plan.length === 0 || this.saving || valid.length !== plan.length) return
     const plannedWrites = valid.map(item => item.op)
-    // Snapshot the fields this save writes, so edits staged while it is in
-    // flight survive: only the staged keys this save actually wrote are cleared.
-    const fields = new Set(plan.map(item => item.field))
+    // Snapshot the staged entries this save writes, so an edit staged while it
+    // is in flight (which replaces the same key) survives: only delete the key
+    // when the entry is still the one this save started from.
+    const pending = new Map<string, StagedEdit | undefined>()
+    for (const item of plan) pending.set(item.field, this.staged.get(item.field))
     this.saving = true
     this.failed = false
     this.failedReason = undefined
@@ -356,11 +358,11 @@ export class CardForm<T> {
         if (await item.run!()) landed.add(item.field)
       }
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
+    for (const [field, before] of pending) {
+      if (landed.has(field) && this.staged.get(field) === before) this.staged.delete(field)
     }
     this.saving = false
-    this.failed = landed.size !== fields.size
+    this.failed = landed.size !== pending.size
     this.publish()
   }
 

--- a/packages/dsh-tool-describe-image/src/client/settings-form.ts
+++ b/packages/dsh-tool-describe-image/src/client/settings-form.ts
@@ -333,9 +333,11 @@ export class CardForm<T> {
     const valid = plan.filter(item => item.run !== undefined)
     if (plan.length === 0 || this.saving || valid.length !== plan.length) return
     const plannedWrites = valid.map(item => item.op)
-    // Snapshot the fields this save writes, so edits staged while it is in
-    // flight survive: only the staged keys this save actually wrote are cleared.
-    const fields = new Set(plan.map(item => item.field))
+    // Snapshot the staged entries this save writes, so an edit staged while it
+    // is in flight (which replaces the same key) survives: only delete the key
+    // when the entry is still the one this save started from.
+    const pending = new Map<string, StagedEdit | undefined>()
+    for (const item of plan) pending.set(item.field, this.staged.get(item.field))
     this.saving = true
     this.failed = false
     this.failedReason = undefined
@@ -356,11 +358,11 @@ export class CardForm<T> {
         if (await item.run!()) landed.add(item.field)
       }
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
+    for (const [field, before] of pending) {
+      if (landed.has(field) && this.staged.get(field) === before) this.staged.delete(field)
     }
     this.saving = false
-    this.failed = landed.size !== fields.size
+    this.failed = landed.size !== pending.size
     this.publish()
   }
 

--- a/shared/client/settings/settings-form.ts
+++ b/shared/client/settings/settings-form.ts
@@ -332,9 +332,11 @@ export class CardForm<T> {
     const valid = plan.filter(item => item.run !== undefined)
     if (plan.length === 0 || this.saving || valid.length !== plan.length) return
     const plannedWrites = valid.map(item => item.op)
-    // Snapshot the fields this save writes, so edits staged while it is in
-    // flight survive: only the staged keys this save actually wrote are cleared.
-    const fields = new Set(plan.map(item => item.field))
+    // Snapshot the staged entries this save writes, so an edit staged while it
+    // is in flight (which replaces the same key) survives: only delete the key
+    // when the entry is still the one this save started from.
+    const pending = new Map<string, StagedEdit | undefined>()
+    for (const item of plan) pending.set(item.field, this.staged.get(item.field))
     this.saving = true
     this.failed = false
     this.failedReason = undefined
@@ -355,11 +357,11 @@ export class CardForm<T> {
         if (await item.run!()) landed.add(item.field)
       }
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
+    for (const [field, before] of pending) {
+      if (landed.has(field) && this.staged.get(field) === before) this.staged.delete(field)
     }
     this.saving = false
-    this.failed = landed.size !== fields.size
+    this.failed = landed.size !== pending.size
     this.publish()
   }
 

--- a/shared/tests/settings-form.spec.ts
+++ b/shared/tests/settings-form.spec.ts
@@ -170,6 +170,33 @@ describe('CardForm', () => {
     expect(form.shell().dirty).toBe(false)
   })
 
+  it('keeps an in-flight edit to the SAME field being saved', async () => {
+    const scope = new FakeScope<Record<string, unknown>>({ enabled: true, size: 32, name: 'old' })
+    scope.autoReflect()
+    const form = new CardForm(scope, fields())
+    const actions = form.actions()
+    actions.edit('name', 'new')
+    // A deferred write keeps the save in flight so we can re-edit the same
+    // field mid-save.
+    let release: (() => void) | undefined
+    const gate = new Promise<void>(resolve => { release = resolve })
+    const originalSet = scope.set.getMockImplementation()
+    scope.set.mockImplementation(async (field: string, value: unknown) => {
+      await gate
+      await originalSet!(field, value)
+    })
+    const saving = form.save()
+    actions.edit('name', 'newer')
+    release!()
+    await saving
+    // The newer draft survives: only the entry this save started from is
+    // cleared, not a draft the user staged while the write was in flight.
+    expect(form.field('name')).toMatchObject({ text: 'newer', invalid: false })
+    expect(form.shell().dirty).toBe(true)
+    await form.save()
+    expect(form.shell().dirty).toBe(false)
+  })
+
   it('marks the shell failed when a write does not land', async () => {
     const scope = new FakeScope<Record<string, unknown>>({ name: 'old' })
     // Drop the write on the floor: the read-back never sees the staged value.


### PR DESCRIPTION
## 摘要（Summary）

修复 shared 设置表单 `CardForm.save()` 在保存期间对**同一字段**的新编辑被静默丢弃的问题。

根因：`save()` 只快照要写的字段名，写完后按字段名 `staged.delete(field)` 删除已落地的草稿。因为 `staged` 以字段名为 key，保存期间对同字段的 `edit()` 会覆盖该条目，删除时把更新的草稿一并抹掉——输入框弹回刚保存的值，用户最新编辑丢失。

修复：快照每个字段**保存前的 staged 条目**（引用），写完后仅当该 key 仍是本次保存出发的那个条目（未被新编辑替换）才删除；保存期间新 stage 的草稿（替换了条目）得以保留。同步 shared 副本到所有消费者，补同字段场景测试。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`（settings-form 副本）
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [x] 宠物 `packages/dsh-pet`（settings-form 副本）
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`（settings-form 副本）
- [x] 其他（请说明）：`shared/`（settings-form 事实源）及 `dsh-task-board` / `dsh-tool-describe-image` / `dsh-community-plugins` / `dsh-aionui-panel` 的 settings-form 同步副本

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/sync-shared.mjs --check
cd shared && npx vitest run
pnpm --filter @linxin666/dsh-pet test
pnpm --filter @linxin666/dsh-client-ui-task-board test
pnpm --filter @linxin666/dsh-remote-web-ui test
```

结果摘要：

- `sync-shared.mjs --check`：all consumer copies in sync。
- shared settings-form 测试：18 个用例全部通过（含新增同字段场景；还原修复时该用例失败，证明能捕捉此 bug）。
- pet 163 / task-board 230 / remote-web-ui 257 用例全部通过；对应包 typecheck 通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：保存进行中对同一字段继续输入的新草稿不再被静默丢弃）。
