### PR TITLE
fix(ssh): 修复 Windows 目标机连接测试失败

### DIFF
--- a/packages/dsh-ssh/src/engine.ts
+++ b/packages/dsh-ssh/src/engine.ts
@@ -148,11 +148,11 @@ export class SshEngine {
 
   // ------------------------------------------------------------- misc
 
-  /** Probe connectivity: connect, run `true`, close. */
+  /** Probe connectivity with a cross-platform shell command. */
   async test(alias: string): Promise<TestResult> {
     const started = Date.now()
     try {
-      const result = await this.exec(alias, 'true', 10_000)
+      const result = await this.exec(alias, 'echo ok', 10_000)
       return result.success
         ? { ok: true, latencyMs: result.durationMs }
         : { ok: false, latencyMs: result.durationMs, error: 'remote exit code ' + result.exitCode }

--- a/packages/dsh-ssh/tests/engine.test.ts
+++ b/packages/dsh-ssh/tests/engine.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { connect, createServer, type AddressInfo } from 'node:net'
 import type { Client } from 'ssh2'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { SshEngine } from '../src/engine.ts'
 import { HostStore } from '../src/store.ts'
 import type { HostPayload } from '../src/protocol.ts'
@@ -564,6 +564,25 @@ describe('upload path rules', () => {
 })
 
 describe('probe', () => {
+  it('uses a cross-platform command to probe connectivity', async () => {
+    const execSpy = vi.spyOn(engine, 'exec').mockResolvedValue({
+      success: true,
+      exitCode: 0,
+      timedOut: false,
+      stdout: 'ok\n',
+      stderr: '',
+      durationMs: 1,
+    })
+
+    try {
+      const result = await engine.test('probe-command')
+      expect(execSpy).toHaveBeenCalledWith('probe-command', 'echo ok', 10_000)
+      expect(result).toEqual({ ok: true, latencyMs: 1 })
+    } finally {
+      execSpy.mockRestore()
+    }
+  })
+
   it('reports a working connection', async () => {
     addHost('probe-host')
     const result = await engine.test('probe-host')

--- a/packages/dsh-ssh/tests/helpers/ssh-server.ts
+++ b/packages/dsh-ssh/tests/helpers/ssh-server.ts
@@ -35,6 +35,7 @@ function handleCommand(command: string, stream: ClientChannel): void {
     stream.close()
   }
   if (command === 'echo hello') respond('hello\n', 0)
+  else if (command === 'echo ok') respond('ok\n', 0)
   else if (command === 'out-and-err') {
     stream.write('hello out\n')
     // Server-side stderr is writable at runtime; the client-facing types


### PR DESCRIPTION
## 摘要（Summary）

修复 SSH「测试连接」在 Windows 目标机上必定失败的问题。将仅适用于 Unix shell 的 `true` 探测命令替换为 POSIX shell 与 Windows `cmd.exe` 均支持的 `echo ok`，并补充回归测试锁定跨平台探测行为。

Fixes #614

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [x] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream
git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5.6 Sol

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未修改 README）。

## 贡献者版权声明（Contributor Copyright）

N/A。本 PR 为现有 SSH 插件的 Bug 修复，不新增插件或皮肤资产。

## 新皮肤收录（New Skin）

N/A。

## 社区插件索引登记（Community Plugin Index）

N/A。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-ssh test
pnpm --filter @linxin666/dsh-ssh typecheck
git diff --check
```

结果摘要：

- `dsh-ssh` 测试：通过。
- `dsh-ssh` TypeScript 类型检查：通过。
- `git diff --check`：通过。
- 新增回归测试明确断言 `SshEngine.test()` 使用 `echo ok` 作为连接探测命令；旧实现使用 `true` 时该测试会失败。
- 嵌入式 SSH 测试服务器同步支持 `echo ok`，现有连接 probe 集成测试继续覆盖真实 SSH 执行路径。

## 用户可见变更证据（Local Feature Evidence）

证据：

本 PR 修复的是 SSH 连接测试行为，无新增界面。

修复前，Windows 目标机默认 `cmd.exe` 不支持：

```text
true
```

因此即使 SSH 连接正常，「测试连接」仍返回失败。

修复后改用：

```text
echo ok
```

该命令同时适用于 POSIX shell 与 Windows `cmd.exe`，连接正常时测试可正确返回成功。

自动化回归测试覆盖了探测命令及成功结果映射。