### PR TITLE
chore(ci): drop --with-deps from the Playwright install and cache the browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,21 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # Browser binaries are cached by lockfile hash (the playwright version
+      # lives in the root package.json). The ubuntu-latest image already
+      # ships Chromium's system libraries via its preinstalled Chrome, so
+      # --with-deps is dropped on purpose: its apt run has hung on the
+      # Ubuntu mirrors until the 30-minute job timeout killed it. The step
+      # timeout keeps any future network hang a fast failure.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 10
+        run: pnpm exec playwright install chromium
 
       - name: Mount + headless-render smoke
         run: bash scripts/e2e-mount.sh


### PR DESCRIPTION
## 摘要（Summary）

多个 PR 的 `plugin-mount` 任务卡在 `Install Playwright Chromium` 一步直到 30 分钟超时被杀（如 run 32209899554：`--with-deps` 触发 apt，Azure/Ubuntu 镜像源一直 Ign 无响应；本日 #589 合并 run 亦同）。本 PR 简化该步骤：

1. 去掉 `--with-deps`（apt 是唯一挂起点）：`ubuntu-latest` 镜像预装 Google Chrome，Chromium 无头运行所需系统库已随镜像提供；
2. 按 pnpm-lock.yaml 哈希缓存 `~/.cache/ms-playwright`（playwright 版本由根 package.json 固定并被 lockfile 锁定），缓存命中后该步骤只剩秒级；
3. 给安装步加 `timeout-minutes: 10`，未来任何网络异常在 10 分钟内快速失败，不再烧满 30 分钟。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：CI 工作流 `.github/workflows/ci.yml`，无包改动

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git worktree add ... origin/main`（基于 4200233b）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（k3）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"   # yaml OK
```

结果摘要：

YAML 校验通过。真实验证即本 PR 的 plugin-mount 运行：新流程（无 apt、缓存浏览器、安装步 10 分钟上限）1 分 22 秒通过，此前同类任务在镜像源异常时挂到 30 分钟被杀。

## 用户可见变更证据（Local Feature Evidence）

证据：

CI 内部改动，无用户可见界面变更。证据为本 PR 的 plugin-mount 运行记录：1m22s 通过（actions/runs/32212406258/job/95947521317）。