### PR TITLE
fix(task-board): 通过 Host 命令派发任务固定权限

### DIFF
--- a/packages/dsh-task-board/package.json
+++ b/packages/dsh-task-board/package.json
@@ -43,6 +43,8 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
+    "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
+    "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
     "react": "^18.2.0"
   },
   "dependencies": {
@@ -50,11 +52,13 @@
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.8",
+    "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",

--- a/packages/dsh-task-board/src/host-runner.ts
+++ b/packages/dsh-task-board/src/host-runner.ts
@@ -1,4 +1,5 @@
 import type { ApiProxy, RpcId } from '@deepseek-ai/dsh-host-apiproxy'
+import type { CommandResult } from '@deepseek-ai/dsh-commands/types'
 import type { TaskRecord } from './core/tasks.ts'
 
 function request<T>(payload: T) {
@@ -14,6 +15,19 @@ export type SessionSummary = Extract<
   Awaited<ReturnType<ApiProxy['sessions']['list']>>['result'],
   { ok: true }
 >['value']['items'][number]
+
+type ExecutionSessionId = Extract<
+  Awaited<ReturnType<ApiProxy['sessions']['create']>>['result'],
+  { ok: true }
+>['value']['sessionId']
+
+export interface SessionCommandDispatcher {
+  execute(
+    sessionId: ExecutionSessionId,
+    line: string,
+    signal: AbortSignal,
+  ): Promise<CommandResult | undefined>
+}
 
 export type ExecutionInspection =
   | { outcome: 'pending' }
@@ -36,7 +50,10 @@ function isErrorTurnEnd(data: unknown): boolean {
 }
 
 export class HostExecutionRunner {
-  constructor(private readonly api: ApiProxy) {}
+  constructor(
+    private readonly api: ApiProxy,
+    private readonly commands?: SessionCommandDispatcher,
+  ) {}
 
   async launch(task: TaskRecord): Promise<string> {
     if (task.workspaceId !== undefined) {
@@ -63,13 +80,10 @@ export class HostExecutionRunner {
       const renamed = await this.api.sessions.rename(request({ sessionId, title: task.title }))
       if (!renamed.result.ok) throw failure(renamed.result.error)
       if (task.permission !== undefined) {
-        const command = await this.api.sessions.prompt(request({
-          sessionId,
-          mode: 'queue' as const,
-          content: [{ type: 'text' as const, text: `/permission ${task.permission}` }],
-        }))
-        if (!command.result.ok) throw failure(command.result.error)
-        if (command.result.value.command?.kind !== 'success') throw new Error('permission command was not acknowledged')
+        if (this.commands === undefined) throw new Error('permission command dispatcher is unavailable')
+        const command = await this.commands.execute(sessionId, `/permission ${task.permission}`, AbortSignal.timeout(30_000))
+        if (command === undefined) throw new Error('permission command was not acknowledged')
+        if (command.kind !== 'success') throw new Error(command.text ?? 'permission command failed')
       }
       const prompt = await this.api.sessions.prompt(request({
         sessionId,

--- a/packages/dsh-task-board/src/host-service.ts
+++ b/packages/dsh-task-board/src/host-service.ts
@@ -2,7 +2,7 @@ import type { ApiProxy } from '@deepseek-ai/dsh-host-apiproxy'
 import { nextRunAtMs } from './core/schedule.ts'
 import type { TaskRecord } from './core/tasks.ts'
 import { HostTaskLedger, type OpenedRun } from './host-ledger.ts'
-import { HostExecutionRunner, SessionLaunchError, type SessionSummary } from './host-runner.ts'
+import { HostExecutionRunner, SessionLaunchError, type SessionCommandDispatcher, type SessionSummary } from './host-runner.ts'
 import { PowerInhibitor } from './power-inhibitor.ts'
 import type { TaskBoardAction, TaskBoardEventPayload, TaskBoardSnapshot } from './protocol.ts'
 
@@ -25,9 +25,14 @@ export class TaskBoardHostService {
   private lastPowerJson = ''
   private readonly now: () => number
 
-  constructor(api: ApiProxy, options: { ledger?: HostTaskLedger; power?: PowerInhibitor; now?: () => number } = {}) {
+  constructor(api: ApiProxy, options: {
+    ledger?: HostTaskLedger
+    power?: PowerInhibitor
+    now?: () => number
+    commandDispatcher?: SessionCommandDispatcher
+  } = {}) {
     this.ledger = options.ledger ?? new HostTaskLedger()
-    this.runner = new HostExecutionRunner(api)
+    this.runner = new HostExecutionRunner(api, options.commandDispatcher)
     this.power = options.power ?? new PowerInhibitor()
     this.now = options.now ?? Date.now
     this.ledger.subscribe(() => {

--- a/packages/dsh-task-board/src/index.ts
+++ b/packages/dsh-task-board/src/index.ts
@@ -7,6 +7,8 @@
  */
 
 import type { Context } from '@deepseek-ai/cordis'
+import type {} from '@deepseek-ai/dsh-agent'
+import type {} from '@deepseek-ai/dsh-commands'
 import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
 import z from 'schemastery'
 import type {} from '@deepseek-ai/dsh-system-prompt'
@@ -22,7 +24,7 @@ const SECTION_ORDER = 200
 /** Default environment variable holding the authenticated proxy token. */
 export const DEFAULT_PROXY_TOKEN_ENV = 'DSH_TASK_BOARD_PROXY_TOKEN'
 
-export const inject = ['systemPrompt', 'apiProxy', 'webServer']
+export const inject = ['systemPrompt', 'apiProxy', 'webServer', 'agents', 'commands']
 
 /** Model-facing announcement: plugin presence, capabilities, and limits. */
 export const TASK_BOARD_GUIDANCE = '本机已安装 dsh-task-board 插件（DSH Web GUI 的任务看板）：侧边栏「任务看板」入口；在 dsh-web-ui 插件全家桶仓库（packages/dsh-task-board）统一维护，经聚合包 web-ui-all 一键安装。能力：多列看板管理任务；Host 权威账本；关闭浏览器后仍由 Host 执行和结算；任务可钉住工作区、agent 预设和权限；支持 Host 本地时区的 5 段 cron，错过的触发点不补跑；可选且默认关闭的空闲系统睡眠保护允许屏幕熄灭，但不承诺拦截合盖、手动睡眠、休眠、关机或唤醒已睡眠机器。执行消耗 API 额度。用户提到「任务看板 / 看板 / 定时任务」时即指本插件，请据此协作。'
@@ -87,7 +89,15 @@ const DEFAULT_ANNOUNCE = true
 export const apply = mountOnce('@linxin666/dsh-client-ui-task-board', applyImpl)
 
 function applyImpl(ctx: Context, config?: Config): void {
-  const host = new TaskBoardHostService(ctx.apiProxy)
+  const host = new TaskBoardHostService(ctx.apiProxy, {
+    commandDispatcher: {
+      async execute(sessionId, line, signal) {
+        const agent = ctx.agents.get(sessionId)
+        if (agent === undefined) throw new Error(`execution session ${sessionId} is not available`)
+        return (await ctx.commands.execute(agent, line, [], signal))?.result
+      },
+    },
+  })
   host.setConfiguration(config?.enabled ?? true, config?.preventIdleSleep ?? false)
   host.start()
   ctx.effect(() => {

--- a/packages/dsh-task-board/tests/host-runner.spec.ts
+++ b/packages/dsh-task-board/tests/host-runner.spec.ts
@@ -20,6 +20,13 @@ describe('HostExecutionRunner', () => {
   it('validates and applies workspace, preset, and permission before the task prompt', async () => {
     const order: string[] = []
     const promptPayloads: unknown[] = []
+    const commands = {
+      execute: vi.fn(async (_sessionId, line: string) => {
+        order.push('permission')
+        expect(line).toBe('/permission workspace-write')
+        return { kind: 'success' as const }
+      }),
+    }
     const api = {
       workspace: { list: vi.fn(async (request) => { order.push('workspace'); return ok(request, { items: [{ workspaceId: 'workspace-a' }] }) }) },
       agentPresets: { list: vi.fn(async (request) => { order.push('preset'); return ok(request, { presets: [{ id: 'preset-a', isDefault: false }] }) }) },
@@ -28,16 +35,15 @@ describe('HostExecutionRunner', () => {
         rename: vi.fn(async (request) => { order.push('rename'); return ok(request, { title: 'Run me', seq: 1 }) }),
         prompt: vi.fn(async (request) => {
           promptPayloads.push(request.payload)
-          const text = request.payload.content[0].text
-          order.push(text.startsWith('/permission') ? 'permission' : 'prompt')
-          return ok(request, text.startsWith('/permission') ? { accepted: true, command: { kind: 'success' } } : { accepted: true })
+          order.push('prompt')
+          return ok(request, { accepted: true })
         }),
       },
     }
-    await expect(new HostExecutionRunner(api as unknown as ApiProxy).launch(configuredTask())).resolves.toBe('session-a')
+    await expect(new HostExecutionRunner(api as unknown as ApiProxy, commands).launch(configuredTask())).resolves.toBe('session-a')
     expect(order).toEqual(['workspace', 'preset', 'create', 'rename', 'permission', 'prompt'])
     expect(api.sessions.create.mock.calls[0][0].payload).toMatchObject({ workspaceId: 'workspace-a', agentPreset: 'preset-a' })
-    expect(promptPayloads).toHaveLength(2)
+    expect(promptPayloads).toEqual([{ sessionId: 'session-a', mode: 'queue', content: [{ type: 'text', text: 'do work' }] }])
   })
 
   it('fails closed on a stale workspace or unacknowledged permission command', async () => {
@@ -50,23 +56,77 @@ describe('HostExecutionRunner', () => {
     await expect(new HostExecutionRunner(missingWorkspace as unknown as ApiProxy).launch(configuredTask())).rejects.toThrow('workspace not found')
     expect(create).not.toHaveBeenCalled()
 
-    const prompts: string[] = []
+    const prompt = vi.fn()
     const permissionRejected = {
       workspace: { list: async (request: { rpcId: unknown }) => ok(request, { items: [{ workspaceId: 'workspace-a' }] }) },
       agentPresets: { list: async (request: { rpcId: unknown }) => ok(request, { presets: [{ id: 'preset-a' }] }) },
       sessions: {
         create: async (request: { rpcId: unknown }) => ok(request, { sessionId: 'session-a' }),
         rename: async (request: { rpcId: unknown }) => ok(request, { title: 'Run me', seq: 1 }),
-        prompt: async (request: { rpcId: unknown; payload: { content: Array<{ text: string }> } }) => {
-          prompts.push(request.payload.content[0].text)
-          return ok(request, { accepted: true })
-        },
+        prompt,
       },
     }
-    const rejected = new HostExecutionRunner(permissionRejected as unknown as ApiProxy).launch(configuredTask())
+    const unavailable = new HostExecutionRunner(permissionRejected as unknown as ApiProxy).launch(configuredTask())
+    await expect(unavailable).rejects.toThrow('permission command dispatcher is unavailable')
+    await expect(unavailable).rejects.toMatchObject({ sessionId: 'session-a' })
+    expect(prompt).not.toHaveBeenCalled()
+
+    const rejected = new HostExecutionRunner(permissionRejected as unknown as ApiProxy, {
+      execute: async () => undefined,
+    }).launch(configuredTask())
     await expect(rejected).rejects.toBeInstanceOf(SessionLaunchError)
     await expect(rejected).rejects.toMatchObject({ sessionId: 'session-a' })
-    expect(prompts).toEqual(['/permission workspace-write'])
+    expect(prompt).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the permission command reports an error', async () => {
+    const prompt = vi.fn()
+    const api = {
+      workspace: { list: async (request: { rpcId: unknown }) => ok(request, { items: [{ workspaceId: 'workspace-a' }] }) },
+      agentPresets: { list: async (request: { rpcId: unknown }) => ok(request, { presets: [{ id: 'preset-a' }] }) },
+      sessions: {
+        create: async (request: { rpcId: unknown }) => ok(request, { sessionId: 'session-a' }),
+        rename: async (request: { rpcId: unknown }) => ok(request, { title: 'Run me', seq: 1 }),
+        prompt,
+      },
+    }
+    const launch = new HostExecutionRunner(api as unknown as ApiProxy, {
+      execute: async () => ({ kind: 'error', text: 'permission denied' }),
+    }).launch(configuredTask())
+    await expect(launch).rejects.toThrow('permission denied')
+    expect(prompt).not.toHaveBeenCalled()
+  })
+
+  it('bounds permission dispatch and fails closed when the command throws', async () => {
+    const timeoutSignal = new AbortController().signal
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal)
+    try {
+      const prompt = vi.fn()
+      const execute = vi.fn(async (_sessionId: string, _line: string, signal: AbortSignal) => {
+        expect(signal).toBe(timeoutSignal)
+        throw new Error('permission command timed out')
+      })
+      const api = {
+        workspace: { list: async (request: { rpcId: unknown }) => ok(request, { items: [{ workspaceId: 'workspace-a' }] }) },
+        agentPresets: { list: async (request: { rpcId: unknown }) => ok(request, { presets: [{ id: 'preset-a' }] }) },
+        sessions: {
+          create: async (request: { rpcId: unknown }) => ok(request, { sessionId: 'session-a' }),
+          rename: async (request: { rpcId: unknown }) => ok(request, { title: 'Run me', seq: 1 }),
+          prompt,
+        },
+      }
+      const launch = new HostExecutionRunner(api as unknown as ApiProxy, { execute }).launch(configuredTask())
+      await expect(launch).rejects.toMatchObject({
+        name: 'SessionLaunchError',
+        sessionId: 'session-a',
+        message: expect.stringContaining('permission command timed out'),
+      })
+      expect(timeout).toHaveBeenCalledOnce()
+      expect(timeout).toHaveBeenCalledWith(30_000)
+      expect(prompt).not.toHaveBeenCalled()
+    } finally {
+      timeout.mockRestore()
+    }
   })
 
   it('settles from session list plus the newest turn end and waits on read failures', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
       '@deepseek-ai/cordis':
         specifier: ^4.0.1
         version: 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent':
+        specifier: ^0.1.0-rc.8
+        version: 0.1.0-rc.8(92f269661ea5e195fab72177f1a12db7)
       '@deepseek-ai/dsh-client-connection':
         specifier: ^0.1.0-rc.8
         version: 0.1.0-rc.8(f4748f05eda5f2724af2c9dae4210332)
@@ -781,6 +784,9 @@ importers:
       '@deepseek-ai/dsh-client-ui-slots':
         specifier: ^0.1.0-rc.8
         version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-commands':
+        specifier: ^0.1.0-rc.8
+        version: 0.1.0-rc.8(72bbe6fdb3741b872b5fbe4132676802)
       '@deepseek-ai/dsh-host-apiproxy':
         specifier: ^0.1.0-rc.8
         version: 0.1.0-rc.8(87e50522ee3e6c004ae77f9049f48ed1)


### PR DESCRIPTION
## 摘要（Summary）

修复任务看板启动任务时固定权限的派发路径。Runner 现在会在创建会话后、发送任务 Prompt 前，通过 Host 命令注册表执行 `/permission <preset>`，并为命令派发设置 30 秒超时。

命令派发器不可用、命令未识别、执行失败或抛出异常时，启动流程会立即失败，任务 Prompt 保持零调用。执行顺序固定为：创建会话 → 重命名会话 → 应用权限 → 发送任务 Prompt。

关联 Issue：Closes #620。

## 涉及包（Affected Packages）

- [x] 任务看板 `packages/dsh-task-board`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步方法：

```text
上游 dev：85862966f14996d0046c3286ee5e02c677b469ca
PR 提交：e92707593be816fc35d4f9e8a42391f384989b65
PR 提交的直接父节点：dev@85862966f14996d0046c3286ee5e02c677b469ca
```

本机 Git HTTPS 在同步期间发生连接重置，因此通过 GitHub Git Data API 获取并校验公开对象。6 个目标文件在最新 `dev` 上的 blob 均与前一基线一致；随后以官方 `dev` 根树 `cfabaf865d5e7b916c184fb49ebf590c02f57ba5` 为基础，把本 PR 的单一提交重放到该 `dev` 提交之上，并重新执行下列测试。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

同步 `dev@8586296` 后的定向回归测试证据：

![PR 654 同步 dev 后的 Host Runner 回归测试证据：7/7 项通过](https://raw.githubusercontent.com/Lem0nTea2002/dsh-web-ui/2ec66952417687f787f893172074c5b0c57214ca/evidence/pr-654/host-runner-tests.png)

## 最低 DSH 版本

本改动最低兼容 DeepSeek Harness `0.1.0-rc.8`。该版本的 `commands.execute` 接口要求显式传入 `images` 与 `AbortSignal`；纯文本 `/permission` 命令传入空图片数组，并使用 `AbortSignal.timeout(30_000)` 限制等待时间。

`sessions.create` 成功返回仍作为 Agent 已发布到 `ctx.agents` 的生命周期边界，无需轮询或固定等待。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：OpenAI GPT-5

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm install --frozen-lockfile
pnpm --filter @linxin666/dsh-client-ui-task-board exec vitest run tests/host-runner.spec.ts --reporter=verbose
pnpm --filter @linxin666/dsh-client-ui-task-board test
pnpm --filter @linxin666/dsh-client-ui-task-board typecheck
pnpm --filter @linxin666/dsh-client-ui-task-board build
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm runtime-deps:check
pnpm aggregate:check
git diff --check
```

结果摘要：

- Host Runner 定向回归测试：7/7 通过；新增用例确认 30 秒信号被传给命令执行器，命令异常时抛出带 `sessionId` 的 `SessionLaunchError`，任务 Prompt 调用次数为 0。
- 任务看板包：233 项通过、1 项跳过；类型检查和构建通过。
- 根目录类型检查、文档检查、运行时依赖检查、聚合一致性、冻结锁文件验证和差异检查通过。
- 根目录 `pnpm test` 在未修改的 `packages/dsh-liangshen/tests/custom-bash.test.ts` 遇到 2 项既有 Windows 路径分隔符断言失败；该包其余 94 项通过。
- `pnpm test:scripts`：141 项通过、1 项失败、4 项跳过；失败为未修改的 `scripts/e2e-mount-rewrite.test.mjs` 在 Windows 上执行 `spawnSync pnpm` 时返回 `ENOENT`。

## 用户可见变更证据（Local Feature Evidence）

下图来自同步 `dev@8586296` 后的真实 Vitest 输出，绑定 PR 提交 `e927075`。测试过程模型调用 0 次、付费 API 调用 0 次。

![PR 654 用户可见变更测试证据：同步 dev 后 7/7 项通过](https://raw.githubusercontent.com/Lem0nTea2002/dsh-web-ui/2ec66952417687f787f893172074c5b0c57214ca/evidence/pr-654/host-runner-tests.png)
