### PR TITLE
fix(pet): 资产路由 realpath containment 与大小上限（宠物中心 M2 P3 首片）

### DIFF
--- a/packages/dsh-pet/src/routes.ts
+++ b/packages/dsh-pet/src/routes.ts
@@ -9,9 +9,9 @@
  * @module @linxin666/dsh-pet/routes
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, realpathSync, statSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { WebRoute } from '@deepseek-ai/dsh-host-webserver'
 import type { PetService } from './service.ts'
@@ -28,6 +28,41 @@ export const PET_ASSET_PREFIX = '/pet'
 const MANIFEST_FILE = 'pet.json'
 const PREVIEW_DIR = 'previews'
 const PREVIEW_PATTERN = /^[A-Za-z0-9._-]+$/
+
+/**
+ * Per-class size ceilings for served pet assets, in bytes (pet-center M2 P3,
+ * issue #623). Constants are tested directly; makePetRoutes accepts an
+ * override so tests can exercise the 413 path with tiny caps.
+ */
+export const PET_ASSET_CAPS = {
+  /** pet.json manifest. */
+  manifest: 64 * 1024,
+  /** Atlas and preview imagery. */
+  image: 20 * 1024 * 1024,
+} as const
+
+/** Size-cap profile the asset route enforces (test seam). */
+export interface PetAssetCaps {
+  manifest: number
+  image: number
+}
+
+/**
+ * realpath containment: resolve both sides and require the candidate to stay
+ * inside the base directory. A pet directory (or an atlas/preview inside it)
+ * that is a symlink escaping its root is rejected, never followed.
+ */
+export function containedRealpath(base: string, candidate: string): string | undefined {
+  try {
+    const realBase = realpathSync(base)
+    const realCandidate = realpathSync(candidate)
+    return realCandidate === realBase || realCandidate.startsWith(realBase + sep)
+      ? realCandidate
+      : undefined
+  } catch {
+    return undefined
+  }
+}
 
 const MIME_BY_EXT: Readonly<Record<string, string>> = {
   '.webp': 'image/webp',
@@ -148,7 +183,7 @@ function dirAliases(registry: PetRegistry): Map<string, PetEntry> {
  * pet.json, the declared spritesheet path, and optional 'previews/<name>'
  * media. Composed pets without a manifest file get a synthesized pet.json.
  */
-function assetHandler(registry: PetRegistry): WebRoute['handler'] {
+function assetHandler(registry: PetRegistry, caps: PetAssetCaps): WebRoute['handler'] {
   const aliases = dirAliases(registry)
   return (req: IncomingMessage, res: ServerResponse): void => {
     if (!guard(req, res)) return
@@ -229,7 +264,26 @@ function assetHandler(registry: PetRegistry): WebRoute['handler'] {
       res.end()
       return
     }
-    const resolved = file
+    // realpath containment: a symlink escaping the pet directory is refused.
+    const resolved = containedRealpath(entry.dir, file)
+    if (resolved === undefined) {
+      res.writeHead(403)
+      res.end()
+      return
+    }
+    // Enforce the size ceiling before the file is read into memory.
+    const cap = rest[0] === MANIFEST_FILE ? caps.manifest : caps.image
+    try {
+      if (statSync(resolved).size > cap) {
+        res.writeHead(413)
+        res.end()
+        return
+      }
+    } catch {
+      res.writeHead(404)
+      res.end()
+      return
+    }
     readFile(resolved).then((body) => {
       res.writeHead(200, {
         'content-type': mimeFor(resolved),
@@ -249,7 +303,7 @@ function assetHandler(registry: PetRegistry): WebRoute['handler'] {
 }
 
 /** Build the full route family (API + assets) for one service. */
-export function makePetRoutes(deps: { service: PetService }): WebRoute[] {
+export function makePetRoutes(deps: { service: PetService; assetCaps?: PetAssetCaps }): WebRoute[] {
   const { service } = deps
   const apiRoutes: WebRoute[] = [
     getRoute(PET_API_PREFIX + '/state', () => service.state()),
@@ -285,7 +339,7 @@ export function makePetRoutes(deps: { service: PetService }): WebRoute[] {
   const assetRoute: WebRoute = {
     kind: 'prefix',
     path: PET_ASSET_PREFIX,
-    handler: assetHandler(service.registrySnapshot()),
+    handler: assetHandler(service.registrySnapshot(), deps.assetCaps ?? PET_ASSET_CAPS),
   }
 
   return [...apiRoutes, assetRoute]

--- a/packages/dsh-pet/tests/asset-security.spec.ts
+++ b/packages/dsh-pet/tests/asset-security.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Pet asset route security — realpath containment, size ceilings, and
+ * traversal lock-down (pet-center M2 P3, issue #623). Same real-server
+ * harness as routes.spec.ts.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { once } from 'node:events'
+import type { AddressInfo } from 'node:net'
+import { Context } from '@deepseek-ai/cordis'
+import { PetService } from '../src/service.ts'
+import { containedRealpath, makePetRoutes, PET_ASSET_CAPS, type PetAssetCaps } from '../src/routes.ts'
+import { loadPetRegistry } from '../src/registry.ts'
+
+const WEBP_BYTES = Buffer.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50])
+
+let dir: string
+let outside: string
+let server: Server
+let port: number
+
+/** Caps small enough that the 12-byte fixture atlas trips them when lowered. */
+const TEST_CAPS: PetAssetCaps = { manifest: 64 * 1024, image: 20 * 1024 * 1024 }
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'dsh-pet-sec-'))
+  outside = mkdtempSync(join(tmpdir(), 'dsh-pet-outside-'))
+  writeFileSync(join(outside, 'secret.webp'), WEBP_BYTES)
+
+  const assets = join(dir, 'assets')
+  // clean pet
+  mkdirSync(join(assets, 'whale'), { recursive: true })
+  writeFileSync(join(assets, 'whale', 'pet.json'), JSON.stringify({
+    id: 'whale-girl', displayName: 'Whale', spritesheetPath: 'spritesheet.webp',
+  }), 'utf8')
+  writeFileSync(join(assets, 'whale', 'spritesheet.webp'), WEBP_BYTES)
+  mkdirSync(join(assets, 'whale', 'previews'), { recursive: true })
+  writeFileSync(join(assets, 'whale', 'previews', 'idle.webp'), WEBP_BYTES)
+  // escaping pet: atlas symlinks out of the pet directory
+  mkdirSync(join(assets, 'sneaky'), { recursive: true })
+  writeFileSync(join(assets, 'sneaky', 'pet.json'), JSON.stringify({
+    id: 'sneaky', displayName: 'Sneaky', spritesheetPath: 'spritesheet.webp',
+  }), 'utf8')
+  symlinkSync(join(outside, 'secret.webp'), join(assets, 'sneaky', 'spritesheet.webp'))
+  symlinkSync(join(outside, 'secret.webp'), join(assets, 'whale', 'previews', 'escape.webp'))
+
+  const ctx = new Context()
+  const registry = loadPetRegistry({ packageRoot: dir, petsDir: '' })
+  const service = new PetService(ctx, { persistDir: join(dir, 'home'), registry })
+  const routes = makePetRoutes({ service, assetCaps: TEST_CAPS })
+  server = createServer((req, res) => {
+    const pathname = (req.url ?? '').split('?')[0]!
+    for (const route of routes) {
+      if (route.kind === 'exact' && pathname === route.path) return void route.handler(req, res)
+    }
+    for (const route of routes) {
+      if (route.kind === 'prefix' && (pathname === route.path || pathname.startsWith(route.path + '/'))) {
+        return void route.handler(req, res)
+      }
+    }
+    res.writeHead(404)
+    res.end()
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  port = (server.address() as AddressInfo).port
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  rmSync(dir, { recursive: true, force: true })
+  rmSync(outside, { recursive: true, force: true })
+})
+
+function url(path: string): string {
+  return 'http://127.0.0.1:' + port + path
+}
+
+describe('containedRealpath', () => {
+  it('accepts files inside the base and the base itself', () => {
+    const inside = join(dir, 'assets', 'whale', 'spritesheet.webp')
+    expect(containedRealpath(join(dir, 'assets', 'whale'), inside)).toBeDefined()
+  })
+  it('rejects escapes, lookalike prefixes and missing files', () => {
+    const base = join(dir, 'assets', 'whale')
+    expect(containedRealpath(base, join(outside, 'secret.webp'))).toBeUndefined()
+    expect(containedRealpath(base, join(dir, 'assets', 'whale-evil', 'x.png'))).toBeUndefined()
+    expect(containedRealpath(base, join(base, 'does-not-exist.png'))).toBeUndefined()
+  })
+})
+
+describe('asset route security', () => {
+  it('serves a clean atlas and preview', async () => {
+    expect((await fetch(url('/pet/whale-girl/spritesheet.webp'))).status).toBe(200)
+    expect((await fetch(url('/pet/whale-girl/previews/idle.webp'))).status).toBe(200)
+    expect((await fetch(url('/pet/whale-girl/pet.json'))).status).toBe(200)
+  })
+  it('refuses an atlas symlink escaping the pet directory', async () => {
+    expect((await fetch(url('/pet/sneaky/spritesheet.webp'))).status).toBe(403)
+  })
+  it('refuses a preview symlink escaping the pet directory', async () => {
+    expect((await fetch(url('/pet/whale-girl/previews/escape.webp'))).status).toBe(403)
+  })
+  it('answers 413 once a served file exceeds its class cap', async () => {
+    // Rebuild a server whose image cap the 12-byte fixture exceeds.
+    const ctx = new Context()
+    const registry = loadPetRegistry({ packageRoot: dir, petsDir: '' })
+    const service = new PetService(ctx, { persistDir: join(dir, 'home2'), registry })
+    const tight = makePetRoutes({ service, assetCaps: { manifest: 64 * 1024, image: 4 } })
+    const tightServer = createServer((req, res) => {
+      const pathname = (req.url ?? '').split('?')[0]!
+      for (const route of tight) {
+        if (route.kind === 'prefix' && (pathname === route.path || pathname.startsWith(route.path + '/'))) {
+          return void route.handler(req, res)
+        }
+      }
+      res.writeHead(404)
+      res.end()
+    })
+    tightServer.listen(0, '127.0.0.1')
+    await once(tightServer, 'listening')
+    const tightPort = (tightServer.address() as AddressInfo).port
+    try {
+      const response = await fetch('http://127.0.0.1:' + tightPort + '/pet/whale-girl/spritesheet.webp')
+      expect(response.status).toBe(413)
+    } finally {
+      await new Promise<void>((resolve) => tightServer.close(() => resolve()))
+    }
+  })
+  it('keeps traversal requests outside the declared files at 404', async () => {
+    expect((await fetch(url('/pet/whale-girl/%2e%2e/%2e%2e/pet.json'))).status).toBe(404)
+    expect((await fetch(url('/pet/whale-girl/spritesheet.webp/extra'))).status).toBe(404)
+  })
+  it('locks the default caps to the documented constants', () => {
+    expect(PET_ASSET_CAPS.manifest).toBe(64 * 1024)
+    expect(PET_ASSET_CAPS.image).toBe(20 * 1024 * 1024)
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

宠物中心重设计（#623）M2 的 P3 第一片（纯安全加固，叠在 P1 #636 之上，diff 仅含本层）：宠物资产路由补上 realpath containment 与大小上限。

现状的两个真实缺口（核查确认）：资产处理器对 `join(entry.dir, ...)` 的结果直接 `readFile`——宠物目录内的 **symlink 逃逸**会被跟随；且读取**无大小上限**。

本 PR：

- `containedRealpath()`：目录与候选项双方 realpath 解析，越界（含形似前缀 `whale-evil`）一律 403；
- 读取前 `stat` 比对分类上限（清单 64KB / 图像 20MB，常量入码并测试锁定），超限 413；
- `makePetRoutes` 新增可选 `assetCaps` 覆盖作为测试缝；
- Live2D 引用闭包放行与 MIME 家族扩展留给 P2/P3b（依赖注册表接线）。

行为兼容：合法资产响应不变（测试锁定 200 基线）。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [x] Bug 修复（安全加固）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 基于 feat/pet-center-m2（最新 main 0e5b5a64 + P1）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（不确定具体模型版本）
使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK 开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig 配置。
- [x] 未新增包目录；文件不含 emoji；未改动 README。

## 本地验证（Local Validation）

```bash
pnpm --filter @linxin666/dsh-pet test        # 20 文件 193 测试全绿（新增 8 项安全用例）
pnpm --filter @linxin666/dsh-pet typecheck  # 通过
```

安全用例覆盖：图集 symlink 逃逸 403、预览 symlink 逃逸 403、形似前缀拒绝、超限 413、编码穿越 404、上限常量锁定。

## 用户可见变更证据（Local Feature Evidence）

N/A——宿主侧安全加固，无用户可见变更（合法资产行为由测试锁定不变）。

---

关联：#623、#636（P1 基座）。安全模型说明将随 M2 P7 文档一并更新进 README。
