### PR TITLE
fix(ssh): refit terminal on container resize so the last line stays visible

### DIFF
--- a/packages/dsh-ssh/src/client/panel/TerminalTab.tsx
+++ b/packages/dsh-ssh/src/client/panel/TerminalTab.tsx
@@ -124,17 +124,38 @@ export function TerminalTab({ api, presetAlias, requestId, terminalFont }: Termi
   // Unmount cleanup (never touches state on an unmounting component).
   useEffect(() => () => { teardown() }, [])
 
-  // Keep the terminal fitted to its container while connected.
+  // Keep the terminal fitted to its container. A window resize is only one
+  // trigger: the status banner appearing after connect, panel resizes, and
+  // sidebar toggles all change the container without a window resize, so the
+  // container itself is observed (otherwise the viewport keeps the pre-banner
+  // height and the last line is clipped below the fold). ResizeObserver may
+  // be absent (jsdom tests); the window listener then remains the only path.
   useEffect(() => {
-    const onResize = (): void => {
+    let lastCols = -1
+    let lastRows = -1
+    const sync = (): void => {
       const term = termRef.current
       const fit = fitRef.current
       if (term === null || fit === null) return
       fit.fit()
-      connRef.current?.resize(term.cols, term.rows)
+      const conn = connRef.current
+      if (conn !== null && (term.cols !== lastCols || term.rows !== lastRows)) {
+        lastCols = term.cols
+        lastRows = term.rows
+        conn.resize(term.cols, term.rows)
+      }
     }
-    window.addEventListener('resize', onResize)
-    return () => { window.removeEventListener('resize', onResize) }
+    window.addEventListener('resize', sync)
+    const container = containerRef.current
+    if (container === null || typeof ResizeObserver === 'undefined') {
+      return () => { window.removeEventListener('resize', sync) }
+    }
+    const observer = new ResizeObserver(() => { sync() })
+    observer.observe(container)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', sync)
+    }
   }, [])
 
   const connect = (): void => {

--- a/packages/dsh-ssh/src/client/panel/panel.module.css
+++ b/packages/dsh-ssh/src/client/panel/panel.module.css
@@ -703,8 +703,10 @@ html[data-dsh-ssh-active]:not([data-dsh-taskboard-active]) [class*='centerCol'] 
 
 .termContainer {
   position: absolute;
-  inset: 0;
-  padding: 8px 10px;
+  /* Inset offsets, not padding: FitAddon measures this element's height as
+     the drawable area, so padding here would be measured as terminal space
+     and clip the bottom line under a global border-box reset. */
+  inset: 8px 10px;
 }
 
 .termPlaceholder {

--- a/packages/dsh-ssh/tests/panel-terminal.test.tsx
+++ b/packages/dsh-ssh/tests/panel-terminal.test.tsx
@@ -73,6 +73,17 @@ describe('TerminalTab dispose and resize cleanup', () => {
     const source = readFileSync(join(process.cwd(), 'src', 'client', 'panel', 'TerminalTab.tsx'), 'utf8')
     expect(source).toContain('dataSubRef.current?.dispose()')
     expect(source).toContain('termRef.current?.dispose()')
-    expect(source).toContain('window.removeEventListener(\'resize\', onResize)')
+    expect(source).toContain('window.removeEventListener(\'resize\', sync)')
+  })
+
+  it('observes the terminal container so banner/panel resizes refit', () => {
+    // The connected banner shrinks the container after the initial fit;
+    // without a container-level observer the viewport keeps the old height
+    // and the last line is clipped. Guard the contract at source level
+    // (jsdom has no ResizeObserver to exercise at runtime).
+    const source = readFileSync(join(process.cwd(), 'src', 'client', 'panel', 'TerminalTab.tsx'), 'utf8')
+    expect(source).toContain('new ResizeObserver(')
+    expect(source).toContain('observer.observe(container)')
+    expect(source).toContain('observer.disconnect()')
   })
 })


### PR DESCRIPTION
## 摘要（Summary）

修复 SSH 终端最后一行被裁掉的问题：连接成功后状态横幅出现、容器变矮，但终端只在 window resize 时才重新 fit，视口停留在横幅出现前的高度，最后一行被裁到可视区外。改为用 ResizeObserver 观察终端容器，任何容器尺寸变化（横幅、面板拖拽、窗口缩放）都会重新 fit 并同步远程 PTY 行列数。

## 根因分析

1. `connect()` 时序：xterm 打开后立即 `fit.fit()`，随后 `onReady` 才渲染「已连接」横幅（`.termBody` flex 布局里 banner + 8px gap 使 `.termWrap` 变矮约两行）。此前唯一的 refit 触发点是 window resize 监听器，横幅出现不会触发。
2. 次要因素：`.termContainer` 用 `padding: 8px 10px` 做内边距，而 `@xterm/addon-fit` 的 `proposeDimensions` 直接取该元素的 computed height 作为可绘制区域（只扣除 `.terminal` 元素自身的 padding）。页面存在全局 `box-sizing: border-box` 时（如某些皮肤注入），这 16px 会被计入终端高度，底部被 `.termWrap` 的 `overflow: hidden` 裁掉。

## 修复内容

- `TerminalTab.tsx`：新增 ResizeObserver 观察终端容器，尺寸变化时重新 fit；远程 `resize()` 仅在 cols/rows 实际变化时发送（避免重复推送）。jsdom 无 ResizeObserver，做了能力检测回退，原 window resize 监听保留。
- `panel.module.css`：`.termContainer` 的 `padding: 8px 10px` 改为 `inset: 8px 10px`，任何盒模型下被测量的元素高度都等于可绘制区域，视觉内缩效果不变。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [x] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：`git fetch origin main`（提交点 ce0bf6f，期间 upstream main 发生 force push，已将改动重新应用到最新 main 并复测）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek（k3）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本 PR 未新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改动 README）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-ssh build
pnpm --filter @linxin666/dsh-ssh typecheck
pnpm --filter @linxin666/dsh-ssh test
```

结果摘要：

- build、typecheck 通过。
- test：113 个测试，105 通过、8 失败。8 个失败均为本机 Windows 平台的既有问题，与本次改动无关（改动前在同一 checkout 上基线失败相同）：POSIX 文件权限位断言（0600/0700 在 Windows 无效）、路径分隔符断言（`keys/id` vs `keys\id`）、symlink EPERM（未开开发者模式）、`/usr/sbin/sshd` 不存在（Windows 无 sshd）。
- 本次改动覆盖的 `tests/panel-terminal.test.tsx` 4 个测试全部通过，其中新增一条源码级契约断言（容器 ResizeObserver 注册与 disconnect；jsdom 无 ResizeObserver 运行时，无法做运行时断言）。

## 用户可见变更证据（Local Feature Evidence）

证据：

根因与修复路径经源码分析确认（`@xterm/addon-fit@0.11.0` 的 `proposeDimensions` 只响应显式 fit 调用；横幅渲染不触发 window resize）。本机为 Windows + 无头 CI 环境，无法提供浏览器截图；维护者可用以下步骤复现验证：连接任意 SSH 主机，连接成功横幅出现后终端底部约两行被裁（在深色背景上不可见）；应用本 PR 后横幅出现时 ResizeObserver 立即 refit，最后一行恢复可见，窗口缩放、面板尺寸变化同样即时生效。若需要，我可以补充 GUI 验证截图。
