### PR TITLE
feat(pet): registry 接入 manifest-v2 与 DSH_HOME 宠物源（宠物中心 M2 P2）

### DIFF
--- a/packages/dsh-pet/src/registry.test.ts
+++ b/packages/dsh-pet/src/registry.test.ts
@@ -152,6 +152,7 @@ describe('loadPetRegistry', () => {
     const registry = loadPetRegistry({
       packageRoot: petPackageRoot(import.meta.url),
       petsDir: '',
+      dshPetsDir: '',
     })
 
     expect(registry.entries.map(entry => entry.id)).toEqual([
@@ -184,7 +185,7 @@ describe('loadPetRegistry', () => {
       mkdirSync(join(petsDir, 'broken'), { recursive: true })
       writeFileSync(join(petsDir, 'broken', 'pet.json'), '{ not json', 'utf8')
 
-      const registry = loadPetRegistry({ packageRoot: root, petsDir })
+      const registry = loadPetRegistry({ packageRoot: root, petsDir, dshPetsDir: '' })
       expect(registry.entries.map(entry => entry.id)).toEqual(['whale-girl', 'otter'])
       expect(registry.defaultEntry().id).toBe('whale-girl')
       expect(registry.warnings.some(warning => warning.includes('broken'))).toBe(true)
@@ -193,6 +194,7 @@ describe('loadPetRegistry', () => {
       const overridden = loadPetRegistry({
         packageRoot: root,
         petsDir,
+        dshPetsDir: '',
         extra: [{ id: 'whale-girl', displayName: '替换鲸', spritesheetPath: 'spritesheet.webp' }],
       })
       expect(overridden.byId('whale-girl')!.displayName).toBe('替换鲸')
@@ -211,6 +213,7 @@ describe('loadPetRegistry', () => {
       const registry = loadPetRegistry({
         packageRoot: root,
         petsDir: '',
+        dshPetsDir: '',
         extra: [{ id: 'otter', displayName: '水獭', spritesheetPath: 'pets/otter/spritesheet.webp' }],
       })
       const entry = registry.byId('otter')
@@ -236,7 +239,7 @@ describe('loadPetRegistry', () => {
       writeFileSync(join(petsDir, 'aardvark', 'pet.json'), JSON.stringify({
         id: 'aardvark', displayName: '土豚', spritesheetPath: 'spritesheet.webp',
       }), 'utf8')
-      const registry = loadPetRegistry({ packageRoot: join(root, 'no-assets'), petsDir })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'no-assets'), petsDir, dshPetsDir: '' })
       expect(registry.defaultEntry().id).toBe('aardvark')
     } finally {
       rmSync(root, { recursive: true, force: true })
@@ -250,5 +253,115 @@ describe('codexPetsDir', () => {
     expect(codexPetsDir({ CODEX_HOME: '/opt/codex' }, '/home/user')).toBe(join('/opt/codex', 'pets'))
     expect(codexPetsDir({ CODEX_HOME: '~/codex' }, '/home/user')).toBe(join('/home/user', 'codex', 'pets'))
     expect(codexPetsDir({}, '/home/user')).toBe(join('/home/user', '.codex', 'pets'))
+  })
+})
+
+describe('loadPetRegistry pet-center v2 (issue #623)', () => {
+  function writePet(dir: string, name: string, manifest: Record<string, unknown>): void {
+    mkdirSync(join(dir, name), { recursive: true })
+    writeFileSync(join(dir, name, 'pet.json'), JSON.stringify(manifest), 'utf8')
+    writeFileSync(join(dir, name, 'spritesheet.webp'), 'webp', 'utf8')
+  }
+
+  it('resolves a v2 sprite2d pet with the same geometry as its v1 twin', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writePet(petsDir, 'v1pet', { id: 'twin-v1', displayName: 'Twin V1', frames: [1, 2, 3, 4, 5, 6, 7, 8, 9] })
+      writePet(petsDir, 'v2pet', {
+        petManifestVersion: 2, id: 'twin-v2', displayName: 'Twin V2', license: 'CC0-1.0',
+        renderer: 'sprite2d', sprite2d: { spritesheetPath: 'spritesheet.webp', frames: [1, 2, 3, 4, 5, 6, 7, 8, 9] },
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      const v1 = registry.byId('twin-v1')!
+      const v2 = registry.byId('twin-v2')!
+      expect(v2.rows).toEqual(v1.rows)
+      expect(v2.tracks.idle.durations).toEqual(v1.tracks.idle.durations)
+      expect(registry.diagnostics.some(d => d.message.includes('v1 compat read'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('round-trips atlasRows 11 through the v1 compat resolver', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writePet(petsDir, 'looky', {
+        petManifestVersion: 2, id: 'looky', displayName: 'Looky', license: 'CC0-1.0',
+        renderer: 'sprite2d', sprite2d: { spritesheetPath: 'spritesheet.webp', atlasRows: 11 },
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('looky')?.atlasRows).toBe(11)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects atlasRows values the v1 compat resolver cannot express', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writePet(petsDir, 'odd', {
+        petManifestVersion: 2, id: 'odd', displayName: 'Odd', license: 'CC0-1.0',
+        renderer: 'sprite2d', sprite2d: { spritesheetPath: 'spritesheet.webp', atlasRows: 7 },
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('odd')).toBeUndefined()
+      expect(registry.diagnostics.some(d => d.level === 'error' && d.message.includes('atlasRows'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts live2d manifests into diagnostics without listing them renderable', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      mkdirSync(join(petsDir, 'haru'), { recursive: true })
+      writeFileSync(join(petsDir, 'haru', 'pet.json'), JSON.stringify({
+        petManifestVersion: 2, id: 'haru', displayName: 'Haru', license: 'Live2D-Sample',
+        renderer: 'live2d', live2d: { model: 'haru.model3.json', motions: { idle: 'Idle' } },
+      }), 'utf8')
+      writeFileSync(join(petsDir, 'haru', 'haru.model3.json'), '{}', 'utf8')
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('haru')).toBeUndefined()
+      expect(registry.diagnostics.some(d => d.message.includes('live2d') && d.message.includes('M3'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed on v2 manifests with unknown fields', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writePet(petsDir, 'surprise', {
+        petManifestVersion: 2, id: 'surprise', displayName: 'S', license: 'CC0-1.0',
+        renderer: 'sprite2d', sprite2d: { spritesheetPath: 'spritesheet.webp' }, sneaky: true,
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('surprise')).toBeUndefined()
+      expect(registry.diagnostics.some(d => d.level === 'error' && d.message.includes('sneaky'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('ranks the DSH_HOME pets source above the legacy codex source', () => {
+    const root = tempDir()
+    try {
+      const legacy = join(root, 'legacy')
+      const dsh = join(root, 'dsh')
+      writePet(legacy, 'cat', { id: 'cat', displayName: 'Legacy Cat' })
+      writePet(dsh, 'cat', { id: 'cat', displayName: 'Home Cat' })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir: legacy, dshPetsDir: dsh })
+      expect(registry.byId('cat')?.displayName).toBe('Home Cat')
+      // '' disables the source entirely.
+      const disabled = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir: '', dshPetsDir: dsh })
+      expect(disabled.entries.map(e => e.id)).toEqual(['cat'])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/dsh-pet/src/registry.ts
+++ b/packages/dsh-pet/src/registry.ts
@@ -1,13 +1,21 @@
 /**
  * Pet registry — the multi-pet contract. One pet is a directory holding a
  * 'pet.json' manifest plus an atlas image; nothing else is required, and no
- * host or client code changes when a pet is added. The registry scans three
+ * host or client code changes when a pet is added. The registry scans four
  * sources, later sources overriding earlier ones on an id collision:
  *
  *   1. the package's own 'assets' subdirectories (built-in pets);
- *   2. '${CODEX_HOME:-~/.codex}/pets' subdirectories (hatch-pet custom pets);
- *   3. 'PetConfig.pets' manifests composed by the embedding application
+ *   2. '${CODEX_HOME:-~/.codex}/pets' subdirectories (hatch-pet custom pets,
+ *      legacy source kept readable);
+ *   3. '$DSH_HOME/pets' subdirectories (the pet-center user directory);
+ *   4. 'PetConfig.pets' manifests composed by the embedding application
  *      (highest precedence).
+ *
+ * Manifests are parsed through manifest-v2 (pet-center M2, issue #623): v1
+ * manifests are compat-read as sprite2d, v2 manifests validate fail-closed,
+ * and structured diagnostics ride alongside the legacy warnings. Valid
+ * live2d entries are accepted by the contract but stay off the renderable
+ * list until the renderer dispatch lands (M3); they surface as diagnostics.
  *
  * The manifest follows the Codex/hatch-pet contract (8 columns x 9 rows of
  * 192x208 cells, the 9-state row order below). Legacy whale-girl manifests
@@ -23,6 +31,8 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ActivityPhase, PetAnimation } from './state.ts'
 import { normalizePetRemarks, type PetRemarks, type PetRemarksManifest } from './remarks.ts'
+import { dshHome } from './dsh-home.ts'
+import { parsePetManifest, type PetManifestV2 } from './manifest-v2.ts'
 
 /** Fixed row order of the 9-state animation contract. */
 export const PET_ROW_ORDER: readonly PetAnimation[] = [
@@ -193,9 +203,19 @@ export interface PetEntry extends PetDefinition {
 export interface PetRegistry {
   entries: PetEntry[]
   warnings: string[]
+  /** Structured diagnostics from the manifest-v2 parse (superset detail of warnings). */
+  diagnostics: PetRegistryDiagnostic[]
   byId(id: string): PetEntry | undefined
   /** The pet an installation falls back to when the selection is unknown. */
   defaultEntry(): PetEntry
+}
+
+/** One structured registry diagnostic (manifest-v2 era). */
+export interface PetRegistryDiagnostic {
+  level: 'error' | 'warning'
+  /** Where the diagnostic originates (directory or file). */
+  source: string
+  message: string
 }
 
 /** Registry sources. */
@@ -206,6 +226,8 @@ export interface PetRegistryOptions {
   assetPrefix?: string
   /** Custom pet directory (defaults to '${CODEX_HOME:-~/.codex}/pets'). */
   petsDir?: string
+  /** Pet-center user directory (defaults to '$DSH_HOME/pets'; '' disables). */
+  dshPetsDir?: string
   /** Extra manifest entries composed by the embedding application. */
   extra?: readonly PetManifest[]
 }
@@ -348,8 +370,36 @@ export function resolvePetManifest(
   }
 }
 
+/**
+ * Adapt a validated v2 manifest's sprite2d block onto the legacy flat shape
+ * the established resolver consumes (pet-center M2 P2). The legacy resolver
+ * only expresses 9-row (default) and 11-row (spriteVersionNumber 2) atlases,
+ * so other atlasRows values are rejected here with a diagnostic.
+ */
+function flattenV2Sprite2d(manifest: PetManifestV2): Record<string, unknown> | undefined {
+  const block = manifest.sprite2d
+  if (block === undefined) return undefined
+  const legacy: Record<string, unknown> = {
+    id: manifest.id,
+    displayName: manifest.displayName,
+    spritesheetPath: block.spritesheetPath,
+  }
+  if (manifest.description !== undefined) legacy.description = manifest.description
+  if (block.cell !== undefined) legacy.cell = block.cell
+  if (block.columns !== undefined) legacy.columns = block.columns
+  if (block.frames !== undefined) legacy.frames = block.frames
+  if (block.tracks !== undefined) legacy.tracks = block.tracks
+  if (block.atlasRows !== undefined) {
+    if (block.atlasRows === 11) legacy.spriteVersionNumber = 2
+    else if (block.atlasRows !== DEFAULT_PET_ROW_COUNT) return undefined
+  }
+  if (manifest.sequences !== undefined) legacy.sequences = manifest.sequences
+  if (manifest.remarks !== undefined) legacy.remarks = manifest.remarks
+  return legacy
+}
+
 /** Scan one directory of pet folders; entries come back in name order. */
-function scanPetDir(dir: string, options: { assetPrefix?: string; warnings?: string[] }): PetEntry[] {
+function scanPetDir(dir: string, options: { assetPrefix?: string; warnings?: string[]; diagnostics?: PetRegistryDiagnostic[] }): PetEntry[] {
   if (!existsSync(dir)) return []
   let names: string[] = []
   try {
@@ -364,7 +414,29 @@ function scanPetDir(dir: string, options: { assetPrefix?: string; warnings?: str
     if (!existsSync(manifestFile)) continue
     const parsed = readPetJson(manifestFile, options.warnings)
     if (parsed === undefined) continue
-    const entry = resolvePetManifest(parsed, join(dir, name), options)
+    const entryDir = join(dir, name)
+    const verdict = parsePetManifest(parsed, entryDir)
+    for (const diagnostic of verdict.diagnostics) {
+      options.diagnostics?.push({ level: diagnostic.level, source: entryDir, message: diagnostic.message })
+      options.warnings?.push(diagnostic.message)
+    }
+    if (!verdict.ok) continue
+    if (verdict.manifest.renderer === 'live2d') {
+      // Valid live2d pet: accepted by the contract, but the renderer dispatch
+      // lands with M3 — keep it off the renderable list until then.
+      const note = 'pet ' + verdict.manifest.id + ' uses renderer live2d (supported from M3); hidden from the list for now'
+      options.diagnostics?.push({ level: 'warning', source: entryDir, message: note })
+      options.warnings?.push(note)
+      continue
+    }
+    const legacy = flattenV2Sprite2d(verdict.manifest)
+    if (legacy === undefined) {
+      const note = 'pet ' + verdict.manifest.id + ': sprite2d.atlasRows only supports 9 or 11 under the v1 compat resolver'
+      options.diagnostics?.push({ level: 'error', source: entryDir, message: note })
+      options.warnings?.push(note)
+      continue
+    }
+    const entry = resolvePetManifest(legacy, entryDir, options)
     if (entry !== undefined) entries.push(entry)
   }
   return entries
@@ -389,10 +461,11 @@ function readPetJson(file: string, warnings: string[] | undefined): unknown {
 export function loadPetRegistry(options: PetRegistryOptions): PetRegistry {
   const { packageRoot, assetPrefix = '/pet' } = options
   const warnings: string[] = []
+  const diagnostics: PetRegistryDiagnostic[] = []
   const byId = new Map<string, PetEntry>()
   const builtinIds = new Set<string>()
 
-  for (const entry of scanPetDir(join(packageRoot, 'assets'), { assetPrefix, warnings })) {
+  for (const entry of scanPetDir(join(packageRoot, 'assets'), { assetPrefix, warnings, diagnostics })) {
     if (byId.has(entry.id)) {
       warnings.push('duplicate built-in pet id ' + entry.id + '; the first one wins')
       continue
@@ -403,8 +476,17 @@ export function loadPetRegistry(options: PetRegistryOptions): PetRegistry {
 
   const petsDir = options.petsDir ?? codexPetsDir()
   if (petsDir !== '') {
-    for (const entry of scanPetDir(petsDir, { assetPrefix, warnings })) {
+    for (const entry of scanPetDir(petsDir, { assetPrefix, warnings, diagnostics })) {
       if (byId.has(entry.id)) warnings.push('custom pet ' + entry.id + ' overrides the built-in one')
+      byId.set(entry.id, entry)
+    }
+  }
+
+  // The pet-center user directory ranks above the legacy hatch-pet source.
+  const dshPetsDir = options.dshPetsDir ?? join(dshHome(), 'pets')
+  if (dshPetsDir !== '') {
+    for (const entry of scanPetDir(dshPetsDir, { assetPrefix, warnings, diagnostics })) {
+      if (byId.has(entry.id)) warnings.push('user pet ' + entry.id + ' overrides an earlier registration')
       byId.set(entry.id, entry)
     }
   }
@@ -431,6 +513,7 @@ export function loadPetRegistry(options: PetRegistryOptions): PetRegistry {
   return {
     entries,
     warnings,
+    diagnostics,
     byId: (id: string) => byId.get(id),
     defaultEntry: () => entries.find(entry => builtinIds.has(entry.id)) ?? entries[0]!,
   }

--- a/packages/dsh-pet/src/routes.ts
+++ b/packages/dsh-pet/src/routes.ts
@@ -254,6 +254,7 @@ export function makePetRoutes(deps: { service: PetService }): WebRoute[] {
   const apiRoutes: WebRoute[] = [
     getRoute(PET_API_PREFIX + '/state', () => service.state()),
     getRoute(PET_API_PREFIX + '/pets', () => service.pets()),
+    getRoute(PET_API_PREFIX + '/diagnostics', () => service.diagnostics()),
     postRoute(PET_API_PREFIX + '/interact', (body) => {
       const kind = body.kind as PetInteraction | undefined
       if (kind !== 'pet' && kind !== 'feed') return Promise.reject(new Error('invalid-kind'))

--- a/packages/dsh-pet/src/service.ts
+++ b/packages/dsh-pet/src/service.ts
@@ -42,6 +42,7 @@ import {
   type PetDefinition,
   type PetManifest,
   type PetRegistry,
+  type PetRegistryDiagnostic,
 } from './registry.ts'
 import { WHISPER_TTL_MS } from './chatter.ts'
 import {
@@ -263,6 +264,11 @@ export class PetService extends Service {
   /** The loaded registry (the asset routes serve its entries). */
   registrySnapshot(): PetRegistry {
     return this.registry
+  }
+
+  /** RPC: structured registry diagnostics (pet-center M2, issue #623). */
+  async diagnostics(): Promise<{ diagnostics: PetRegistryDiagnostic[] }> {
+    return { diagnostics: this.registry.diagnostics }
   }
 
   /** The selected pet's registry entry. */

--- a/packages/dsh-pet/tests/routes.spec.ts
+++ b/packages/dsh-pet/tests/routes.spec.ts
@@ -35,7 +35,7 @@ beforeAll(async () => {
   writeFileSync(join(assets, 'otter', 'spritesheet.webp'), WEBP_BYTES)
 
   const ctx = new Context()
-  const registry = loadPetRegistry({ packageRoot: dir, petsDir: '' })
+  const registry = loadPetRegistry({ packageRoot: dir, petsDir: '', dshPetsDir: '' })
   const service = new PetService(ctx, { persistDir: join(dir, 'home'), registry })
   routes = makePetRoutes({ service })
   server = createServer((req, res) => {
@@ -78,6 +78,17 @@ describe('pet routes', () => {
     const state = await fetch(url('/api/pet/state')).then(res => res.json()) as { pet: { id: string }; name: string }
     expect(state.pet.id).toBe('whale-girl')
     expect(state.name).toBe('鲸鱼娘')
+  })
+
+  it('serves structured registry diagnostics (#623)', async () => {
+    const res = await fetch(url('/api/pet/diagnostics'))
+    expect(res.status).toBe(200)
+    const body = await res.json() as { diagnostics: Array<{ level: string; source: string; message: string }> }
+    expect(Array.isArray(body.diagnostics)).toBe(true)
+    // The two fixture pets are v1 manifests: each yields one migration hint.
+    const v1Notes = body.diagnostics.filter(d => d.message.includes('treated as renderer'))
+    expect(v1Notes.length).toBe(2)
+    expect(v1Notes[0]!.level).toBe('warning')
   })
 
   it('serves the atlas under the pet id and the legacy directory alias', async () => {

--- a/packages/dsh-pet/tests/service-enabled.spec.ts
+++ b/packages/dsh-pet/tests/service-enabled.spec.ts
@@ -26,6 +26,7 @@ function fixtureRegistry(): PetRegistry {
   return {
     entries,
     warnings,
+    diagnostics: [],
     byId: id => entries.find(entry => entry.id === id),
     defaultEntry: () => entries[0]!,
   }


### PR DESCRIPTION
## 摘要（Summary）

宠物中心重设计（#623）M2 的 P2（叠在 P1 #636 之上，diff 仅含本层）：**registry 全面接入 manifest-v2 解析 + 第四源 `$DSH_HOME/pets` + 结构化诊断端点**。

- 目录扫描统一走 `parsePetManifest`：v1 兼容读（迁移提示诊断）、v2 fail-closed、**live2d 清单验收但暂不进可渲染列表**（渲染分发 M3 落地，诊断如实说明）——每个中间 PR 都对用户安全；
- `flattenV2Sprite2d` 适配器把 v2 sprite2d 块拍平委托现有 `resolvePetManifest`（几何/轨道逻辑 100% 复用）；`atlasRows: 11` 回写 `spriteVersionNumber: 2`，其他值 fail-closed（兼容解析器表达不了）；
- 源优先级：内置 < `~/.codex/pets`（legacy）< `$DSH_HOME/pets`（新）< `PetConfig.pets`；
- 注册表携带结构化 `diagnostics[]`（与 legacy warnings 双轨），经新端点 `GET /api/pet/diagnostics` 输出（回环围栏不变）；
- 既有测试补 `dshPetsDir: ''` 隔离，真实用户目录不进测试。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 基于 feat/pet-center-m2（最新 main + P1）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（不确定具体模型版本）
使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码；未新增 tsconfig 指向；未新增包目录；无 emoji；未改动 README。

## 本地验证（Local Validation）

```bash
pnpm --filter @linxin666/dsh-pet test        # 19 文件 192 测试全绿（新增 7 项）
pnpm --filter @linxin666/dsh-pet typecheck  # 通过
```

## 用户可见变更证据（Local Feature Evidence）

N/A——`pet.*` API 与资产路由形状不变；live2d 宠物暂不进列表（诊断可见）；`$DSH_HOME/pets` 成为新的用户宠物源。

---

关联：#623、#636（P1 基座）。
