### PR TITLE
chore(pet): 内置宠物迁移清单 v2（宠物中心 M2 P6 主体）

### DIFF
--- a/packages/dsh-pet/assets/whale-refined/pet.json
+++ b/packages/dsh-pet/assets/whale-refined/pet.json
@@ -1,7 +1,22 @@
 {
+  "petManifestVersion": 2,
   "id": "whale-girl-refined",
   "displayName": "鲸鱼娘（精致版）",
+  "renderer": "sprite2d",
+  "sprite2d": {
+    "spritesheetPath": "spritesheet.webp",
+    "frames": [
+      6,
+      8,
+      8,
+      4,
+      5,
+      8,
+      6,
+      6,
+      6
+    ]
+  },
   "description": "基于鲸鱼娘形象进行 AI 辅助二次创作、修复与细节精修的内置变体。",
-  "spritesheetPath": "spritesheet.webp",
-  "frames": [6, 8, 8, 4, 5, 8, 6, 6, 6]
+  "license": "BSD-3-Clause"
 }

--- a/packages/dsh-pet/assets/whale/pet.json
+++ b/packages/dsh-pet/assets/whale/pet.json
@@ -1,27 +1,176 @@
 {
+  "petManifestVersion": 2,
   "id": "whale-girl",
   "displayName": "鲸鱼娘（原版）",
-  "description": "一只软萌治愈的鲸鱼娘，来自深海的陪伴小伙伴。",
-  "spritesheetPath": "spritesheet.webp",
-  "frames": [6, 8, 8, 4, 5, 8, 6, 6, 6],
-  "tracks": {
-    "idle": { "durations": [400, 400, 500, 400, 400, 500] },
-    "running-right": { "durations": [225, 225, 225, 225, 225, 225, 225, 225] },
-    "running-left": { "durations": [225, 225, 225, 225, 225, 225, 225, 225] },
-    "waving": { "durations": [350, 350, 350, 350] },
-    "jumping": { "durations": [300, 300, 300, 350, 350] },
-    "failed": { "durations": [450, 450, 450, 500, 550, 600, 450, 450] },
-    "waiting": { "durations": [450, 450, 500, 450, 450, 500] },
-    "running": { "durations": [250, 250, 250, 250, 250, 250] },
-    "review": { "durations": [550, 550, 550, 550, 550, 550] }
+  "renderer": "sprite2d",
+  "sprite2d": {
+    "spritesheetPath": "spritesheet.webp",
+    "frames": [
+      6,
+      8,
+      8,
+      4,
+      5,
+      8,
+      6,
+      6,
+      6
+    ],
+    "tracks": {
+      "idle": {
+        "durations": [
+          400,
+          400,
+          500,
+          400,
+          400,
+          500
+        ]
+      },
+      "running-right": {
+        "durations": [
+          225,
+          225,
+          225,
+          225,
+          225,
+          225,
+          225,
+          225
+        ]
+      },
+      "running-left": {
+        "durations": [
+          225,
+          225,
+          225,
+          225,
+          225,
+          225,
+          225,
+          225
+        ]
+      },
+      "waving": {
+        "durations": [
+          350,
+          350,
+          350,
+          350
+        ]
+      },
+      "jumping": {
+        "durations": [
+          300,
+          300,
+          300,
+          350,
+          350
+        ]
+      },
+      "failed": {
+        "durations": [
+          450,
+          450,
+          450,
+          500,
+          550,
+          600,
+          450,
+          450
+        ]
+      },
+      "waiting": {
+        "durations": [
+          450,
+          450,
+          500,
+          450,
+          450,
+          500
+        ]
+      },
+      "running": {
+        "durations": [
+          250,
+          250,
+          250,
+          250,
+          250,
+          250
+        ]
+      },
+      "review": {
+        "durations": [
+          550,
+          550,
+          550,
+          550,
+          550,
+          550
+        ]
+      }
+    }
   },
+  "description": "一只软萌治愈的鲸鱼娘，来自深海的陪伴小伙伴。",
+  "license": "BSD-3-Clause",
   "sequences": {
-    "idle": ["idle", "waving", "idle", "waiting", "idle", "idle"],
-    "waiting": ["waiting", "idle", "waving", "waiting", "idle", "waiting"],
-    "thinking": ["running", "running-right", "running", "running-left", "running", "waiting", "running"],
-    "tool": ["running-right", "running", "running-left", "running", "running-right", "running"],
-    "review": ["review", "waiting", "review", "running", "review", "idle"],
-    "done": ["jumping", "waving", "jumping", "waving", "jumping", "idle"],
-    "failed": ["failed", "waiting", "failed", "idle", "waiting", "failed"]
+    "idle": [
+      "idle",
+      "waving",
+      "idle",
+      "waiting",
+      "idle",
+      "idle"
+    ],
+    "waiting": [
+      "waiting",
+      "idle",
+      "waving",
+      "waiting",
+      "idle",
+      "waiting"
+    ],
+    "thinking": [
+      "running",
+      "running-right",
+      "running",
+      "running-left",
+      "running",
+      "waiting",
+      "running"
+    ],
+    "tool": [
+      "running-right",
+      "running",
+      "running-left",
+      "running",
+      "running-right",
+      "running"
+    ],
+    "review": [
+      "review",
+      "waiting",
+      "review",
+      "running",
+      "review",
+      "idle"
+    ],
+    "done": [
+      "jumping",
+      "waving",
+      "jumping",
+      "waving",
+      "jumping",
+      "idle"
+    ],
+    "failed": [
+      "failed",
+      "waiting",
+      "failed",
+      "idle",
+      "waiting",
+      "failed"
+    ]
   }
 }


### PR DESCRIPTION
## 摘要（Summary）

用 #650 落地的 codemod 把两个内置宠物（whale / whale-refined）迁移到清单 v2（petManifestVersion 2 + renderer sprite2d + license BSD-3-Clause；v1 扁平图集字段收入 sprite2d 块）。渲染零变化（registry 兼容路径由 v1/v2 孪生对照测试锁定）。.v1.bak 备份为本地留存，未提交。

## 涉及包

- [x] 宠物 packages/dsh-pet

## PR 类型

- [x] 维护 / 重构

## 最新代码确认

- [x] 基于最新 main（72458f0c）。

## AI 编码披露

- [x] 完全 AI 编码。模型：DeepSeek（不确定具体版本）；工具：DeepSeek Harness。

## 本地验证

- pnpm --filter @linxin666/dsh-pet test：22 文件 210 测试全绿
- node scripts/dsh-pet validate 两个内置宠物均 valid
- node --test scripts/dsh-pet-migrate-v2.test.mjs：10/10（含内置只读验收用例）

关联：#623、#650。