### PR TITLE
ci(e2e-mount): targeted rewrite for unpublished family deps + post-publish strict mount gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,12 @@ name: Release
 
 # Tag-triggered publish pipeline: pushing a vX.Y.Z tag is the single release
 # switch. The workflow verifies every package version equals the tag version
-# (the tag is the version source of truth), runs the full gate, publishes all
-# packages to npm in dependency order, and creates the GitHub Release.
+# (the tag is the version source of truth), runs the full gate, and publishes
+# all packages to npm in dependency order. A second job then re-runs the
+# aggregate mount smoke in strict npm mode (every dependency resolves from
+# the registry — the real consumer install path, verified after publish when
+# the assertion holds) and only then creates the GitHub Release with the npm
+# tarball assets.
 #
 # Requires the repository secret NPM_TOKEN (npm automation token for the
 # @linxin666 scope) to publish.
@@ -22,7 +26,7 @@ concurrency:
 
 jobs:
   publish:
-    name: Build, test, publish, release
+    name: Build, test, publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -108,6 +112,16 @@ jobs:
             node scripts/release-notes.mjs "$GITHUB_REF_NAME" > "$RUNNER_TEMP/release-notes.md"
           fi
 
+      # Hand the notes to the release job (job 2): they must exist before
+      # publish (a notes failure aborts before anything reaches npm), and
+      # the release job consumes them after the post-publish mount smoke.
+      - name: Upload release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: ${{ runner.temp }}/release-notes.md
+          if-no-files-found: error
+
       # Publish with the explicit "latest" dist-tag so that installing the
       # package without a version (or with @latest) always resolves to the
       # newest release, never a stale earlier one.
@@ -118,6 +132,68 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
           pnpm -r publish --no-git-checks --access public --registry=https://registry.npmjs.org/ --tag latest
 
+      # The GitHub Release is created by the verify-release job only after
+      # the post-publish mount smoke passes; a failed publish cannot be
+      # re-run for an already-published version, but a failed smoke leaves
+      # the tag without a release for inspection instead of shipping a bad
+      # consumer path silently.
+
+  verify-release:
+    name: Post-publish mount smoke (npm strict) + GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DSH_TELEMETRY_DISABLED: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 11
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      # Pin the DSH CLI the lane mounts into (same pin as ci.yml's
+      # plugin-mount lane).
+      - name: Install dsh CLI (pinned)
+        run: npm install -g @deepseek-ai/dsh@0.1.0-rc.6
+
+      # The aggregate tarball must be produced from a fresh build.
+      - name: Build
+        run: pnpm build
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        timeout-minutes: 10
+        run: pnpm exec playwright install chromium
+
+      # Strict npm mode: at this point every family dependency is published,
+      # so the auto rewrite in scripts/e2e-mount-rewrite leaves the tarball
+      # untouched and the smoke exercises the real consumer install path.
+      - name: Mount + headless-render smoke
+        run: bash scripts/e2e-mount.sh
+
+      - name: Download release notes artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+          path: ${{ runner.temp }}
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -126,10 +202,9 @@ jobs:
             --notes-file "$RUNNER_TEMP/release-notes.md" \
             --title "dsh-web-ui $GITHUB_REF_NAME"
 
-      # A bare `gh release create` carries only GitHub's auto-generated
-      # source archives. Pack the published tarballs back from the npm
-      # registry (byte-identical to what pnpm -r publish pushed above) and
-      # attach them as real installable release artifacts.
+      # Pack the published tarballs back from the npm registry (byte-identical
+      # to what the publish job pushed) and attach them as real installable
+      # release artifacts.
       - name: Upload npm tarballs to the release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/e2e-mount-rewrite
+++ b/scripts/e2e-mount-rewrite
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Rewrite the packed dsh-web-ui-all tarball's dependency table for the
+ * e2e mount smoke (scripts/e2e-mount.sh).
+ *
+ * Modes:
+ *   auto (default): every @linxin666/* dependency that already exists on
+ *     npm at the packed version stays pointed at the registry (the gate's
+ *     original "npm consumers can install this" assertion is unchanged);
+ *     only a dependency NOT yet published — a brand-new family package in
+ *     the push-to-publish window — is packed from its workspace directory
+ *     and rewritten to a file: tarball. This removes the red window without
+ *     weakening the gate for anything already published.
+ *   --family-dir DIR: manual full override (the old FAMILY_TGZS_DIR
+ *     behavior): rewrite ALL @linxin666/* dependencies to the same-named
+ *     tarballs in DIR.
+ *   --better-sidebar-tgz TGZ: rewrite the dsh-better-sidebar dependency to
+ *     the given tarball (pre-release local 联调).
+ *
+ * Usage:
+ *   node scripts/e2e-mount-rewrite <tarball package.json> [--root DIR]
+ *     [--family-dir DIR] [--better-sidebar-tgz TGZ]
+ *
+ * Exit code is 0 on success; a missing workspace package or tarball exits 1.
+ */
+'use strict'
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { execFileSync } = require('node:child_process')
+
+const FAMILY_SCOPE = '@linxin666/'
+const REGISTRY = 'https://registry.npmjs.org'
+
+/** Default registry probe: true when name@version exists on npm. */
+async function checkPublished(name, version) {
+  const res = await fetch(REGISTRY + '/' + name.replace('/', '%2f'))
+  if (!res.ok) return false
+  const data = await res.json()
+  return Boolean(data.versions && data.versions[version])
+}
+
+/** Default packer: pnpm pack the workspace directory into outDir, return the tarball path. */
+function packWorkspace(pkgDir, outDir) {
+  execFileSync('pnpm', ['pack', '--pack-destination', outDir], { cwd: pkgDir, stdio: 'pipe' })
+  const names = fs.readdirSync(outDir).filter(name => name.endsWith('.tgz'))
+  if (names.length === 0) throw new Error('pnpm pack 未产出 tarball（' + pkgDir + '）')
+  return path.join(outDir, names.sort().pop())
+}
+
+/** Locate a workspace package directory by its package name. */
+function findWorkspacePackage(root, name) {
+  const dirs = [path.join(root, 'packages'), path.join(root, 'packages', 'skins')]
+  for (const base of dirs) {
+    if (!fs.existsSync(base)) continue
+    for (const entry of fs.readdirSync(base)) {
+      const manifest = path.join(base, entry, 'package.json')
+      if (!fs.existsSync(manifest)) continue
+      try {
+        if (JSON.parse(fs.readFileSync(manifest, 'utf8')).name === name) return path.join(base, entry)
+      } catch { /* ignore unreadable manifests */ }
+    }
+  }
+  return null
+}
+
+/** Read a tarball's embedded package name (family-dir manual mode). */
+function readTgzName(tgz) {
+  const raw = execFileSync('tar', ['-xzf', tgz, '-O', 'package/package.json'], { stdio: 'pipe' }).toString()
+  return JSON.parse(raw).name
+}
+
+/**
+ * Rewrite the tarball's dependency table in place.
+ * @param {object} opts
+ * @param {string} opts.pkgPath - path to the extracted tarball's package.json.
+ * @param {string} opts.root - repository root (workspace package lookup).
+ * @param {string} [opts.familyDir] - manual override directory of family tarballs.
+ * @param {string} [opts.betterSidebarTgz] - manual dsh-better-sidebar tarball.
+ * @param {(name: string, version: string) => Promise<boolean>} [opts.checkPublished] - registry probe (auto mode).
+ * @param {(pkgDir: string, outDir: string) => string} [opts.pack] - workspace packer (auto mode).
+ * @param {(message: string) => void} [opts.log]
+ * @returns {Promise<string[]>} human-readable report lines.
+ */
+async function rewriteDependencies(opts) {
+  const { pkgPath, root, familyDir, betterSidebarTgz } = opts
+  const log = opts.log ?? (() => {})
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+  if (!pkg.dependencies) throw new Error('tarball package.json 没有 dependencies')
+  const report = []
+
+  if (betterSidebarTgz) {
+    if (!('dsh-better-sidebar' in pkg.dependencies)) throw new Error('tarball package.json 缺少 dsh-better-sidebar 依赖')
+    pkg.dependencies['dsh-better-sidebar'] = 'file:' + betterSidebarTgz
+    report.push('dsh-better-sidebar → file:' + betterSidebarTgz + '（手工覆盖）')
+  }
+
+  const familyNames = Object.keys(pkg.dependencies).filter(key => key.startsWith(FAMILY_SCOPE))
+
+  if (familyDir) {
+    const byName = {}
+    for (const file of fs.readdirSync(familyDir)) {
+      if (!file.endsWith('.tgz')) continue
+      byName[readTgzName(path.join(familyDir, file))] = path.join(familyDir, file)
+    }
+    for (const name of familyNames) {
+      if (!byName[name]) throw new Error('缺少本地 tarball：' + name)
+      pkg.dependencies[name] = 'file:' + byName[name]
+      report.push(name + ' → file:' + byName[name] + '（family-dir 全覆盖）')
+    }
+  } else {
+    const check = opts.checkPublished ?? checkPublished
+    const pack = opts.pack ?? packWorkspace
+    const packOut = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-family-tgz-'))
+    for (const name of familyNames) {
+      const version = pkg.dependencies[name]
+      if (await check(name, version)) {
+        report.push(name + '@' + version + ' npm 已发布（保持 registry 安装）')
+        continue
+      }
+      const dir = findWorkspacePackage(root, name)
+      if (!dir) throw new Error('npm 未发布且仓库内找不到 workspace 包：' + name)
+      const tgz = pack(dir, packOut)
+      pkg.dependencies[name] = 'file:' + tgz
+      report.push(name + '@' + version + ' npm 未发布 → file:' + tgz + '（发布窗口本地 tarball）')
+    }
+  }
+
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+  for (const line of report) log(line)
+  return report
+}
+
+function parseArgs(argv) {
+  const opts = { root: path.resolve(__dirname, '..') }
+  const positional = []
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--root') opts.root = argv[++i]
+    else if (argv[i] === '--family-dir') opts.familyDir = argv[++i]
+    else if (argv[i] === '--better-sidebar-tgz') opts.betterSidebarTgz = argv[++i]
+    else positional.push(argv[i])
+  }
+  opts.pkgPath = positional[0]
+  return opts
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  if (!opts.pkgPath) {
+    console.error('用法: node scripts/e2e-mount-rewrite <tarball package.json> [--root DIR] [--family-dir DIR] [--better-sidebar-tgz TGZ]')
+    process.exit(1)
+  }
+  try {
+    await rewriteDependencies({ ...opts, log: line => console.log('[e2e-mount-rewrite]', line) })
+  } catch (error) {
+    console.error('[e2e-mount-rewrite]', error.message)
+    process.exit(1)
+  }
+}
+
+if (require.main === module) main()
+
+module.exports = { rewriteDependencies, findWorkspacePackage, checkPublished, packWorkspace, FAMILY_SCOPE }
+

--- a/scripts/e2e-mount-rewrite.test.mjs
+++ b/scripts/e2e-mount-rewrite.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * e2e-mount-rewrite contract: auto mode keeps npm-published family
+ * dependencies on the registry and rewrites only unpublished ones to local
+ * file: tarballs (the push-to-publish window fix); the manual family-dir
+ * override still rewrites everything; a dependency that is unpublished and
+ * missing from the workspace fails loudly.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { rewriteDependencies, findWorkspacePackage } from './e2e-mount-rewrite'
+
+function makeTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-rewrite-test-'))
+}
+
+function writePkg(dir, body) {
+  fs.mkdirSync(dir, { recursive: true })
+  const file = path.join(dir, 'package.json')
+  fs.writeFileSync(file, JSON.stringify(body, null, 2) + '\n')
+  return file
+}
+
+function makeWorkspace(root) {
+  writePkg(path.join(root, 'packages', 'dsh-a'), { name: '@linxin666/dsh-a', version: '0.1.0' })
+  writePkg(path.join(root, 'packages', 'dsh-b'), { name: '@linxin666/dsh-b', version: '0.2.0' })
+  writePkg(path.join(root, 'packages', 'skins', 'skin-x'), { name: '@linxin666/dsh-skin-x', version: '0.1.0' })
+}
+
+function makeTarballPkg(dir) {
+  return writePkg(dir, {
+    name: '@linxin666/dsh-web-ui-all',
+    version: '9.9.9',
+    dependencies: {
+      '@linxin666/dsh-a': '0.1.0',
+      '@linxin666/dsh-b': '0.2.0',
+      'dsh-better-sidebar': '0.13.0',
+      react: '^18.3.1',
+    },
+  })
+}
+
+function makeTgz(dir, pkgName) {
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-tgz-stage-'))
+  writePkg(path.join(staging, 'package'), { name: pkgName, version: '0.0.0' })
+  const tgz = path.join(dir, pkgName.split('/').pop() + '.tgz')
+  execFileSync('tar', ['-czf', tgz, '-C', staging, 'package'])
+  return tgz
+}
+
+test('auto mode: published deps stay on npm, unpublished deps rewrite to file:', async () => {
+  const tmp = makeTmp()
+  const root = path.join(tmp, 'repo')
+  makeWorkspace(root)
+  const pkgPath = makeTarballPkg(path.join(tmp, 'tarball'))
+  const published = new Set(['@linxin666/dsh-a@0.1.0'])
+  const packed = []
+  const report = await rewriteDependencies({
+    pkgPath,
+    root,
+    checkPublished: async (name, version) => published.has(name + '@' + version),
+    pack: (dir, outDir) => {
+      packed.push(dir)
+      const tgz = path.join(outDir, path.basename(dir) + '.tgz')
+      fs.writeFileSync(tgz, 'fake')
+      return tgz
+    },
+  })
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+  assert.equal(pkg.dependencies['@linxin666/dsh-a'], '0.1.0')
+  assert.match(pkg.dependencies['@linxin666/dsh-b'], /^file:.*dsh-b\.tgz$/)
+  assert.equal(pkg.dependencies['react'], '^18.3.1')
+  assert.equal(pkg.dependencies['dsh-better-sidebar'], '0.13.0')
+  assert.equal(packed.length, 1)
+  assert.match(packed[0], /dsh-b$/)
+  assert.ok(report.some(line => line.includes('npm 已发布')))
+  assert.ok(report.some(line => line.includes('npm 未发布')))
+})
+
+test('auto mode: unpublished dep missing from the workspace fails loudly', async () => {
+  const tmp = makeTmp()
+  const root = path.join(tmp, 'repo')
+  fs.mkdirSync(path.join(root, 'packages'), { recursive: true })
+  const pkgPath = makeTarballPkg(path.join(tmp, 'tarball'))
+  await assert.rejects(
+    rewriteDependencies({ pkgPath, root, checkPublished: async () => false }),
+    /找不到 workspace 包/,
+  )
+})
+
+test('family-dir mode: every family dep rewrites to the same-named tarball', async () => {
+  const tmp = makeTmp()
+  const familyDir = path.join(tmp, 'family')
+  fs.mkdirSync(familyDir, { recursive: true })
+  const tgzA = makeTgz(familyDir, '@linxin666/dsh-a')
+  const tgzB = makeTgz(familyDir, '@linxin666/dsh-b')
+  const pkgPath = makeTarballPkg(path.join(tmp, 'tarball'))
+  await rewriteDependencies({ pkgPath, root: tmp, familyDir })
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+  assert.equal(pkg.dependencies['@linxin666/dsh-a'], 'file:' + tgzA)
+  assert.equal(pkg.dependencies['@linxin666/dsh-b'], 'file:' + tgzB)
+  assert.equal(pkg.dependencies['react'], '^18.3.1')
+})
+
+test('family-dir mode: missing tarball fails loudly', async () => {
+  const tmp = makeTmp()
+  const familyDir = path.join(tmp, 'family')
+  fs.mkdirSync(familyDir, { recursive: true })
+  makeTgz(familyDir, '@linxin666/dsh-a')
+  const pkgPath = makeTarballPkg(path.join(tmp, 'tarball'))
+  await assert.rejects(
+    rewriteDependencies({ pkgPath, root: tmp, familyDir }),
+    /缺少本地 tarball/,
+  )
+})
+
+test('better-sidebar manual override rewrites only that dep', async () => {
+  const tmp = makeTmp()
+  const pkgPath = makeTarballPkg(path.join(tmp, 'tarball'))
+  const published = new Set(['@linxin666/dsh-a@0.1.0', '@linxin666/dsh-b@0.2.0'])
+  await rewriteDependencies({
+    pkgPath,
+    root: tmp,
+    betterSidebarTgz: '/tmp/bs.tgz',
+    checkPublished: async (name, version) => published.has(name + '@' + version),
+  })
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+  assert.equal(pkg.dependencies['dsh-better-sidebar'], 'file:/tmp/bs.tgz')
+  assert.equal(pkg.dependencies['@linxin666/dsh-a'], '0.1.0')
+})
+
+test('findWorkspacePackage scans packages/ and packages/skins/', () => {
+  const tmp = makeTmp()
+  makeWorkspace(tmp)
+  assert.match(findWorkspacePackage(tmp, '@linxin666/dsh-a'), /packages\/dsh-a$/)
+  assert.match(findWorkspacePackage(tmp, '@linxin666/dsh-skin-x'), /packages\/skins\/skin-x$/)
+  assert.equal(findWorkspacePackage(tmp, '@linxin666/nope'), null)
+})
+

--- a/scripts/e2e-mount.sh
+++ b/scripts/e2e-mount.sh
@@ -13,6 +13,11 @@
 # 用法：
 #   bash scripts/e2e-mount.sh
 #
+# 依赖改写（scripts/e2e-mount-rewrite，默认 auto 模式）：聚合包 tarball 里
+# 已在 npm 发布的 @linxin666/* 依赖保持 registry 安装（门禁原语义不变），
+# 仅尚未发布的新包（推送 → 发布窗口）自动打包仓库 workspace 改写为 file:
+# tarball——窗口期不再必红。
+#
 # 环境变量（均可省略）：
 #   DSH_CMD             dsh 命令；缺省 PATH 上的 `dsh`，回退 npx 拉官方包
 #   WEB_UI_ALL_DIR      聚合包目录；缺省 packages/dsh-web-ui-all
@@ -20,10 +25,10 @@
 #                       里的 dsh-better-sidebar 依赖改写为 file:<该 tarball>
 #                       （用于 dsh-better-sidebar@0.13.0 尚未发版前的本地
 #                       联调；CI 不设此变量，走 npm 已发布版本）
-#   FAMILY_TGZS_DIR     本地家族 tarball 目录；给出时把聚合包 tarball 里全部
-#                       @linxin666/* 依赖改写为 file:<目录内同名 tarball>
-#                       （验证仓库当前构建，而非 npm 已发布版本；与本地
-#                       全 tarball 安装流程一致。CI 不设此变量）
+#   FAMILY_TGZS_DIR     本地家族 tarball 目录（手工全覆盖，优先级高于 auto
+#                       模式）：给出时把聚合包 tarball 里全部 @linxin666/* 依赖
+#                       改写为 file:<目录内同名 tarball>（验证仓库当前构建，
+#                       而非 npm 已发布版本；与本地全 tarball 安装流程一致）
 #   PORT                固定端口（默认 0 = OS 分配，从日志解析 URL）
 #   DSH_HOME_BASE       覆盖 scratch 根目录（默认 mktemp -d）
 #   KEEP_HOME           非空时保留 scratch home（调试用）
@@ -92,56 +97,33 @@ TARBALL="$(cd "$WEB_UI_ALL_DIR" && pwd)/$TARBALL"
 [ -f "$TARBALL" ] || die "pnpm pack 未产出 tarball（${WEB_UI_ALL_DIR}）"
 say "tarball: $TARBALL"
 
-# 可选：把聚合包 tarball 的依赖改写为本地 tarball（发版前/仓库构建联调用）。
-# FAMILY_TGZS_DIR 覆盖全部 @linxin666/* 依赖；BETTER_SIDEBAR_TGZ 覆盖
-# dsh-better-sidebar 依赖。两者都不设时走 npm 已发布版本（CI 形态）。
-if [ -n "$FAMILY_TGZS_DIR" ] || [ -n "$BETTER_SIDEBAR_TGZ" ]; then
-  if [ -n "$FAMILY_TGZS_DIR" ]; then
-    [ -d "$FAMILY_TGZS_DIR" ] || die "FAMILY_TGZS_DIR 不存在：$FAMILY_TGZS_DIR"
-  fi
-  if [ -n "$BETTER_SIDEBAR_TGZ" ]; then
-    [ -f "$BETTER_SIDEBAR_TGZ" ] || die "BETTER_SIDEBAR_TGZ 不存在：$BETTER_SIDEBAR_TGZ"
-    BETTER_SIDEBAR_TGZ="$(cd "$(dirname "$BETTER_SIDEBAR_TGZ")" && pwd)/$(basename "$BETTER_SIDEBAR_TGZ")"
-  fi
-  say "改写聚合包 tarball 依赖（FAMILY_TGZS_DIR=${FAMILY_TGZS_DIR:-无}，BETTER_SIDEBAR_TGZ=${BETTER_SIDEBAR_TGZ:-无}）"
-  REWRITE_DIR="$SCRATCH/tarball-rewrite"
-  mkdir -p "$REWRITE_DIR"
-  tar -xzf "$TARBALL" -C "$REWRITE_DIR"
-  PACKAGE_JSON="$REWRITE_DIR/package/package.json"
-  node -e '
-    const fs = require("fs")
-    const { execSync } = require("child_process")
-    const path = process.argv[1]
-    const familyDir = process.argv[2] || ""
-    const betterSidebarTgz = process.argv[3] || ""
-    const pkg = JSON.parse(fs.readFileSync(path, "utf8"))
-    if (!pkg.dependencies) { console.error("[e2e-mount] tarball package.json 没有 dependencies"); process.exit(1) }
-    if (familyDir) {
-      const byName = {}
-      for (const f of fs.readdirSync(familyDir)) {
-        if (!f.endsWith(".tgz")) continue
-        const raw = execSync(`tar -xzf ${JSON.stringify(familyDir + "/" + f)} -O package/package.json`).toString()
-        byName[JSON.parse(raw).name] = familyDir + "/" + f
-      }
-      for (const [key] of Object.entries(pkg.dependencies)) {
-        if (!key.startsWith("@linxin666/")) continue
-        if (!byName[key]) { console.error("[e2e-mount] 缺少本地 tarball：", key); process.exit(1) }
-        pkg.dependencies[key] = "file:" + byName[key]
-      }
-    }
-    if (betterSidebarTgz) {
-      if (!("dsh-better-sidebar" in pkg.dependencies)) {
-        console.error("[e2e-mount] tarball package.json 缺少 dsh-better-sidebar 依赖")
-        process.exit(1)
-      }
-      pkg.dependencies["dsh-better-sidebar"] = "file:" + betterSidebarTgz
-    }
-    fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n")
-  ' "$PACKAGE_JSON" "$FAMILY_TGZS_DIR" "$BETTER_SIDEBAR_TGZ"
-  TARBALL="$SCRATCH/dsh-web-ui-all-rewritten.tgz"
-  tar -czf "$TARBALL" -C "$REWRITE_DIR" package
-  say "改写后 tarball: $TARBALL"
+# 步骤 1b：解析聚合包 tarball 依赖（scripts/e2e-mount-rewrite）。auto 模式
+# 只把 npm 上尚未发布的 @linxin666/* 依赖改写为仓库 workspace 打包的 file:
+# tarball（发布窗口治理）；FAMILY_TGZS_DIR / BETTER_SIDEBAR_TGZ 为手工全
+# 覆盖，优先级高于 auto 模式。
+if [ -n "$FAMILY_TGZS_DIR" ]; then
+  [ -d "$FAMILY_TGZS_DIR" ] || die "FAMILY_TGZS_DIR 不存在：$FAMILY_TGZS_DIR"
 fi
+if [ -n "$BETTER_SIDEBAR_TGZ" ]; then
+  [ -f "$BETTER_SIDEBAR_TGZ" ] || die "BETTER_SIDEBAR_TGZ 不存在：$BETTER_SIDEBAR_TGZ"
+  BETTER_SIDEBAR_TGZ="$(cd "$(dirname "$BETTER_SIDEBAR_TGZ")" && pwd)/$(basename "$BETTER_SIDEBAR_TGZ")"
+fi
+say "解析聚合包 tarball 依赖（auto=仅未发布走本地；FAMILY_TGZS_DIR=${FAMILY_TGZS_DIR:-无}，BETTER_SIDEBAR_TGZ=${BETTER_SIDEBAR_TGZ:-无}）"
+REWRITE_DIR="$SCRATCH/tarball-rewrite"
+mkdir -p "$REWRITE_DIR"
+tar -xzf "$TARBALL" -C "$REWRITE_DIR"
+PACKAGE_JSON="$REWRITE_DIR/package/package.json"
+REWRITE_ARGS=(--root "$ROOT")
+if [ -n "$FAMILY_TGZS_DIR" ]; then
+  REWRITE_ARGS+=(--family-dir "$FAMILY_TGZS_DIR")
+fi
+if [ -n "$BETTER_SIDEBAR_TGZ" ]; then
+  REWRITE_ARGS+=(--better-sidebar-tgz "$BETTER_SIDEBAR_TGZ")
+fi
+node "$ROOT/scripts/e2e-mount-rewrite" "$PACKAGE_JSON" "${REWRITE_ARGS[@]}"
+TARBALL="$SCRATCH/dsh-web-ui-all-rewritten.tgz"
+tar -czf "$TARBALL" -C "$REWRITE_DIR" package
+say "改写后 tarball: $TARBALL"
 
 # 步骤 2：引导 scratch profile（web 模板；先写 pnpm-workspace.yaml 的
 # allowBuilds / minimumReleaseAgeExclude，避免 pnpm 11 strict-dep-builds


### PR DESCRIPTION
## 摘要（Summary）

根治 plugin-mount 的「发布窗口必红」：聚合包纳入尚未发布 npm 的新家族包后，从 main 推送到 npm publish 完成之间，e2e 挂载冒烟必因 registry 404 失败（0.2.2 发布时已实际发生一次，run 32215789929）。本 PR 让每个断言在它成立的时刻执行：push/PR 时段对未发布依赖做**定点本地 tarball 改写**（已发布依赖照旧走 registry，门禁强度不变），并在 release 流水线**发布后**以纯 npm 严格模式重跑挂载冒烟，通过后才创建 GitHub Release。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）：仅 CI / 脚本维护（`scripts/e2e-mount-rewrite` 新增、`scripts/e2e-mount.sh`、`.github/workflows/release.yml`）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```sh
git worktree add <dir> -b chore/e2e-publish-window origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek（k3）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本 PR 无新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。（CI 同款脚本扫描通过）
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改 README）

## 改动明细

### A. 定点改写（根治 push 窗口）

- `scripts/e2e-mount-rewrite`（新，可测试 CJS 模块）：解析聚合包 tarball 的 dependencies，auto 模式下逐个探测 `@linxin666/*` 依赖在 npm registry 上 `name@version` 是否存在——已发布则保持不变（原「npm 消费者可安装」断言强度不变）；未发布则从仓库 workspace（`packages/` 与 `packages/skins/`）`pnpm pack` 并改写为 `file:` tarball；未发布且仓库内找不到则响亮失败。手工覆盖保留且优先：`--family-dir`（原 FAMILY_TGZS_DIR 全覆盖语义）、`--better-sidebar-tgz`。
- `scripts/e2e-mount.sh`：删除内联 node -e 改写块，改为总是调用 `scripts/e2e-mount-rewrite`（auto 为默认）；头注释同步新语义。
- `scripts/e2e-mount-rewrite.test.mjs`（新，6 用例进 `test:scripts`）：已发布保持 / 未发布改写 / 未发布且缺 workspace 包响亮失败 / family-dir 全覆盖与缺 tarball 失败 / better-sidebar 手工覆盖 / workspace 包定位。

### B. 发布后严检（release.yml 两段式）

- `publish` job（更名 Build, test, publish to npm）：至 `pnpm -r publish` 为止；release notes 生成后上传为 artifact（保留「notes 失败先于发布中止」的既有性质）。
- `verify-release` job（新，needs: publish）：与 ci.yml plugin-mount 相同环境（pinned dsh CLI、Playwright Chromium）跑 `bash scripts/e2e-mount.sh`——此刻全部家族依赖已发布，auto 改写零触碰，等价于**纯 npm 严格模式的真实消费者安装路径验证**；通过后才下载 notes artifact、创建 GitHub Release 并挂载 npm tarball 资产。失败则 tag 不出 Release，发布缺口显眼可见而非带病发布。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm test:scripts                 # 113 pass / 0 fail（含新增 6 用例）
pnpm docs:check                   # all documentation gates passed
bash -n scripts/e2e-mount.sh      # 语法检查
# 真实验证：pnpm pack 聚合包（0.2.2）→ 解包 → node scripts/e2e-mount-rewrite（auto）
```

结果摘要：真实聚合 tarball 上 14 个家族依赖全部探测为已发布、零 file: 改写（严格路径逐字节保留）；未发布路径由单测覆盖（stub 注入，无网络）。emoji 扫描通过。

## 用户可见变更证据（Local Feature Evidence）

N/A（CI / 发布流水线内部改动，无用户可见变更）。合并后观察点：下个含新包发布的窗口期 main CI 不再红；0.2.2 时失败的 run（32215789929）手工 rerun 已绿，证明 npm 侧状态正常。
