### PR TITLE
fix(skins): keep legacy junction targets resolvable (#605)

### DIFF
--- a/packages/dsh-skins/AGENTS.md
+++ b/packages/dsh-skins/AGENTS.md
@@ -2,12 +2,12 @@
 
 已退役的兼容载具（保留一个发布周期，issue #506）：皮肤是纯资产目录，全部内置在
 `packages/skins/skin-center/skins/<id>/`，由皮肤中心包（`@linxin666/dsh-client-ui-skin-center`）
-统一加载。本包不再携带皮肤资产。
+统一加载。本包不再携带皮肤资产，只保留旧 junction 可解析所需的空兼容叶包。
 
 ## 当前形态
 
-- `build.mjs` 是刻意的 no-op（保留在 build/prepare 钩子上，让既有自动化不炸）；
-  没有 `skins/` 目录，`package.json` 的 `files` 不含 `skins`。
+- `build.mjs` 只生成 11 个旧皮肤名对应的空兼容叶包；不得把 CSS、图片或旧版
+  client 运行时复制回来。生成目录随 npm 包发布，让旧 junction 在 bridge 清理前可解析。
 - 唯一的 dependency 是 `@linxin666/dsh-client-ui-skin-center`（`workspace:*`）：
   升级用户自动获得皮肤中心与全部内置皮肤。
 - `aggregate.yml` 的 `patchFrom` / `deps` 指向 `../skins/skin-center`，保持不变；

--- a/packages/dsh-skins/README.i18n.yaml
+++ b/packages/dsh-skins/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 7baaeaeb96864840d9e6dd5b9f88be37396ada45
-README.zh.md: b315322701accb0ae2ddb10fbb24df5cf2c4fca8
+README.md: b8d9dc964601733d15cd73928564b0dd23262c2b
+README.zh.md: d742420e2b1646c743e5c3a250b5cfdae812ecaa

--- a/packages/dsh-skins/README.md
+++ b/packages/dsh-skins/README.md
@@ -2,12 +2,12 @@
 
 English | [中文](README.zh.md)
 
-Retired compatibility carrier (kept for one release cycle): every skin is built into `@linxin666/dsh-client-ui-skin-center`. This package no longer ships skin assets; it only pulls the skin center in as a dependency so users upgrading @linxin666/dsh-skins get it automatically.
+Retired compatibility carrier (kept for one release cycle): every skin is built into `@linxin666/dsh-client-ui-skin-center`. This package pulls in the skin center and ships asset-free no-op leaf packages so stale v1 profile junctions remain resolvable until the legacy bridge removes them.
 
 ## What it is
 
-- **Dependency carrier only**: installing or upgrading this package installs the skin center (`skin-center`), which ships the full built-in skin collection (xp / blue-fantasy / dragon-heir / minecraft / miku / trading / whale-song / harbor / whale-mom / matrix / maid-atelier / mint) as pure asset directories.
-- **No build output**: `build.mjs` is an intentional no-op; there is nothing to copy.
+- **Compatibility carrier**: installing or upgrading this package installs the skin center (`skin-center`), which ships the full built-in skin collection (xp / blue-fantasy / dragon-heir / minecraft / miku / trading / whale-song / harbor / whale-mom / matrix / maid-atelier / mint) as pure asset directories.
+- **No-op v1 leaves**: `build.mjs` generates asset-free packages for the 11 retired v1 package names. They do not apply a skin; they only keep an existing profile junction importable during one cleanup boot.
 - **Removal next cycle**: this package is scheduled for retirement; new installs should use `@linxin666/dsh-client-ui-skin-center` directly (or the family aggregate `@linxin666/dsh-web-ui-all`).
 
 ## Install
@@ -33,4 +33,5 @@ Switch skins in the GUI's first-level Skin Center section, or with `dsh-skin use
 
 - The browser bundle targets the web only, scoped to the dsh web GUI.
 - Skins are presentation-only: they mutate the browser DOM and never touch a model request.
+- A profile overlay that is already invalid YAML fails inside DSH before this compatibility package can load; repair that overlay before booting.
 - Maid Atelier is licensed separately under CC BY-NC-SA 4.0 and is restricted to non-commercial use; its license and attribution ship inside the skin-center package's skin directory.

--- a/packages/dsh-skins/README.zh.md
+++ b/packages/dsh-skins/README.zh.md
@@ -2,12 +2,12 @@
 
 [English](README.md) | 中文
 
-已退役的兼容载具（保留一个发布周期）：皮肤已全部内置进 `@linxin666/dsh-client-ui-skin-center`，本包不再携带皮肤资产，仅通过依赖把皮肤中心带给升级用户。
+已退役的兼容载具（保留一个发布周期）：皮肤已全部内置进 `@linxin666/dsh-client-ui-skin-center`。本包带入皮肤中心，并发布不含资产的空叶包，让遗留 v1 profile junction 在旧版 bridge 清理前仍可解析。
 
 ## 是什么
 
-- **纯依赖载具**：安装或升级本包即装上皮肤中心（`skin-center`），全部内置皮肤（xp / blue-fantasy / dragon-heir / minecraft / miku / trading / whale-song / harbor / whale-mom / matrix / maid-atelier / mint）以纯资产目录形态随它分发。
-- **无构建产物**：`build.mjs` 是刻意的 no-op，没有资产可复制。
+- **兼容载具**：安装或升级本包即装上皮肤中心（`skin-center`），全部内置皮肤（xp / blue-fantasy / dragon-heir / minecraft / miku / trading / whale-song / harbor / whale-mom / matrix / maid-atelier / mint）以纯资产目录形态随它分发。
+- **空 v1 叶包**：`build.mjs` 为 11 个已退役的 v1 包名生成不含资产的空包。它们不会应用皮肤，只用于让现有 profile junction 在一次清理启动期间仍可 import。
 - **下个周期移除**：本包计划退役；新安装请直接用 `@linxin666/dsh-client-ui-skin-center`（或全家桶聚合包 `@linxin666/dsh-web-ui-all`）。
 
 ## 安装
@@ -33,4 +33,5 @@ dsh plugin --profile web add link:$(pwd)/packages/skins/skin-center
 
 - 浏览器 bundle 仅面向 Web，作用域限定在 dsh web GUI。
 - 皮肤只做呈现：只改浏览器 DOM，不触及模型请求。
+- 已经是非法 YAML 的 profile overlay 会在此兼容包加载前由 DSH 报错，需先修复 overlay 再启动。
 - Maid Atelier 单独采用 CC BY-NC-SA 4.0，仅限非商业使用；完整许可与署名随皮肤中心包内的皮肤目录分发。

--- a/packages/dsh-skins/build.mjs
+++ b/packages/dsh-skins/build.mjs
@@ -1,15 +1,56 @@
 #!/usr/bin/env node
-/**
- * dsh-skins build — retired no-op carrier (issue #506).
- *
- * Skins are pure asset directories built into the skin-center package
- * (packages/skins/skin-center/skins/<id>/); this aggregate no longer copies
- * skin assets. The package is kept for one release cycle as a dependency
- * carrier: users who upgrade @linxin666/dsh-skins automatically pull in
- * @linxin666/dsh-client-ui-skin-center, which ships every built-in skin.
- *
- * The script stays on the package's build/prepare hooks so existing
- * automation keeps working; it intentionally does nothing.
- */
+/** Generate no-op leaf packages for paths used by retired v1 skin junctions. */
 
-console.log('dsh-skins build: no-op (skins are built into @linxin666/dsh-client-ui-skin-center; see issue #506)')
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const carrierVersion = JSON.parse(readFileSync(join(here, 'package.json'), 'utf8')).version
+
+export const LEGACY_SKIN_IDS = [
+  'blue-fantasy',
+  'dragon-heir',
+  'harbor',
+  'maid-atelier',
+  'matrix',
+  'miku',
+  'minecraft',
+  'trading',
+  'whale-mom',
+  'whale-song',
+  'xp',
+]
+
+export function renderPackageJson(id) {
+  return JSON.stringify({
+    name: `@linxin666/dsh-client-ui-skin-${id}`,
+    version: carrierVersion,
+    description: `No-op compatibility shim for the retired ${id} skin package.`,
+    type: 'module',
+    main: 'lib/index.js',
+    exports: {
+      '.': './lib/index.js',
+      './client': './lib/client.js',
+      './package.json': './package.json',
+    },
+    dsh: { client: { inject: [], platform: 'web' } },
+    license: 'Apache-2.0',
+  }, null, 2) + '\n'
+}
+
+export function buildCompatibilityShims(outDir = join(here, 'skins')) {
+  rmSync(outDir, { recursive: true, force: true })
+  for (const id of LEGACY_SKIN_IDS) {
+    const dir = join(outDir, id)
+    mkdirSync(join(dir, 'lib'), { recursive: true })
+    writeFileSync(join(dir, 'package.json'), renderPackageJson(id))
+    writeFileSync(join(dir, 'lib', 'index.js'), '/** Retired v1 skin compatibility shim. */\nexport function apply() {}\n')
+    writeFileSync(join(dir, 'lib', 'client.js'), `window.__ModuleLoader__.load({\n  id: "@linxin666/dsh-client-ui-skin-${id}",\n  factory: () => ({ apply() {} }),\n});\n`)
+  }
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  buildCompatibilityShims()
+  console.log(`dsh-skins build: generated ${LEGACY_SKIN_IDS.length} legacy compatibility shims`)
+}

--- a/packages/dsh-skins/build.test.mjs
+++ b/packages/dsh-skins/build.test.mjs
@@ -1,15 +1,26 @@
 import assert from 'node:assert/strict'
-import { execFileSync } from 'node:child_process'
-import fs from 'node:fs'
-import path from 'node:path'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import test from 'node:test'
-import { fileURLToPath } from 'node:url'
 
-const here = path.dirname(fileURLToPath(import.meta.url))
+import { buildCompatibilityShims, LEGACY_SKIN_IDS } from './build.mjs'
 
-test('retired carrier build is a no-op and copies no skin assets', () => {
-  const out = execFileSync(process.execPath, [path.join(here, 'build.mjs')], { encoding: 'utf8' })
-  assert.match(out, /no-op/)
-  // The carrier ships no skins/ directory: assets live in the skin-center package.
-  assert.equal(fs.existsSync(path.join(here, 'skins')), false)
+test('builds resolvable no-op packages for every retired v1 skin junction', async (t) => {
+  const out = mkdtempSync(join(tmpdir(), 'dsh-skins-shims-'))
+  t.after(() => rmSync(out, { recursive: true, force: true }))
+  buildCompatibilityShims(out)
+
+  for (const id of LEGACY_SKIN_IDS) {
+    const dir = join(out, id)
+    const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    assert.equal(pkg.name, `@linxin666/dsh-client-ui-skin-${id}`)
+    assert.equal(typeof (await import(join(dir, 'lib', 'index.js'))).apply, 'function')
+    assert.match(readFileSync(join(dir, 'lib', 'client.js'), 'utf8'), new RegExp(`skin-${id}`))
+  }
+
+  const link = join(out, 'node_modules', '@linxin666', 'dsh-client-ui-skin-whale-song')
+  mkdirSync(join(link, '..'), { recursive: true })
+  symlinkSync(join(out, 'whale-song'), link, process.platform === 'win32' ? 'junction' : 'dir')
+  assert.equal(typeof (await import(join(link, 'lib', 'index.js'))).apply, 'function')
 })

--- a/packages/dsh-skins/package.json
+++ b/packages/dsh-skins/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "files": [
-    "lib",
+    "skins",
     "cordis.patch.yml",
     "THIRD_PARTY_NOTICES.md"
   ],

--- a/packages/dsh-skins/skins/blue-fantasy/lib/client.js
+++ b/packages/dsh-skins/skins/blue-fantasy/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-blue-fantasy",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/blue-fantasy/lib/index.js
+++ b/packages/dsh-skins/skins/blue-fantasy/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/blue-fantasy/package.json
+++ b/packages/dsh-skins/skins/blue-fantasy/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-blue-fantasy",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired blue-fantasy skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/dragon-heir/lib/client.js
+++ b/packages/dsh-skins/skins/dragon-heir/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-dragon-heir",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/dragon-heir/lib/index.js
+++ b/packages/dsh-skins/skins/dragon-heir/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/dragon-heir/package.json
+++ b/packages/dsh-skins/skins/dragon-heir/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-dragon-heir",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired dragon-heir skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/harbor/lib/client.js
+++ b/packages/dsh-skins/skins/harbor/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-harbor",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/harbor/lib/index.js
+++ b/packages/dsh-skins/skins/harbor/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/harbor/package.json
+++ b/packages/dsh-skins/skins/harbor/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-harbor",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired harbor skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/maid-atelier/lib/client.js
+++ b/packages/dsh-skins/skins/maid-atelier/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-maid-atelier",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/maid-atelier/lib/index.js
+++ b/packages/dsh-skins/skins/maid-atelier/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/maid-atelier/package.json
+++ b/packages/dsh-skins/skins/maid-atelier/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-maid-atelier",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired maid-atelier skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/matrix/lib/client.js
+++ b/packages/dsh-skins/skins/matrix/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-matrix",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/matrix/lib/index.js
+++ b/packages/dsh-skins/skins/matrix/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/matrix/package.json
+++ b/packages/dsh-skins/skins/matrix/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-matrix",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired matrix skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/miku/lib/client.js
+++ b/packages/dsh-skins/skins/miku/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-miku",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/miku/lib/index.js
+++ b/packages/dsh-skins/skins/miku/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/miku/package.json
+++ b/packages/dsh-skins/skins/miku/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-miku",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired miku skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/minecraft/lib/client.js
+++ b/packages/dsh-skins/skins/minecraft/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-minecraft",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/minecraft/lib/index.js
+++ b/packages/dsh-skins/skins/minecraft/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/minecraft/package.json
+++ b/packages/dsh-skins/skins/minecraft/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-minecraft",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired minecraft skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/trading/lib/client.js
+++ b/packages/dsh-skins/skins/trading/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-trading",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/trading/lib/index.js
+++ b/packages/dsh-skins/skins/trading/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/trading/package.json
+++ b/packages/dsh-skins/skins/trading/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-trading",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired trading skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/whale-mom/lib/client.js
+++ b/packages/dsh-skins/skins/whale-mom/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-whale-mom",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/whale-mom/lib/index.js
+++ b/packages/dsh-skins/skins/whale-mom/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/whale-mom/package.json
+++ b/packages/dsh-skins/skins/whale-mom/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-whale-mom",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired whale-mom skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/whale-song/lib/client.js
+++ b/packages/dsh-skins/skins/whale-song/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-whale-song",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/whale-song/lib/index.js
+++ b/packages/dsh-skins/skins/whale-song/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/whale-song/package.json
+++ b/packages/dsh-skins/skins/whale-song/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-whale-song",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired whale-song skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/dsh-skins/skins/xp/lib/client.js
+++ b/packages/dsh-skins/skins/xp/lib/client.js
@@ -1,0 +1,4 @@
+window.__ModuleLoader__.load({
+  id: "@linxin666/dsh-client-ui-skin-xp",
+  factory: () => ({ apply() {} }),
+});

--- a/packages/dsh-skins/skins/xp/lib/index.js
+++ b/packages/dsh-skins/skins/xp/lib/index.js
@@ -1,0 +1,2 @@
+/** Retired v1 skin compatibility shim. */
+export function apply() {}

--- a/packages/dsh-skins/skins/xp/package.json
+++ b/packages/dsh-skins/skins/xp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linxin666/dsh-client-ui-skin-xp",
+  "version": "0.2.2",
+  "description": "No-op compatibility shim for the retired xp skin package.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [],
+      "platform": "web"
+    }
+  },
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
## 摘要（Summary）

修复 #605 中 `dsh-skins` 升级后遗留皮肤 junction 指向已删除目录，导致同次启动出现 `ERR_MODULE_NOT_FOUND` 的问题。为 11 个已退役的 v1 皮肤包名生成不含资源和旧运行时的 no-op 兼容叶包，使旧 junction 可正常解析，并让 legacy bridge 完成迁移和清理。

Fixes #605 

非法 `cordis.patch.yml` 在 DSH 加载插件前即解析失败，超出本仓插件可介入的生命周期，仍需由 DSH 侧处理 overlay 容错。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream main
git switch -c fix/legacy-skin-upgrade upstream/main
```

修复分支基于当时最新的 `upstream/main` 提交 `be4d1b6` 创建。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5.6 Sol

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

N/A

## 新皮肤收录（New Skin）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
node --test packages/dsh-skins/build.test.mjs
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm aggregate:check
git diff --check
npm pack --dry-run --ignore-scripts --cache /private/tmp/dsh-web-ui-npm-cache
```

结果摘要：

- `dsh-skins` 回归测试通过，覆盖全部 11 个旧皮肤包名，并验证遗留 `whale-song` junction 可通过生成的兼容叶包正常 import。
- 全仓 typecheck、测试和脚本测试通过。
- 文档双语配对与链接检查通过。
- 聚合包一致性检查通过。
- `git diff --check` 通过。
- npm dry-run 打包成功，确认 11 个兼容叶包均进入 tarball；包体约 5.2 kB，不包含旧版 CSS、图片或皮肤运行时。

## 用户可见变更证据（Local Feature Evidence）

证据：

无新增 UI，截图不适用。该修复作用于升级启动路径：

- 旧 profile 中的 `@linxin666/dsh-client-ui-skin-*` junction 仍可解析。
- 兼容叶包的 host/client `apply` 均为空操作，不会重新启用旧皮肤运行时。
- legacy bridge 可在同次启动中迁移选择并清理旧配置行。
- 实际皮肤继续由 skin-center 的 v2 内置资产加载。