### PR TITLE
fix(community-plugins): 避免旧连接覆盖插件状态

### DIFF
--- a/packages/dsh-community-plugins/src/client/CommunityPluginsCard.tsx
+++ b/packages/dsh-community-plugins/src/client/CommunityPluginsCard.tsx
@@ -7,7 +7,7 @@
  * indexes them, it never vendors their code.
  */
 
-import { useEffect, useMemo, useState, useSyncExternalStore, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from 'react'
 import { Button, Modal } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { InjectFace, PropsLocale, PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
 // Type-only: pulls the settings-surface SlotMap merge (the 'settings.section' entry).
@@ -160,6 +160,15 @@ export function CommunityPluginsCard(props: CommunityPluginsCardProps): ReactNod
   const bridge = useSyncExternalStore(subscribePluginManager, getPluginManagerSnapshot)
   const face = props.pluginManager !== undefined ? props.pluginManager : bridge.face
   const faceLoopback = face !== null && face.isLoopback
+  // A bridge version can change while cordis re-provides the same face
+  // reference. Give every committed provision its own lifetime so async
+  // completions from the previous one cannot mutate the replacement UI.
+  const faceRevision = props.pluginManager !== undefined ? face : bridge.version
+  const faceLifetime = useMemo(() => ({ active: true }), [face, faceRevision])
+  useLayoutEffect(() => {
+    faceLifetime.active = true
+    return () => { faceLifetime.active = false }
+  }, [faceLifetime])
 
   // Installed snapshot served by the face (null = not loaded / no face).
   const [installed, setInstalled] = useState<readonly InstalledPluginItem[] | null>(null)
@@ -171,26 +180,40 @@ export function CommunityPluginsCard(props: CommunityPluginsCardProps): ReactNod
   const [errors, setErrors] = useState<Readonly<Record<string, string>>>({})
   // The entry awaiting uninstall confirmation.
   const [uninstallTarget, setUninstallTarget] = useState<CommunityPluginEntry | null>(null)
+  // Latest-issued list request wins. An earlier request may complete after a
+  // mutation refresh even when the service face itself did not change.
+  const listRequestRef = useRef(0)
 
   // Keep the installed snapshot in sync with the face: initial load, plus
   // onChange so edits made in the Plugin manager tab reflect here. Only
   // loopback faces are queried — remote browsers render the read-only index.
   useEffect(() => {
+    // An operation belongs to the face that started it. Once that face is
+    // replaced, release its local UI lock and discard its dialog/error state;
+    // the new face's list request below becomes authoritative.
+    setPending(null)
+    setProgress(null)
+    setErrors({})
+    setUninstallTarget(null)
+    listRequestRef.current += 1
     if (face === null || !face.isLoopback) {
       setInstalled(null)
       return
     }
     let alive = true
     const refresh = (): void => {
+      const request = ++listRequestRef.current
       void face.list().then(
-        (list) => { if (alive) setInstalled(list) },
+        (list) => {
+          if (alive && faceLifetime.active && request === listRequestRef.current) setInstalled(list)
+        },
         () => { /* keep the last known snapshot on transient failures */ },
       )
     }
     refresh()
     const unsubscribe = face.onChange(refresh)
     return () => { alive = false; unsubscribe() }
-  }, [face, faceLoopback])
+  }, [face, faceLoopback, faceLifetime])
 
   // Poll the host's install progress while an install is in flight; the
   // first poll runs immediately so the stage line appears without delay.
@@ -202,7 +225,7 @@ export function CommunityPluginsCard(props: CommunityPluginsCardProps): ReactNod
     let alive = true
     const poll = (): void => {
       void face.status().then(
-        (item) => { if (alive) setProgress(item) },
+        (item) => { if (alive && faceLifetime.active) setProgress(item) },
         () => { /* transient poll failure: keep the last known stage */ },
       )
     }
@@ -210,7 +233,7 @@ export function CommunityPluginsCard(props: CommunityPluginsCardProps): ReactNod
     const timer = setInterval(poll, PROGRESS_POLL_MS)
     return () => { alive = false; clearInterval(timer) }
     // Keyed on the boolean, not the entry: restarting the poll per entry is unnecessary.
-  }, [face, pending?.kind === 'install'])
+  }, [face, faceLifetime, pending?.kind === 'install'])
 
   const clearError = (id: string): void => {
     setErrors((previous) => {
@@ -223,14 +246,23 @@ export function CommunityPluginsCard(props: CommunityPluginsCardProps): ReactNod
 
   const onInstall = (entry: CommunityPluginEntry): void => {
     if (face === null || !face.isLoopback || pending !== null) return
+    const lifetime = faceLifetime
     clearError(entry.id)
     setPending({ kind: 'install', id: entry.id })
-    face.install(installSpec(entry)).then(
-      () => { void face.list().then(setInstalled, () => {}) },
-      (reason: unknown) => {
+    void (async () => {
+      try {
+        await face.install(installSpec(entry))
+        if (!lifetime.active) return
+        const request = ++listRequestRef.current
+        const list = await face.list().catch(() => undefined)
+        if (lifetime.active && list !== undefined && request === listRequestRef.current) setInstalled(list)
+      } catch (reason) {
+        if (!lifetime.active) return
         setErrors((previous) => ({ ...previous, [entry.id]: t('installFailed', { reason: messageOf(reason) }) }))
-      },
-    ).finally(() => { setPending(null) })
+      } finally {
+        if (lifetime.active) setPending(null)
+      }
+    })()
   }
 
   const onUninstallConfirm = (): void => {
@@ -243,14 +275,21 @@ export function CommunityPluginsCard(props: CommunityPluginsCardProps): ReactNod
       setUninstallTarget(null)
       return
     }
+    const lifetime = faceLifetime
     setPending({ kind: 'uninstall', id: target.id })
     face.uninstall(item.id).then(
-      (list) => { setInstalled(list); setUninstallTarget(null) },
+      (list) => {
+        if (!lifetime.active) return
+        listRequestRef.current += 1
+        setInstalled(list)
+        setUninstallTarget(null)
+      },
       (reason: unknown) => {
+        if (!lifetime.active) return
         setErrors((previous) => ({ ...previous, [target.id]: t('uninstallFailed', { reason: messageOf(reason) }) }))
         setUninstallTarget(null)
       },
-    ).finally(() => { setPending(null) })
+    ).finally(() => { if (lifetime.active) setPending(null) })
   }
 
   const copyCommand = (id: string, command: string): void => {

--- a/packages/dsh-community-plugins/tests/community-install.spec.tsx
+++ b/packages/dsh-community-plugins/tests/community-install.spec.tsx
@@ -9,7 +9,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import React, { useSyncExternalStore, type ComponentProps } from 'react'
 import type { SettingsScope, SettingsScopeSnapshot } from '@deepseek-ai/dsh-client-runtime/client'
 // The npm SDK's client half is a closure-factory bundle for the GUI's
@@ -190,6 +190,65 @@ describe('CommunityPluginsCard install states', () => {
     expect(screen.getByRole('button', { name: 'Copy install command' })).toBeTruthy()
   })
 
+  it('keeps a mutation refresh newer than an earlier list request', async () => {
+    const initialList = deferred<InstalledPluginItem[]>()
+    const list = vi.fn()
+      .mockImplementationOnce(() => initialList.promise)
+      .mockResolvedValue([INSTALLED_ROW])
+    const face = fakeFace({ list })
+    render(<CommunityPluginsCard {...cardProps(new FakeScope({}), [NPM_ENTRY], face)} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+    expect(await screen.findByText('Installed · restart to take effect')).toBeTruthy()
+
+    await act(async () => {
+      initialList.resolve([])
+      await initialList.promise
+    })
+    expect(screen.getByText('Installed · restart to take effect')).toBeTruthy()
+  })
+
+  it('ignores an install completion from a replaced plugin-manager face', async () => {
+    const pending = deferred<InstalledPluginItem>()
+    const previousFace = fakeFace({
+      install: vi.fn(() => pending.promise),
+      list: vi.fn(async () => []),
+    })
+    const currentFace = fakeFace({ list: vi.fn(async () => [INSTALLED_ROW]) })
+    const scope = new FakeScope({})
+    const view = render(<CommunityPluginsCard {...cardProps(scope, [NPM_ENTRY], previousFace)} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+    view.rerender(<CommunityPluginsCard {...cardProps(scope, [NPM_ENTRY], currentFace)} />)
+    expect(await screen.findByText('Installed · restart to take effect')).toBeTruthy()
+
+    await act(async () => {
+      pending.resolve(INSTALLED_ROW)
+      await pending.promise
+    })
+    expect(screen.getByText('Installed · restart to take effect')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Uninstall' })).toHaveProperty('disabled', false)
+  })
+
+  it('ignores an install failure from a replaced plugin-manager face', async () => {
+    const pending = deferred<InstalledPluginItem>()
+    const previousFace = fakeFace({ install: vi.fn(() => pending.promise) })
+    const currentFace = fakeFace()
+    const scope = new FakeScope({})
+    const view = render(<CommunityPluginsCard {...cardProps(scope, [NPM_ENTRY], previousFace)} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+    view.rerender(<CommunityPluginsCard {...cardProps(scope, [NPM_ENTRY], currentFace)} />)
+    await screen.findByRole('button', { name: 'Install' })
+
+    await act(async () => {
+      pending.reject(new Error('old connection failed'))
+      await pending.promise.catch(() => undefined)
+    })
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Install' })).toHaveProperty('disabled', false)
+  })
+
   it('shows the polled stage while installing and locks other cards', async () => {
     const pending = deferred<InstalledPluginItem>()
     const face = fakeFace({
@@ -221,6 +280,29 @@ describe('CommunityPluginsCard install states', () => {
     // The fresh snapshot has no row: the card returns to the install state.
     await screen.findByRole('button', { name: 'Install' })
     expect(screen.queryByText('Installed · restart to take effect')).toBeNull()
+  })
+
+  it('ignores an uninstall completion from a replaced plugin-manager face', async () => {
+    const pending = deferred<InstalledPluginItem[]>()
+    const previousFace = fakeFace({
+      list: vi.fn(async () => [INSTALLED_ROW]),
+      uninstall: vi.fn(() => pending.promise),
+    })
+    const currentFace = fakeFace({ list: vi.fn(async () => [INSTALLED_ROW]) })
+    const scope = new FakeScope({})
+    const view = render(<CommunityPluginsCard {...cardProps(scope, [NPM_ENTRY], previousFace)} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Uninstall' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Confirm uninstall' }))
+    view.rerender(<CommunityPluginsCard {...cardProps(scope, [NPM_ENTRY], currentFace)} />)
+    expect(await screen.findByText('Installed · restart to take effect')).toBeTruthy()
+
+    await act(async () => {
+      pending.resolve([])
+      await pending.promise
+    })
+    expect(screen.getByText('Installed · restart to take effect')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Uninstall' })).toHaveProperty('disabled', false)
   })
 
   it('shows a bilingual-keyed inline error when install fails', async () => {


### PR DESCRIPTION
## 摘要（Summary）

修复社区插件安装或卸载期间，`pluginManager` 服务被重新提供后，旧连接的异步结果仍会覆盖新连接插件状态的问题。

卡片现在按 `pluginManager` 提供代际隔离异步操作：连接切换或组件卸载后，旧安装、卸载、错误和进度结果不再更新当前界面，同时释放旧操作遗留的按钮锁和确认弹窗。列表刷新采用“后发请求优先”，避免较早发出的 `list` 请求晚返回后覆盖安装完成后的最新快照。

新增安装成功、安装失败、卸载成功及列表乱序四组回归测试。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他：`packages/dsh-community-plugins`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream main
git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5.6

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README，文档门禁已通过）。

## 贡献者版权声明（Contributor Copyright）

本 PR 不新增需要单独声明来源或许可的第三方资产。

## 新皮肤收录（New Skin）

不适用。本 PR 不新增或修改皮肤。

## 社区插件索引登记（Community Plugin Index）

不适用。本 PR 不新增社区插件条目或索引登记。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-community-plugins typecheck
pnpm --filter @linxin666/dsh-client-ui-community-plugins test
pnpm --filter @linxin666/dsh-client-ui-community-plugins build
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm sync-shared:check
pnpm aggregate:check
pnpm community:check
pnpm runtime-deps:check
git diff --check
```

结果摘要：

- 社区插件包类型检查、构建均通过。
- 社区插件包测试通过：4 个测试文件、37 个测试全部通过；本次定向回归测试 11/11 通过，竞态用例独立重复 5 次均通过。
- 全工作区类型检查通过。
- 文档、共享同步、聚合、社区索引和运行时依赖门禁均通过。
- 全工作区测试运行时，社区插件包 37/37 通过；随后仅在未改动的 `dsh-liangshen/tests/custom-bash.test.ts` 出现 2 个 Windows 路径格式断言失败。
- `test:scripts` 为 118 通过、9 失败、4 跳过；失败均为现有 Windows 路径/File URL 与 aggregate fixture 冲突，未涉及本 PR 文件。
- `git diff --check` 通过。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A。该修复不改变界面布局或视觉表现，异步先后顺序由确定性回归测试验证。
