### PR TITLE
feat(pet): list live2d pets with their model closure servable set (#623)

### DIFF
--- a/packages/dsh-pet/src/registry.test.ts
+++ b/packages/dsh-pet/src/registry.test.ts
@@ -8,6 +8,7 @@ import {
   codexPetsDir,
   loadPetRegistry,
   petAtlasFile,
+  petEntryView,
   petPackageRoot,
   resolvePetManifest,
 } from './registry.ts'
@@ -314,7 +315,81 @@ describe('loadPetRegistry pet-center v2 (issue #623)', () => {
     }
   })
 
-  it('accepts live2d manifests into diagnostics without listing them renderable', () => {
+  it('lists live2d pets with the render block and the servable closure (M3)', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      mkdirSync(join(petsDir, 'haru', 'motions'), { recursive: true })
+      mkdirSync(join(petsDir, 'haru', 'textures'), { recursive: true })
+      writeFileSync(join(petsDir, 'haru', 'pet.json'), JSON.stringify({
+        petManifestVersion: 2, id: 'haru', displayName: 'Haru', license: 'Live2D-Sample',
+        renderer: 'live2d',
+        live2d: {
+          model: 'haru.model3.json',
+          scale: 1.2,
+          motions: { idle: 'Idle', thinking: 'TapBody' },
+          hitAreas: ['Head'],
+        },
+      }), 'utf8')
+      writeFileSync(join(petsDir, 'haru', 'haru.model3.json'), JSON.stringify({
+        Version: 3,
+        FileReferences: {
+          Moc: 'haru.moc3',
+          Textures: ['textures/texture_00.png'],
+          Motions: { Idle: [{ File: 'motions/idle_00.motion3.json' }] },
+        },
+        HitAreas: [{ Name: 'Head', Id: 'HitAreaHead' }],
+      }), 'utf8')
+      writeFileSync(join(petsDir, 'haru', 'haru.moc3'), 'moc', 'utf8')
+      writeFileSync(join(petsDir, 'haru', 'textures', 'texture_00.png'), 'png', 'utf8')
+      writeFileSync(join(petsDir, 'haru', 'motions', 'idle_00.motion3.json'), '{}', 'utf8')
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      const entry = registry.byId('haru')
+      expect(entry).toBeDefined()
+      expect(entry!.renderer).toBe('live2d')
+      expect(entry!.live2d).toBeDefined()
+      expect(entry!.live2d!.modelUrl).toBe('/pet/haru/haru.model3.json')
+      expect(entry!.live2d!.modelPath).toBe('haru.model3.json')
+      expect(entry!.live2d!.scale).toBe(1.2)
+      expect(entry!.live2d!.motions).toEqual({ idle: 'Idle', thinking: 'TapBody' })
+      expect(entry!.live2d!.hitAreas).toEqual(['Head'])
+      // The servable closure covers the model plus every referenced file.
+      expect(entry!.servable).toEqual([
+        'haru.model3.json', 'haru.moc3', 'motions/idle_00.motion3.json', 'textures/texture_00.png',
+      ])
+      // Sprite fields carry harmless contract defaults (chrome sizing only).
+      expect(entry!.cell).toEqual(DEFAULT_PET_CELL)
+      expect(entry!.rows).toEqual([...DEFAULT_FRAME_COUNTS])
+      expect(entry!.tracks.idle.frames.length).toBe(entry!.rows[0])
+      // The client-visible view keeps the live2d block, drops host paths.
+      const view = petEntryView(entry!)
+      expect(view.live2d!.modelPath).toBe('haru.model3.json')
+      expect('servable' in view).toBe(false)
+      expect('dir' in view).toBe(false)
+      // A healthy live2d entry records no diagnostics.
+      expect(registry.diagnostics.filter(d => d.message.includes('haru'))).toEqual([])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects live2d pets whose model3.json is unreadable', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writePet(petsDir, 'haru', {
+        petManifestVersion: 2, id: 'haru', displayName: 'Haru', license: 'Live2D-Sample',
+        renderer: 'live2d', live2d: { model: 'haru.model3.json', motions: { idle: 'Idle' } },
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('haru')).toBeUndefined()
+      expect(registry.diagnostics.some(d => d.level === 'error' && d.message.includes('not readable'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects live2d pets whose model3.json declares unsafe references', () => {
     const root = tempDir()
     try {
       const petsDir = join(root, 'pets')
@@ -323,10 +398,35 @@ describe('loadPetRegistry pet-center v2 (issue #623)', () => {
         petManifestVersion: 2, id: 'haru', displayName: 'Haru', license: 'Live2D-Sample',
         renderer: 'live2d', live2d: { model: 'haru.model3.json', motions: { idle: 'Idle' } },
       }), 'utf8')
-      writeFileSync(join(petsDir, 'haru', 'haru.model3.json'), '{}', 'utf8')
+      writeFileSync(join(petsDir, 'haru', 'haru.model3.json'), JSON.stringify({
+        Version: 3,
+        FileReferences: { Moc: '../escape.moc3' },
+      }), 'utf8')
       const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
       expect(registry.byId('haru')).toBeUndefined()
-      expect(registry.diagnostics.some(d => d.message.includes('live2d') && d.message.includes('M3'))).toBe(true)
+      expect(registry.diagnostics.some(d => d.level === 'error' && d.message.includes('not a safe relative path'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('warns on closure files missing on disk but keeps the live2d pet listed', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      mkdirSync(join(petsDir, 'haru'), { recursive: true })
+      writeFileSync(join(petsDir, 'haru', 'pet.json'), JSON.stringify({
+        petManifestVersion: 2, id: 'haru', displayName: 'Haru', license: 'Live2D-Sample',
+        renderer: 'live2d', live2d: { model: 'haru.model3.json', motions: { idle: 'Idle' } },
+      }), 'utf8')
+      writeFileSync(join(petsDir, 'haru', 'haru.model3.json'), JSON.stringify({
+        Version: 3,
+        FileReferences: { Moc: 'haru.moc3', Textures: ['missing.png'] },
+      }), 'utf8')
+      writeFileSync(join(petsDir, 'haru', 'haru.moc3'), 'moc', 'utf8')
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('haru')).toBeDefined()
+      expect(registry.diagnostics.some(d => d.level === 'warning' && d.message.includes('closure file missing: missing.png'))).toBe(true)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/packages/dsh-pet/src/registry.ts
+++ b/packages/dsh-pet/src/registry.ts
@@ -13,9 +13,11 @@
  *
  * Manifests are parsed through manifest-v2 (pet-center M2, issue #623): v1
  * manifests are compat-read as sprite2d, v2 manifests validate fail-closed,
- * and structured diagnostics ride alongside the legacy warnings. Valid
- * live2d entries are accepted by the contract but stay off the renderable
- * list until the renderer dispatch lands (M3); they surface as diagnostics.
+ * and structured diagnostics ride alongside the legacy warnings. Live2d
+ * entries (pet-center M3) list like any other pet: the entry carries the
+ * validated live2d block plus the model's reference closure (the servable
+ * set the asset route allows), and a model3.json that is unreadable or
+ * declares unsafe references rejects the entry with an error diagnostic.
  *
  * The manifest follows the Codex/hatch-pet contract (8 columns x 9 rows of
  * 192x208 cells, the 9-state row order below). Legacy whale-girl manifests
@@ -32,7 +34,8 @@ import { fileURLToPath } from 'node:url'
 import type { ActivityPhase, PetAnimation } from './state.ts'
 import { normalizePetRemarks, type PetRemarks, type PetRemarksManifest } from './remarks.ts'
 import { dshHome } from './dsh-home.ts'
-import { parsePetManifest, type PetManifestV2, type PetRendererKind } from './manifest-v2.ts'
+import { parsePetManifest, type PetManifestLive2d, type PetManifestV2, type PetRendererKind } from './manifest-v2.ts'
+import { collectModel3References } from './model3.ts'
 
 /** Fixed row order of the 9-state animation contract. */
 export const PET_ROW_ORDER: readonly PetAnimation[] = [
@@ -166,13 +169,33 @@ export interface PetTrackOverride {
   fallback?: PetAnimation
 }
 
+/** The live2d renderer block as served to the browser half (pet-center M3). */
+export interface PetLive2dDefinition {
+  /** Browser URL of the .model3.json (served by the host asset route). */
+  modelUrl: string
+  /** Manifest-relative model path (host route allow-list key). */
+  modelPath: string
+  /** Scale multiplier over the canvas auto-fit, (0, 10]. */
+  scale?: number
+  /** Model offset in canvas px from the center-bottom anchor. */
+  translate?: { x?: number; y?: number }
+  /** ActivityPhase -> motion group; unmapped phases fall back to idle. */
+  motions: Partial<Record<ActivityPhase, string>> & { idle: string }
+  /** Optional ActivityPhase -> expression name layered over the motion. */
+  expressions?: Partial<Record<ActivityPhase, string>>
+  /** Hit area names triggering the tap motion; defaults to every model HitArea. */
+  hitAreas?: string[]
+}
+
 /** A normalized pet as served to the browser half. */
 export interface PetDefinition {
   id: string
   displayName: string
   description: string
-  /** The renderer this entry mounts with (pet-center M2; sprite2d today). */
+  /** The renderer this entry mounts with (pet-center M2). */
   renderer: PetRendererKind
+  /** Live2d render block; present exactly when renderer is 'live2d' (M3). */
+  live2d?: PetLive2dDefinition
   /** Atlas cell size in px. */
   cell: PetCell
   /** Columns per row. */
@@ -197,6 +220,12 @@ export interface PetEntry extends PetDefinition {
   dir: string
   /** Atlas path relative to 'dir' (declared by the manifest). */
   spritesheetPath: string
+  /**
+   * Manifest-relative files the asset route may serve beyond pet.json and
+   * 'previews/*' (pet-center M3): the sprite2d atlas, or the live2d model
+   * plus its model3.json reference closure.
+   */
+  servable: readonly string[]
   /** Normalized per-pet remark pools (manifest 'remarks'), when declared. */
   remarks?: PetRemarks
 }
@@ -274,6 +303,47 @@ function normalizeSequences(
 }
 
 /**
+ * Build the fully resolved animation tracks from the contract defaults plus
+ * optional per-track overrides. Shared by the sprite2d resolver and the
+ * live2d entry builder (which fills the sprite fields with contract
+ * defaults so the flat PetDefinition shape holds for every renderer).
+ */
+function buildTracks(
+  rows: readonly number[],
+  columns: number,
+  trackOverrides: Partial<Record<PetAnimation, PetTrackOverride>>,
+  warn: (message: string) => void,
+): Record<PetAnimation, PetTrackDef> | undefined {
+  const tracks = {} as Record<PetAnimation, PetTrackDef>
+  for (const [row, animation] of PET_ROW_ORDER.entries()) {
+    const pattern = DEFAULT_TRACK_PATTERNS[animation]
+    const override = trackOverrides[animation]
+    const durations = Array.isArray(override?.durations) && override.durations.length > 0
+      ? override.durations.filter((value): value is number => typeof value === 'number' && Number.isFinite(value) && value > 0)
+      : pattern.durations
+    if (durations.length === 0) {
+      warn('track ' + animation + ' carries no usable durations')
+      return undefined
+    }
+    const frameCount = Math.max(1, Math.min(rows[row]!, columns))
+    const sized = durations.length >= frameCount
+      ? durations.slice(0, frameCount)
+      : Array.from({ length: frameCount }, (_, index) => durations[index % durations.length]!)
+    tracks[animation] = {
+      frames: Array.from({ length: frameCount }, (_, index) => index),
+      durations: sized,
+      loop: typeof override?.loop === 'boolean' ? override.loop : pattern.loop,
+      ...(override?.fallback === undefined
+        ? pattern.fallback === undefined ? {} : { fallback: pattern.fallback }
+        : PET_ROW_ORDER.includes(override.fallback)
+          ? { fallback: override.fallback }
+          : pattern.fallback === undefined ? {} : { fallback: pattern.fallback }),
+    }
+  }
+  return tracks
+}
+
+/**
  * Normalize one parsed manifest into a renderable pet entry, or undefined
  * (with a warning recorded) when the manifest violates the contract.
  */
@@ -328,32 +398,9 @@ export function resolvePetManifest(
   const remarks = normalizePetRemarks(source.remarks, message => warn('manifest ' + id + ': ' + message))
   const sequences = normalizeSequences(source.sequences, id, warn)
   const trackOverrides = (typeof source.tracks === 'object' && source.tracks !== null ? source.tracks : {}) as Partial<Record<PetAnimation, PetTrackOverride>>
-  const tracks = {} as Record<PetAnimation, PetTrackDef>
-  for (const [row, animation] of PET_ROW_ORDER.entries()) {
-    const pattern = DEFAULT_TRACK_PATTERNS[animation]
-    const override = trackOverrides[animation]
-    const durations = Array.isArray(override?.durations) && override.durations.length > 0
-      ? override.durations.filter((value): value is number => typeof value === 'number' && Number.isFinite(value) && value > 0)
-      : pattern.durations
-    if (durations.length === 0) {
-      warn('manifest ' + id + ': track ' + animation + ' carries no usable durations')
-      return undefined
-    }
-    const frameCount = Math.max(1, Math.min(rows[row]!, columns))
-    const sized = durations.length >= frameCount
-      ? durations.slice(0, frameCount)
-      : Array.from({ length: frameCount }, (_, index) => durations[index % durations.length]!)
-    tracks[animation] = {
-      frames: Array.from({ length: frameCount }, (_, index) => index),
-      durations: sized,
-      loop: typeof override?.loop === 'boolean' ? override.loop : pattern.loop,
-      ...(override?.fallback === undefined
-        ? pattern.fallback === undefined ? {} : { fallback: pattern.fallback }
-        : PET_ROW_ORDER.includes(override.fallback)
-          ? { fallback: override.fallback }
-          : pattern.fallback === undefined ? {} : { fallback: pattern.fallback }),
-    }
-  }
+  const tracks = buildTracks(rows, columns, trackOverrides, message => warn('manifest ' + id + ': ' + message))
+  if (tracks === undefined) return undefined
+  const sheet = spritesheetPath.join('/')
   return {
     id,
     displayName,
@@ -368,7 +415,8 @@ export function resolvePetManifest(
     atlasUrl: assetUrl(assetPrefix, id, spritesheet),
     manifestUrl: assetUrl(assetPrefix, id, 'pet.json'),
     dir,
-    spritesheetPath: spritesheetPath.join('/'),
+    spritesheetPath: sheet,
+    servable: [sheet],
     ...(remarks === undefined ? {} : { remarks }),
   }
 }
@@ -401,6 +449,85 @@ function flattenV2Sprite2d(manifest: PetManifestV2): Record<string, unknown> | u
   return legacy
 }
 
+/**
+ * Resolve a validated live2d manifest into a renderable entry (pet-center
+ * M3). The model3.json is read at scan time: its reference closure becomes
+ * the entry's servable set (the asset route's allow-list), and a model that
+ * is unreadable or declares unsafe references rejects the entry fail-closed
+ * with an error diagnostic. Closure files missing on disk warn but keep the
+ * entry listed — the client renderer's diagnostic card reports the broken
+ * render, matching the registry's never-throw philosophy (install-time
+ * strictness belongs to the CLI validator). The sprite fields carry contract
+ * defaults: the chrome sizes live2d pets off 'display.size', not the atlas.
+ */
+function resolveLive2dEntry(
+  manifest: PetManifestV2,
+  dir: string,
+  options: { assetPrefix?: string; warnings?: string[]; diagnostics?: PetRegistryDiagnostic[] },
+): PetEntry | undefined {
+  const assetPrefix = options.assetPrefix ?? '/pet'
+  const record = (level: 'error' | 'warning', message: string): void => {
+    options.diagnostics?.push({ level, source: dir, message })
+    options.warnings?.push(message)
+  }
+  const block = manifest.live2d as PetManifestLive2d | undefined
+  if (block === undefined) {
+    record('error', 'pet ' + manifest.id + ': renderer live2d requires a live2d block')
+    return undefined
+  }
+  let model3: unknown
+  try {
+    model3 = JSON.parse(readFileSync(join(dir, block.model), 'utf8'))
+  } catch (error) {
+    record('error', 'pet ' + manifest.id + ': live2d model ' + block.model + ' is not readable: '
+      + (error instanceof Error ? error.message : String(error)))
+    return undefined
+  }
+  const { references, errors } = collectModel3References(model3)
+  if (errors.length > 0) {
+    for (const message of errors) {
+      record('error', 'pet ' + manifest.id + ': live2d model ' + block.model + ': ' + message)
+    }
+    return undefined
+  }
+  for (const reference of references) {
+    if (!existsSync(join(dir, reference))) {
+      record('warning', 'pet ' + manifest.id + ': live2d closure file missing: ' + reference)
+    }
+  }
+  const tracks = buildTracks(DEFAULT_FRAME_COUNTS, DEFAULT_PET_COLUMNS, {}, message => record('warning', 'pet ' + manifest.id + ': ' + message))
+  if (tracks === undefined) return undefined
+  const remarks = normalizePetRemarks(manifest.remarks, message => record('warning', 'pet ' + manifest.id + ': ' + message))
+  const modelUrl = assetUrl(assetPrefix, manifest.id, block.model)
+  const live2d: PetLive2dDefinition = {
+    modelUrl,
+    modelPath: block.model,
+    ...(block.scale === undefined ? {} : { scale: block.scale }),
+    ...(block.translate === undefined ? {} : { translate: block.translate }),
+    motions: block.motions,
+    ...(block.expressions === undefined ? {} : { expressions: block.expressions }),
+    ...(block.hitAreas === undefined ? {} : { hitAreas: block.hitAreas }),
+  }
+  return {
+    id: manifest.id,
+    displayName: manifest.displayName,
+    description: manifest.description ?? '',
+    renderer: 'live2d' as const,
+    live2d,
+    cell: { ...DEFAULT_PET_CELL },
+    columns: DEFAULT_PET_COLUMNS,
+    rows: [...DEFAULT_FRAME_COUNTS],
+    atlasRows: DEFAULT_PET_ROW_COUNT,
+    tracks,
+    atlasUrl: modelUrl,
+    manifestUrl: assetUrl(assetPrefix, manifest.id, 'pet.json'),
+    dir,
+    spritesheetPath: block.model,
+    servable: [block.model, ...references],
+    ...(remarks === undefined ? {} : { remarks }),
+  }
+}
+
 /** Scan one directory of pet folders; entries come back in name order. */
 function scanPetDir(dir: string, options: { assetPrefix?: string; warnings?: string[]; diagnostics?: PetRegistryDiagnostic[] }): PetEntry[] {
   if (!existsSync(dir)) return []
@@ -425,11 +552,8 @@ function scanPetDir(dir: string, options: { assetPrefix?: string; warnings?: str
     }
     if (!verdict.ok) continue
     if (verdict.manifest.renderer === 'live2d') {
-      // Valid live2d pet: accepted by the contract, but the renderer dispatch
-      // lands with M3 — keep it off the renderable list until then.
-      const note = 'pet ' + verdict.manifest.id + ' uses renderer live2d (supported from M3); hidden from the list for now'
-      options.diagnostics?.push({ level: 'warning', source: entryDir, message: note })
-      options.warnings?.push(note)
+      const entry = resolveLive2dEntry(verdict.manifest, entryDir, options)
+      if (entry !== undefined) entries.push(entry)
       continue
     }
     const legacy = flattenV2Sprite2d(verdict.manifest)
@@ -529,6 +653,7 @@ export function petEntryView(entry: PetEntry): PetDefinition {
     displayName: entry.displayName,
     description: entry.description,
     renderer: entry.renderer,
+    ...(entry.live2d === undefined ? {} : { live2d: entry.live2d }),
     cell: entry.cell,
     columns: entry.columns,
     rows: entry.rows,


### PR DESCRIPTION
## 摘要（Summary）

宠物中心 M3-1：registry 解除 live2d 过滤——live2d 宠物正常上市，条目携带验证过的 live2d 渲染块与 model3.json 引用闭包（servable 白名单，供 M3-2 资产路由放行）；model3 不可读/引用不安全 fail-closed 不上市，闭包缺盘 warn 仍上市。sprite2d 行为零变化（track 构建原样提取为 helper）。架构权威：#623。

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：git worktree add 自 origin/main（78070695），分支直接基于该点。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：Claude Opus 4.8

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

维持现有版权归属。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-pet && pnpm run typecheck && npx vitest run
node --test scripts/dsh-pet.test.mjs scripts/dsh-pet-migrate-v2.test.mjs
pnpm typecheck && pnpm test && pnpm test:scripts && pnpm docs:check && pnpm runtime-deps:check
```

结果摘要：

dsh-pet vitest 218/218（新增 4 个 live2d 用例：上市+闭包 / 模型不可读拒绝 / 不安全引用拒绝 / 缺盘警告仍上市）；CLI 18/18；仓库门禁全绿。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（纯 host 侧 registry 改动；本层后 live2d 宠物若被选中走 M2 既定兜底诊断卡，渲染器在 M3-3 落地后附 GUI 证据）。
