### PR TITLE
feat(ssh): add defaultPermissionMode for agent SSH tools

### DIFF
--- a/packages/dsh-ssh/AGENTS.md
+++ b/packages/dsh-ssh/AGENTS.md
@@ -14,6 +14,8 @@ dsh Web GUI 的远程 SSH 运维插件：Host 进程内的持久 ssh2 连接池 
   对话记录；传输 / 执行消耗**真实远程资源**，Agent 使用前先确认。
 - `ssh_upload` / `ssh_download` 以宿主进程权限直接读写本机任意路径（不经
   bash 沙箱）；所有 `/api/dsh-ssh/*` 路由仅限 loopback，隧道只监听 `127.0.0.1`。
+- Agent 工具默认全部可用；`defaultPermissionMode` 可设为 `readonly` / `deny` /
+  `ask` 收紧模型侧行为（GUI 人工操作不受影响）。改权限语义必须同步 README 与测试。
 
 ## Agent 工具面
 
@@ -21,6 +23,7 @@ dsh Web GUI 的远程 SSH 运维插件：Host 进程内的持久 ssh2 连接池 
   `ssh_tunnel` / `ssh_cluster`，GUI 与 Agent 共享同一份主机配置。
 - Agent 只能用**用户在 GUI 配置过**（或从 `~/.ssh/config` 导入）的主机；别名
   未配置时先告知用户去 GUI 配置，不得臆造。
+- 权限策略只拦截列在 `permissionTools` 中的 Agent 工具；非 SSH 工具不受本包策略影响。
 
 ## 提交前检查
 

--- a/packages/dsh-ssh/README.i18n.yaml
+++ b/packages/dsh-ssh/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: f9476df50bac571b567512cfa5272b5a64a1c3d6
-README.zh.md: ec991222c0a38f2376acdd21ae52fe185facd0c2
+README.md: 5da7eacf8f53d65fa26d1a7ce4f5b86a97179957
+README.zh.md: c7a908f96ec344e40283a5139d98e7d9c5f1b2a1

--- a/packages/dsh-ssh/README.md
+++ b/packages/dsh-ssh/README.md
@@ -27,6 +27,7 @@ Built on the capability list of [badseal/ssh-skill](https://github.com/badseal/s
 - Before the Agent uses a tool, the host must first be configured in the GUI (or imported from ~/.ssh/config).
 - `ssh_upload` / `ssh_download` read/write arbitrary local paths on this machine with host-process privileges (not through the bash sandbox) — same host-local-path semantics as ssh-skill, be aware of that permission surface.
 - The remote output of exec / cluster is returned verbatim (not sanitized); a command like `env` may bring secrets from the remote environment back into the conversation log.
+- Agent tool use can be restricted through `defaultPermissionMode` (see Configuration); the default `allow` keeps full functionality, while `readonly` / `deny` / `ask` reduce what the model may do on your behalf.
 
 ## Install
 
@@ -49,6 +50,32 @@ After installing, **restart `dsh web`**: a "SSH" entry appears in the sidebar; t
 ## Configuration
 
 The settings panel (plugin config) toggles `announceToAgent` (whether to announce the plugin to the Agent) and `enabled` (master switch), and sets `terminalFontFamily` (the web terminal font; empty defers to the CSS chain: `--dsh-ssh-terminal-font` → the official `--ds-font-family-code` token → the built-in monospace stack). The terminal font is fixed in the xterm constructor, so a plain stylesheet cannot override it; to render powerline / Nerd Font glyphs, enter a Nerd Font stack here (e.g. `"SauceCodePro Nerd Font", monospace`). Changes re-apply to open terminals live, no reconnect needed.
+
+The SSH agent tools can also be gated by a permission policy:
+
+- `defaultPermissionMode`: `allow` (default), `readonly`, `deny`, or `ask`.
+  - `allow` — all SSH agent tools run normally.
+  - `readonly` — only `permissionReadonlyTools` are allowed.
+  - `deny` — all `permissionTools` are denied.
+  - `ask` — every call to a listed SSH tool requests human approval.
+- `permissionTools`: the tools governed by the mode; defaults to all six SSH agent tools.
+- `permissionReadonlyTools`: tools still allowed in `readonly` mode; defaults to `ssh_list`.
+
+This policy applies only to the agent-facing tools. The web GUI (host manager, terminal, transfers, tunnels) is always manual user interaction and is never gated. Example in `~/.dsh/settings.yaml`:
+
+```yaml
+dsh-ssh:
+  defaultPermissionMode: readonly
+  permissionTools:
+    - ssh_list
+    - ssh_exec
+    - ssh_upload
+    - ssh_download
+    - ssh_tunnel
+    - ssh_cluster
+  permissionReadonlyTools:
+    - ssh_list
+```
 
 ## Data
 

--- a/packages/dsh-ssh/README.zh.md
+++ b/packages/dsh-ssh/README.zh.md
@@ -27,6 +27,7 @@
 - Agent 使用工具前，主机需先在 GUI 中配置（或从 ~/.ssh/config 导入）。
 - `ssh_upload` / `ssh_download` 以宿主进程权限直接读写本机任意路径（不经 bash 沙箱）——与 ssh-skill 的宿主本地路径语义一致，注意该权限面。
 - exec / cluster 的远程输出原样返回（不脱敏），命令如 `env` 可能把远端环境中的密钥带回对话记录。
+- Agent 工具可通过 `defaultPermissionMode` 限制（见「配置」）；默认 `allow` 保持完整能力，`readonly` / `deny` / `ask` 可降低模型代替你执行操作的风险。
 
 ## 安装
 
@@ -49,6 +50,32 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-ssh
 ## 配置
 
 设置面板（插件配置）可开关 `announceToAgent`（是否向 Agent 宣告插件）与 `enabled`（总开关），并可设置 `terminalFontFamily`（Web 终端字体，留空则按 CSS 链解析：`--dsh-ssh-terminal-font` → 官方 `--ds-font-family-code` token → 内置 monospace 栈）。终端字体写死在 xterm 构造参数里，CSS 无法直接覆盖；要渲染 powerline / Nerd Font 图标，请在此填入对应 Nerd Font 栈（如 `"SauceCodePro Nerd Font", monospace`），修改对已打开的终端即时生效，无需重连。
+
+SSH Agent 工具还可通过权限策略进行限制：
+
+- `defaultPermissionMode`：`allow`（默认）、`readonly`、`deny` 或 `ask`。
+  - `allow` — 全部 SSH Agent 工具正常运行。
+  - `readonly` — 只允许 `permissionReadonlyTools` 中的工具。
+  - `deny` — 拒绝全部 `permissionTools` 中的工具。
+  - `ask` — 每次调用受管工具都请求人工批准。
+- `permissionTools`：受该模式管理的工具；默认是全部六个 SSH Agent 工具。
+- `permissionReadonlyTools`：`readonly` 模式下仍允许的工具；默认是 `ssh_list`。
+
+该策略只作用于 Agent 工具。Web GUI（主机管理、终端、传输、隧道）始终是人工操作，不受此策略限制。`~/.dsh/settings.yaml` 示例：
+
+```yaml
+dsh-ssh:
+  defaultPermissionMode: readonly
+  permissionTools:
+    - ssh_list
+    - ssh_exec
+    - ssh_upload
+    - ssh_download
+    - ssh_tunnel
+    - ssh_cluster
+  permissionReadonlyTools:
+    - ssh_list
+```
 
 ## 数据
 

--- a/packages/dsh-ssh/src/index.ts
+++ b/packages/dsh-ssh/src/index.ts
@@ -16,6 +16,12 @@ import type {} from '@deepseek-ai/dsh-system-prompt'
 import type {} from '@deepseek-ai/dsh-tools'
 import { SshEngine } from './engine.ts'
 import { makeRoutes } from './routes.ts'
+import {
+  resolveSshPermission,
+  SSH_PERMISSION_TOOLS,
+  SSH_READONLY_TOOLS,
+  type SshPermissionMode,
+} from './permission.ts'
 import { HostStore } from './store.ts'
 import { sshClusterTool, sshDownloadTool, sshExecTool, sshListTool, sshTunnelTool, sshUploadTool } from './tools.ts'
 import { mountOnce } from './mount-once.ts'
@@ -49,12 +55,28 @@ export interface Config {
    * Nerd Font stack here to render powerline/Nerd glyphs.
    */
   terminalFontFamily?: string
+  /**
+   * Default permission mode for the six SSH agent tools. The GUI surfaces are
+   * manual user actions and are never gated by this setting.
+   * - `allow`: all SSH tools run normally (default).
+   * - `readonly`: only `permissionReadonlyTools` are allowed.
+   * - `deny`: all `permissionTools` are denied.
+   * - `ask`: every call to a listed SSH tool requests human approval.
+   */
+  defaultPermissionMode?: SshPermissionMode
+  /** Tools governed by `defaultPermissionMode`; defaults to all six SSH tools. */
+  permissionTools?: string[]
+  /** Tools still allowed when `defaultPermissionMode` is `readonly`; defaults to `ssh_list`. */
+  permissionReadonlyTools?: string[]
 }
 
 export const Config: z<Config> = z.object({
   announceToAgent: z.boolean().default(true),
   enabled: z.boolean().default(true),
   terminalFontFamily: z.string().default(''),
+  defaultPermissionMode: z.union(['allow', 'readonly', 'deny', 'ask']).default('allow'),
+  permissionTools: z.array(z.string()).default([...SSH_PERMISSION_TOOLS]),
+  permissionReadonlyTools: z.array(z.string()).default([...SSH_READONLY_TOOLS]),
 })
 
 /** Schema default, re-read for hand-built test contexts (the loader applies them normally). */
@@ -82,6 +104,9 @@ function applyImpl(ctx: Context, config?: Config): void {
     return {
       announceToAgent: value.announceToAgent ?? DEFAULT_ANNOUNCE,
       enabled: value.enabled ?? true,
+      defaultPermissionMode: value.defaultPermissionMode ?? 'allow',
+      permissionTools: value.permissionTools,
+      permissionReadonlyTools: value.permissionReadonlyTools,
     }
   }
 
@@ -107,6 +132,9 @@ function applyImpl(ctx: Context, config?: Config): void {
   // System-prompt announcement.
   let disposeSection: (() => void) | undefined
 
+  // Agent-tool permission policy (guard / pre-execute approval).
+  let disposePermission: (() => void) | undefined
+
   // Register (or drop) every surface to match the current source. Each group
   // is kept under one disposer: re-registering first tears the old one down
   // so duplicate-name registrations never throw.
@@ -123,6 +151,10 @@ function applyImpl(ctx: Context, config?: Config): void {
     if (disposeTools !== undefined) {
       disposeTools()
       disposeTools = undefined
+    }
+    if (disposePermission !== undefined) {
+      disposePermission()
+      disposePermission = undefined
     }
     if (!value.enabled) return
     if (value.announceToAgent) {
@@ -150,6 +182,26 @@ function applyImpl(ctx: Context, config?: Config): void {
       },
       'dsh-ssh: tools',
     )
+
+    // Permission policy: guards only the six SSH agent tools; the web GUI is
+    // always manual and unaffected. `allow` (the default) installs nothing.
+    const permission = {
+      mode: value.defaultPermissionMode ?? 'allow',
+      tools: value.permissionTools,
+      readonlyTools: value.permissionReadonlyTools,
+    }
+    if (permission.mode === 'ask') {
+      disposePermission = ctx.on('tools/pre-execute', async (exec, next) => {
+        const decision = resolveSshPermission(exec.name, permission)
+        if (decision.kind === 'ask') return { kind: 'ask', reason: decision.reason }
+        return next()
+      })
+    } else if (permission.mode === 'deny' || permission.mode === 'readonly') {
+      disposePermission = ctx.tools.guard((exec) => {
+        const decision = resolveSshPermission(exec.name, permission)
+        return decision.kind === 'deny' ? decision.reason : undefined
+      })
+    }
   }
 
   installSettingsSection(ctx, SSH_SETTINGS_NAMESPACE, Config, config ?? {}, {

--- a/packages/dsh-ssh/src/permission.ts
+++ b/packages/dsh-ssh/src/permission.ts
@@ -1,0 +1,69 @@
+/**
+ * Agent-tool permission policy for the SSH tools.
+ *
+ * The GUI surfaces (host manager, terminal, transfers, tunnels) are manual
+ * user actions and are never gated by this policy. It only applies to the six
+ * agent-facing tools, so deployments can keep a remote-operations toolbelt
+ * visible to the model while restricting what it may actually do.
+ */
+
+/** All SSH agent tools governed by the permission policy. */
+export const SSH_PERMISSION_TOOLS = [
+  'ssh_list',
+  'ssh_exec',
+  'ssh_upload',
+  'ssh_download',
+  'ssh_tunnel',
+  'ssh_cluster',
+] as const
+
+/** Tools still allowed when the mode is `readonly`. */
+export const SSH_READONLY_TOOLS = ['ssh_list'] as const
+
+/** Supported permission modes for the SSH agent tools. */
+export type SshPermissionMode = 'allow' | 'readonly' | 'deny' | 'ask'
+
+/** Policy inputs resolved from the plugin settings. */
+export interface SshPermissionOptions {
+  /** Default mode; `allow` when omitted. */
+  mode?: SshPermissionMode
+  /** Tools governed by the mode; all six SSH tools when omitted. */
+  tools?: readonly string[]
+  /** Tools allowed under `readonly`; `ssh_list` when omitted. */
+  readonlyTools?: readonly string[]
+}
+
+/** One pre-dispatch decision for an SSH tool call. */
+export type SshPermissionDecision =
+  | { kind: 'allow' }
+  | { kind: 'deny'; reason: string }
+  | { kind: 'ask'; reason?: string }
+
+/**
+ * Resolve the policy for one tool call. Tools outside `tools` are always
+ * allowed so the policy never broadens or narrows anything it does not own.
+ */
+export function resolveSshPermission(
+  name: string,
+  options: SshPermissionOptions = {},
+): SshPermissionDecision {
+  const mode = options.mode ?? 'allow'
+  const governed = new Set(options.tools ?? SSH_PERMISSION_TOOLS)
+  if (!governed.has(name)) return { kind: 'allow' }
+
+  if (mode === 'deny') {
+    return { kind: 'deny', reason: `SSH operation "${name}" is disabled by dsh-ssh permission policy (mode=deny)` }
+  }
+
+  if (mode === 'readonly') {
+    const allowed = new Set(options.readonlyTools ?? SSH_READONLY_TOOLS)
+    if (allowed.has(name)) return { kind: 'allow' }
+    return { kind: 'deny', reason: `SSH operation "${name}" is not allowed in readonly mode by dsh-ssh permission policy` }
+  }
+
+  if (mode === 'ask') {
+    return { kind: 'ask', reason: `SSH operation "${name}" requires approval (mode=ask)` }
+  }
+
+  return { kind: 'allow' }
+}

--- a/packages/dsh-ssh/tests/permission.test.ts
+++ b/packages/dsh-ssh/tests/permission.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Permission-policy tests: the pure resolver behind the SSH agent-tool
+ * permission modes (allow / readonly / deny / ask).
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  resolveSshPermission,
+  SSH_PERMISSION_TOOLS,
+  SSH_READONLY_TOOLS,
+} from '../src/permission.ts'
+
+describe('SSH permission defaults', () => {
+  it('governs every SSH agent tool', () => {
+    expect(SSH_PERMISSION_TOOLS).toEqual([
+      'ssh_list',
+      'ssh_exec',
+      'ssh_upload',
+      'ssh_download',
+      'ssh_tunnel',
+      'ssh_cluster',
+    ])
+  })
+
+  it('keeps ssh_list as the readonly tool', () => {
+    expect(SSH_READONLY_TOOLS).toEqual(['ssh_list'])
+  })
+})
+
+describe('resolveSshPermission', () => {
+  it('allows every governed tool under the default allow mode', () => {
+    for (const name of SSH_PERMISSION_TOOLS) {
+      expect(resolveSshPermission(name)).toEqual({ kind: 'allow' })
+      expect(resolveSshPermission(name, { mode: 'allow' })).toEqual({ kind: 'allow' })
+    }
+  })
+
+  it('does not touch tools outside the governed list', () => {
+    const decision = resolveSshPermission('bash', { mode: 'deny' })
+    expect(decision).toEqual({ kind: 'allow' })
+  })
+
+  it('denies every governed tool under deny mode', () => {
+    const decision = resolveSshPermission('ssh_exec', { mode: 'deny' })
+    expect(decision.kind).toBe('deny')
+    if (decision.kind === 'deny') {
+      expect(decision.reason).toContain('ssh_exec')
+      expect(decision.reason).toContain('deny')
+    }
+  })
+
+  it('allows only readonly tools under readonly mode', () => {
+    expect(resolveSshPermission('ssh_list', { mode: 'readonly' })).toEqual({ kind: 'allow' })
+    const denied = resolveSshPermission('ssh_exec', { mode: 'readonly' })
+    expect(denied.kind).toBe('deny')
+    if (denied.kind === 'deny') {
+      expect(denied.reason).toContain('readonly')
+    }
+  })
+
+  it('asks for governed tools under ask mode and leaves others alone', () => {
+    const decision = resolveSshPermission('ssh_upload', { mode: 'ask' })
+    expect(decision.kind).toBe('ask')
+    if (decision.kind === 'ask') {
+      expect(decision.reason).toContain('ssh_upload')
+    }
+    expect(resolveSshPermission('bash', { mode: 'ask' })).toEqual({ kind: 'allow' })
+  })
+
+  it('honours custom tool lists and readonly lists', () => {
+    const tools = ['ssh_exec', 'ssh_tunnel']
+    expect(resolveSshPermission('ssh_upload', { mode: 'deny', tools })).toEqual({ kind: 'allow' })
+    expect(resolveSshPermission('ssh_exec', { mode: 'deny', tools })).toMatchObject({ kind: 'deny' })
+    expect(resolveSshPermission('ssh_exec', {
+      mode: 'readonly',
+      tools,
+      readonlyTools: ['ssh_exec'],
+    })).toEqual({ kind: 'allow' })
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

为 `@linxin666/dsh-ssh` 的 Agent 工具新增 `defaultPermissionMode` 权限策略：`allow` / `readonly` / `deny` / `ask`，并支持 `permissionTools` 与 `permissionReadonlyTools` 自定义受管工具集合。Web GUI（主机管理、终端、传输、隧道）始终是人工操作，不受该策略影响。

## 涉及包（Affected Packages）

- [x] SSH 远程运维 `packages/dsh-ssh`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness (DSH)

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-ssh
pnpm install --ignore-workspace --no-frozen-lockfile --ignore-scripts
node_modules/.bin/tsc -p tsconfig.json --noEmit
node --experimental-strip-types -e "import('./src/permission.ts').then(m => { console.log(JSON.stringify(m.resolveSshPermission('ssh_exec', { mode: 'deny' }))); console.log(JSON.stringify(m.resolveSshPermission('ssh_list', { mode: 'readonly' }))); console.log(JSON.stringify(m.resolveSshPermission('ssh_upload', { mode: 'ask' }))); console.log(JSON.stringify(m.resolveSshPermission('bash', { mode: 'deny' }))); })"
```

结果摘要：

- `tsc -p tsconfig.json --noEmit` 通过。
- 权限解析函数冒烟验证输出符合预期（deny / readonly / ask / allow）。
- 完整 `pnpm test` 在本机沙箱中因 `esbuild spawn EPERM` 未能执行；新增测试为纯函数测试，已随 PR 提交，CI 将执行全量门禁。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（配置项新增，用户可见行为由设置面板展示；本地沙箱无法启动 Web GUI 截图，待维护者 / CI 环境补充验证）。
