### PR TITLE
feat(pet): 渲染器契约/注册表/阶段流（宠物中心 M2 P4）

### DIFF
--- a/packages/dsh-pet/src/client/phase-stream.test.ts
+++ b/packages/dsh-pet/src/client/phase-stream.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { createPhaseStream } from './phase-stream.ts'
+import { RendererRegistry } from './renderers/registry.ts'
+import { PET_RENDERER_API_VERSION, type PetRenderer, type PetRendererContext } from '../contracts/renderer.ts'
+import type { ActivityPhase } from '../state.ts'
+
+describe('createPhaseStream', () => {
+  it('dispatches on change only and supports unsubscribe', () => {
+    const stream = createPhaseStream()
+    const seen: ActivityPhase[] = []
+    const off = stream.subscribe(phase => seen.push(phase))
+    stream.push('idle')       // unchanged: no dispatch
+    stream.push('thinking')
+    stream.push('thinking')   // unchanged: no dispatch
+    stream.push('done')
+    expect(seen).toEqual(['thinking', 'done'])
+    expect(stream.get()).toBe('done')
+    off()
+    stream.push('idle')
+    expect(seen).toHaveLength(2) // no dispatch after unsubscribe
+  })
+})
+
+function fakeContext(): PetRendererContext & { cleanups: Array<() => void> } {
+  const cleanups: Array<() => void> = []
+  return {
+    petId: 'test',
+    assetBase: '/pet/test',
+    container: document.createElement('div'),
+    phase: { get: () => 'idle', subscribe: () => () => {} },
+    interact: () => {},
+    onCleanup: fn => cleanups.push(fn),
+    cleanups,
+  }
+}
+
+describe('RendererRegistry', () => {
+  it('mounts a registered renderer with its validated config', () => {
+    const registry = new RendererRegistry()
+    const calls: unknown[] = []
+    const renderer: PetRenderer<{ tag: string }> = {
+      id: 'sprite2d',
+      apiVersion: PET_RENDERER_API_VERSION,
+      validateConfig: config => ({ tag: String((config as { tag: string }).tag) }),
+      mount: (ctx, config) => {
+        calls.push(config.tag)
+        return { dispose: () => calls.push('disposed') }
+      },
+    }
+    registry.register(renderer)
+    expect(registry.kinds()).toEqual(['sprite2d'])
+    const handle = registry.mount('sprite2d', fakeContext(), { tag: 'hello' })
+    expect(calls).toEqual(['hello'])
+    handle.dispose()
+    expect(calls).toEqual(['hello', 'disposed'])
+  })
+
+  it('renders a diagnostic card for an unknown renderer instead of blanking', () => {
+    const registry = new RendererRegistry()
+    const ctx = fakeContext()
+    const handle = registry.mount('live2d', ctx, {})
+    const note = ctx.container.querySelector('[data-dsh-pet-renderer-fallback]')
+    expect(note?.textContent).toContain('live2d')
+    expect(note?.textContent).toContain('supported')
+    handle.dispose()
+    handle.dispose() // idempotent
+    expect(ctx.container.querySelector('[data-dsh-pet-renderer-fallback]')).toBeNull()
+  })
+})
+
+describe('contract constants', () => {
+  it('locks the renderer apiVersion', () => {
+    expect(PET_RENDERER_API_VERSION).toBe('x-org.linxin666.pet-center/v1alpha1')
+  })
+})

--- a/packages/dsh-pet/src/client/phase-stream.ts
+++ b/packages/dsh-pet/src/client/phase-stream.ts
@@ -1,0 +1,39 @@
+/**
+ * Phase stream — bridges the polled host snapshots onto the renderer
+ * contract's { get, subscribe } shape (pet-center M2 P4, issue #623). The
+ * existing poll loop pushes each snapshot's ActivityPhase; subscribers are
+ * dispatched on CHANGE only (phase transitions are sparse — done/failed hold
+ * a timed window before falling back to idle — and renderers like Live2D pay
+ * per transition, not per tick).
+ * @module @linxin666/dsh-pet/client/phase-stream
+ */
+
+import type { ActivityPhase } from '../state.ts'
+
+/** The renderer-facing phase stream. */
+export interface PhaseStream {
+  /** The latest pushed phase. */
+  get(): ActivityPhase
+  /** Subscribe to phase changes; returns the unsubscribe. */
+  subscribe(listener: (phase: ActivityPhase) => void): () => void
+  /** Feed a fresh snapshot phase; no-op when unchanged. */
+  push(phase: ActivityPhase): void
+}
+
+/** Create the stream (one per pet entry lifetime, owned by the plugin body). */
+export function createPhaseStream(initial: ActivityPhase = 'idle'): PhaseStream {
+  let current = initial
+  const listeners = new Set<(phase: ActivityPhase) => void>()
+  return {
+    get: () => current,
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => { listeners.delete(listener) }
+    },
+    push(phase) {
+      if (phase === current) return
+      current = phase
+      for (const listener of [...listeners]) listener(phase)
+    },
+  }
+}

--- a/packages/dsh-pet/src/client/renderers/registry.ts
+++ b/packages/dsh-pet/src/client/renderers/registry.ts
@@ -1,0 +1,46 @@
+/**
+ * Renderer registry — dispatches a manifest's renderer kind to its
+ * implementation (pet-center M2 P4, issue #623). Unknown kinds never blank
+ * the pet: a fallback card names the problem and reports the kinds this
+ * build actually supports.
+ * @module @linxin666/dsh-pet/client/renderers/registry
+ */
+
+import type { PetRenderer, PetRendererContext, PetRendererHandle } from '../../contracts/renderer.ts'
+
+/** Renderer dispatch table. */
+export class RendererRegistry {
+  private readonly renderers = new Map<string, PetRenderer>()
+
+  /** Register one renderer implementation (id wins on re-register). */
+  register(renderer: PetRenderer): void {
+    this.renderers.set(renderer.id, renderer)
+  }
+
+  /** Whether a renderer kind is available in this build. */
+  has(id: string): boolean {
+    return this.renderers.has(id)
+  }
+
+  /** The registered renderer kinds (for diagnostics). */
+  kinds(): string[] {
+    return [...this.renderers.keys()].sort()
+  }
+
+  /**
+   * Mount a renderer for one activation. An unknown kind renders a clear
+   * diagnostic card into the container instead of failing silently.
+   */
+  mount(kind: string, ctx: PetRendererContext, config: unknown): PetRendererHandle {
+    const renderer = this.renderers.get(kind)
+    if (renderer === undefined) {
+      const note = document.createElement('div')
+      note.dataset.dshPetRendererFallback = kind
+      note.textContent = 'Pet renderer "' + kind + '" is not available in this build (supported: ' + this.kinds().join(', ') + ').'
+      ctx.container.appendChild(note)
+      ctx.onCleanup(() => note.remove())
+      return { dispose: () => note.remove() }
+    }
+    return renderer.mount(ctx, renderer.validateConfig(config))
+  }
+}

--- a/packages/dsh-pet/src/contracts/renderer.ts
+++ b/packages/dsh-pet/src/contracts/renderer.ts
@@ -1,0 +1,54 @@
+/**
+ * Renderer contract — the seam between the pet center and its renderers
+ * (issue #623, milestone M2 P4). Renderers never see the DSH session, the
+ * registry, or the network: they receive exactly three capabilities — an
+ * asset base URL, the ActivityPhase stream, and the interaction write-back —
+ * inside a center-owned container. Every mount is a fresh activation whose
+ * cleanups must be idempotent.
+ *
+ * This contract only serves real consumers: sprite2d (existing) and live2d
+ * (M3). Speculative capabilities join only when a renderer actually needs
+ * them.
+ * @module @linxin666/dsh-pet/contracts/renderer
+ */
+
+import type { ActivityPhase } from '../state.ts'
+
+/** Contract version renderers declare against (independent of the manifest). */
+export const PET_RENDERER_API_VERSION = 'x-org.linxin666.pet-center/v1alpha1'
+
+/** What the pet center hands a renderer on mount. */
+export interface PetRendererContext {
+  /** The selected pet's id. */
+  readonly petId: string
+  /** Same-origin URL prefix of this pet's assets ('/pet/<id>'). */
+  readonly assetBase: string
+  /** Center-owned mount root; renderers must not attach to document.body. */
+  readonly container: HTMLElement
+  /** The ActivityPhase stream (pet-center owned; renderers subscribe). */
+  readonly phase: {
+    get(): ActivityPhase
+    subscribe(listener: (phase: ActivityPhase) => void): () => void
+  }
+  /** The single interaction write-back into the affinity economy. */
+  readonly interact: (kind: 'tap') => void
+  /** Register an activation-scoped cleanup; run on dispose, idempotently. */
+  onCleanup(fn: () => void): void
+}
+
+/** A mounted renderer activation. */
+export interface PetRendererHandle {
+  /** Tear the activation down; may be called 0/1/N times. */
+  dispose(): void
+}
+
+/**
+ * One renderer implementation. validateConfig is fail-closed over the
+ * renderer-specific manifest block (schema v2 'sprite2d'/'live2d' blocks).
+ */
+export interface PetRenderer<Config = unknown> {
+  readonly id: string
+  readonly apiVersion: string
+  validateConfig(config: unknown): Config
+  mount(ctx: PetRendererContext, config: Config): PetRendererHandle
+}


### PR DESCRIPTION
## 摘要（Summary）

宠物中心重设计（#623）M2 的 P4（叠在 P1 #636 之上，diff 仅含本层）：**渲染器契约 + 注册表 + 阶段流桥**——呈现端与宠物核心解耦的代码缝。

- `src/contracts/renderer.ts`：`PetRendererContext` 三件套（资产前缀 / ActivityPhase 阶段流 / `interact('tap')` 写回）+ `PET_RENDERER_API_VERSION`——渲染器拿不到 session、registry、网络（耦合边界的代码形态）；
- `src/client/renderers/registry.ts`：按清单 `renderer` 分发；未知渲染器渲染**诊断卡**而非空白；dispose 幂等；
- `src/client/phase-stream.ts`：把现有 2s 轮询桥成 `{get, subscribe}`，**仅在阶段变更时派发**（为 Live2D motion 切换省工）。

本层无消费方——sprite2d 平移进契约是 P5。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 基于 feat/pet-center-m2（最新 main + P1）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（不确定具体模型版本）
使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码；浏览器半区纯度门保持（契约仅 type-only 导入 `../state.ts`）；未新增包目录；无 emoji；未改动 README。

## 本地验证（Local Validation）

```bash
pnpm --filter @linxin666/dsh-pet test        # 20 文件 189 测试全绿（新增 4 项）
pnpm --filter @linxin666/dsh-pet typecheck  # 通过
```

## 用户可见变更证据（Local Feature Evidence）

N/A——契约层无消费方接线，无用户可见变更。

---

关联：#623、#636（P1 基座）。#567 装饰槽届时复用本层的 `phase.subscribe`（已与 skymecode 在 #623 确认）。
