### PR TITLE
fix(skin-center): import catalog with file URL (#633)

### DIFF
--- a/scripts/skin-center-catalog-check
+++ b/scripts/skin-center-catalog-check
@@ -11,13 +11,14 @@
 'use strict'
 
 const path = require('node:path')
+const { pathToFileURL } = require('node:url')
 
 const LIB_PATH = path.join(__dirname, '..', 'packages', 'skins', 'skin-center', 'lib', 'index.js')
 const SKINS_DIR = path.join(__dirname, '..', 'packages', 'skins', 'skin-center', 'skins')
 
 async function main() {
   const checkMode = process.argv.includes('--check')
-  const lib = await import(LIB_PATH)
+  const lib = await import(pathToFileURL(LIB_PATH).href)
   const catalog = lib.loadSkinCatalog({ builtinDir: SKINS_DIR, userDir: path.join(SKINS_DIR, '.nonexistent-user-root') })
   let failed = false
   if (catalog.skins.length === 0) {


### PR DESCRIPTION
## 摘要（Summary）

修复 Windows 下运行 `pnpm skin-center:check` 时，ESM loader 将 `C:\...` 绝对路径误识别为 `c:` URL 协议的问题。使用 Node.js 标准库 `pathToFileURL()` 将模块路径转换为合法的 `file://` URL。

Fixes #633

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他：仓库维护脚本 `scripts/skin-center-catalog-check`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream --prune
git switch -c fix/skin-center-check-windows upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5.6 Sol

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未修改 README）；`pnpm docs:check` 已通过。

## 贡献者版权声明（Contributor Copyright）

N/A。本 PR 仅修改仓库维护脚本，不涉及插件或皮肤版权声明。

## 新皮肤收录（New Skin）

N/A。本 PR 未新增或修改皮肤。

## 社区插件索引登记（Community Plugin Index）

N/A。本 PR 未新增或修改社区插件索引。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/skin-center-catalog-check --check
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
git diff --check
```

结果摘要：

全部通过。

- `skin-center:check`：13 个内置皮肤检查通过。
- 全仓类型检查通过。
- 全仓测试通过。
- 脚本测试通过：109 项通过，4 项跳过，0 项失败。
- 文档一致性检查通过。
- Git diff 格式检查通过。

本地测试环境启用了 Git commit/tag 签名，因此运行涉及临时 Git 仓库的测试时，仅在测试进程内临时关闭签名配置；未修改用户全局 Git 配置。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A。本 PR 仅修复跨平台检查脚本的模块路径加载，不涉及 Web UI 或其他用户可见界面变更。修复后 Windows 会将绝对模块路径转换为合法的 `file://` URL，解决 #633 报告的 `Received protocol 'c:'` 错误。