### PR TITLE
feat(pet): 宠物中心 M2 中间层集成（P1+P2+P4+P3a+P6）

### DIFF
--- a/packages/dsh-pet/src/client/phase-stream.test.ts
+++ b/packages/dsh-pet/src/client/phase-stream.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { createPhaseStream } from './phase-stream.ts'
+import { RendererRegistry } from './renderers/registry.ts'
+import { PET_RENDERER_API_VERSION, type PetRenderer, type PetRendererContext } from '../contracts/renderer.ts'
+import type { ActivityPhase } from '../state.ts'
+
+describe('createPhaseStream', () => {
+  it('dispatches on change only and supports unsubscribe', () => {
+    const stream = createPhaseStream()
+    const seen: ActivityPhase[] = []
+    const off = stream.subscribe(phase => seen.push(phase))
+    stream.push('idle')       // unchanged: no dispatch
+    stream.push('thinking')
+    stream.push('thinking')   // unchanged: no dispatch
+    stream.push('done')
+    expect(seen).toEqual(['thinking', 'done'])
+    expect(stream.get()).toBe('done')
+    off()
+    stream.push('idle')
+    expect(seen).toHaveLength(2) // no dispatch after unsubscribe
+  })
+})
+
+function fakeContext(): PetRendererContext & { cleanups: Array<() => void> } {
+  const cleanups: Array<() => void> = []
+  return {
+    petId: 'test',
+    assetBase: '/pet/test',
+    container: document.createElement('div'),
+    phase: { get: () => 'idle', subscribe: () => () => {} },
+    interact: () => {},
+    onCleanup: fn => cleanups.push(fn),
+    cleanups,
+  }
+}
+
+describe('RendererRegistry', () => {
+  it('mounts a registered renderer with its validated config', () => {
+    const registry = new RendererRegistry()
+    const calls: unknown[] = []
+    const renderer: PetRenderer<{ tag: string }> = {
+      id: 'sprite2d',
+      apiVersion: PET_RENDERER_API_VERSION,
+      validateConfig: config => ({ tag: String((config as { tag: string }).tag) }),
+      mount: (ctx, config) => {
+        calls.push(config.tag)
+        return { dispose: () => calls.push('disposed') }
+      },
+    }
+    registry.register(renderer)
+    expect(registry.kinds()).toEqual(['sprite2d'])
+    const handle = registry.mount('sprite2d', fakeContext(), { tag: 'hello' })
+    expect(calls).toEqual(['hello'])
+    handle.dispose()
+    expect(calls).toEqual(['hello', 'disposed'])
+  })
+
+  it('renders a diagnostic card for an unknown renderer instead of blanking', () => {
+    const registry = new RendererRegistry()
+    const ctx = fakeContext()
+    const handle = registry.mount('live2d', ctx, {})
+    const note = ctx.container.querySelector('[data-dsh-pet-renderer-fallback]')
+    expect(note?.textContent).toContain('live2d')
+    expect(note?.textContent).toContain('supported')
+    handle.dispose()
+    handle.dispose() // idempotent
+    expect(ctx.container.querySelector('[data-dsh-pet-renderer-fallback]')).toBeNull()
+  })
+})
+
+describe('contract constants', () => {
+  it('locks the renderer apiVersion', () => {
+    expect(PET_RENDERER_API_VERSION).toBe('x-org.linxin666.pet-center/v1alpha1')
+  })
+})

--- a/packages/dsh-pet/src/client/phase-stream.ts
+++ b/packages/dsh-pet/src/client/phase-stream.ts
@@ -1,0 +1,39 @@
+/**
+ * Phase stream — bridges the polled host snapshots onto the renderer
+ * contract's { get, subscribe } shape (pet-center M2 P4, issue #623). The
+ * existing poll loop pushes each snapshot's ActivityPhase; subscribers are
+ * dispatched on CHANGE only (phase transitions are sparse — done/failed hold
+ * a timed window before falling back to idle — and renderers like Live2D pay
+ * per transition, not per tick).
+ * @module @linxin666/dsh-pet/client/phase-stream
+ */
+
+import type { ActivityPhase } from '../state.ts'
+
+/** The renderer-facing phase stream. */
+export interface PhaseStream {
+  /** The latest pushed phase. */
+  get(): ActivityPhase
+  /** Subscribe to phase changes; returns the unsubscribe. */
+  subscribe(listener: (phase: ActivityPhase) => void): () => void
+  /** Feed a fresh snapshot phase; no-op when unchanged. */
+  push(phase: ActivityPhase): void
+}
+
+/** Create the stream (one per pet entry lifetime, owned by the plugin body). */
+export function createPhaseStream(initial: ActivityPhase = 'idle'): PhaseStream {
+  let current = initial
+  const listeners = new Set<(phase: ActivityPhase) => void>()
+  return {
+    get: () => current,
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => { listeners.delete(listener) }
+    },
+    push(phase) {
+      if (phase === current) return
+      current = phase
+      for (const listener of [...listeners]) listener(phase)
+    },
+  }
+}

--- a/packages/dsh-pet/src/client/renderers/registry.ts
+++ b/packages/dsh-pet/src/client/renderers/registry.ts
@@ -1,0 +1,46 @@
+/**
+ * Renderer registry — dispatches a manifest's renderer kind to its
+ * implementation (pet-center M2 P4, issue #623). Unknown kinds never blank
+ * the pet: a fallback card names the problem and reports the kinds this
+ * build actually supports.
+ * @module @linxin666/dsh-pet/client/renderers/registry
+ */
+
+import type { PetRenderer, PetRendererContext, PetRendererHandle } from '../../contracts/renderer.ts'
+
+/** Renderer dispatch table. */
+export class RendererRegistry {
+  private readonly renderers = new Map<string, PetRenderer>()
+
+  /** Register one renderer implementation (id wins on re-register). */
+  register(renderer: PetRenderer): void {
+    this.renderers.set(renderer.id, renderer)
+  }
+
+  /** Whether a renderer kind is available in this build. */
+  has(id: string): boolean {
+    return this.renderers.has(id)
+  }
+
+  /** The registered renderer kinds (for diagnostics). */
+  kinds(): string[] {
+    return [...this.renderers.keys()].sort()
+  }
+
+  /**
+   * Mount a renderer for one activation. An unknown kind renders a clear
+   * diagnostic card into the container instead of failing silently.
+   */
+  mount(kind: string, ctx: PetRendererContext, config: unknown): PetRendererHandle {
+    const renderer = this.renderers.get(kind)
+    if (renderer === undefined) {
+      const note = document.createElement('div')
+      note.dataset.dshPetRendererFallback = kind
+      note.textContent = 'Pet renderer "' + kind + '" is not available in this build (supported: ' + this.kinds().join(', ') + ').'
+      ctx.container.appendChild(note)
+      ctx.onCleanup(() => note.remove())
+      return { dispose: () => note.remove() }
+    }
+    return renderer.mount(ctx, renderer.validateConfig(config))
+  }
+}

--- a/packages/dsh-pet/src/contracts/renderer.ts
+++ b/packages/dsh-pet/src/contracts/renderer.ts
@@ -1,0 +1,54 @@
+/**
+ * Renderer contract — the seam between the pet center and its renderers
+ * (issue #623, milestone M2 P4). Renderers never see the DSH session, the
+ * registry, or the network: they receive exactly three capabilities — an
+ * asset base URL, the ActivityPhase stream, and the interaction write-back —
+ * inside a center-owned container. Every mount is a fresh activation whose
+ * cleanups must be idempotent.
+ *
+ * This contract only serves real consumers: sprite2d (existing) and live2d
+ * (M3). Speculative capabilities join only when a renderer actually needs
+ * them.
+ * @module @linxin666/dsh-pet/contracts/renderer
+ */
+
+import type { ActivityPhase } from '../state.ts'
+
+/** Contract version renderers declare against (independent of the manifest). */
+export const PET_RENDERER_API_VERSION = 'x-org.linxin666.pet-center/v1alpha1'
+
+/** What the pet center hands a renderer on mount. */
+export interface PetRendererContext {
+  /** The selected pet's id. */
+  readonly petId: string
+  /** Same-origin URL prefix of this pet's assets ('/pet/<id>'). */
+  readonly assetBase: string
+  /** Center-owned mount root; renderers must not attach to document.body. */
+  readonly container: HTMLElement
+  /** The ActivityPhase stream (pet-center owned; renderers subscribe). */
+  readonly phase: {
+    get(): ActivityPhase
+    subscribe(listener: (phase: ActivityPhase) => void): () => void
+  }
+  /** The single interaction write-back into the affinity economy. */
+  readonly interact: (kind: 'tap') => void
+  /** Register an activation-scoped cleanup; run on dispose, idempotently. */
+  onCleanup(fn: () => void): void
+}
+
+/** A mounted renderer activation. */
+export interface PetRendererHandle {
+  /** Tear the activation down; may be called 0/1/N times. */
+  dispose(): void
+}
+
+/**
+ * One renderer implementation. validateConfig is fail-closed over the
+ * renderer-specific manifest block (schema v2 'sprite2d'/'live2d' blocks).
+ */
+export interface PetRenderer<Config = unknown> {
+  readonly id: string
+  readonly apiVersion: string
+  validateConfig(config: unknown): Config
+  mount(ctx: PetRendererContext, config: Config): PetRendererHandle
+}

--- a/packages/dsh-pet/src/model3.test.ts
+++ b/packages/dsh-pet/src/model3.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { collectModel3References, model3HitAreas, model3MotionGroups } from './model3.ts'
+
+/** Fixture mirroring the real Haru sample's FileReferences shape. */
+const HARU_LIKE = {
+  Version: 3,
+  FileReferences: {
+    Moc: 'haru.moc3',
+    Textures: ['haru.2048/texture_00.png', 'haru.2048/texture_01.png'],
+    Physics: 'haru.physics3.json',
+    Pose: 'haru.pose3.json',
+    DisplayInfo: 'haru.cdi3.json',
+    Expressions: [
+      { Name: 'f01', File: 'expressions/f01.exp3.json' },
+      { Name: 'f02', File: 'expressions/f02.exp3.json' },
+    ],
+    Motions: {
+      Idle: [{ File: 'motions/idle_00.motion3.json' }],
+      TapBody: [{ File: 'motions/tap_00.motion3.json' }, { File: 'motions/tap_01.motion3.json' }],
+    },
+    UserData: 'haru.userdata3.json',
+  },
+  Groups: [{ Name: 'EyeBlink' }, { Name: 'LipSync' }],
+  HitAreas: [{ Id: 'Head', Name: 'Head' }, { Id: 'Body', Name: 'Body' }],
+}
+
+describe('collectModel3References', () => {
+  it('collects the complete reference closure of the eight Cubism file families', () => {
+    const { references, errors } = collectModel3References(HARU_LIKE)
+    expect(errors).toEqual([])
+    expect(references).toEqual([
+      'expressions/f01.exp3.json',
+      'expressions/f02.exp3.json',
+      'haru.2048/texture_00.png',
+      'haru.2048/texture_01.png',
+      'haru.cdi3.json',
+      'haru.moc3',
+      'haru.physics3.json',
+      'haru.pose3.json',
+      'haru.userdata3.json',
+      'motions/idle_00.motion3.json',
+      'motions/tap_00.motion3.json',
+      'motions/tap_01.motion3.json',
+    ])
+  })
+  it('rejects unsafe references instead of collecting them', () => {
+    const bad = {
+      FileReferences: {
+        Moc: '../escape.moc3',
+        Textures: ['/abs/path.png', 'ok.png'],
+        Motions: { Idle: [{ File: 'https://evil.example/x.motion3.json' }] },
+      },
+    }
+    const { references, errors } = collectModel3References(bad)
+    expect(references).toEqual(['ok.png'])
+    expect(errors).toHaveLength(3)
+  })
+  it('tolerates missing optional families', () => {
+    const minimal = { FileReferences: { Moc: 'a.moc3', Textures: ['a.png'] } }
+    const { references, errors } = collectModel3References(minimal)
+    expect(errors).toEqual([])
+    expect(references).toEqual(['a.moc3', 'a.png'])
+  })
+  it('reports malformed model3 roots', () => {
+    expect(collectModel3References(null).errors.length).toBeGreaterThan(0)
+    expect(collectModel3References({}).errors.length).toBeGreaterThan(0)
+  })
+})
+
+describe('model3MotionGroups / model3HitAreas', () => {
+  it('reads motion groups and hit areas for diagnostics', () => {
+    expect(model3MotionGroups(HARU_LIKE)).toEqual(['Idle', 'TapBody'])
+    expect(model3HitAreas(HARU_LIKE)).toEqual(['Body', 'Head'])
+  })
+  it('returns empty lists for malformed models', () => {
+    expect(model3MotionGroups(null)).toEqual([])
+    expect(model3HitAreas({})).toEqual([])
+  })
+})

--- a/packages/dsh-pet/src/model3.ts
+++ b/packages/dsh-pet/src/model3.ts
@@ -1,0 +1,91 @@
+/**
+ * Live2D .model3.json reference closure — the set of files a model declares
+ * (pet-center M2, issue #623). The host asset route only ever serves a pet's
+ * declared manifest, its declared primary assets, and this closure; the CLI
+ * validator reuses the same extractor so an install-time check proves the
+ * serving set is complete.
+ *
+ * Cubism file family: Moc (.moc3), Textures (images), Physics (.physics3.json),
+ * Pose (.pose3.json), DisplayInfo (.cdi3.json), Expressions[].File
+ * (.exp3.json), Motions.<group>[].File (.motion3.json), UserData
+ * (.userdata3.json). Every reference must be a safe manifest-relative path
+ * (safeManifestPath); unsafe entries make the model unloadable.
+ *
+ * Erasable-syntax-only: scripts/ import this under node strip-only mode.
+ * @module @linxin666/dsh-pet/model3
+ */
+
+import { safeManifestPath } from './manifest-v2.ts'
+
+/** Collect the safe relative paths one model3.json references. */
+export function collectModel3References(model3: unknown): { references: string[]; errors: string[] } {
+  const errors: string[] = []
+  if (typeof model3 !== 'object' || model3 === null) {
+    return { references: [], errors: ['model3.json is not an object'] }
+  }
+  const fileReferences = (model3 as Record<string, unknown>).FileReferences
+  if (typeof fileReferences !== 'object' || fileReferences === null) {
+    return { references: [], errors: ['model3.json has no FileReferences'] }
+  }
+  const refs = fileReferences as Record<string, unknown>
+  const collected = new Set<string>()
+  const push = (raw: unknown, field: string): void => {
+    const safe = safeManifestPath(raw)
+    if (safe === undefined) {
+      errors.push(field + ' is not a safe relative path: ' + JSON.stringify(String(raw)))
+      return
+    }
+    collected.add(safe)
+  }
+  if (refs.Moc !== undefined) push(refs.Moc, 'FileReferences.Moc')
+  if (Array.isArray(refs.Textures)) {
+    refs.Textures.forEach((texture, index) => push(texture, 'FileReferences.Textures[' + index + ']'))
+  }
+  for (const scalar of ['Physics', 'Pose', 'DisplayInfo', 'UserData'] as const) {
+    if (refs[scalar] !== undefined) push(refs[scalar], 'FileReferences.' + scalar)
+  }
+  if (Array.isArray(refs.Expressions)) {
+    refs.Expressions.forEach((expression, index) => {
+      const file = typeof expression === 'object' && expression !== null
+        ? (expression as Record<string, unknown>).File
+        : undefined
+      if (file !== undefined) push(file, 'FileReferences.Expressions[' + index + '].File')
+    })
+  }
+  if (typeof refs.Motions === 'object' && refs.Motions !== null) {
+    for (const [group, motions] of Object.entries(refs.Motions as Record<string, unknown>)) {
+      if (!Array.isArray(motions)) {
+        errors.push('FileReferences.Motions.' + group + ' is not an array')
+        continue
+      }
+      motions.forEach((motion, index) => {
+        const file = typeof motion === 'object' && motion !== null
+          ? (motion as Record<string, unknown>).File
+          : undefined
+        if (file !== undefined) push(file, 'FileReferences.Motions.' + group + '[' + index + '].File')
+      })
+    }
+  }
+  return { references: [...collected].sort(), errors }
+}
+
+/** The motion group names a model3.json declares (for CLI diagnostics). */
+export function model3MotionGroups(model3: unknown): string[] {
+  if (typeof model3 !== 'object' || model3 === null) return []
+  const fileReferences = (model3 as Record<string, unknown>).FileReferences
+  if (typeof fileReferences !== 'object' || fileReferences === null) return []
+  const motions = (fileReferences as Record<string, unknown>).Motions
+  if (typeof motions !== 'object' || motions === null) return []
+  return Object.keys(motions as Record<string, unknown>).sort()
+}
+
+/** The hit area names a model3.json declares (top-level HitAreas). */
+export function model3HitAreas(model3: unknown): string[] {
+  if (typeof model3 !== 'object' || model3 === null) return []
+  const hitAreas = (model3 as Record<string, unknown>).HitAreas
+  if (!Array.isArray(hitAreas)) return []
+  return hitAreas
+    .map(area => typeof area === 'object' && area !== null ? (area as Record<string, unknown>).Name : undefined)
+    .filter((name): name is string => typeof name === 'string')
+    .sort()
+}

--- a/packages/dsh-pet/src/registry.test.ts
+++ b/packages/dsh-pet/src/registry.test.ts
@@ -152,6 +152,7 @@ describe('loadPetRegistry', () => {
     const registry = loadPetRegistry({
       packageRoot: petPackageRoot(import.meta.url),
       petsDir: '',
+      dshPetsDir: '',
     })
 
     expect(registry.entries.map(entry => entry.id)).toEqual([
@@ -184,7 +185,7 @@ describe('loadPetRegistry', () => {
       mkdirSync(join(petsDir, 'broken'), { recursive: true })
       writeFileSync(join(petsDir, 'broken', 'pet.json'), '{ not json', 'utf8')
 
-      const registry = loadPetRegistry({ packageRoot: root, petsDir })
+      const registry = loadPetRegistry({ packageRoot: root, petsDir, dshPetsDir: '' })
       expect(registry.entries.map(entry => entry.id)).toEqual(['whale-girl', 'otter'])
       expect(registry.defaultEntry().id).toBe('whale-girl')
       expect(registry.warnings.some(warning => warning.includes('broken'))).toBe(true)
@@ -193,6 +194,7 @@ describe('loadPetRegistry', () => {
       const overridden = loadPetRegistry({
         packageRoot: root,
         petsDir,
+        dshPetsDir: '',
         extra: [{ id: 'whale-girl', displayName: '替换鲸', spritesheetPath: 'spritesheet.webp' }],
       })
       expect(overridden.byId('whale-girl')!.displayName).toBe('替换鲸')
@@ -211,6 +213,7 @@ describe('loadPetRegistry', () => {
       const registry = loadPetRegistry({
         packageRoot: root,
         petsDir: '',
+        dshPetsDir: '',
         extra: [{ id: 'otter', displayName: '水獭', spritesheetPath: 'pets/otter/spritesheet.webp' }],
       })
       const entry = registry.byId('otter')
@@ -236,7 +239,7 @@ describe('loadPetRegistry', () => {
       writeFileSync(join(petsDir, 'aardvark', 'pet.json'), JSON.stringify({
         id: 'aardvark', displayName: '土豚', spritesheetPath: 'spritesheet.webp',
       }), 'utf8')
-      const registry = loadPetRegistry({ packageRoot: join(root, 'no-assets'), petsDir })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'no-assets'), petsDir, dshPetsDir: '' })
       expect(registry.defaultEntry().id).toBe('aardvark')
     } finally {
       rmSync(root, { recursive: true, force: true })
@@ -250,5 +253,115 @@ describe('codexPetsDir', () => {
     expect(codexPetsDir({ CODEX_HOME: '/opt/codex' }, '/home/user')).toBe(join('/opt/codex', 'pets'))
     expect(codexPetsDir({ CODEX_HOME: '~/codex' }, '/home/user')).toBe(join('/home/user', 'codex', 'pets'))
     expect(codexPetsDir({}, '/home/user')).toBe(join('/home/user', '.codex', 'pets'))
+  })
+})
+
+describe('loadPetRegistry pet-center v2 (issue #623)', () => {
+  function writePet(dir: string, name: string, manifest: Record<string, unknown>): void {
+    mkdirSync(join(dir, name), { recursive: true })
+    writeFileSync(join(dir, name, 'pet.json'), JSON.stringify(manifest), 'utf8')
+    writeFileSync(join(dir, name, 'spritesheet.webp'), 'webp', 'utf8')
+  }
+
+  it('resolves a v2 sprite2d pet with the same geometry as its v1 twin', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writePet(petsDir, 'v1pet', { id: 'twin-v1', displayName: 'Twin V1', frames: [1, 2, 3, 4, 5, 6, 7, 8, 9] })
+      writePet(petsDir, 'v2pet', {
+        petManifestVersion: 2, id: 'twin-v2', displayName: 'Twin V2', license: 'CC0-1.0',
+        renderer: 'sprite2d', sprite2d: { spritesheetPath: 'spritesheet.webp', frames: [1, 2, 3, 4, 5, 6, 7, 8, 9] },
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      const v1 = registry.byId('twin-v1')!
+      const v2 = registry.byId('twin-v2')!
+      expect(v2.rows).toEqual(v1.rows)
+      expect(v2.tracks.idle.durations).toEqual(v1.tracks.idle.durations)
+      expect(registry.diagnostics.some(d => d.message.includes('v1 compat read'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('round-trips atlasRows 11 through the v1 compat resolver', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writePet(petsDir, 'looky', {
+        petManifestVersion: 2, id: 'looky', displayName: 'Looky', license: 'CC0-1.0',
+        renderer: 'sprite2d', sprite2d: { spritesheetPath: 'spritesheet.webp', atlasRows: 11 },
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('looky')?.atlasRows).toBe(11)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects atlasRows values the v1 compat resolver cannot express', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writePet(petsDir, 'odd', {
+        petManifestVersion: 2, id: 'odd', displayName: 'Odd', license: 'CC0-1.0',
+        renderer: 'sprite2d', sprite2d: { spritesheetPath: 'spritesheet.webp', atlasRows: 7 },
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('odd')).toBeUndefined()
+      expect(registry.diagnostics.some(d => d.level === 'error' && d.message.includes('atlasRows'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts live2d manifests into diagnostics without listing them renderable', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      mkdirSync(join(petsDir, 'haru'), { recursive: true })
+      writeFileSync(join(petsDir, 'haru', 'pet.json'), JSON.stringify({
+        petManifestVersion: 2, id: 'haru', displayName: 'Haru', license: 'Live2D-Sample',
+        renderer: 'live2d', live2d: { model: 'haru.model3.json', motions: { idle: 'Idle' } },
+      }), 'utf8')
+      writeFileSync(join(petsDir, 'haru', 'haru.model3.json'), '{}', 'utf8')
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('haru')).toBeUndefined()
+      expect(registry.diagnostics.some(d => d.message.includes('live2d') && d.message.includes('M3'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed on v2 manifests with unknown fields', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writePet(petsDir, 'surprise', {
+        petManifestVersion: 2, id: 'surprise', displayName: 'S', license: 'CC0-1.0',
+        renderer: 'sprite2d', sprite2d: { spritesheetPath: 'spritesheet.webp' }, sneaky: true,
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('surprise')).toBeUndefined()
+      expect(registry.diagnostics.some(d => d.level === 'error' && d.message.includes('sneaky'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('ranks the DSH_HOME pets source above the legacy codex source', () => {
+    const root = tempDir()
+    try {
+      const legacy = join(root, 'legacy')
+      const dsh = join(root, 'dsh')
+      writePet(legacy, 'cat', { id: 'cat', displayName: 'Legacy Cat' })
+      writePet(dsh, 'cat', { id: 'cat', displayName: 'Home Cat' })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir: legacy, dshPetsDir: dsh })
+      expect(registry.byId('cat')?.displayName).toBe('Home Cat')
+      // '' disables the source entirely.
+      const disabled = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir: '', dshPetsDir: dsh })
+      expect(disabled.entries.map(e => e.id)).toEqual(['cat'])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/dsh-pet/src/registry.ts
+++ b/packages/dsh-pet/src/registry.ts
@@ -1,13 +1,21 @@
 /**
  * Pet registry — the multi-pet contract. One pet is a directory holding a
  * 'pet.json' manifest plus an atlas image; nothing else is required, and no
- * host or client code changes when a pet is added. The registry scans three
+ * host or client code changes when a pet is added. The registry scans four
  * sources, later sources overriding earlier ones on an id collision:
  *
  *   1. the package's own 'assets' subdirectories (built-in pets);
- *   2. '${CODEX_HOME:-~/.codex}/pets' subdirectories (hatch-pet custom pets);
- *   3. 'PetConfig.pets' manifests composed by the embedding application
+ *   2. '${CODEX_HOME:-~/.codex}/pets' subdirectories (hatch-pet custom pets,
+ *      legacy source kept readable);
+ *   3. '$DSH_HOME/pets' subdirectories (the pet-center user directory);
+ *   4. 'PetConfig.pets' manifests composed by the embedding application
  *      (highest precedence).
+ *
+ * Manifests are parsed through manifest-v2 (pet-center M2, issue #623): v1
+ * manifests are compat-read as sprite2d, v2 manifests validate fail-closed,
+ * and structured diagnostics ride alongside the legacy warnings. Valid
+ * live2d entries are accepted by the contract but stay off the renderable
+ * list until the renderer dispatch lands (M3); they surface as diagnostics.
  *
  * The manifest follows the Codex/hatch-pet contract (8 columns x 9 rows of
  * 192x208 cells, the 9-state row order below). Legacy whale-girl manifests
@@ -23,6 +31,8 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ActivityPhase, PetAnimation } from './state.ts'
 import { normalizePetRemarks, type PetRemarks, type PetRemarksManifest } from './remarks.ts'
+import { dshHome } from './dsh-home.ts'
+import { parsePetManifest, type PetManifestV2 } from './manifest-v2.ts'
 
 /** Fixed row order of the 9-state animation contract. */
 export const PET_ROW_ORDER: readonly PetAnimation[] = [
@@ -193,9 +203,19 @@ export interface PetEntry extends PetDefinition {
 export interface PetRegistry {
   entries: PetEntry[]
   warnings: string[]
+  /** Structured diagnostics from the manifest-v2 parse (superset detail of warnings). */
+  diagnostics: PetRegistryDiagnostic[]
   byId(id: string): PetEntry | undefined
   /** The pet an installation falls back to when the selection is unknown. */
   defaultEntry(): PetEntry
+}
+
+/** One structured registry diagnostic (manifest-v2 era). */
+export interface PetRegistryDiagnostic {
+  level: 'error' | 'warning'
+  /** Where the diagnostic originates (directory or file). */
+  source: string
+  message: string
 }
 
 /** Registry sources. */
@@ -206,6 +226,8 @@ export interface PetRegistryOptions {
   assetPrefix?: string
   /** Custom pet directory (defaults to '${CODEX_HOME:-~/.codex}/pets'). */
   petsDir?: string
+  /** Pet-center user directory (defaults to '$DSH_HOME/pets'; '' disables). */
+  dshPetsDir?: string
   /** Extra manifest entries composed by the embedding application. */
   extra?: readonly PetManifest[]
 }
@@ -348,8 +370,36 @@ export function resolvePetManifest(
   }
 }
 
+/**
+ * Adapt a validated v2 manifest's sprite2d block onto the legacy flat shape
+ * the established resolver consumes (pet-center M2 P2). The legacy resolver
+ * only expresses 9-row (default) and 11-row (spriteVersionNumber 2) atlases,
+ * so other atlasRows values are rejected here with a diagnostic.
+ */
+function flattenV2Sprite2d(manifest: PetManifestV2): Record<string, unknown> | undefined {
+  const block = manifest.sprite2d
+  if (block === undefined) return undefined
+  const legacy: Record<string, unknown> = {
+    id: manifest.id,
+    displayName: manifest.displayName,
+    spritesheetPath: block.spritesheetPath,
+  }
+  if (manifest.description !== undefined) legacy.description = manifest.description
+  if (block.cell !== undefined) legacy.cell = block.cell
+  if (block.columns !== undefined) legacy.columns = block.columns
+  if (block.frames !== undefined) legacy.frames = block.frames
+  if (block.tracks !== undefined) legacy.tracks = block.tracks
+  if (block.atlasRows !== undefined) {
+    if (block.atlasRows === 11) legacy.spriteVersionNumber = 2
+    else if (block.atlasRows !== DEFAULT_PET_ROW_COUNT) return undefined
+  }
+  if (manifest.sequences !== undefined) legacy.sequences = manifest.sequences
+  if (manifest.remarks !== undefined) legacy.remarks = manifest.remarks
+  return legacy
+}
+
 /** Scan one directory of pet folders; entries come back in name order. */
-function scanPetDir(dir: string, options: { assetPrefix?: string; warnings?: string[] }): PetEntry[] {
+function scanPetDir(dir: string, options: { assetPrefix?: string; warnings?: string[]; diagnostics?: PetRegistryDiagnostic[] }): PetEntry[] {
   if (!existsSync(dir)) return []
   let names: string[] = []
   try {
@@ -364,7 +414,29 @@ function scanPetDir(dir: string, options: { assetPrefix?: string; warnings?: str
     if (!existsSync(manifestFile)) continue
     const parsed = readPetJson(manifestFile, options.warnings)
     if (parsed === undefined) continue
-    const entry = resolvePetManifest(parsed, join(dir, name), options)
+    const entryDir = join(dir, name)
+    const verdict = parsePetManifest(parsed, entryDir)
+    for (const diagnostic of verdict.diagnostics) {
+      options.diagnostics?.push({ level: diagnostic.level, source: entryDir, message: diagnostic.message })
+      options.warnings?.push(diagnostic.message)
+    }
+    if (!verdict.ok) continue
+    if (verdict.manifest.renderer === 'live2d') {
+      // Valid live2d pet: accepted by the contract, but the renderer dispatch
+      // lands with M3 — keep it off the renderable list until then.
+      const note = 'pet ' + verdict.manifest.id + ' uses renderer live2d (supported from M3); hidden from the list for now'
+      options.diagnostics?.push({ level: 'warning', source: entryDir, message: note })
+      options.warnings?.push(note)
+      continue
+    }
+    const legacy = flattenV2Sprite2d(verdict.manifest)
+    if (legacy === undefined) {
+      const note = 'pet ' + verdict.manifest.id + ': sprite2d.atlasRows only supports 9 or 11 under the v1 compat resolver'
+      options.diagnostics?.push({ level: 'error', source: entryDir, message: note })
+      options.warnings?.push(note)
+      continue
+    }
+    const entry = resolvePetManifest(legacy, entryDir, options)
     if (entry !== undefined) entries.push(entry)
   }
   return entries
@@ -389,10 +461,11 @@ function readPetJson(file: string, warnings: string[] | undefined): unknown {
 export function loadPetRegistry(options: PetRegistryOptions): PetRegistry {
   const { packageRoot, assetPrefix = '/pet' } = options
   const warnings: string[] = []
+  const diagnostics: PetRegistryDiagnostic[] = []
   const byId = new Map<string, PetEntry>()
   const builtinIds = new Set<string>()
 
-  for (const entry of scanPetDir(join(packageRoot, 'assets'), { assetPrefix, warnings })) {
+  for (const entry of scanPetDir(join(packageRoot, 'assets'), { assetPrefix, warnings, diagnostics })) {
     if (byId.has(entry.id)) {
       warnings.push('duplicate built-in pet id ' + entry.id + '; the first one wins')
       continue
@@ -403,8 +476,17 @@ export function loadPetRegistry(options: PetRegistryOptions): PetRegistry {
 
   const petsDir = options.petsDir ?? codexPetsDir()
   if (petsDir !== '') {
-    for (const entry of scanPetDir(petsDir, { assetPrefix, warnings })) {
+    for (const entry of scanPetDir(petsDir, { assetPrefix, warnings, diagnostics })) {
       if (byId.has(entry.id)) warnings.push('custom pet ' + entry.id + ' overrides the built-in one')
+      byId.set(entry.id, entry)
+    }
+  }
+
+  // The pet-center user directory ranks above the legacy hatch-pet source.
+  const dshPetsDir = options.dshPetsDir ?? join(dshHome(), 'pets')
+  if (dshPetsDir !== '') {
+    for (const entry of scanPetDir(dshPetsDir, { assetPrefix, warnings, diagnostics })) {
+      if (byId.has(entry.id)) warnings.push('user pet ' + entry.id + ' overrides an earlier registration')
       byId.set(entry.id, entry)
     }
   }
@@ -431,6 +513,7 @@ export function loadPetRegistry(options: PetRegistryOptions): PetRegistry {
   return {
     entries,
     warnings,
+    diagnostics,
     byId: (id: string) => byId.get(id),
     defaultEntry: () => entries.find(entry => builtinIds.has(entry.id)) ?? entries[0]!,
   }

--- a/packages/dsh-pet/src/routes.ts
+++ b/packages/dsh-pet/src/routes.ts
@@ -254,6 +254,7 @@ export function makePetRoutes(deps: { service: PetService }): WebRoute[] {
   const apiRoutes: WebRoute[] = [
     getRoute(PET_API_PREFIX + '/state', () => service.state()),
     getRoute(PET_API_PREFIX + '/pets', () => service.pets()),
+    getRoute(PET_API_PREFIX + '/diagnostics', () => service.diagnostics()),
     postRoute(PET_API_PREFIX + '/interact', (body) => {
       const kind = body.kind as PetInteraction | undefined
       if (kind !== 'pet' && kind !== 'feed') return Promise.reject(new Error('invalid-kind'))

--- a/packages/dsh-pet/src/routes.ts
+++ b/packages/dsh-pet/src/routes.ts
@@ -9,9 +9,9 @@
  * @module @linxin666/dsh-pet/routes
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, realpathSync, statSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { WebRoute } from '@deepseek-ai/dsh-host-webserver'
 import type { PetService } from './service.ts'
@@ -28,6 +28,41 @@ export const PET_ASSET_PREFIX = '/pet'
 const MANIFEST_FILE = 'pet.json'
 const PREVIEW_DIR = 'previews'
 const PREVIEW_PATTERN = /^[A-Za-z0-9._-]+$/
+
+/**
+ * Per-class size ceilings for served pet assets, in bytes (pet-center M2 P3,
+ * issue #623). Constants are tested directly; makePetRoutes accepts an
+ * override so tests can exercise the 413 path with tiny caps.
+ */
+export const PET_ASSET_CAPS = {
+  /** pet.json manifest. */
+  manifest: 64 * 1024,
+  /** Atlas and preview imagery. */
+  image: 20 * 1024 * 1024,
+} as const
+
+/** Size-cap profile the asset route enforces (test seam). */
+export interface PetAssetCaps {
+  manifest: number
+  image: number
+}
+
+/**
+ * realpath containment: resolve both sides and require the candidate to stay
+ * inside the base directory. A pet directory (or an atlas/preview inside it)
+ * that is a symlink escaping its root is rejected, never followed.
+ */
+export function containedRealpath(base: string, candidate: string): string | undefined {
+  try {
+    const realBase = realpathSync(base)
+    const realCandidate = realpathSync(candidate)
+    return realCandidate === realBase || realCandidate.startsWith(realBase + sep)
+      ? realCandidate
+      : undefined
+  } catch {
+    return undefined
+  }
+}
 
 const MIME_BY_EXT: Readonly<Record<string, string>> = {
   '.webp': 'image/webp',
@@ -148,7 +183,7 @@ function dirAliases(registry: PetRegistry): Map<string, PetEntry> {
  * pet.json, the declared spritesheet path, and optional 'previews/<name>'
  * media. Composed pets without a manifest file get a synthesized pet.json.
  */
-function assetHandler(registry: PetRegistry): WebRoute['handler'] {
+function assetHandler(registry: PetRegistry, caps: PetAssetCaps): WebRoute['handler'] {
   const aliases = dirAliases(registry)
   return (req: IncomingMessage, res: ServerResponse): void => {
     if (!guard(req, res)) return
@@ -229,7 +264,26 @@ function assetHandler(registry: PetRegistry): WebRoute['handler'] {
       res.end()
       return
     }
-    const resolved = file
+    // realpath containment: a symlink escaping the pet directory is refused.
+    const resolved = containedRealpath(entry.dir, file)
+    if (resolved === undefined) {
+      res.writeHead(403)
+      res.end()
+      return
+    }
+    // Enforce the size ceiling before the file is read into memory.
+    const cap = rest[0] === MANIFEST_FILE ? caps.manifest : caps.image
+    try {
+      if (statSync(resolved).size > cap) {
+        res.writeHead(413)
+        res.end()
+        return
+      }
+    } catch {
+      res.writeHead(404)
+      res.end()
+      return
+    }
     readFile(resolved).then((body) => {
       res.writeHead(200, {
         'content-type': mimeFor(resolved),
@@ -249,7 +303,7 @@ function assetHandler(registry: PetRegistry): WebRoute['handler'] {
 }
 
 /** Build the full route family (API + assets) for one service. */
-export function makePetRoutes(deps: { service: PetService }): WebRoute[] {
+export function makePetRoutes(deps: { service: PetService; assetCaps?: PetAssetCaps }): WebRoute[] {
   const { service } = deps
   const apiRoutes: WebRoute[] = [
     getRoute(PET_API_PREFIX + '/state', () => service.state()),
@@ -285,7 +339,7 @@ export function makePetRoutes(deps: { service: PetService }): WebRoute[] {
   const assetRoute: WebRoute = {
     kind: 'prefix',
     path: PET_ASSET_PREFIX,
-    handler: assetHandler(service.registrySnapshot()),
+    handler: assetHandler(service.registrySnapshot(), deps.assetCaps ?? PET_ASSET_CAPS),
   }
 
   return [...apiRoutes, assetRoute]

--- a/packages/dsh-pet/src/service.ts
+++ b/packages/dsh-pet/src/service.ts
@@ -42,6 +42,7 @@ import {
   type PetDefinition,
   type PetManifest,
   type PetRegistry,
+  type PetRegistryDiagnostic,
 } from './registry.ts'
 import { WHISPER_TTL_MS } from './chatter.ts'
 import {
@@ -263,6 +264,11 @@ export class PetService extends Service {
   /** The loaded registry (the asset routes serve its entries). */
   registrySnapshot(): PetRegistry {
     return this.registry
+  }
+
+  /** RPC: structured registry diagnostics (pet-center M2, issue #623). */
+  async diagnostics(): Promise<{ diagnostics: PetRegistryDiagnostic[] }> {
+    return { diagnostics: this.registry.diagnostics }
   }
 
   /** The selected pet's registry entry. */

--- a/packages/dsh-pet/tests/asset-security.spec.ts
+++ b/packages/dsh-pet/tests/asset-security.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Pet asset route security — realpath containment, size ceilings, and
+ * traversal lock-down (pet-center M2 P3, issue #623). Same real-server
+ * harness as routes.spec.ts.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { once } from 'node:events'
+import type { AddressInfo } from 'node:net'
+import { Context } from '@deepseek-ai/cordis'
+import { PetService } from '../src/service.ts'
+import { containedRealpath, makePetRoutes, PET_ASSET_CAPS, type PetAssetCaps } from '../src/routes.ts'
+import { loadPetRegistry } from '../src/registry.ts'
+
+const WEBP_BYTES = Buffer.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50])
+
+let dir: string
+let outside: string
+let server: Server
+let port: number
+
+/** Caps small enough that the 12-byte fixture atlas trips them when lowered. */
+const TEST_CAPS: PetAssetCaps = { manifest: 64 * 1024, image: 20 * 1024 * 1024 }
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'dsh-pet-sec-'))
+  outside = mkdtempSync(join(tmpdir(), 'dsh-pet-outside-'))
+  writeFileSync(join(outside, 'secret.webp'), WEBP_BYTES)
+
+  const assets = join(dir, 'assets')
+  // clean pet
+  mkdirSync(join(assets, 'whale'), { recursive: true })
+  writeFileSync(join(assets, 'whale', 'pet.json'), JSON.stringify({
+    id: 'whale-girl', displayName: 'Whale', spritesheetPath: 'spritesheet.webp',
+  }), 'utf8')
+  writeFileSync(join(assets, 'whale', 'spritesheet.webp'), WEBP_BYTES)
+  mkdirSync(join(assets, 'whale', 'previews'), { recursive: true })
+  writeFileSync(join(assets, 'whale', 'previews', 'idle.webp'), WEBP_BYTES)
+  // escaping pet: atlas symlinks out of the pet directory
+  mkdirSync(join(assets, 'sneaky'), { recursive: true })
+  writeFileSync(join(assets, 'sneaky', 'pet.json'), JSON.stringify({
+    id: 'sneaky', displayName: 'Sneaky', spritesheetPath: 'spritesheet.webp',
+  }), 'utf8')
+  symlinkSync(join(outside, 'secret.webp'), join(assets, 'sneaky', 'spritesheet.webp'))
+  symlinkSync(join(outside, 'secret.webp'), join(assets, 'whale', 'previews', 'escape.webp'))
+
+  const ctx = new Context()
+  const registry = loadPetRegistry({ packageRoot: dir, petsDir: '' })
+  const service = new PetService(ctx, { persistDir: join(dir, 'home'), registry })
+  const routes = makePetRoutes({ service, assetCaps: TEST_CAPS })
+  server = createServer((req, res) => {
+    const pathname = (req.url ?? '').split('?')[0]!
+    for (const route of routes) {
+      if (route.kind === 'exact' && pathname === route.path) return void route.handler(req, res)
+    }
+    for (const route of routes) {
+      if (route.kind === 'prefix' && (pathname === route.path || pathname.startsWith(route.path + '/'))) {
+        return void route.handler(req, res)
+      }
+    }
+    res.writeHead(404)
+    res.end()
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  port = (server.address() as AddressInfo).port
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  rmSync(dir, { recursive: true, force: true })
+  rmSync(outside, { recursive: true, force: true })
+})
+
+function url(path: string): string {
+  return 'http://127.0.0.1:' + port + path
+}
+
+describe('containedRealpath', () => {
+  it('accepts files inside the base and the base itself', () => {
+    const inside = join(dir, 'assets', 'whale', 'spritesheet.webp')
+    expect(containedRealpath(join(dir, 'assets', 'whale'), inside)).toBeDefined()
+  })
+  it('rejects escapes, lookalike prefixes and missing files', () => {
+    const base = join(dir, 'assets', 'whale')
+    expect(containedRealpath(base, join(outside, 'secret.webp'))).toBeUndefined()
+    expect(containedRealpath(base, join(dir, 'assets', 'whale-evil', 'x.png'))).toBeUndefined()
+    expect(containedRealpath(base, join(base, 'does-not-exist.png'))).toBeUndefined()
+  })
+})
+
+describe('asset route security', () => {
+  it('serves a clean atlas and preview', async () => {
+    expect((await fetch(url('/pet/whale-girl/spritesheet.webp'))).status).toBe(200)
+    expect((await fetch(url('/pet/whale-girl/previews/idle.webp'))).status).toBe(200)
+    expect((await fetch(url('/pet/whale-girl/pet.json'))).status).toBe(200)
+  })
+  it('refuses an atlas symlink escaping the pet directory', async () => {
+    expect((await fetch(url('/pet/sneaky/spritesheet.webp'))).status).toBe(403)
+  })
+  it('refuses a preview symlink escaping the pet directory', async () => {
+    expect((await fetch(url('/pet/whale-girl/previews/escape.webp'))).status).toBe(403)
+  })
+  it('answers 413 once a served file exceeds its class cap', async () => {
+    // Rebuild a server whose image cap the 12-byte fixture exceeds.
+    const ctx = new Context()
+    const registry = loadPetRegistry({ packageRoot: dir, petsDir: '' })
+    const service = new PetService(ctx, { persistDir: join(dir, 'home2'), registry })
+    const tight = makePetRoutes({ service, assetCaps: { manifest: 64 * 1024, image: 4 } })
+    const tightServer = createServer((req, res) => {
+      const pathname = (req.url ?? '').split('?')[0]!
+      for (const route of tight) {
+        if (route.kind === 'prefix' && (pathname === route.path || pathname.startsWith(route.path + '/'))) {
+          return void route.handler(req, res)
+        }
+      }
+      res.writeHead(404)
+      res.end()
+    })
+    tightServer.listen(0, '127.0.0.1')
+    await once(tightServer, 'listening')
+    const tightPort = (tightServer.address() as AddressInfo).port
+    try {
+      const response = await fetch('http://127.0.0.1:' + tightPort + '/pet/whale-girl/spritesheet.webp')
+      expect(response.status).toBe(413)
+    } finally {
+      await new Promise<void>((resolve) => tightServer.close(() => resolve()))
+    }
+  })
+  it('keeps traversal requests outside the declared files at 404', async () => {
+    expect((await fetch(url('/pet/whale-girl/%2e%2e/%2e%2e/pet.json'))).status).toBe(404)
+    expect((await fetch(url('/pet/whale-girl/spritesheet.webp/extra'))).status).toBe(404)
+  })
+  it('locks the default caps to the documented constants', () => {
+    expect(PET_ASSET_CAPS.manifest).toBe(64 * 1024)
+    expect(PET_ASSET_CAPS.image).toBe(20 * 1024 * 1024)
+  })
+})

--- a/packages/dsh-pet/tests/routes.spec.ts
+++ b/packages/dsh-pet/tests/routes.spec.ts
@@ -35,7 +35,7 @@ beforeAll(async () => {
   writeFileSync(join(assets, 'otter', 'spritesheet.webp'), WEBP_BYTES)
 
   const ctx = new Context()
-  const registry = loadPetRegistry({ packageRoot: dir, petsDir: '' })
+  const registry = loadPetRegistry({ packageRoot: dir, petsDir: '', dshPetsDir: '' })
   const service = new PetService(ctx, { persistDir: join(dir, 'home'), registry })
   routes = makePetRoutes({ service })
   server = createServer((req, res) => {
@@ -78,6 +78,17 @@ describe('pet routes', () => {
     const state = await fetch(url('/api/pet/state')).then(res => res.json()) as { pet: { id: string }; name: string }
     expect(state.pet.id).toBe('whale-girl')
     expect(state.name).toBe('鲸鱼娘')
+  })
+
+  it('serves structured registry diagnostics (#623)', async () => {
+    const res = await fetch(url('/api/pet/diagnostics'))
+    expect(res.status).toBe(200)
+    const body = await res.json() as { diagnostics: Array<{ level: string; source: string; message: string }> }
+    expect(Array.isArray(body.diagnostics)).toBe(true)
+    // The two fixture pets are v1 manifests: each yields one migration hint.
+    const v1Notes = body.diagnostics.filter(d => d.message.includes('treated as renderer'))
+    expect(v1Notes.length).toBe(2)
+    expect(v1Notes[0]!.level).toBe('warning')
   })
 
   it('serves the atlas under the pet id and the legacy directory alias', async () => {

--- a/packages/dsh-pet/tests/service-enabled.spec.ts
+++ b/packages/dsh-pet/tests/service-enabled.spec.ts
@@ -26,6 +26,7 @@ function fixtureRegistry(): PetRegistry {
   return {
     entries,
     warnings,
+    diagnostics: [],
     byId: id => entries.find(entry => entry.id === id),
     defaultEntry: () => entries[0]!,
   }

--- a/scripts/dsh-pet
+++ b/scripts/dsh-pet
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+'use strict'
+
+/**
+ * dsh-pet — pet tooling for the DSH Web GUI pet center (issue #623).
+ *
+ * Pets are pure asset directories (pet.json + assets). This CLI validates a
+ * pet directory against the v2 contract (v1 manifests are compat-read with a
+ * migration hint) and installs it into $DSH_HOME/pets/<id>/. It never touches
+ * cordis.patch.yml and never downloads anything — Live2D pets additionally
+ * need the user-supplied Cubism Core (see the package README).
+ *
+ * Commands:
+ *   dsh-pet validate <dir>   validate manifest + declared assets + Live2D closure
+ *   dsh-pet install <dir>    validate, then copy into $DSH_HOME/pets/<id>/
+ *                            [--force overwrites an existing same-id install]
+ *
+ * The validator/parsers are imported from the dsh-pet package sources
+ * (erasable TS, node strip-only mode) — never re-implemented here.
+ */
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { pathToFileURL } = require('node:url')
+
+const SRC = path.join(__dirname, '..', 'packages', 'dsh-pet', 'src')
+
+/** Load the package's contract surface (erasable TS via strip-only mode). */
+async function loadContracts() {
+  const manifest = await import(pathToFileURL(path.join(SRC, 'manifest-v2.ts')).href)
+  const model3 = await import(pathToFileURL(path.join(SRC, 'model3.ts')).href)
+  const dshHome = await import(pathToFileURL(path.join(SRC, 'dsh-home.ts')).href)
+  return { parsePetManifest: manifest.parsePetManifest, model3, dshHome: dshHome.dshHome }
+}
+
+function printDiagnostics(diagnostics) {
+  let errors = 0
+  for (const d of diagnostics) {
+    if (d.level === 'error') errors += 1
+    console.log('  [' + d.level + '] ' + d.message)
+  }
+  return errors
+}
+
+/** Existence checks for the assets a manifest declares (and Live2D closure). */
+async function checkAssets(dir, manifest, contracts) {
+  const diagnostics = []
+  const error = (message) => diagnostics.push({ level: 'error', message })
+  const warn = (message) => diagnostics.push({ level: 'warning', message })
+  if (manifest.renderer === 'sprite2d') {
+    const atlas = path.join(dir, manifest.sprite2d.spritesheetPath)
+    if (!fs.existsSync(atlas)) error('atlas not found: ' + manifest.sprite2d.spritesheetPath)
+  } else if (manifest.renderer === 'live2d') {
+    const modelFile = path.join(dir, manifest.live2d.model)
+    if (!fs.existsSync(modelFile)) {
+      error('model not found: ' + manifest.live2d.model)
+      return diagnostics
+    }
+    let model3
+    try {
+      model3 = JSON.parse(fs.readFileSync(modelFile, 'utf8'))
+    } catch (e) {
+      error('model3.json is not valid JSON: ' + (e && e.message ? e.message : String(e)))
+      return diagnostics
+    }
+    const { references, errors } = contracts.model3.collectModel3References(model3)
+    for (const message of errors) error(message)
+    for (const reference of references) {
+      if (!fs.existsSync(path.join(dir, reference))) error('referenced asset missing: ' + reference)
+    }
+    const groups = contracts.model3.model3MotionGroups(model3)
+    const declared = Object.values(manifest.live2d.motions).filter(Boolean)
+    for (const group of declared) {
+      if (!groups.includes(group)) warn('motion group "' + group + '" is not declared by the model; it falls back to idle at runtime')
+    }
+    const modelAreas = contracts.model3.model3HitAreas(model3)
+    for (const area of manifest.live2d.hitAreas ?? []) {
+      if (!modelAreas.includes(area)) warn('hitArea "' + area + '" is not declared by the model')
+    }
+  }
+  return diagnostics
+}
+
+async function validate(dir, contracts) {
+  const manifestFile = path.join(dir, 'pet.json')
+  if (!fs.existsSync(manifestFile)) {
+    console.error('no pet.json in ' + dir)
+    return { ok: false, manifest: undefined }
+  }
+  let raw
+  try {
+    raw = JSON.parse(fs.readFileSync(manifestFile, 'utf8'))
+  } catch (e) {
+    console.error('pet.json is not valid JSON: ' + (e && e.message ? e.message : String(e)))
+    return { ok: false, manifest: undefined }
+  }
+  const verdict = contracts.parsePetManifest(raw, dir)
+  const diagnostics = [...verdict.diagnostics]
+  let manifest
+  if (verdict.ok) {
+    manifest = verdict.manifest
+    diagnostics.push(...await checkAssets(dir, manifest, contracts))
+    if (verdict.migrated === 'v1-compat') {
+      console.log('note: v1 manifest compat-read as sprite2d; run scripts/dsh-pet-migrate-v2.mjs to migrate')
+    }
+  }
+  const errors = printDiagnostics(diagnostics)
+  return { ok: verdict.ok && errors === 0, manifest }
+}
+
+async function main(argv) {
+  const args = [...argv]
+  const command = args.shift()
+  const target = args.find(a => !a.startsWith('--'))
+  if ((command !== 'validate' && command !== 'install') || target === undefined) {
+    console.log('usage: dsh-pet validate <dir> | dsh-pet install <dir> [--force]')
+    return 2
+  }
+  const dir = path.resolve(target)
+  const contracts = await loadContracts()
+  const { ok, manifest } = await validate(dir, contracts)
+  if (!ok) {
+    console.error('validation failed')
+    return 1
+  }
+  console.log('valid: ' + manifest.id + ' (renderer ' + manifest.renderer + ')')
+  if (command === 'validate') return 0
+  const destination = path.join(contracts.dshHome(), 'pets', manifest.id)
+  if (fs.existsSync(destination)) {
+    if (!args.includes('--force')) {
+      console.error(destination + ' already exists; pass --force to overwrite')
+      return 1
+    }
+    fs.rmSync(destination, { recursive: true, force: true })
+  }
+  fs.mkdirSync(path.dirname(destination), { recursive: true })
+  fs.cpSync(dir, destination, { recursive: true })
+  console.log('installed to ' + destination + ' — refresh the pet list in settings to use it')
+  return 0
+}
+
+main(process.argv.slice(2)).then(code => { process.exitCode = code }, error => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/scripts/dsh-pet-migrate-v2.mjs
+++ b/scripts/dsh-pet-migrate-v2.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * dsh-pet-migrate-v2 — one-shot codemod: migrate a v1 pet directory (pet.json
+ * without petManifestVersion) onto the pet-center v2 manifest contract
+ * (issue #623, milestone M2 P6).
+ *
+ * Usage:
+ *   node scripts/dsh-pet-migrate-v2.mjs <petDir>              # dry-run report
+ *   node scripts/dsh-pet-migrate-v2.mjs <petDir> --check      # validate only
+ *   node scripts/dsh-pet-migrate-v2.mjs <petDir> --write      # in-place; keeps pet.json.v1.bak
+ *
+ * Options:
+ *   --license <id>   license identifier for the v2 manifest (required when the
+ *                    v1 source declares none; v2 requires license)
+ *   --author <name>  optional author carried into the v2 manifest
+ *   --force          allow overwriting an existing pet.json.v1.bak
+ *
+ * The mapping (M1 §4): petManifestVersion/renderer are filled in; the flat
+ * v1 atlas fields (spritesheetPath/cell/columns/frames/tracks) nest into the
+ * sprite2d block; spriteVersionNumber 2 becomes sprite2d.atlasRows 11;
+ * id/displayName/description/version/sequences/remarks carry over verbatim.
+ *
+ * The codemod validates its product through the package's authoritative
+ * parser (packages/dsh-pet/src/manifest-v2.ts) and refuses to write output
+ * that fails validation. With --write the original pet.json is kept as
+ * pet.json.v1.bak; without it the source directory is never modified.
+ */
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve as resolvePath } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const PARSER_URL = pathToFileURL(join(SCRIPT_DIR, '..', 'packages', 'dsh-pet', 'src', 'manifest-v2.ts')).href
+
+/** Load the package's authoritative manifest parser (type-stripped TS). */
+export async function loadPetParser() {
+  const mod = await import(PARSER_URL)
+  return mod.parsePetManifest
+}
+
+/**
+ * Map a v1 manifest onto the v2 shape. Pure; never mutates the source.
+ * @param {Record<string, unknown>} source - the parsed v1 pet.json.
+ * @param {{ license?: string, author?: string }} [options]
+ * @returns {{ manifest: Record<string, unknown>, warnings: string[] }}
+ */
+export function migratePetManifestV1toV2(source, options = {}) {
+  const warnings = []
+  const sprite2d = {}
+  if (typeof source.spritesheetPath === 'string' && source.spritesheetPath.trim() !== '') {
+    sprite2d.spritesheetPath = source.spritesheetPath.trim()
+  } else {
+    sprite2d.spritesheetPath = 'spritesheet.webp'
+  }
+  if (typeof source.cell === 'object' && source.cell !== null) sprite2d.cell = source.cell
+  if (typeof source.columns === 'number') sprite2d.columns = source.columns
+  if (Array.isArray(source.frames)) sprite2d.frames = source.frames
+  if (typeof source.tracks === 'object' && source.tracks !== null) sprite2d.tracks = source.tracks
+  // v2 spritesheet atlases (spriteVersionNumber 2) hold 11 rows: 9 + 2 look rows.
+  if (source.spriteVersionNumber === 2) sprite2d.atlasRows = 11
+
+  const license = typeof source.license === 'string' && source.license.trim() !== ''
+    ? source.license.trim()
+    : options.license
+  if (license === undefined) {
+    warnings.push('v1 manifest declares no license; pass --license <id> (v2 requires it)')
+  }
+  const manifest = {
+    petManifestVersion: 2,
+    id: source.id,
+    displayName: source.displayName,
+    renderer: 'sprite2d',
+    sprite2d,
+  }
+  if (typeof source.description === 'string' && source.description !== '') manifest.description = source.description
+  if (typeof source.version === 'string') manifest.version = source.version
+  if (typeof source.author === 'string') manifest.author = source.author
+  else if (options.author !== undefined) manifest.author = options.author
+  if (license !== undefined) manifest.license = license
+  if (source.sequences !== undefined) manifest.sequences = source.sequences
+  if (source.remarks !== undefined) manifest.remarks = source.remarks
+  return { manifest, warnings }
+}
+
+function usage() {
+  console.log('usage: node scripts/dsh-pet-migrate-v2.mjs <petDir> [--check|--write] [--license <id>] [--author <name>] [--force]')
+}
+
+async function main(argv) {
+  const args = [...argv]
+  const petDir = args.find(a => !a.startsWith('--'))
+  if (petDir === undefined) {
+    usage()
+    return 2
+  }
+  const write = args.includes('--write')
+  const force = args.includes('--force')
+  const flagValue = (name) => {
+    const index = args.indexOf(name)
+    return index !== -1 ? args[index + 1] : undefined
+  }
+  const dir = resolvePath(petDir)
+  const file = join(dir, 'pet.json')
+  if (!existsSync(file)) {
+    console.error('no pet.json in ' + dir)
+    return 1
+  }
+  const source = JSON.parse(readFileSync(file, 'utf8'))
+  const parsePetManifest = await loadPetParser()
+  if (source.petManifestVersion !== undefined) {
+    const verdict = parsePetManifest(source, file)
+    console.log(verdict.ok ? 'already v2: manifest validates, nothing to do' : 'already v2 but INVALID:')
+    if (!verdict.ok) for (const d of verdict.diagnostics) console.error('  [' + d.level + '] ' + d.message)
+    return verdict.ok ? 0 : 1
+  }
+  const { manifest, warnings } = migratePetManifestV1toV2(source, {
+    license: flagValue('--license'),
+    author: flagValue('--author'),
+  })
+  for (const warning of warnings) console.warn('warning: ' + warning)
+  const verdict = parsePetManifest(manifest, file + ' (migrated)')
+  if (!verdict.ok) {
+    console.error('migration product failed validation; nothing written:')
+    for (const d of verdict.diagnostics) console.error('  [' + d.level + '] ' + d.message)
+    return 1
+  }
+  for (const d of verdict.diagnostics) console.warn('  [' + d.level + '] ' + d.message)
+  if (!write) {
+    console.log(JSON.stringify(manifest, null, 2))
+    console.log(warnings.length > 0 ? 'dry-run: valid but unresolved warnings above; --write to apply' : 'dry-run: valid; --write to apply')
+    return warnings.length > 0 ? 1 : 0
+  }
+  const backup = file + '.v1.bak'
+  if (existsSync(backup) && !force) {
+    console.error(backup + ' already exists; pass --force to overwrite')
+    return 1
+  }
+  copyFileSync(file, backup)
+  writeFileSync(file, JSON.stringify(manifest, null, 2) + '\n')
+  console.log('migrated: ' + file + ' (backup at ' + backup + ')')
+  return 0
+}
+
+const invokedAsScript = process.argv[1] !== undefined && resolvePath(process.argv[1]) === fileURLToPath(import.meta.url)
+if (invokedAsScript) {
+  main(process.argv.slice(2)).then(code => { process.exitCode = code }, error => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  })
+}

--- a/scripts/dsh-pet-migrate-v2.test.mjs
+++ b/scripts/dsh-pet-migrate-v2.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * Tests for scripts/dsh-pet-migrate-v2.mjs — the v1 -> v2 pet manifest
+ * codemod (issue #623, milestone M2 P6). Unit tests cover the pure mapping;
+ * integration tests run the codemod over fixture directories and validate
+ * products through the package's authoritative parser.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { loadPetParser, migratePetManifestV1toV2 } from './dsh-pet-migrate-v2.mjs'
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'dsh-pet-migrate-v2.mjs')
+
+function fixtureDir(manifest) {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-pet-migrate-'))
+  writeFileSync(join(dir, 'pet.json'), JSON.stringify(manifest, null, 2) + '\n')
+  return dir
+}
+
+const V1_FULL = {
+  id: 'whale-girl',
+  displayName: 'Whale Girl',
+  description: 'A whale girl.',
+  spritesheetPath: 'spritesheet.webp',
+  cell: { width: 192, height: 208 },
+  columns: 8,
+  frames: [6, 8, 8, 4, 5, 8, 6, 6, 6],
+  tracks: { idle: { durations: [400, 400] } },
+  sequences: { idle: ['idle', 'waving', 'idle', 'waiting', 'idle'] },
+  remarks: { tap: ['hi'] },
+  spriteVersionNumber: 2,
+}
+
+test('maps the full v1 field set onto the v2 sprite2d shape', () => {
+  const { manifest } = migratePetManifestV1toV2(V1_FULL, { license: 'CC0-1.0' })
+  assert.equal(manifest.petManifestVersion, 2)
+  assert.equal(manifest.renderer, 'sprite2d')
+  assert.equal(manifest.license, 'CC0-1.0')
+  assert.deepEqual(manifest.sprite2d, {
+    spritesheetPath: 'spritesheet.webp',
+    cell: { width: 192, height: 208 },
+    columns: 8,
+    frames: [6, 8, 8, 4, 5, 8, 6, 6, 6],
+    tracks: { idle: { durations: [400, 400] } },
+    atlasRows: 11,
+  })
+  assert.equal(manifest.sprite2d.spritesheetPath, 'spritesheet.webp')
+  assert.ok(!('spriteVersionNumber' in manifest), 'legacy version flag folded into atlasRows')
+  assert.deepEqual(manifest.sequences, V1_FULL.sequences)
+  assert.deepEqual(manifest.remarks, V1_FULL.remarks)
+})
+
+test('defaults a missing spritesheetPath to the contract default', () => {
+  const { manifest } = migratePetManifestV1toV2({ id: 'bare', displayName: 'Bare' }, { license: 'CC0-1.0' })
+  assert.equal(manifest.sprite2d.spritesheetPath, 'spritesheet.webp')
+  assert.ok(!('atlasRows' in manifest.sprite2d), 'no atlasRows without spriteVersionNumber 2')
+})
+
+test('warns when no license is available from source or options', () => {
+  const { manifest, warnings } = migratePetManifestV1toV2({ id: 'bare', displayName: 'Bare' })
+  assert.equal(warnings.length, 1)
+  assert.ok(!('license' in manifest))
+})
+
+test('keeps a source-declared license over the option', () => {
+  const { manifest } = migratePetManifestV1toV2({ ...V1_FULL, license: 'MIT' }, { license: 'CC0-1.0' })
+  assert.equal(manifest.license, 'MIT')
+})
+
+test('migration product passes the authoritative parser', async () => {
+  const parsePetManifest = await loadPetParser()
+  const { manifest } = migratePetManifestV1toV2(V1_FULL, { license: 'CC0-1.0' })
+  const verdict = parsePetManifest(manifest, 'fixture')
+  assert.equal(verdict.ok, true, JSON.stringify(verdict.ok ? [] : verdict.diagnostics))
+  assert.equal(verdict.manifest.sprite2d.atlasRows, 11)
+})
+
+test('codemod dry-run prints the v2 manifest without writing', async () => {
+  const dir = fixtureDir(V1_FULL)
+  const out = execFileSync(process.execPath, [SCRIPT, dir, '--license', 'CC0-1.0'], { encoding: 'utf8' })
+  assert.match(out, /"petManifestVersion": 2/)
+  const onDisk = JSON.parse(readFileSync(join(dir, 'pet.json'), 'utf8'))
+  assert.equal(onDisk.petManifestVersion, undefined, 'source untouched')
+  assert.ok(!existsSync(join(dir, 'pet.json.v1.bak')))
+})
+
+test('codemod refuses a v1 manifest without any license source', () => {
+  const dir = fixtureDir({ id: 'bare', displayName: 'Bare' })
+  assert.throws(
+    () => execFileSync(process.execPath, [SCRIPT, dir, '--write'], { encoding: 'utf8', stdio: 'pipe' }),
+    /warning|license|exit/i,
+  )
+  assert.ok(!existsSync(join(dir, 'pet.json.v1.bak')), 'no write on invalid product')
+})
+
+test('codemod --write migrates in place with a v1 backup', () => {
+  const dir = fixtureDir(V1_FULL)
+  execFileSync(process.execPath, [SCRIPT, dir, '--write', '--license', 'CC0-1.0'], { encoding: 'utf8' })
+  const migrated = JSON.parse(readFileSync(join(dir, 'pet.json'), 'utf8'))
+  assert.equal(migrated.petManifestVersion, 2)
+  assert.equal(migrated.renderer, 'sprite2d')
+  const backup = JSON.parse(readFileSync(join(dir, 'pet.json.v1.bak'), 'utf8'))
+  assert.equal(backup.petManifestVersion, undefined, 'backup preserves the v1 source')
+  // Re-running on the migrated file reports already-v2 and exits 0.
+  const again = execFileSync(process.execPath, [SCRIPT, dir], { encoding: 'utf8' })
+  assert.match(again, /already v2/)
+})
+
+test('codemod refuses to overwrite an existing backup without --force', () => {
+  const dir = fixtureDir(V1_FULL)
+  writeFileSync(join(dir, 'pet.json.v1.bak'), '{}')
+  assert.throws(() => execFileSync(process.execPath, [SCRIPT, dir, '--write', '--license', 'CC0-1.0'], { encoding: 'utf8', stdio: 'pipe' }))
+})
+
+test('migrating the real built-in pets yields valid v2 manifests', async (t) => {
+  const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+  const parsePetManifest = await loadPetParser()
+  for (const builtin of ['whale', 'whale-refined']) {
+    const file = join(root, 'packages', 'dsh-pet', 'assets', builtin, 'pet.json')
+    if (!existsSync(file)) continue
+    const source = JSON.parse(readFileSync(file, 'utf8'))
+    if (source.petManifestVersion !== undefined) continue // already migrated
+    const { manifest } = migratePetManifestV1toV2(source, { license: 'CC0-1.0' })
+    const verdict = parsePetManifest(manifest, file)
+    assert.equal(verdict.ok, true, builtin + ': ' + JSON.stringify(verdict.ok ? [] : verdict.diagnostics))
+  }
+})

--- a/scripts/dsh-pet.test.mjs
+++ b/scripts/dsh-pet.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * Tests for scripts/dsh-pet — the pet-center validate/install CLI
+ * (issue #623, milestone M2 P6). Fixture-driven; install targets a temporary
+ * DSH_HOME so the real user home is never touched.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'dsh-pet')
+
+function tmp() {
+  return mkdtempSync(join(tmpdir(), 'dsh-pet-cli-'))
+}
+
+function makeSpritePet(dir, manifest = {}) {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'pet.json'), JSON.stringify({
+    id: 'test-cat', displayName: 'Test Cat', ...manifest,
+  }))
+  writeFileSync(join(dir, 'spritesheet.webp'), Buffer.from([0x52, 0x49, 0x46, 0x46]))
+  return dir
+}
+
+function makeLive2dPet(dir, { omitReference = false, unknownGroup = false } = {}) {
+  mkdirSync(join(dir, 'motions'), { recursive: true })
+  mkdirSync(join(dir, 'tex'), { recursive: true })
+  writeFileSync(join(dir, 'pet.json'), JSON.stringify({
+    petManifestVersion: 2,
+    id: 'test-live',
+    displayName: 'Test Live',
+    license: 'CC0-1.0',
+    renderer: 'live2d',
+    live2d: {
+      model: 'm.model3.json',
+      motions: unknownGroup ? { idle: 'Idle', done: 'NoSuchGroup' } : { idle: 'Idle', done: 'TapBody' },
+    },
+  }))
+  writeFileSync(join(dir, 'm.model3.json'), JSON.stringify({
+    Version: 3,
+    FileReferences: {
+      Moc: 'm.moc3',
+      Textures: ['tex/t0.png'],
+      Motions: {
+        Idle: [{ File: 'motions/idle.motion3.json' }],
+        TapBody: [{ File: 'motions/tap.motion3.json' }],
+      },
+    },
+    HitAreas: [{ Id: 'Body', Name: 'Body' }],
+  }))
+  writeFileSync(join(dir, 'm.moc3'), Buffer.from([1]))
+  writeFileSync(join(dir, 'tex', 't0.png'), Buffer.from([2]))
+  writeFileSync(join(dir, 'motions', 'idle.motion3.json'), '{}')
+  if (!omitReference) writeFileSync(join(dir, 'motions', 'tap.motion3.json'), '{}')
+  return dir
+}
+
+function run(args, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    })
+    return { code: 0, stdout, stderr: '' }
+  } catch (error) {
+    return {
+      code: error.status ?? 1,
+      stdout: (error.stdout ?? '').toString(),
+      stderr: (error.stderr ?? '').toString(),
+    }
+  }
+}
+
+test('validate accepts a v1 sprite2d pet via compat read', () => {
+  const dir = makeSpritePet(join(tmp(), 'cat'))
+  const result = run(['validate', dir])
+  assert.equal(result.code, 0, result.stderr + result.stdout)
+  assert.match(result.stdout, /v1 manifest compat-read/)
+  assert.match(result.stdout, /valid: test-cat/)
+})
+
+test('validate accepts a complete live2d pet and checks its closure', () => {
+  const dir = makeLive2dPet(join(tmp(), 'live'))
+  const result = run(['validate', dir])
+  assert.equal(result.code, 0, result.stderr + result.stdout)
+  assert.match(result.stdout, /renderer live2d/)
+})
+
+test('validate rejects a live2d pet with a missing referenced asset', () => {
+  const dir = makeLive2dPet(join(tmp(), 'live'), { omitReference: true })
+  const result = run(['validate', dir])
+  assert.equal(result.code, 1)
+  assert.ok((result.stderr + result.stdout).includes('referenced asset missing: motions/tap.motion3.json'))
+})
+
+test('validate warns (not fails) on motion groups the model lacks', () => {
+  const dir = makeLive2dPet(join(tmp(), 'live'), { unknownGroup: true })
+  const result = run(['validate', dir])
+  assert.equal(result.code, 0)
+  assert.match(result.stdout, /NoSuchGroup/)
+})
+
+test('validate rejects a structurally invalid manifest', () => {
+  const dir = makeSpritePet(join(tmp(), 'bad'), { petManifestVersion: 2, renderer: 'sprite2d' })
+  // missing license + sprite2d block -> fail-closed
+  const result = run(['validate', dir])
+  assert.equal(result.code, 1)
+  assert.match(result.stdout, /license/)
+})
+
+test('install copies a valid pet into DSH_HOME/pets and respects --force', () => {
+  const home = tmp()
+  const dir = makeSpritePet(join(tmp(), 'cat'))
+  const first = run(['install', dir], { DSH_HOME: home })
+  assert.equal(first.code, 0, first.stderr + first.stdout)
+  const installed = join(home, 'pets', 'test-cat')
+  assert.ok(existsSync(join(installed, 'pet.json')))
+  assert.ok(existsSync(join(installed, 'spritesheet.webp')))
+  const second = run(['install', dir], { DSH_HOME: home })
+  assert.equal(second.code, 1)
+  assert.match(second.stderr, /--force/)
+  const forced = run(['install', dir, '--force'], { DSH_HOME: home })
+  assert.equal(forced.code, 0, forced.stderr + forced.stdout)
+})
+
+test('install refuses an invalid pet and writes nothing', () => {
+  const home = tmp()
+  const dir = makeSpritePet(join(tmp(), 'bad'), { petManifestVersion: 2, renderer: 'sprite2d' })
+  const result = run(['install', dir], { DSH_HOME: home })
+  assert.equal(result.code, 1)
+  assert.ok(!existsSync(join(home, 'pets')))
+})
+
+test('usage errors exit 2 with guidance', () => {
+  assert.equal(run([]).code, 2)
+  assert.equal(run(['validate']).code, 2)
+  assert.equal(run(['bogus', 'x']).code, 2)
+})


### PR DESCRIPTION
## 摘要（Summary）

宠物中心重设计（#623）M2 中间层集成：本分支顺序集成了 #636（P1 schema/校验器）、#647（P2 registry 接线 + 第四源 + 诊断端点）、#648（P4 渲染器契约/注册表/阶段流）、#643（P3a 资产安全）、#641（P6 codemod）、#645（P6 CLI + model3 闭包）——六个已逐层 CI 验证的 Draft 层均误以本分支为 base 合并（叠层 PR 的 base 陷阱），现整体合入 main。

每层独立提交与测试边界完整；集成态已跑整仓门禁。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [x] 维护 / 重构

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码。

使用的 AI 模型：DeepSeek（不确定具体模型版本）
使用的编码 Agent 工具：DeepSeek Harness

## 本地验证（Local Validation）

集成态（99fcd542）：

```bash
pnpm typecheck                    # 整仓通过
pnpm test                         # 全部包绿（dsh-pet 22 文件）
node --test scripts/*.test.mjs    # 131/131
pnpm docs:check / sync-shared:check / aggregate:check / gallery:check / runtime-deps:check
```

全绿。

## 用户可见变更证据（Local Feature Evidence）

行为不变（sprite2d 路径零回归由测试锁定）；新增 `$DSH_HOME/pets` 用户宠物源与 `/api/pet/diagnostics` 诊断端点；live2d 清单可校验但暂不进可渲染列表（M3 接入渲染分发）。

---

关联：#623。
