### PR TITLE
feat(pet): 设置页诊断与宠物中心文档（宠物中心 M2 P7）

### DIFF
--- a/packages/dsh-pet/README.i18n.yaml
+++ b/packages/dsh-pet/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 7bbc716cb77d488334ef3bfb9638823d549fd530
-README.zh.md: d72e002e27ea84dd9da33efb3b3b0585a70a273a
+README.md: 35d055fc293d3545c71c1b32ff9c72e29d24dbfe
+README.zh.md: 412ea4ddf6d37858395d42f8c1b4a342d4fd43a8

--- a/packages/dsh-pet/README.md
+++ b/packages/dsh-pet/README.md
@@ -59,13 +59,43 @@ A pet is a directory holding one `pet.json` manifest and one atlas image. Nothin
 - `frames` counts the used columns per row (defaults to the hatch-pet contract table `[6, 8, 8, 4, 5, 8, 6, 6, 6]`); `tracks` overrides per-frame durations (cycled to the row's frame count), `loop`, and `fallback` per animation (defaults: everything loops; `jumping` and `failed` hold their last frame, then fall back to `idle`).
 - `sequences` optionally maps activity scenes (`idle` / `waiting` / `thinking` / `tool` / `review` / `done` / `failed`) to at least 5 animation tracks. Each item plays every frame for the durations in `tracks`, then the next item starts; the complete sequence loops. An omitted scene keeps its canonical single-track playback.
 
+### Manifest v2 (pet center, #623)
+
+A pet directory's `pet.json` declares its renderer explicitly in v2:
+
+- `petManifestVersion: 2` (absent = v1, compat-read as `sprite2d` with a migration hint);
+- `renderer`: `"sprite2d"` (the atlas contract above) or `"live2d"`;
+- `license` (required in v2): asset license identifier — community pets carry provenance;
+- a renderer block: `sprite2d` (spritesheetPath/cell/columns/atlasRows/frames/tracks) or `live2d` (model/motions/expressions/hitAreas/scale/translate).
+
+Validation is fail-closed on structure (unknown fields or renderer kinds reject the entry with a diagnostic) and warn-and-drop on sequence/remark content. The machine-readable schema lives at `contracts/pet-manifest-v2.schema.json`; the authoritative validator is `src/manifest-v2.ts`. Migrate v1 manifests with `node scripts/dsh-pet-migrate-v2.mjs <dir> --write` (dry-run by default; keeps `pet.json.v1.bak`).
+
 Where pets come from (later sources override earlier ones on id collision):
 
 1. **Built-in**: `assets/<dir>/pet.json` in this package.
-2. **Custom pets**: `${CODEX_HOME:-~/.codex}/pets/<pet>/pet.json` — the hatch-pet pipeline stages its output there, so a hatched pet appears in the selector with no further wiring.
-3. **Composed**: `PetConfig.pets` manifest entries passed to the plugin by the embedding application.
+2. **Legacy custom pets**: `${CODEX_HOME:-~/.codex}/pets/<pet>/pet.json` — the hatch-pet pipeline stages its output there, so a hatched pet appears in the selector with no further wiring.
+3. **Pet-center user directory**: `$DSH_HOME/pets/<id>/` — the recommended home for your pets (see the CLI below).
+4. **Composed**: `PetConfig.pets` manifest entries passed to the plugin by the embedding application.
 
-The registry is built once at host startup; add or change a pet, then restart `dsh web`.
+Validate and install a pet directory with the CLI (no build step, no npm publish):
+
+```sh
+node scripts/dsh-pet validate <dir>           # manifest + assets + Live2D reference closure
+node scripts/dsh-pet install <dir>            # validate, then copy into $DSH_HOME/pets/<id>/
+node scripts/dsh-pet install <dir> --force    # overwrite an existing same-id install
+```
+
+Invalid entries never override a working pet: they are skipped with a diagnostic listed in the settings (Pet section). The registry is built once at host startup; add or change a pet, then restart `dsh web`.
+
+## Live2D pets (renderer: live2d)
+
+Live2D pets render through PixiJS/WebGL. **The Cubism Core runtime is never bundled or downloaded by this plugin** — Live2D's proprietary license forbids redistributing it. To enable a Live2D pet:
+
+1. Obtain the official Live2D Cubism SDK for Web yourself (you accept Live2D's license) and take `live2dcubismcore.min.js` from it.
+2. Place it at `$DSH_HOME/pets/.runtime/live2dcubismcore.min.js`.
+3. Install a Live2D pet (a directory with `pet.json` v2, `renderer: "live2d"`, and the model files).
+
+If the core is absent, Live2D pets stay unavailable with a clear diagnostic; sprite2d pets are unaffected. Legal note: this plugin is an "extensible application" in Live2D's terms — works you publish with user-loadable models may require a Live2D release license regardless of scale; evaluate your obligations before publishing derivative works.
 
 ## Built-in pets
 
@@ -167,6 +197,14 @@ The browser bundle rides the `window.__ModuleLoader__.load` contract; React/cord
 ## Sprites and animation-track calibration
 
 The two built-in whale-girl atlases use the same 9-state × 8-column contract: `assets/whale/` is the original and `assets/whale-refined/` is the refined variant. Each atlas is 1536×1872 (8 columns × 9 rows of 192×208 cells). Frame counts, rhythm, and scene rotation live in each directory's `pet.json`; pets without overrides follow the hatch-pet contract rhythm and canonical single-track scene mapping (row order: 0 idle / 1 running-right / 2 running-left / 3 waving / 4 jumping / 5 failed / 6 waiting / 7 running / 8 review).
+
+## Security model
+
+- All pet API and asset routes are fenced to loopback clients.
+- Asset serving resolves both the pet directory and the candidate file through `realpath`; symlink escapes are refused (403). Files are size-capped before being read into memory (manifest 64 KB, imagery 20 MB; over-cap answers 413).
+- Live2D models are served by closure: only the manifest, the declared primary assets, and the files the `.model3.json` references (each screened against traversal, absolute and URL forms).
+- The plugin never downloads executables and never bundles the Live2D Cubism Core.
+- Manifests are fail-closed on structure: unknown fields or renderers reject the entry with a diagnostic shown in settings.
 
 ## License
 

--- a/packages/dsh-pet/README.zh.md
+++ b/packages/dsh-pet/README.zh.md
@@ -59,13 +59,43 @@
 - `frames` 记录每行用到的列数（缺省按 hatch-pet 契约表 `[6, 8, 8, 4, 5, 8, 6, 6, 6]`）；`tracks` 按动画覆盖每帧时长（按该行帧数循环补足）、`loop` 与 `fallback`（默认：全部循环；`jumping` 与 `failed` 停在最后一帧后回到 `idle`）。
 - `sequences` 可选地把活动场景（`idle` / `waiting` / `thinking` / `tool` / `review` / `done` / `failed`）映射到至少 5 条动画轨道。每项按 `tracks` 中的时长播完所有帧后进入下一项，整条序列循环；未声明的场景保持标准单轨播放。
 
+### 清单 v2（宠物中心，#623）
+
+宠物目录的 `pet.json` 在 v2 中显式声明渲染器：
+
+- `petManifestVersion: 2`（缺省 = v1，按 `sprite2d` 兼容读并给出迁移提示）；
+- `renderer`：`"sprite2d"`（上文图集契约）或 `"live2d"`；
+- `license`（v2 必填）：资产授权标识——社区宠物必须携带来源声明；
+- 渲染器专属块：`sprite2d`（spritesheetPath/cell/columns/atlasRows/frames/tracks）或 `live2d`（model/motions/expressions/hitAreas/scale/translate）。
+
+校验纪律：结构 fail-closed（未知字段或未知渲染器直接拒载并给出诊断），sequences/remarks 内容维持 warn-and-drop。机器可读 schema 见 `contracts/pet-manifest-v2.schema.json`，权威校验器为 `src/manifest-v2.ts`。迁移 v1 清单：`node scripts/dsh-pet-migrate-v2.mjs <dir> --write`（默认 dry-run；保留 `pet.json.v1.bak`）。
+
 宠物的来源（后注册的来源在同 id 冲突时覆盖前者）：
 
 1. **内置**：本包 `assets/<dir>/pet.json`。
-2. **自定义宠物**：`${CODEX_HOME:-~/.codex}/pets/<pet>/pet.json` —— hatch-pet 流水线把产物放在这里，孵化的宠物无需任何接线即可出现在选择器里。
-3. **组合注入**：嵌入应用通过 `PetConfig.pets` 传入的 manifest 条目。
+2. **legacy 自定义宠物**：`${CODEX_HOME:-~/.codex}/pets/<pet>/pet.json` —— hatch-pet 流水线把产物放在这里，孵化的宠物无需任何接线即可出现在选择器里。
+3. **宠物中心用户目录**：`$DSH_HOME/pets/<id>/`——推荐安放位（见下方 CLI）。
+4. **组合注入**：嵌入应用通过 `PetConfig.pets` 传入的 manifest 条目。
 
-注册表在宿主启动时构建一次；新增或修改宠物后重启 `dsh web` 生效。
+用 CLI 校验并安装宠物目录（零构建、零发布）：
+
+```sh
+node scripts/dsh-pet validate <dir>           # 清单 + 资产 + Live2D 引用闭包
+node scripts/dsh-pet install <dir>            # 校验通过后拷入 $DSH_HOME/pets/<id>/
+node scripts/dsh-pet install <dir> --force    # 覆盖同名已安装宠物
+```
+
+非法条目永不覆盖可用宠物：它们被跳过并在设置（宠物栏目）给出诊断。注册表在宿主启动时构建一次；新增或修改宠物后重启 `dsh web` 生效。
+
+## Live2D 宠物（renderer: live2d）
+
+Live2D 宠物经 PixiJS/WebGL 渲染。**本插件永不内置、永不代下 Cubism Core 运行时**——Live2D 专有许可不允许再分发。启用 Live2D 宠物：
+
+1. 自行从 Live2D 官方渠道获取 Cubism SDK for Web（你自行同意其许可），取得 `live2dcubismcore.min.js`；
+2. 放到 `$DSH_HOME/pets/.runtime/live2dcubismcore.min.js`；
+3. 安装 Live2D 宠物（含 `pet.json` v2、`renderer: "live2d"` 与模型文件的目录）。
+
+core 缺失时 Live2D 宠物不可用并给出明确诊断，sprite2d 宠物不受影响。法律提示：本插件属 Live2D 术语下的「可扩展性 APP」——你公开发布基于可加载用户模型的衍生作品时，可能不论规模都须与 Live2D 签订发行许可；发布前请自行评估义务。
 
 ## 内置宠物
 
@@ -167,6 +197,14 @@ pnpm typecheck    # 仅类型检查
 ## 精灵图与动画轨道校准
 
 两套内置鲸鱼娘图集使用同一份 9 态 × 8 列契约：`assets/whale/` 是原版，`assets/whale-refined/` 是精致版。每张图集均为 1536×1872（8 列 × 9 行，192×208 单元格）。每行帧数、节奏与场景轮换写在各目录的 `pet.json` 中；未覆盖的宠物沿用 hatch-pet 契约节奏和标准单轨场景映射（行序：0 idle / 1 running-right / 2 running-left / 3 waving / 4 jumping / 5 failed / 6 waiting / 7 running / 8 review）。
+
+## 安全模型
+
+- 全部宠物 API 与资产路由仅服务回环客户端。
+- 资产服务对宠物目录与目标文件双双做 `realpath` 解析；symlink 越界一律拒绝（403）。文件读入内存前按类限大小（清单 64 KB、图像 20 MB；超限 413）。
+- Live2D 模型按闭包放行：仅清单、声明的主资产与 `.model3.json` 引用到的文件（引用先经穿越/绝对路径/URL 形态筛查）。
+- 插件从不下载可执行文件，也从不内置 Live2D Cubism Core。
+- 清单结构 fail-closed：未知字段或未知渲染器直接拒载，并在设置中给出诊断。
 
 ## 许可证
 

--- a/packages/dsh-pet/assets/whale-refined/pet.json
+++ b/packages/dsh-pet/assets/whale-refined/pet.json
@@ -18,5 +18,5 @@
     ]
   },
   "description": "基于鲸鱼娘形象进行 AI 辅助二次创作、修复与细节精修的内置变体。",
-  "license": "BSD-3-Clause"
+  "license": "MIT"
 }

--- a/packages/dsh-pet/src/client/PetSettingsCard.tsx
+++ b/packages/dsh-pet/src/client/PetSettingsCard.tsx
@@ -48,6 +48,8 @@ export interface PetSettingsCardState extends CardShell {
   petId: CardFieldState
   /** Pet choices (registry ids + display names), loaded from the host. */
   petChoices: readonly { value: string; label: string }[]
+  /** Registry diagnostics (v1 migration hints, invalid entries), host-served. */
+  petDiagnostics: readonly PetDiagnosticView[]
 }
 
 /** The registration-side face the card's slot entry injects. */
@@ -64,11 +66,25 @@ interface PetChoice {
   displayName: string
 }
 
+/** One registry diagnostic as served by '/api/pet/diagnostics' (#623). */
+export interface PetDiagnosticView {
+  level: 'error' | 'warning'
+  message: string
+}
+
 /** Fetch the registry list (the same data the sprite renders from). */
 async function fetchPetChoices(): Promise<PetChoice[]> {
   const response = await fetch('/api/pet/pets')
   if (!response.ok) throw new Error('pet pets failed: ' + response.status)
   return (await response.json()) as PetChoice[]
+}
+
+/** Fetch the registry diagnostics (v1 migration hints, invalid entries). */
+async function fetchPetDiagnostics(): Promise<PetDiagnosticView[]> {
+  const response = await fetch('/api/pet/diagnostics')
+  if (!response.ok) throw new Error('pet diagnostics failed: ' + response.status)
+  const body = (await response.json()) as { diagnostics?: PetDiagnosticView[] }
+  return body.diagnostics ?? []
 }
 
 /** Bridges the 'pet' scope onto the card's staged form. */
@@ -80,6 +96,7 @@ export class PetSettingsCardController {
   // without rebuilding the form.
   private readonly petChoices: string[] = []
   private readonly petLabels = new Map<string, string>()
+  private diagnostics: PetDiagnosticView[] = []
   private loaded = false
   private attempts = 0
 
@@ -95,6 +112,17 @@ export class PetSettingsCardController {
     ])
     this.store = this.form.bind(() => this.projection())
     void this.loadPets()
+    void this.loadDiagnostics()
+  }
+
+  /** Fetch registry diagnostics once (soft-fail: an empty list on error). */
+  private async loadDiagnostics(): Promise<void> {
+    try {
+      this.diagnostics = await fetchPetDiagnostics()
+      this.store.set(this.projection())
+    } catch {
+      this.diagnostics = []
+    }
   }
 
   /** Resolve the registry choices once (retried a few times on failure). */
@@ -124,6 +152,7 @@ export class PetSettingsCardController {
       bottom: this.form.field('bottom'),
       petId: this.form.field('petId'),
       petChoices: this.petChoices.map(id => ({ value: id, label: this.petLabels.get(id) ?? id })),
+      petDiagnostics: this.diagnostics,
     }
   }
 
@@ -197,6 +226,16 @@ export function PetSettingsCard(props: PetSettingsCardProps) {
         onEdit={(text) => { props.edit('petId', text) }}
         onReset={() => { props.resetField('petId') }}
       />
+      {state.petDiagnostics.length === 0 ? null : (
+        <li className={sectionCss.diagnostics} data-dsh-part="diagnostics">
+          <span className={sectionCss.diagnosticsTitle}>{t('settings.diagnosticsTitle')}</span>
+          <ul>
+            {state.petDiagnostics.map((diagnostic, index) => (
+              <li key={index} data-level={diagnostic.level}>{diagnostic.message}</li>
+            ))}
+          </ul>
+        </li>
+      )}
       <BooleanField
         id="settings-pet-visible"
         label={t('settings.visible')}

--- a/packages/dsh-pet/src/client/locales.ts
+++ b/packages/dsh-pet/src/client/locales.ts
@@ -25,6 +25,7 @@ export const zh = {
   'pet.collapseSessions': '收起会话气泡',
   // 一级设置页（settings.section 席位）。
   'settings.title': '宠物',
+  'settings.diagnosticsTitle': '宠物目录诊断',
   'settings.description': '选择宠物并调整它的显示布局。',
   'settings.pet': '宠物',
   'settings.petHint': '选择显示哪只宠物；每只宠物独立命名，可在宠物悬浮面板改名。',
@@ -74,6 +75,7 @@ export const en = {
   'pet.collapseSessions': 'Collapse session bubbles',
   // First-level settings section (the `settings.section` seat).
   'settings.title': 'Pet',
+  'settings.diagnosticsTitle': 'Pet directory diagnostics',
   'settings.description': 'Pick a pet and tune its display layout.',
   'settings.pet': 'Pet',
   'settings.petHint': 'Choose which pet shows. Names are stored per pet; rename from the pet hover panel.',

--- a/packages/dsh-pet/src/client/settings-section.module.css
+++ b/packages/dsh-pet/src/client/settings-section.module.css
@@ -3,3 +3,26 @@
   margin: 0;
   padding: 0;
 }
+
+/* Registry diagnostics block (pet-center M2 P7, issue #623). */
+.diagnostics {
+  margin: 8px 0;
+  padding: 8px 12px;
+  border: 1px dashed var(--dsw-alias-border-l2);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--dsw-alias-label-dimmed);
+}
+.diagnosticsTitle {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--dsw-alias-label);
+}
+.diagnostics ul {
+  margin: 0;
+  padding-left: 16px;
+}
+.diagnostics li[data-level="error"] {
+  color: var(--dsw-alias-error, #c04848);
+}

--- a/packages/dsh-pet/tests/pet-diagnostics.spec.tsx
+++ b/packages/dsh-pet/tests/pet-diagnostics.spec.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+
+/**
+ * Pet settings card diagnostics (pet-center M2 P7, issue #623): the card
+ * projects host-served registry diagnostics (v1 migration hints, invalid
+ * entries) next to the pet chooser; a failed diagnostics fetch degrades to an
+ * empty list, never an error state.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SettingsScope } from '@deepseek-ai/dsh-client-runtime/client'
+// The npm SDK's client half is a closure-factory bundle for the GUI's
+// __ModuleLoader__ (not importable under vitest); provide the one value
+// member the card chain needs (same pattern as pet-section.spec.tsx).
+vi.mock('@deepseek-ai/dsh-client-runtime/client', () => ({
+  createSnapshotStore: (init: unknown) => {
+    let value = init
+    const listeners = new Set<() => void>()
+    return {
+      getSnapshot: () => value,
+      set: (next: unknown) => { value = next; for (const listener of listeners) listener() },
+      update: (mutator: (draft: never) => void) => { mutator(value as never); for (const listener of listeners) listener() },
+      subscribe: (listener: () => void) => { listeners.add(listener); return () => { listeners.delete(listener) } },
+    }
+  },
+}))
+import { PetSettingsCardController, type PetSettings } from '../src/client/PetSettingsCard.tsx'
+
+/** Minimal in-memory scope backing the card controller. */
+function fakeScope(): SettingsScope<PetSettings> {
+  return {
+    subscribe: () => () => {},
+    getSnapshot: () => ({ value: {}, base: {}, user: {}, writable: true }),
+    set: async () => {},
+    unset: async () => {},
+  } as unknown as SettingsScope<PetSettings>
+}
+
+function stubFetch(diagnostics: Array<{ level: string; message: string }> | 'fail') {
+  vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+    if (input === '/api/pet/diagnostics') {
+      if (diagnostics === 'fail') return new Response('x', { status: 500 })
+      return new Response(JSON.stringify({ diagnostics }), { status: 200 })
+    }
+    return new Response(JSON.stringify([{ id: 'whale-girl', displayName: '鲸鱼娘' }]), { status: 200 })
+  }))
+}
+
+/** Flush the controller's async loaders. */
+async function settle() {
+  await new Promise(resolve => setTimeout(resolve, 10))
+}
+
+describe('PetSettingsCardController diagnostics', () => {
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('projects host diagnostics into the card state', async () => {
+    stubFetch([{ level: 'warning', message: 'pet x: v1 compat read' }])
+    const controller = new PetSettingsCardController(fakeScope())
+    await settle()
+    const state = controller.inject().hooks.petSettingsCard.getSnapshot()
+    expect(state.petDiagnostics).toEqual([{ level: 'warning', message: 'pet x: v1 compat read' }])
+    expect(state.petChoices).toEqual([{ value: 'whale-girl', label: '鲸鱼娘' }])
+    controller.dispose()
+  })
+
+  it('degrades to an empty diagnostics list when the endpoint fails', async () => {
+    stubFetch('fail')
+    const controller = new PetSettingsCardController(fakeScope())
+    await settle()
+    const state = controller.inject().hooks.petSettingsCard.getSnapshot()
+    expect(state.petDiagnostics).toEqual([])
+    expect(state.petChoices).toEqual([{ value: 'whale-girl', label: '鲸鱼娘' }])
+    controller.dispose()
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

宠物中心重设计（#623）M2 的 P7 收尾：设置页诊断 + 文档双语 + 授权修正。

- **设置页诊断**：宠物设置卡拉取新端点 `/api/pet/diagnostics`，在选择器下方以虚线诊断块呈现 v1 迁移提示/非法条目（`data-dsh-part="diagnostics"` 供皮肤 L2 语义层）；端点失败降级为空列表，不进错误态；
- **README 中英三件套**：清单 v2 契约段、`$DSH_HOME/pets` 源 + `dsh-pet` CLI 用法、Live2D 宠物节（core 用户自带纪律 + 可扩展性 APP 许可提示）、安全模型节（回环围栏/containment/上限/闭包/零下载）；i18n.yaml 已重录；
- **授权修正**：whale-refined 清单 license 改为 MIT（对齐 README 中 DreamSkin「DeepSeek-Whale」主题归属段）。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更（设置页诊断区）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 基于最新 main（含 #650 集成与 #652/#653）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码。

使用的 AI 模型：DeepSeek（不确定具体模型版本）
使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码；未新增包目录；无 emoji；README 中英双语三件套同步并 `pnpm docs:check` 通过；安全模型说明已进 README（仓库安全语义规则）。

## 本地验证（Local Validation）

```bash
pnpm --filter @linxin666/dsh-pet test        # 24 文件 215 测试全绿（新增 2 项诊断投影用例）
pnpm --filter @linxin666/dsh-pet typecheck  # 通过
pnpm --filter @linxin666/dsh-pet build      # 通过
pnpm docs:check                             # 通过
```

## 用户可见变更证据（Local Feature Evidence）

设置 → 宠物 栏目在有诊断时出现「宠物目录诊断」虚线块（v1 清单迁移提示默认即有两条内置之外的用户 v1 宠物时可见）。GUI 验收证据见 #623 收口评论。

---

关联：#623、#650、#652、#653。
