### PR TITLE
fix(plugin-manager): 串行化配置变更避免并发丢写

### DIFF
--- a/packages/dsh-plugin-manager/src/host/gateway.ts
+++ b/packages/dsh-plugin-manager/src/host/gateway.ts
@@ -198,9 +198,22 @@ export class CliGateway {
     } = {},
   ) {}
 
-  /** Chain one mutation onto the queue; a settled job never blocks the next one. */
+  /**
+   * Run one profile mutation after every mutation already queued. The returned
+   * promise keeps the task's own result or rejection, while the queue tail is
+   * always recovered so one failed write cannot block later work. Routes that
+   * edit profile files directly must use this seam so they cannot overlap the
+   * CLI install/remove writer.
+   */
+  withMutationLock<T>(task: () => Promise<T>): Promise<T> {
+    const result = this.queue.then(task)
+    this.queue = result.then(() => undefined, () => undefined)
+    return result
+  }
+
+  /** Chain one fire-and-forget CLI mutation onto the shared queue. */
   private enqueue(task: () => Promise<void>): void {
-    this.queue = this.queue.then(task).catch(() => {})
+    void this.withMutationLock(task).catch(() => {})
   }
 
   /** The dsh CLI path, through the test seam when present. */

--- a/packages/dsh-plugin-manager/src/host/routes.ts
+++ b/packages/dsh-plugin-manager/src/host/routes.ts
@@ -176,25 +176,27 @@ export function makeGatewayRoutes(deps: GatewayRouteDeps): WebRoute[] {
       sendJson(res, 400, { error: unsafeTarget })
       return
     }
-    const patchText = await readPatchText(facts.patchPath)
-    // Write and read the same id space: the entry ids the package's bundle
-    // patch claims (falling back to the package name), not the package name
-    // itself. Package-name rows never matched the loader entries. The row
-    // carries the entry's own name: the include semantics skip a bare row
-    // whose name mismatches the inserted entry.
-    const manifest = await readProfileManifest(facts.packageJsonPath)
-    const entries = manifest.dependencies[target] !== undefined
-      ? await claimedEntryRowsOf(facts, target)
-      : [{ id: target, name: target }]
-    let next = patchText
-    for (const entry of entries) {
-      next = setRowEnabled(next, facts.patchPath, entry.id, entry.name, enabled)
-    }
-    if (next !== patchText) {
-      await writePatchAtomic(facts.patchPath, next)
-    }
-    const snapshot = await snapshotGateway(facts, next)
-    const plugin = snapshot.plugins.find(item => item.id === target)
+    const plugin = await gateway.withMutationLock(async () => {
+      const patchText = await readPatchText(facts.patchPath)
+      // Write and read the same id space: the entry ids the package's bundle
+      // patch claims (falling back to the package name), not the package name
+      // itself. Package-name rows never matched the loader entries. The row
+      // carries the entry's own name: the include semantics skip a bare row
+      // whose name mismatches the inserted entry.
+      const manifest = await readProfileManifest(facts.packageJsonPath)
+      const entries = manifest.dependencies[target] !== undefined
+        ? await claimedEntryRowsOf(facts, target)
+        : [{ id: target, name: target }]
+      let next = patchText
+      for (const entry of entries) {
+        next = setRowEnabled(next, facts.patchPath, entry.id, entry.name, enabled)
+      }
+      if (next !== patchText) {
+        await writePatchAtomic(facts.patchPath, next)
+      }
+      const snapshot = await snapshotGateway(facts, next)
+      return snapshot.plugins.find(item => item.id === target)
+    })
     sendJson(res, 200, { plugin: plugin ?? {
       id: target, name: target, version: 'unknown',
       source: { kind: 'npm', spec: target }, installedAt: '', enabled,

--- a/packages/dsh-plugin-manager/tests/gateway-jobs.spec.ts
+++ b/packages/dsh-plugin-manager/tests/gateway-jobs.spec.ts
@@ -277,6 +277,39 @@ describe('CliGateway unresolvable insert rollback (B6)', () => {
 })
 
 describe('CliGateway mutation queue (B7)', () => {
+  it('uses the same queue for direct profile writes and CLI jobs', async () => {
+    const { facts, dir } = makeProfile({})
+    tempDirs.push(dir)
+    const calls: string[][] = []
+    const gateway = gatewayFor(facts, (args) => {
+      if (args[0] === 'plugin' && args[3] === 'add') installPackage(facts.profileDir, args[4] ?? '', {})
+      return { code: 0 }
+    }, calls)
+    let release!: () => void
+    const blocker = new Promise<void>(resolve => { release = resolve })
+    const direct = gateway.withMutationLock(async () => {
+      await blocker
+    })
+    const { jobId } = gateway.install('queued-after-toggle')
+    await Promise.resolve()
+    expect(calls).toEqual([])
+    release()
+    await direct
+    const job = await settle(gateway, jobId)
+    expect(job.phase).toBe('done')
+    expect(calls.filter(args => args[3] === 'add').map(args => args[4])).toEqual(['queued-after-toggle'])
+  })
+
+  it('does not let a rejected direct mutation poison the queue', async () => {
+    const { facts, dir } = makeProfile({})
+    tempDirs.push(dir)
+    const gateway = gatewayFor(facts, () => ({ code: 0 }), [])
+    await expect(gateway.withMutationLock(async () => {
+      throw new Error('write failed')
+    })).rejects.toThrow('write failed')
+    await expect(gateway.withMutationLock(async () => 'next mutation')).resolves.toBe('next mutation')
+  })
+
   it('two concurrent installs stay serialized and attribute rows correctly', async () => {
     const { facts, dir } = makeProfile({})
     tempDirs.push(dir)

--- a/packages/dsh-plugin-manager/tests/set-enabled.spec.ts
+++ b/packages/dsh-plugin-manager/tests/set-enabled.spec.ts
@@ -5,7 +5,7 @@ import { Readable } from 'node:stream'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { makeGatewayRoutes } from '../src/host/routes.ts'
-import type { CliGateway } from '../src/host/gateway.ts'
+import { CliGateway } from '../src/host/gateway.ts'
 import type { ProfileFacts } from '../src/host/profile.ts'
 
 /** One temp profile with a dsh-memoir-shaped dependency (bundle patch claims id=memoir). */
@@ -21,6 +21,26 @@ function makeProfile(): { facts: ProfileFacts; dir: string } {
   writeFileSync(join(profileDir, 'cordis.patch.yml'), '# layer\n[]\n')
   writeFileSync(join(profileDir, 'node_modules', 'dsh-memoir', 'package.json'), JSON.stringify({ name: 'dsh-memoir', version: '0.4.3' }))
   writeFileSync(join(profileDir, 'node_modules', 'dsh-memoir', 'cordis.patch.yml'), '- insert:\n    - id: memoir\n      name: dsh-memoir\n')
+  const facts: ProfileFacts = {
+    profileName: 'web',
+    profileDir,
+    patchPath: join(profileDir, 'cordis.patch.yml'),
+    packageJsonPath: join(profileDir, 'package.json'),
+  }
+  return { facts, dir }
+}
+
+/** One temp profile with several plain plugins for concurrent row mutations. */
+function makePlainProfile(ids: readonly string[]): { facts: ProfileFacts; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'plugin-manager-set-enabled-concurrent-'))
+  const profileDir = join(dir, 'profiles', 'web')
+  mkdirSync(profileDir, { recursive: true })
+  writeFileSync(join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dependencies: Object.fromEntries(ids.map(id => [id, `link:/${id}`])),
+    dsh: { profile: { bundles: [] } },
+  }))
+  writeFileSync(join(profileDir, 'cordis.patch.yml'), '# layer\n[]\n')
   const facts: ProfileFacts = {
     profileName: 'web',
     profileDir,
@@ -52,7 +72,7 @@ function captureResponse(): { res: ServerResponse; body: () => string; status: (
 
 /** The set-enabled route handler of a gateway route set. */
 function setEnabledHandler(facts: ProfileFacts) {
-  const gateway = {} as CliGateway
+  const gateway = new CliGateway(facts)
   const routes = makeGatewayRoutes({ facts, gateway, cliAvailable: () => true })
   return routes.find(route => route.path === '/api/plugin-manager/set-enabled')!.handler
 }
@@ -63,6 +83,21 @@ afterEach(() => {
 })
 
 describe('set-enabled id space', () => {
+  it('serializes concurrent toggles so every acknowledged row persists', async () => {
+    const ids = Array.from({ length: 16 }, (_, index) => `dsh-concurrent-${String(index)}`)
+    const { facts, dir } = makePlainProfile(ids)
+    tempDirs.push(dir)
+    const handler = setEnabledHandler(facts)
+    const responses = await Promise.all(ids.map(async id => {
+      const response = captureResponse()
+      await handler(loopbackRequest({ id, enabled: false }), response.res)
+      return response
+    }))
+    expect(responses.map(response => response.status())).toEqual(ids.map(() => 200))
+    const patch = readFileSync(facts.patchPath, 'utf8')
+    for (const id of ids) expect(patch).toContain(`id: ${id}`)
+  })
+
   it('writes the claimed entry id (memoir), not the package name, and the row reports disabled', async () => {
     const { facts, dir } = makeProfile()
     tempDirs.push(dir)


### PR DESCRIPTION
## 摘要（Summary）

修复插件启停请求并发执行时，多个请求同时读写 `cordis.patch.yml`，造成部分请求返回 500、已经确认成功的配置被后续写入覆盖的问题。

`set-enabled` 现在通过 `CliGateway` 的统一 mutation queue 执行完整的读取、修改、原子写入和快照计算，并与 CLI 安装、卸载操作共用同一队列。失败的写入不会阻塞后续配置变更。

新增并发回归测试：修复前 16 个同时执行的启停请求中有 12 个返回 500；修复后 16 个请求全部返回 200，且所有配置行均正确落盘。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他：`packages/dsh-plugin-manager`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream main
git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5.6

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未修改 README）。

## 贡献者版权声明（Contributor Copyright）

不新增版权声明。

## 新皮肤收录（New Skin）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-plugin-manager typecheck
pnpm --filter @linxin666/dsh-client-ui-plugin-manager test
pnpm --filter @linxin666/dsh-client-ui-plugin-manager build
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm aggregate:check
pnpm runtime-deps:check
```

结果摘要：

- dsh-plugin-manager 类型检查通过。
- dsh-plugin-manager 14 个测试文件、104 项测试全部通过。
- dsh-plugin-manager 构建通过。
- 全仓类型检查通过。
- `docs:check`、`aggregate:check`、`runtime-deps:check` 通过。
- 全仓 `pnpm test` 在未修改的 `dsh-liangshen` Windows 路径断言处失败。
- `pnpm test:scripts` 在最新 main 已存在的 Windows 路径、绝对路径导入及聚合碰撞用例处失败；本 PR 未修改相关文件。
- 定向并发回归：16/16 请求返回 200，16 条配置全部持久化。
- `git diff --check` 通过。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A。该变更是 Host 侧配置写入的一致性修复，无新增 UI；并发行为由自动化回归测试验证。
