### PR TITLE
feat(pet): dsh-pet 校验/安装 CLI 与 Live2D 闭包提取器（宠物中心 M2 P6 工具层）

### DIFF
--- a/packages/dsh-pet/src/model3.test.ts
+++ b/packages/dsh-pet/src/model3.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { collectModel3References, model3HitAreas, model3MotionGroups } from './model3.ts'
+
+/** Fixture mirroring the real Haru sample's FileReferences shape. */
+const HARU_LIKE = {
+  Version: 3,
+  FileReferences: {
+    Moc: 'haru.moc3',
+    Textures: ['haru.2048/texture_00.png', 'haru.2048/texture_01.png'],
+    Physics: 'haru.physics3.json',
+    Pose: 'haru.pose3.json',
+    DisplayInfo: 'haru.cdi3.json',
+    Expressions: [
+      { Name: 'f01', File: 'expressions/f01.exp3.json' },
+      { Name: 'f02', File: 'expressions/f02.exp3.json' },
+    ],
+    Motions: {
+      Idle: [{ File: 'motions/idle_00.motion3.json' }],
+      TapBody: [{ File: 'motions/tap_00.motion3.json' }, { File: 'motions/tap_01.motion3.json' }],
+    },
+    UserData: 'haru.userdata3.json',
+  },
+  Groups: [{ Name: 'EyeBlink' }, { Name: 'LipSync' }],
+  HitAreas: [{ Id: 'Head', Name: 'Head' }, { Id: 'Body', Name: 'Body' }],
+}
+
+describe('collectModel3References', () => {
+  it('collects the complete reference closure of the eight Cubism file families', () => {
+    const { references, errors } = collectModel3References(HARU_LIKE)
+    expect(errors).toEqual([])
+    expect(references).toEqual([
+      'expressions/f01.exp3.json',
+      'expressions/f02.exp3.json',
+      'haru.2048/texture_00.png',
+      'haru.2048/texture_01.png',
+      'haru.cdi3.json',
+      'haru.moc3',
+      'haru.physics3.json',
+      'haru.pose3.json',
+      'haru.userdata3.json',
+      'motions/idle_00.motion3.json',
+      'motions/tap_00.motion3.json',
+      'motions/tap_01.motion3.json',
+    ])
+  })
+  it('rejects unsafe references instead of collecting them', () => {
+    const bad = {
+      FileReferences: {
+        Moc: '../escape.moc3',
+        Textures: ['/abs/path.png', 'ok.png'],
+        Motions: { Idle: [{ File: 'https://evil.example/x.motion3.json' }] },
+      },
+    }
+    const { references, errors } = collectModel3References(bad)
+    expect(references).toEqual(['ok.png'])
+    expect(errors).toHaveLength(3)
+  })
+  it('tolerates missing optional families', () => {
+    const minimal = { FileReferences: { Moc: 'a.moc3', Textures: ['a.png'] } }
+    const { references, errors } = collectModel3References(minimal)
+    expect(errors).toEqual([])
+    expect(references).toEqual(['a.moc3', 'a.png'])
+  })
+  it('reports malformed model3 roots', () => {
+    expect(collectModel3References(null).errors.length).toBeGreaterThan(0)
+    expect(collectModel3References({}).errors.length).toBeGreaterThan(0)
+  })
+})
+
+describe('model3MotionGroups / model3HitAreas', () => {
+  it('reads motion groups and hit areas for diagnostics', () => {
+    expect(model3MotionGroups(HARU_LIKE)).toEqual(['Idle', 'TapBody'])
+    expect(model3HitAreas(HARU_LIKE)).toEqual(['Body', 'Head'])
+  })
+  it('returns empty lists for malformed models', () => {
+    expect(model3MotionGroups(null)).toEqual([])
+    expect(model3HitAreas({})).toEqual([])
+  })
+})

--- a/packages/dsh-pet/src/model3.ts
+++ b/packages/dsh-pet/src/model3.ts
@@ -1,0 +1,91 @@
+/**
+ * Live2D .model3.json reference closure — the set of files a model declares
+ * (pet-center M2, issue #623). The host asset route only ever serves a pet's
+ * declared manifest, its declared primary assets, and this closure; the CLI
+ * validator reuses the same extractor so an install-time check proves the
+ * serving set is complete.
+ *
+ * Cubism file family: Moc (.moc3), Textures (images), Physics (.physics3.json),
+ * Pose (.pose3.json), DisplayInfo (.cdi3.json), Expressions[].File
+ * (.exp3.json), Motions.<group>[].File (.motion3.json), UserData
+ * (.userdata3.json). Every reference must be a safe manifest-relative path
+ * (safeManifestPath); unsafe entries make the model unloadable.
+ *
+ * Erasable-syntax-only: scripts/ import this under node strip-only mode.
+ * @module @linxin666/dsh-pet/model3
+ */
+
+import { safeManifestPath } from './manifest-v2.ts'
+
+/** Collect the safe relative paths one model3.json references. */
+export function collectModel3References(model3: unknown): { references: string[]; errors: string[] } {
+  const errors: string[] = []
+  if (typeof model3 !== 'object' || model3 === null) {
+    return { references: [], errors: ['model3.json is not an object'] }
+  }
+  const fileReferences = (model3 as Record<string, unknown>).FileReferences
+  if (typeof fileReferences !== 'object' || fileReferences === null) {
+    return { references: [], errors: ['model3.json has no FileReferences'] }
+  }
+  const refs = fileReferences as Record<string, unknown>
+  const collected = new Set<string>()
+  const push = (raw: unknown, field: string): void => {
+    const safe = safeManifestPath(raw)
+    if (safe === undefined) {
+      errors.push(field + ' is not a safe relative path: ' + JSON.stringify(String(raw)))
+      return
+    }
+    collected.add(safe)
+  }
+  if (refs.Moc !== undefined) push(refs.Moc, 'FileReferences.Moc')
+  if (Array.isArray(refs.Textures)) {
+    refs.Textures.forEach((texture, index) => push(texture, 'FileReferences.Textures[' + index + ']'))
+  }
+  for (const scalar of ['Physics', 'Pose', 'DisplayInfo', 'UserData'] as const) {
+    if (refs[scalar] !== undefined) push(refs[scalar], 'FileReferences.' + scalar)
+  }
+  if (Array.isArray(refs.Expressions)) {
+    refs.Expressions.forEach((expression, index) => {
+      const file = typeof expression === 'object' && expression !== null
+        ? (expression as Record<string, unknown>).File
+        : undefined
+      if (file !== undefined) push(file, 'FileReferences.Expressions[' + index + '].File')
+    })
+  }
+  if (typeof refs.Motions === 'object' && refs.Motions !== null) {
+    for (const [group, motions] of Object.entries(refs.Motions as Record<string, unknown>)) {
+      if (!Array.isArray(motions)) {
+        errors.push('FileReferences.Motions.' + group + ' is not an array')
+        continue
+      }
+      motions.forEach((motion, index) => {
+        const file = typeof motion === 'object' && motion !== null
+          ? (motion as Record<string, unknown>).File
+          : undefined
+        if (file !== undefined) push(file, 'FileReferences.Motions.' + group + '[' + index + '].File')
+      })
+    }
+  }
+  return { references: [...collected].sort(), errors }
+}
+
+/** The motion group names a model3.json declares (for CLI diagnostics). */
+export function model3MotionGroups(model3: unknown): string[] {
+  if (typeof model3 !== 'object' || model3 === null) return []
+  const fileReferences = (model3 as Record<string, unknown>).FileReferences
+  if (typeof fileReferences !== 'object' || fileReferences === null) return []
+  const motions = (fileReferences as Record<string, unknown>).Motions
+  if (typeof motions !== 'object' || motions === null) return []
+  return Object.keys(motions as Record<string, unknown>).sort()
+}
+
+/** The hit area names a model3.json declares (top-level HitAreas). */
+export function model3HitAreas(model3: unknown): string[] {
+  if (typeof model3 !== 'object' || model3 === null) return []
+  const hitAreas = (model3 as Record<string, unknown>).HitAreas
+  if (!Array.isArray(hitAreas)) return []
+  return hitAreas
+    .map(area => typeof area === 'object' && area !== null ? (area as Record<string, unknown>).Name : undefined)
+    .filter((name): name is string => typeof name === 'string')
+    .sort()
+}

--- a/scripts/dsh-pet
+++ b/scripts/dsh-pet
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+'use strict'
+
+/**
+ * dsh-pet — pet tooling for the DSH Web GUI pet center (issue #623).
+ *
+ * Pets are pure asset directories (pet.json + assets). This CLI validates a
+ * pet directory against the v2 contract (v1 manifests are compat-read with a
+ * migration hint) and installs it into $DSH_HOME/pets/<id>/. It never touches
+ * cordis.patch.yml and never downloads anything — Live2D pets additionally
+ * need the user-supplied Cubism Core (see the package README).
+ *
+ * Commands:
+ *   dsh-pet validate <dir>   validate manifest + declared assets + Live2D closure
+ *   dsh-pet install <dir>    validate, then copy into $DSH_HOME/pets/<id>/
+ *                            [--force overwrites an existing same-id install]
+ *
+ * The validator/parsers are imported from the dsh-pet package sources
+ * (erasable TS, node strip-only mode) — never re-implemented here.
+ */
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { pathToFileURL } = require('node:url')
+
+const SRC = path.join(__dirname, '..', 'packages', 'dsh-pet', 'src')
+
+/** Load the package's contract surface (erasable TS via strip-only mode). */
+async function loadContracts() {
+  const manifest = await import(pathToFileURL(path.join(SRC, 'manifest-v2.ts')).href)
+  const model3 = await import(pathToFileURL(path.join(SRC, 'model3.ts')).href)
+  const dshHome = await import(pathToFileURL(path.join(SRC, 'dsh-home.ts')).href)
+  return { parsePetManifest: manifest.parsePetManifest, model3, dshHome: dshHome.dshHome }
+}
+
+function printDiagnostics(diagnostics) {
+  let errors = 0
+  for (const d of diagnostics) {
+    if (d.level === 'error') errors += 1
+    console.log('  [' + d.level + '] ' + d.message)
+  }
+  return errors
+}
+
+/** Existence checks for the assets a manifest declares (and Live2D closure). */
+async function checkAssets(dir, manifest, contracts) {
+  const diagnostics = []
+  const error = (message) => diagnostics.push({ level: 'error', message })
+  const warn = (message) => diagnostics.push({ level: 'warning', message })
+  if (manifest.renderer === 'sprite2d') {
+    const atlas = path.join(dir, manifest.sprite2d.spritesheetPath)
+    if (!fs.existsSync(atlas)) error('atlas not found: ' + manifest.sprite2d.spritesheetPath)
+  } else if (manifest.renderer === 'live2d') {
+    const modelFile = path.join(dir, manifest.live2d.model)
+    if (!fs.existsSync(modelFile)) {
+      error('model not found: ' + manifest.live2d.model)
+      return diagnostics
+    }
+    let model3
+    try {
+      model3 = JSON.parse(fs.readFileSync(modelFile, 'utf8'))
+    } catch (e) {
+      error('model3.json is not valid JSON: ' + (e && e.message ? e.message : String(e)))
+      return diagnostics
+    }
+    const { references, errors } = contracts.model3.collectModel3References(model3)
+    for (const message of errors) error(message)
+    for (const reference of references) {
+      if (!fs.existsSync(path.join(dir, reference))) error('referenced asset missing: ' + reference)
+    }
+    const groups = contracts.model3.model3MotionGroups(model3)
+    const declared = Object.values(manifest.live2d.motions).filter(Boolean)
+    for (const group of declared) {
+      if (!groups.includes(group)) warn('motion group "' + group + '" is not declared by the model; it falls back to idle at runtime')
+    }
+    const modelAreas = contracts.model3.model3HitAreas(model3)
+    for (const area of manifest.live2d.hitAreas ?? []) {
+      if (!modelAreas.includes(area)) warn('hitArea "' + area + '" is not declared by the model')
+    }
+  }
+  return diagnostics
+}
+
+async function validate(dir, contracts) {
+  const manifestFile = path.join(dir, 'pet.json')
+  if (!fs.existsSync(manifestFile)) {
+    console.error('no pet.json in ' + dir)
+    return { ok: false, manifest: undefined }
+  }
+  let raw
+  try {
+    raw = JSON.parse(fs.readFileSync(manifestFile, 'utf8'))
+  } catch (e) {
+    console.error('pet.json is not valid JSON: ' + (e && e.message ? e.message : String(e)))
+    return { ok: false, manifest: undefined }
+  }
+  const verdict = contracts.parsePetManifest(raw, dir)
+  const diagnostics = [...verdict.diagnostics]
+  let manifest
+  if (verdict.ok) {
+    manifest = verdict.manifest
+    diagnostics.push(...await checkAssets(dir, manifest, contracts))
+    if (verdict.migrated === 'v1-compat') {
+      console.log('note: v1 manifest compat-read as sprite2d; run scripts/dsh-pet-migrate-v2.mjs to migrate')
+    }
+  }
+  const errors = printDiagnostics(diagnostics)
+  return { ok: verdict.ok && errors === 0, manifest }
+}
+
+async function main(argv) {
+  const args = [...argv]
+  const command = args.shift()
+  const target = args.find(a => !a.startsWith('--'))
+  if ((command !== 'validate' && command !== 'install') || target === undefined) {
+    console.log('usage: dsh-pet validate <dir> | dsh-pet install <dir> [--force]')
+    return 2
+  }
+  const dir = path.resolve(target)
+  const contracts = await loadContracts()
+  const { ok, manifest } = await validate(dir, contracts)
+  if (!ok) {
+    console.error('validation failed')
+    return 1
+  }
+  console.log('valid: ' + manifest.id + ' (renderer ' + manifest.renderer + ')')
+  if (command === 'validate') return 0
+  const destination = path.join(contracts.dshHome(), 'pets', manifest.id)
+  if (fs.existsSync(destination)) {
+    if (!args.includes('--force')) {
+      console.error(destination + ' already exists; pass --force to overwrite')
+      return 1
+    }
+    fs.rmSync(destination, { recursive: true, force: true })
+  }
+  fs.mkdirSync(path.dirname(destination), { recursive: true })
+  fs.cpSync(dir, destination, { recursive: true })
+  console.log('installed to ' + destination + ' — refresh the pet list in settings to use it')
+  return 0
+}
+
+main(process.argv.slice(2)).then(code => { process.exitCode = code }, error => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/scripts/dsh-pet.test.mjs
+++ b/scripts/dsh-pet.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * Tests for scripts/dsh-pet — the pet-center validate/install CLI
+ * (issue #623, milestone M2 P6). Fixture-driven; install targets a temporary
+ * DSH_HOME so the real user home is never touched.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'dsh-pet')
+
+function tmp() {
+  return mkdtempSync(join(tmpdir(), 'dsh-pet-cli-'))
+}
+
+function makeSpritePet(dir, manifest = {}) {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'pet.json'), JSON.stringify({
+    id: 'test-cat', displayName: 'Test Cat', ...manifest,
+  }))
+  writeFileSync(join(dir, 'spritesheet.webp'), Buffer.from([0x52, 0x49, 0x46, 0x46]))
+  return dir
+}
+
+function makeLive2dPet(dir, { omitReference = false, unknownGroup = false } = {}) {
+  mkdirSync(join(dir, 'motions'), { recursive: true })
+  mkdirSync(join(dir, 'tex'), { recursive: true })
+  writeFileSync(join(dir, 'pet.json'), JSON.stringify({
+    petManifestVersion: 2,
+    id: 'test-live',
+    displayName: 'Test Live',
+    license: 'CC0-1.0',
+    renderer: 'live2d',
+    live2d: {
+      model: 'm.model3.json',
+      motions: unknownGroup ? { idle: 'Idle', done: 'NoSuchGroup' } : { idle: 'Idle', done: 'TapBody' },
+    },
+  }))
+  writeFileSync(join(dir, 'm.model3.json'), JSON.stringify({
+    Version: 3,
+    FileReferences: {
+      Moc: 'm.moc3',
+      Textures: ['tex/t0.png'],
+      Motions: {
+        Idle: [{ File: 'motions/idle.motion3.json' }],
+        TapBody: [{ File: 'motions/tap.motion3.json' }],
+      },
+    },
+    HitAreas: [{ Id: 'Body', Name: 'Body' }],
+  }))
+  writeFileSync(join(dir, 'm.moc3'), Buffer.from([1]))
+  writeFileSync(join(dir, 'tex', 't0.png'), Buffer.from([2]))
+  writeFileSync(join(dir, 'motions', 'idle.motion3.json'), '{}')
+  if (!omitReference) writeFileSync(join(dir, 'motions', 'tap.motion3.json'), '{}')
+  return dir
+}
+
+function run(args, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    })
+    return { code: 0, stdout, stderr: '' }
+  } catch (error) {
+    return {
+      code: error.status ?? 1,
+      stdout: (error.stdout ?? '').toString(),
+      stderr: (error.stderr ?? '').toString(),
+    }
+  }
+}
+
+test('validate accepts a v1 sprite2d pet via compat read', () => {
+  const dir = makeSpritePet(join(tmp(), 'cat'))
+  const result = run(['validate', dir])
+  assert.equal(result.code, 0, result.stderr + result.stdout)
+  assert.match(result.stdout, /v1 manifest compat-read/)
+  assert.match(result.stdout, /valid: test-cat/)
+})
+
+test('validate accepts a complete live2d pet and checks its closure', () => {
+  const dir = makeLive2dPet(join(tmp(), 'live'))
+  const result = run(['validate', dir])
+  assert.equal(result.code, 0, result.stderr + result.stdout)
+  assert.match(result.stdout, /renderer live2d/)
+})
+
+test('validate rejects a live2d pet with a missing referenced asset', () => {
+  const dir = makeLive2dPet(join(tmp(), 'live'), { omitReference: true })
+  const result = run(['validate', dir])
+  assert.equal(result.code, 1)
+  assert.ok((result.stderr + result.stdout).includes('referenced asset missing: motions/tap.motion3.json'))
+})
+
+test('validate warns (not fails) on motion groups the model lacks', () => {
+  const dir = makeLive2dPet(join(tmp(), 'live'), { unknownGroup: true })
+  const result = run(['validate', dir])
+  assert.equal(result.code, 0)
+  assert.match(result.stdout, /NoSuchGroup/)
+})
+
+test('validate rejects a structurally invalid manifest', () => {
+  const dir = makeSpritePet(join(tmp(), 'bad'), { petManifestVersion: 2, renderer: 'sprite2d' })
+  // missing license + sprite2d block -> fail-closed
+  const result = run(['validate', dir])
+  assert.equal(result.code, 1)
+  assert.match(result.stdout, /license/)
+})
+
+test('install copies a valid pet into DSH_HOME/pets and respects --force', () => {
+  const home = tmp()
+  const dir = makeSpritePet(join(tmp(), 'cat'))
+  const first = run(['install', dir], { DSH_HOME: home })
+  assert.equal(first.code, 0, first.stderr + first.stdout)
+  const installed = join(home, 'pets', 'test-cat')
+  assert.ok(existsSync(join(installed, 'pet.json')))
+  assert.ok(existsSync(join(installed, 'spritesheet.webp')))
+  const second = run(['install', dir], { DSH_HOME: home })
+  assert.equal(second.code, 1)
+  assert.match(second.stderr, /--force/)
+  const forced = run(['install', dir, '--force'], { DSH_HOME: home })
+  assert.equal(forced.code, 0, forced.stderr + forced.stdout)
+})
+
+test('install refuses an invalid pet and writes nothing', () => {
+  const home = tmp()
+  const dir = makeSpritePet(join(tmp(), 'bad'), { petManifestVersion: 2, renderer: 'sprite2d' })
+  const result = run(['install', dir], { DSH_HOME: home })
+  assert.equal(result.code, 1)
+  assert.ok(!existsSync(join(home, 'pets')))
+})
+
+test('usage errors exit 2 with guidance', () => {
+  assert.equal(run([]).code, 2)
+  assert.equal(run(['validate']).code, 2)
+  assert.equal(run(['bogus', 'x']).code, 2)
+})


### PR DESCRIPTION
## 摘要（Summary）

宠物中心重设计（#623）M2 的 P6 工具层（叠在 P1 #636 之上，diff 仅含本层）：`dsh-pet` 校验/安装 CLI + Live2D 模型引用闭包提取器。

- `packages/dsh-pet/src/model3.ts`：`.model3.json` 的 FileReferences 闭包提取（覆盖 Moc/Textures/Physics/Pose/DisplayInfo/Expressions/Motions/UserData 八类 Cubism 文件族），每个引用过 `safeManifestPath` 筛查；附 motion 组/HitArea 读取。**P3b 资产路由的闭包放行将复用这同一实现**（单一来源）；
- `scripts/dsh-pet`（对齐 `scripts/dsh-skin` 风格）：
  - `validate <dir>`：清单校验（v1 兼容读给迁移提示）+ 声明资产存在性 + Live2D 闭包存在性 + 模型缺失组/HitArea 警告（组缺失运行时会回退 idle）；
  - `install <dir>`：校验通过后拷入 `$DSH_HOME/pets/<id>/`（已存在需 `--force`）；
  - 工具不下载任何文件——Live2D 宠物仍需用户自带 Cubism Core；
- 测试：6 项 vitest（闭包）+ 8 项 node --test（CLI，含临时 DSH_HOME 安装验证）。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`（含 scripts 工具）

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 基于 feat/pet-center-m2（最新 main 0e5b5a64 + P1）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（不确定具体模型版本）
使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码；未新增 tsconfig 指向；未新增包目录；无 emoji；未改动 README。

## 本地验证（Local Validation）

```bash
pnpm --filter @linxin666/dsh-pet test    # 20 文件 191 测试全绿（新增 6 项闭包用例）
pnpm --filter @linxin666/dsh-pet typecheck
node --test scripts/*.test.mjs           # 121/121 全绿（新增 8 项 CLI 用例）
```

## 用户可见变更证据（Local Feature Evidence）

N/A——开发者工具与内部模块，无用户可见变更。

---

关联：#623、#636（P1 基座）、#641（codemod 姊妹层）。
