### PR TITLE
feat(pet): v1→v2 清单迁移 codemod（宠物中心 M2 P6 前置）

### DIFF
--- a/scripts/dsh-pet-migrate-v2.mjs
+++ b/scripts/dsh-pet-migrate-v2.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * dsh-pet-migrate-v2 — one-shot codemod: migrate a v1 pet directory (pet.json
+ * without petManifestVersion) onto the pet-center v2 manifest contract
+ * (issue #623, milestone M2 P6).
+ *
+ * Usage:
+ *   node scripts/dsh-pet-migrate-v2.mjs <petDir>              # dry-run report
+ *   node scripts/dsh-pet-migrate-v2.mjs <petDir> --check      # validate only
+ *   node scripts/dsh-pet-migrate-v2.mjs <petDir> --write      # in-place; keeps pet.json.v1.bak
+ *
+ * Options:
+ *   --license <id>   license identifier for the v2 manifest (required when the
+ *                    v1 source declares none; v2 requires license)
+ *   --author <name>  optional author carried into the v2 manifest
+ *   --force          allow overwriting an existing pet.json.v1.bak
+ *
+ * The mapping (M1 §4): petManifestVersion/renderer are filled in; the flat
+ * v1 atlas fields (spritesheetPath/cell/columns/frames/tracks) nest into the
+ * sprite2d block; spriteVersionNumber 2 becomes sprite2d.atlasRows 11;
+ * id/displayName/description/version/sequences/remarks carry over verbatim.
+ *
+ * The codemod validates its product through the package's authoritative
+ * parser (packages/dsh-pet/src/manifest-v2.ts) and refuses to write output
+ * that fails validation. With --write the original pet.json is kept as
+ * pet.json.v1.bak; without it the source directory is never modified.
+ */
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve as resolvePath } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const PARSER_URL = pathToFileURL(join(SCRIPT_DIR, '..', 'packages', 'dsh-pet', 'src', 'manifest-v2.ts')).href
+
+/** Load the package's authoritative manifest parser (type-stripped TS). */
+export async function loadPetParser() {
+  const mod = await import(PARSER_URL)
+  return mod.parsePetManifest
+}
+
+/**
+ * Map a v1 manifest onto the v2 shape. Pure; never mutates the source.
+ * @param {Record<string, unknown>} source - the parsed v1 pet.json.
+ * @param {{ license?: string, author?: string }} [options]
+ * @returns {{ manifest: Record<string, unknown>, warnings: string[] }}
+ */
+export function migratePetManifestV1toV2(source, options = {}) {
+  const warnings = []
+  const sprite2d = {}
+  if (typeof source.spritesheetPath === 'string' && source.spritesheetPath.trim() !== '') {
+    sprite2d.spritesheetPath = source.spritesheetPath.trim()
+  } else {
+    sprite2d.spritesheetPath = 'spritesheet.webp'
+  }
+  if (typeof source.cell === 'object' && source.cell !== null) sprite2d.cell = source.cell
+  if (typeof source.columns === 'number') sprite2d.columns = source.columns
+  if (Array.isArray(source.frames)) sprite2d.frames = source.frames
+  if (typeof source.tracks === 'object' && source.tracks !== null) sprite2d.tracks = source.tracks
+  // v2 spritesheet atlases (spriteVersionNumber 2) hold 11 rows: 9 + 2 look rows.
+  if (source.spriteVersionNumber === 2) sprite2d.atlasRows = 11
+
+  const license = typeof source.license === 'string' && source.license.trim() !== ''
+    ? source.license.trim()
+    : options.license
+  if (license === undefined) {
+    warnings.push('v1 manifest declares no license; pass --license <id> (v2 requires it)')
+  }
+  const manifest = {
+    petManifestVersion: 2,
+    id: source.id,
+    displayName: source.displayName,
+    renderer: 'sprite2d',
+    sprite2d,
+  }
+  if (typeof source.description === 'string' && source.description !== '') manifest.description = source.description
+  if (typeof source.version === 'string') manifest.version = source.version
+  if (typeof source.author === 'string') manifest.author = source.author
+  else if (options.author !== undefined) manifest.author = options.author
+  if (license !== undefined) manifest.license = license
+  if (source.sequences !== undefined) manifest.sequences = source.sequences
+  if (source.remarks !== undefined) manifest.remarks = source.remarks
+  return { manifest, warnings }
+}
+
+function usage() {
+  console.log('usage: node scripts/dsh-pet-migrate-v2.mjs <petDir> [--check|--write] [--license <id>] [--author <name>] [--force]')
+}
+
+async function main(argv) {
+  const args = [...argv]
+  const petDir = args.find(a => !a.startsWith('--'))
+  if (petDir === undefined) {
+    usage()
+    return 2
+  }
+  const write = args.includes('--write')
+  const force = args.includes('--force')
+  const flagValue = (name) => {
+    const index = args.indexOf(name)
+    return index !== -1 ? args[index + 1] : undefined
+  }
+  const dir = resolvePath(petDir)
+  const file = join(dir, 'pet.json')
+  if (!existsSync(file)) {
+    console.error('no pet.json in ' + dir)
+    return 1
+  }
+  const source = JSON.parse(readFileSync(file, 'utf8'))
+  const parsePetManifest = await loadPetParser()
+  if (source.petManifestVersion !== undefined) {
+    const verdict = parsePetManifest(source, file)
+    console.log(verdict.ok ? 'already v2: manifest validates, nothing to do' : 'already v2 but INVALID:')
+    if (!verdict.ok) for (const d of verdict.diagnostics) console.error('  [' + d.level + '] ' + d.message)
+    return verdict.ok ? 0 : 1
+  }
+  const { manifest, warnings } = migratePetManifestV1toV2(source, {
+    license: flagValue('--license'),
+    author: flagValue('--author'),
+  })
+  for (const warning of warnings) console.warn('warning: ' + warning)
+  const verdict = parsePetManifest(manifest, file + ' (migrated)')
+  if (!verdict.ok) {
+    console.error('migration product failed validation; nothing written:')
+    for (const d of verdict.diagnostics) console.error('  [' + d.level + '] ' + d.message)
+    return 1
+  }
+  for (const d of verdict.diagnostics) console.warn('  [' + d.level + '] ' + d.message)
+  if (!write) {
+    console.log(JSON.stringify(manifest, null, 2))
+    console.log(warnings.length > 0 ? 'dry-run: valid but unresolved warnings above; --write to apply' : 'dry-run: valid; --write to apply')
+    return warnings.length > 0 ? 1 : 0
+  }
+  const backup = file + '.v1.bak'
+  if (existsSync(backup) && !force) {
+    console.error(backup + ' already exists; pass --force to overwrite')
+    return 1
+  }
+  copyFileSync(file, backup)
+  writeFileSync(file, JSON.stringify(manifest, null, 2) + '\n')
+  console.log('migrated: ' + file + ' (backup at ' + backup + ')')
+  return 0
+}
+
+const invokedAsScript = process.argv[1] !== undefined && resolvePath(process.argv[1]) === fileURLToPath(import.meta.url)
+if (invokedAsScript) {
+  main(process.argv.slice(2)).then(code => { process.exitCode = code }, error => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  })
+}

--- a/scripts/dsh-pet-migrate-v2.test.mjs
+++ b/scripts/dsh-pet-migrate-v2.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * Tests for scripts/dsh-pet-migrate-v2.mjs — the v1 -> v2 pet manifest
+ * codemod (issue #623, milestone M2 P6). Unit tests cover the pure mapping;
+ * integration tests run the codemod over fixture directories and validate
+ * products through the package's authoritative parser.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { loadPetParser, migratePetManifestV1toV2 } from './dsh-pet-migrate-v2.mjs'
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'dsh-pet-migrate-v2.mjs')
+
+function fixtureDir(manifest) {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-pet-migrate-'))
+  writeFileSync(join(dir, 'pet.json'), JSON.stringify(manifest, null, 2) + '\n')
+  return dir
+}
+
+const V1_FULL = {
+  id: 'whale-girl',
+  displayName: 'Whale Girl',
+  description: 'A whale girl.',
+  spritesheetPath: 'spritesheet.webp',
+  cell: { width: 192, height: 208 },
+  columns: 8,
+  frames: [6, 8, 8, 4, 5, 8, 6, 6, 6],
+  tracks: { idle: { durations: [400, 400] } },
+  sequences: { idle: ['idle', 'waving', 'idle', 'waiting', 'idle'] },
+  remarks: { tap: ['hi'] },
+  spriteVersionNumber: 2,
+}
+
+test('maps the full v1 field set onto the v2 sprite2d shape', () => {
+  const { manifest } = migratePetManifestV1toV2(V1_FULL, { license: 'CC0-1.0' })
+  assert.equal(manifest.petManifestVersion, 2)
+  assert.equal(manifest.renderer, 'sprite2d')
+  assert.equal(manifest.license, 'CC0-1.0')
+  assert.deepEqual(manifest.sprite2d, {
+    spritesheetPath: 'spritesheet.webp',
+    cell: { width: 192, height: 208 },
+    columns: 8,
+    frames: [6, 8, 8, 4, 5, 8, 6, 6, 6],
+    tracks: { idle: { durations: [400, 400] } },
+    atlasRows: 11,
+  })
+  assert.equal(manifest.sprite2d.spritesheetPath, 'spritesheet.webp')
+  assert.ok(!('spriteVersionNumber' in manifest), 'legacy version flag folded into atlasRows')
+  assert.deepEqual(manifest.sequences, V1_FULL.sequences)
+  assert.deepEqual(manifest.remarks, V1_FULL.remarks)
+})
+
+test('defaults a missing spritesheetPath to the contract default', () => {
+  const { manifest } = migratePetManifestV1toV2({ id: 'bare', displayName: 'Bare' }, { license: 'CC0-1.0' })
+  assert.equal(manifest.sprite2d.spritesheetPath, 'spritesheet.webp')
+  assert.ok(!('atlasRows' in manifest.sprite2d), 'no atlasRows without spriteVersionNumber 2')
+})
+
+test('warns when no license is available from source or options', () => {
+  const { manifest, warnings } = migratePetManifestV1toV2({ id: 'bare', displayName: 'Bare' })
+  assert.equal(warnings.length, 1)
+  assert.ok(!('license' in manifest))
+})
+
+test('keeps a source-declared license over the option', () => {
+  const { manifest } = migratePetManifestV1toV2({ ...V1_FULL, license: 'MIT' }, { license: 'CC0-1.0' })
+  assert.equal(manifest.license, 'MIT')
+})
+
+test('migration product passes the authoritative parser', async () => {
+  const parsePetManifest = await loadPetParser()
+  const { manifest } = migratePetManifestV1toV2(V1_FULL, { license: 'CC0-1.0' })
+  const verdict = parsePetManifest(manifest, 'fixture')
+  assert.equal(verdict.ok, true, JSON.stringify(verdict.ok ? [] : verdict.diagnostics))
+  assert.equal(verdict.manifest.sprite2d.atlasRows, 11)
+})
+
+test('codemod dry-run prints the v2 manifest without writing', async () => {
+  const dir = fixtureDir(V1_FULL)
+  const out = execFileSync(process.execPath, [SCRIPT, dir, '--license', 'CC0-1.0'], { encoding: 'utf8' })
+  assert.match(out, /"petManifestVersion": 2/)
+  const onDisk = JSON.parse(readFileSync(join(dir, 'pet.json'), 'utf8'))
+  assert.equal(onDisk.petManifestVersion, undefined, 'source untouched')
+  assert.ok(!existsSync(join(dir, 'pet.json.v1.bak')))
+})
+
+test('codemod refuses a v1 manifest without any license source', () => {
+  const dir = fixtureDir({ id: 'bare', displayName: 'Bare' })
+  assert.throws(
+    () => execFileSync(process.execPath, [SCRIPT, dir, '--write'], { encoding: 'utf8', stdio: 'pipe' }),
+    /warning|license|exit/i,
+  )
+  assert.ok(!existsSync(join(dir, 'pet.json.v1.bak')), 'no write on invalid product')
+})
+
+test('codemod --write migrates in place with a v1 backup', () => {
+  const dir = fixtureDir(V1_FULL)
+  execFileSync(process.execPath, [SCRIPT, dir, '--write', '--license', 'CC0-1.0'], { encoding: 'utf8' })
+  const migrated = JSON.parse(readFileSync(join(dir, 'pet.json'), 'utf8'))
+  assert.equal(migrated.petManifestVersion, 2)
+  assert.equal(migrated.renderer, 'sprite2d')
+  const backup = JSON.parse(readFileSync(join(dir, 'pet.json.v1.bak'), 'utf8'))
+  assert.equal(backup.petManifestVersion, undefined, 'backup preserves the v1 source')
+  // Re-running on the migrated file reports already-v2 and exits 0.
+  const again = execFileSync(process.execPath, [SCRIPT, dir], { encoding: 'utf8' })
+  assert.match(again, /already v2/)
+})
+
+test('codemod refuses to overwrite an existing backup without --force', () => {
+  const dir = fixtureDir(V1_FULL)
+  writeFileSync(join(dir, 'pet.json.v1.bak'), '{}')
+  assert.throws(() => execFileSync(process.execPath, [SCRIPT, dir, '--write', '--license', 'CC0-1.0'], { encoding: 'utf8', stdio: 'pipe' }))
+})
+
+test('migrating the real built-in pets yields valid v2 manifests', async (t) => {
+  const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+  const parsePetManifest = await loadPetParser()
+  for (const builtin of ['whale', 'whale-refined']) {
+    const file = join(root, 'packages', 'dsh-pet', 'assets', builtin, 'pet.json')
+    if (!existsSync(file)) continue
+    const source = JSON.parse(readFileSync(file, 'utf8'))
+    if (source.petManifestVersion !== undefined) continue // already migrated
+    const { manifest } = migratePetManifestV1toV2(source, { license: 'CC0-1.0' })
+    const verdict = parsePetManifest(manifest, file)
+    assert.equal(verdict.ok, true, builtin + ': ' + JSON.stringify(verdict.ok ? [] : verdict.diagnostics))
+  }
+})


### PR DESCRIPTION
## 摘要（Summary）

宠物中心重设计（#623）M2 的 P6 前置件：**v1→v2 清单迁移 codemod**（叠在 P1 #636 之上，diff 仅含本层）。

- `scripts/dsh-pet-migrate-v2.mjs`：默认 dry-run 打印 v2 清单；`--check` 仅校验；`--write` 原地迁移并保留 `pet.json.v1.bak`；已 v2 的清单幂等报出。映射规则按 M1 §4：扁平 v1 图集字段收进 `sprite2d` 块、`spriteVersionNumber: 2` 折叠为 `atlasRows: 11`、`license` 必填（源缺失时须 `--license` 提供）；
- 产物必经包内权威解析器 `parsePetManifest` 验证，验证不过不写盘；
- `scripts/dsh-pet-migrate-v2.test.mjs`：10 项 node --test（纯映射、CLI 行为、备份纪律，以及对两个真实内置宠物的只读迁移验收）。

内置宠物的实际迁移在 M2 P6 主体阶段执行（等 17:00 反馈窗口关闭）。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`（scripts 工具，间接）

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 基于 feat/pet-center-m2（即最新 main 0e5b5a64 + P1）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（不确定具体模型版本）
使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig 配置。
- [x] 未新增包目录。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 未改动 README。

## 本地验证（Local Validation）

```bash
node --test scripts/dsh-pet-migrate-v2.test.mjs   # 10/10
node --test scripts/*.test.mjs                    # 123/123 全绿
pnpm --filter @linxin666/dsh-pet test             # 19 文件 185 测试全绿
```

## 用户可见变更证据（Local Feature Evidence）

N/A——维护工具，无用户可见变更。

---

关联：#623、#636（P1 基座）。
