### PR TITLE
feat(pet): serve the live2d closure and the plugin runtime files (#623)

### DIFF
--- a/packages/dsh-pet/src/routes.ts
+++ b/packages/dsh-pet/src/routes.ts
@@ -16,8 +16,9 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { WebRoute } from '@deepseek-ai/dsh-host-webserver'
 import type { PetService } from './service.ts'
 import type { PetInteraction } from './affinity.ts'
-import { petEntryView, type PetEntry, type PetRegistry } from './registry.ts'
+import { petEntryView, petPackageRoot, type PetEntry, type PetRegistry } from './registry.ts'
 import { isLoopbackRequest } from './loopback.ts'
+import { dshHome } from './dsh-home.ts'
 
 /** Browser-facing base path of the pet API. */
 export const PET_API_PREFIX = '/api/pet'
@@ -37,14 +38,26 @@ const PREVIEW_PATTERN = /^[A-Za-z0-9._-]+$/
 export const PET_ASSET_CAPS = {
   /** pet.json manifest. */
   manifest: 64 * 1024,
-  /** Atlas and preview imagery. */
+  /** Atlas, preview and Live2D texture imagery. */
   image: 20 * 1024 * 1024,
+  /** Live2D model closure files (.moc3, motion/physics/expression JSON; M3). */
+  model: 32 * 1024 * 1024,
 } as const
 
 /** Size-cap profile the asset route enforces (test seam). */
 export interface PetAssetCaps {
   manifest: number
   image: number
+  model: number
+}
+
+/** Imagery extensions classify into the image cap; everything else served from a closure is model-class. */
+const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set(['.webp', '.png', '.gif', '.jpg', '.jpeg'])
+
+/** Lowercased file extension ('' when none). */
+function extensionOf(file: string): string {
+  const dot = file.lastIndexOf('.')
+  return dot < 0 ? '' : file.slice(dot).toLowerCase()
 }
 
 /**
@@ -180,8 +193,12 @@ function dirAliases(registry: PetRegistry): Map<string, PetEntry> {
 /**
  * The one asset handler behind the '/pet' prefix. Resolves the pet by id (or
  * legacy directory alias), then serves exactly the files a manifest declares:
- * pet.json, the declared spritesheet path, and optional 'previews/<name>'
- * media. Composed pets without a manifest file get a synthesized pet.json.
+ * pet.json, the entry's servable set (the sprite2d atlas, or the live2d
+ * model3.json plus its reference closure — pet-center M3), and optional
+ * 'previews/<name>' media. The servable match is an exact string comparison
+ * against scan-time normalized paths, so crafted '..' or '.' segments never
+ * match; containedRealpath stays as the second layer. Composed pets without
+ * a manifest file get a synthesized pet.json.
  */
 function assetHandler(registry: PetRegistry, caps: PetAssetCaps): WebRoute['handler'] {
   const aliases = dirAliases(registry)
@@ -239,8 +256,8 @@ function assetHandler(registry: PetRegistry, caps: PetAssetCaps): WebRoute['hand
       const manifestFile = join(entry.dir, MANIFEST_FILE)
       file = existsSync(manifestFile) ? manifestFile : undefined
       if (file === undefined) synthesized = true
-    } else if (rest.length > 0 && rel === entry.spritesheetPath) {
-      file = join(entry.dir, entry.spritesheetPath)
+    } else if (rest.length > 0 && entry.servable.includes(rel)) {
+      file = join(entry.dir, rel)
     } else if (rest.length === 2 && rest[0] === PREVIEW_DIR && PREVIEW_PATTERN.test(rest[1]!)) {
       const preview = join(entry.dir, PREVIEW_DIR, rest[1]!)
       file = existsSync(preview) ? preview : undefined
@@ -272,7 +289,9 @@ function assetHandler(registry: PetRegistry, caps: PetAssetCaps): WebRoute['hand
       return
     }
     // Enforce the size ceiling before the file is read into memory.
-    const cap = rest[0] === MANIFEST_FILE ? caps.manifest : caps.image
+    const cap = rest.length === 1 && rest[0] === MANIFEST_FILE
+      ? caps.manifest
+      : IMAGE_EXTENSIONS.has(extensionOf(rel)) ? caps.image : caps.model
     try {
       if (statSync(resolved).size > cap) {
         res.writeHead(413)
@@ -302,8 +321,114 @@ function assetHandler(registry: PetRegistry, caps: PetAssetCaps): WebRoute['hand
   }
 }
 
-/** Build the full route family (API + assets) for one service. */
-export function makePetRoutes(deps: { service: PetService; assetCaps?: PetAssetCaps }): WebRoute[] {
+/** Browser-facing base path of the plugin runtime files (pet-center M3). */
+export const PET_RUNTIME_PREFIX = PET_API_PREFIX + '/runtime'
+
+/**
+ * The runtime files the route may serve, by exact name (no slashes, no
+ * user-controlled path segments, so traversal is structurally impossible):
+ * the user-supplied Cubism Core from the pet runtime directory (the plugin
+ * never bundles or downloads it — issue #623 M1 §0) and the plugin-shipped
+ * MIT vendor bundle from the package lib directory.
+ */
+const RUNTIME_FILES: Readonly<Record<string, { root: 'runtimeDir' | 'vendorDir' }>> = {
+  'live2dcubismcore.min.js': { root: 'runtimeDir' },
+  'live2d-vendor.js': { root: 'vendorDir' },
+  'live2d-vendor.js.map': { root: 'vendorDir' },
+}
+
+/** Size ceiling for one runtime file (the Cubism Core is ~200 KB today). */
+export const PET_RUNTIME_CAP = 16 * 1024 * 1024
+
+/** Runtime file roots (test seam; defaults resolve from the environment). */
+export interface PetRuntimeRoots {
+  /** User-supplied runtime directory (defaults to '$DSH_HOME/pets/.runtime'). */
+  runtimeDir?: string
+  /** Plugin vendor bundle directory (defaults to the package 'lib'). */
+  vendorDir?: string
+}
+
+/**
+ * The runtime handler behind '/api/pet/runtime/<name>'. A missing file
+ * answers 404 with a JSON marker the client renderer turns into install
+ * guidance (the Cubism Core is user-supplied, so its absence is a normal
+ * state, not an error).
+ */
+function runtimeHandler(roots: { runtimeDir: string; vendorDir: string }): WebRoute['handler'] {
+  return (req: IncomingMessage, res: ServerResponse): void => {
+    if (!guard(req, res)) return
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      res.writeHead(405)
+      res.end()
+      return
+    }
+    let pathname: string
+    try {
+      pathname = new URL(req.url ?? '/', 'http://pet.local').pathname
+    } catch {
+      res.writeHead(400)
+      res.end()
+      return
+    }
+    const rest = pathname.slice(PET_RUNTIME_PREFIX.length).replace(/^\/+/, '')
+    let name: string
+    try {
+      name = decodeURIComponent(rest)
+    } catch {
+      res.writeHead(400)
+      res.end()
+      return
+    }
+    const spec = RUNTIME_FILES[name]
+    // Exact-name allow-list: anything with a path separator never matches.
+    if (spec === undefined) {
+      res.writeHead(404)
+      res.end()
+      return
+    }
+    const base = spec.root === 'runtimeDir' ? roots.runtimeDir : roots.vendorDir
+    const file = join(base, name)
+    if (!existsSync(file)) {
+      json(res, 404, { ok: false, error: 'runtime-file-missing', file: name })
+      return
+    }
+    const resolved = containedRealpath(base, file)
+    if (resolved === undefined) {
+      res.writeHead(403)
+      res.end()
+      return
+    }
+    try {
+      if (statSync(resolved).size > PET_RUNTIME_CAP) {
+        res.writeHead(413)
+        res.end()
+        return
+      }
+    } catch {
+      res.writeHead(404)
+      res.end()
+      return
+    }
+    readFile(resolved).then((body) => {
+      res.writeHead(200, {
+        'content-type': name.endsWith('.map') ? 'application/json' : 'application/javascript; charset=utf-8',
+        'content-length': String(body.byteLength),
+        'cache-control': 'no-cache',
+      })
+      if (req.method === 'HEAD') {
+        res.end()
+        return
+      }
+      res.end(body)
+    }, () => {
+      res.writeHead(404)
+      res.end()
+    })
+  }
+}
+
+/** Build the full route family (API + assets + runtime) for one service. */
+export function makePetRoutes(deps: { service: PetService; assetCaps?: PetAssetCaps } & PetRuntimeRoots): WebRoute[] {
   const { service } = deps
   const apiRoutes: WebRoute[] = [
     getRoute(PET_API_PREFIX + '/state', () => service.state()),
@@ -343,7 +468,16 @@ export function makePetRoutes(deps: { service: PetService; assetCaps?: PetAssetC
     handler: assetHandler(service.registrySnapshot(), deps.assetCaps ?? PET_ASSET_CAPS),
   }
 
-  return [...apiRoutes, assetRoute]
+  const runtimeRoute: WebRoute = {
+    kind: 'prefix',
+    path: PET_RUNTIME_PREFIX,
+    handler: runtimeHandler({
+      runtimeDir: deps.runtimeDir ?? join(dshHome(), 'pets', '.runtime'),
+      vendorDir: deps.vendorDir ?? join(petPackageRoot(import.meta.url), 'lib'),
+    }),
+  }
+
+  return [...apiRoutes, assetRoute, runtimeRoute]
 }
 
 // Re-exported for the package surface (the registry owns the definition now).

--- a/packages/dsh-pet/tests/asset-security.spec.ts
+++ b/packages/dsh-pet/tests/asset-security.spec.ts
@@ -23,7 +23,7 @@ let server: Server
 let port: number
 
 /** Caps small enough that the 12-byte fixture atlas trips them when lowered. */
-const TEST_CAPS: PetAssetCaps = { manifest: 64 * 1024, image: 20 * 1024 * 1024 }
+const TEST_CAPS: PetAssetCaps = { manifest: 64 * 1024, image: 20 * 1024 * 1024, model: 32 * 1024 * 1024 }
 
 beforeAll(async () => {
   dir = mkdtempSync(join(tmpdir(), 'dsh-pet-sec-'))
@@ -109,7 +109,7 @@ describe('asset route security', () => {
     const ctx = new Context()
     const registry = loadPetRegistry({ packageRoot: dir, petsDir: '' })
     const service = new PetService(ctx, { persistDir: join(dir, 'home2'), registry })
-    const tight = makePetRoutes({ service, assetCaps: { manifest: 64 * 1024, image: 4 } })
+    const tight = makePetRoutes({ service, assetCaps: { manifest: 64 * 1024, image: 4, model: 32 * 1024 * 1024 } })
     const tightServer = createServer((req, res) => {
       const pathname = (req.url ?? '').split('?')[0]!
       for (const route of tight) {
@@ -137,5 +137,6 @@ describe('asset route security', () => {
   it('locks the default caps to the documented constants', () => {
     expect(PET_ASSET_CAPS.manifest).toBe(64 * 1024)
     expect(PET_ASSET_CAPS.image).toBe(20 * 1024 * 1024)
+    expect(PET_ASSET_CAPS.model).toBe(32 * 1024 * 1024)
   })
 })

--- a/packages/dsh-pet/tests/live2d-assets.spec.ts
+++ b/packages/dsh-pet/tests/live2d-assets.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Live2D asset closure serving and the plugin runtime route (pet-center M3,
+ * issue #623). The asset route serves exactly the scan-time closure
+ * (model3.json + referenced files); the runtime route serves the
+ * user-supplied Cubism Core and the plugin-shipped vendor bundle by exact
+ * name. Same real-server harness as asset-security.spec.ts.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { once } from 'node:events'
+import type { AddressInfo } from 'node:net'
+import { Context } from '@deepseek-ai/cordis'
+import { PetService } from '../src/service.ts'
+import { makePetRoutes, type PetAssetCaps } from '../src/routes.ts'
+import { loadPetRegistry } from '../src/registry.ts'
+
+const MOC_BYTES = Buffer.from([0x6d, 0x6f, 0x63, 0x33])
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+const TEST_CAPS: PetAssetCaps = { manifest: 64 * 1024, image: 20 * 1024 * 1024, model: 32 * 1024 * 1024 }
+
+let dir: string
+let runtimeDir: string
+let vendorDir: string
+let outside: string
+let server: Server
+let port: number
+
+function serve(routes: ReturnType<typeof makePetRoutes>): Promise<Server> {
+  const s = createServer((req, res) => {
+    const pathname = (req.url ?? '').split('?')[0]!
+    for (const route of routes) {
+      if (route.kind === 'exact' && pathname === route.path) return void route.handler(req, res)
+    }
+    for (const route of routes) {
+      if (route.kind === 'prefix' && (pathname === route.path || pathname.startsWith(route.path + '/'))) {
+        return void route.handler(req, res)
+      }
+    }
+    res.writeHead(404)
+    res.end()
+  })
+  return new Promise((resolve) => {
+    s.listen(0, '127.0.0.1', () => resolve(s))
+  })
+}
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'dsh-pet-l2d-'))
+  runtimeDir = mkdtempSync(join(tmpdir(), 'dsh-pet-runtime-'))
+  vendorDir = mkdtempSync(join(tmpdir(), 'dsh-pet-vendor-'))
+  outside = mkdtempSync(join(tmpdir(), 'dsh-pet-outside-'))
+
+  // A live2d pet whose model3.json declares a moc, a texture and one motion.
+  const pet = join(dir, 'assets', 'hiyori')
+  mkdirSync(join(pet, 'motions'), { recursive: true })
+  mkdirSync(join(pet, 'textures'), { recursive: true })
+  writeFileSync(join(pet, 'pet.json'), JSON.stringify({
+    petManifestVersion: 2, id: 'hiyori', displayName: 'Hiyori', license: 'Live2D-Sample',
+    renderer: 'live2d', live2d: { model: 'hiyori.model3.json', motions: { idle: 'Idle' } },
+  }), 'utf8')
+  writeFileSync(join(pet, 'hiyori.model3.json'), JSON.stringify({
+    Version: 3,
+    FileReferences: {
+      Moc: 'hiyori.moc3',
+      Textures: ['textures/tex.png'],
+      Motions: { Idle: [{ File: 'motions/idle_00.motion3.json' }] },
+    },
+  }), 'utf8')
+  writeFileSync(join(pet, 'hiyori.moc3'), MOC_BYTES)
+  writeFileSync(join(pet, 'textures', 'tex.png'), PNG_BYTES)
+  writeFileSync(join(pet, 'motions', 'idle_00.motion3.json'), '{}', 'utf8')
+  // A file inside the pet directory that the model never references.
+  writeFileSync(join(pet, 'notes.txt'), 'author notes', 'utf8')
+
+  // Runtime roots: the vendor dir holds the plugin bundle; the runtime dir
+  // starts WITHOUT the user-supplied core (the not-installed state).
+  writeFileSync(join(vendorDir, 'live2d-vendor.js'), 'window.__dshPetLive2d={};', 'utf8')
+  writeFileSync(join(outside, 'escaped-core.js'), '/* escaped */', 'utf8')
+
+  const ctx = new Context()
+  const registry = loadPetRegistry({ packageRoot: dir, petsDir: '', dshPetsDir: '' })
+  const service = new PetService(ctx, { persistDir: join(dir, 'home'), registry })
+  server = await serve(makePetRoutes({ service, assetCaps: TEST_CAPS, runtimeDir, vendorDir }))
+  port = (server.address() as AddressInfo).port
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  for (const d of [dir, runtimeDir, vendorDir, outside]) rmSync(d, { recursive: true, force: true })
+})
+
+function url(path: string): string {
+  return 'http://127.0.0.1:' + port + path
+}
+
+describe('live2d closure serving', () => {
+  it('serves the model3.json, its moc, textures and motions from the closure', async () => {
+    const model = await fetch(url('/pet/hiyori/hiyori.model3.json'))
+    expect(model.status).toBe(200)
+    expect(model.headers.get('content-type')).toContain('application/json')
+    const moc = await fetch(url('/pet/hiyori/hiyori.moc3'))
+    expect(moc.status).toBe(200)
+    expect(moc.headers.get('content-type')).toBe('application/octet-stream')
+    expect((await fetch(url('/pet/hiyori/textures/tex.png'))).status).toBe(200)
+    expect((await fetch(url('/pet/hiyori/motions/idle_00.motion3.json'))).status).toBe(200)
+  })
+  it('keeps non-closure files and traversal at 404', async () => {
+    expect((await fetch(url('/pet/hiyori/notes.txt'))).status).toBe(404)
+    // The WHATWG URL parser resolves dot segments BEFORE the allow-list sees
+    // the path: a '..' request collapses onto its normalized target, which
+    // the exact-match closure still gates. Collapsing onto a closure file
+    // serves it (that IS the file); collapsing anywhere else stays 404.
+    expect((await fetch(url('/pet/hiyori/%2e%2e/hiyori/notes.txt'))).status).toBe(404)
+    expect((await fetch(url('/pet/hiyori/%2e%2e/%2e%2e/pet.json'))).status).toBe(404)
+    expect((await fetch(url('/pet/hiyori/%2e%2e/hiyori/hiyori.moc3'))).status).toBe(200)
+  })
+  it('answers 413 once a closure file exceeds the model cap', async () => {
+    const ctx = new Context()
+    const registry = loadPetRegistry({ packageRoot: dir, petsDir: '', dshPetsDir: '' })
+    const service = new PetService(ctx, { persistDir: join(dir, 'home-tight'), registry })
+    const tight = await serve(makePetRoutes({
+      service,
+      assetCaps: { manifest: 64 * 1024, image: 20 * 1024 * 1024, model: 2 },
+      runtimeDir,
+      vendorDir,
+    }))
+    try {
+      const moc = await fetch('http://127.0.0.1:' + (tight.address() as AddressInfo).port + '/pet/hiyori/hiyori.moc3')
+      expect(moc.status).toBe(413)
+    } finally {
+      await new Promise<void>((resolve) => tight.close(() => resolve()))
+    }
+  })
+})
+
+describe('runtime route', () => {
+  it('serves the plugin vendor bundle from the vendor directory', async () => {
+    const response = await fetch(url('/api/pet/runtime/live2d-vendor.js'))
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('application/javascript')
+    expect(await response.text()).toContain('__dshPetLive2d')
+  })
+  it('answers a JSON marker when the user-supplied core is not installed', async () => {
+    const response = await fetch(url('/api/pet/runtime/live2dcubismcore.min.js'))
+    expect(response.status).toBe(404)
+    const body = await response.json() as { ok: boolean; error: string; file: string }
+    expect(body.ok).toBe(false)
+    expect(body.error).toBe('runtime-file-missing')
+    expect(body.file).toBe('live2dcubismcore.min.js')
+  })
+  it('serves the core once the user installs it', async () => {
+    writeFileSync(join(runtimeDir, 'live2dcubismcore.min.js'), 'window.Live2DCubismCore={};', 'utf8')
+    try {
+      const response = await fetch(url('/api/pet/runtime/live2dcubismcore.min.js'))
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('Live2DCubismCore')
+    } finally {
+      rmSync(join(runtimeDir, 'live2dcubismcore.min.js'), { force: true })
+    }
+  })
+  it('rejects unknown names, nested paths and symlink escapes', async () => {
+    expect((await fetch(url('/api/pet/runtime/evil.js'))).status).toBe(404)
+    expect((await fetch(url('/api/pet/runtime/sub/dir.js'))).status).toBe(404)
+    expect((await fetch(url('/api/pet/runtime/%2e%2e/live2d-vendor.js'))).status).toBe(404)
+    symlinkSync(join(outside, 'escaped-core.js'), join(runtimeDir, 'live2dcubismcore.min.js'))
+    try {
+      expect((await fetch(url('/api/pet/runtime/live2dcubismcore.min.js'))).status).toBe(403)
+    } finally {
+      rmSync(join(runtimeDir, 'live2dcubismcore.min.js'), { force: true })
+    }
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

宠物中心 M3-2（P3b 收口）：资产路由白名单从「单张图集」推广为条目的 servable 集合——live2d 宠物按扫描期 model3.json 引用闭包放行（模型/moc/贴图/动作可加载，非闭包文件与目录穿越保持 404）；容量新增 model 类（32MB）。新增 `/api/pet/runtime/<name>` 路由：按精确文件名服务用户自备的 Cubism Core（$DSH_HOME/pets/.runtime，缺失时返回 JSON 'runtime-file-missing' 标记，客户端据此给安装指引）与插件自带的 MIT vendor 包；双重 realpath 包含检查 + 16MB 上限。架构权威：#623。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：分支基于 origin/main（含 #662 合并点）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：Claude Opus 4.8

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

维持现有版权归属。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-pet && pnpm run typecheck && npx vitest run
pnpm typecheck && pnpm test && pnpm test:scripts && pnpm docs:check && pnpm runtime-deps:check
```

结果摘要：

dsh-pet vitest 225/225（新增 tests/live2d-assets.spec.ts：闭包服务 / 非闭包与穿越 404 / model 容量 413 / vendor 服务 / core 缺失 JSON 标记 / core 安装后服务 / 未知名与 symlink 逃逸拒绝）；仓库门禁全绿。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（纯 host 侧路由改动；GUI 证据随 M3-3b 渲染器层附）。
