### PR TITLE
fix(skin-center): tolerate CRLF line endings when reading the legacy active skin

### DIFF
--- a/packages/skins/skin-center/src/legacy-bridge.ts
+++ b/packages/skins/skin-center/src/legacy-bridge.ts
@@ -162,7 +162,7 @@ export function readLegacyActiveId(patch: string, knownIds: readonly string[]): 
   }
   if (!patch.includes(MANAGED_START)) return null
   const disabled = new Set<string>()
-  for (const m of patch.matchAll(/^- id: (ui-skin-[a-z0-9-]+)\n  disabled: true/gm)) {
+  for (const m of patch.matchAll(/^- id: (ui-skin-[a-z0-9-]+)\r?\n  disabled: true/gm)) {
     disabled.add(m[1].replace('ui-skin-', ''))
   }
   const candidates = knownIds.filter((id) => !disabled.has(id))

--- a/packages/skins/skin-center/tests/legacy-bridge.spec.ts
+++ b/packages/skins/skin-center/tests/legacy-bridge.spec.ts
@@ -83,6 +83,10 @@ describe('readLegacyActiveId', () => {
     expect(readLegacyActiveId(WIRED_PATCH, KNOWN)).toBe('harbor')
   })
 
+  it('reads the bundle-wired skin on CRLF line endings too', () => {
+    expect(readLegacyActiveId(WIRED_PATCH.replace(/\n/g, '\r\n'), KNOWN)).toBe('harbor')
+  })
+
   it('returns null for the stock look and for no managed state', () => {
     expect(readLegacyActiveId(STOCK_PATCH, KNOWN)).toBeNull()
     expect(readLegacyActiveId('- insert: []\n', KNOWN)).toBeNull()
@@ -121,6 +125,14 @@ describe('migrateLegacySelection', () => {
     expect(result.patchCleaned).toBe(true)
     expect(readActiveSelection(statePath)).toBe('xp')
     expect(readFileSync(patchPath, 'utf8')).not.toContain('dsh-skin managed')
+  })
+
+  it('migrates the active id from a CRLF patch', () => {
+    writeFileSync(patchPath, WIRED_PATCH.replace(/\n/g, '\r\n'))
+    const result = migrateLegacySelection({ knownIds: KNOWN, activeStatePath: statePath, patchPath })
+    expect(result.migrated).toBe('harbor')
+    expect(result.patchCleaned).toBe(true)
+    expect(readActiveSelection(statePath)).toBe('harbor')
   })
 
   it('is a no-op on the second run', () => {


### PR DESCRIPTION
## 摘要（Summary）

legacy bridge 把激活皮肤迁移到 v2 store 时，在 Windows 上偶尔会丢。同样的 patch 内容，编辑器以 CRLF 保存过之后 readLegacyActiveId 就识别不出 bundle-wired 激活皮肤，迁移直接返回 null，皮肤回退官方默认。

原因在 readLegacyActiveId 判断哪些皮肤被 disabled 的正则上，写的是 \n，没有兼容 \r\n：

/^- id: (ui-skin-[a-z0-9-]+)\n  disabled: true/gm

CRLF 文件整条正则失配，disabled 集合为空，所有 known skin 都是候选，非歧义判断失败，返回 null。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

git fetch origin && git rebase origin/main

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek v4 Pro

使用的编码 Agent 工具：

## 本地验证（Local Validation）

执行的命令：

```bash
npx vitest run tests/legacy-bridge.spec.ts
```

结果摘要：

17 通过（原 15 个用例加新增 2 个回归用例：CRLF 下 readLegacyActiveId 仍能读出 bundle-wired 激活皮肤；CRLF patch 迁移后 v2 store 写入正确 id）。
