### PR TITLE
feat(pet): voice-pack pool layer for status and whisper copy (#677)

### DIFF
--- a/packages/dsh-pet/src/chatter.test.ts
+++ b/packages/dsh-pet/src/chatter.test.ts
@@ -14,6 +14,7 @@ import {
   WHISPER_GENERIC_POOL,
   WHISPER_RULES,
   WhisperEngine,
+  type VoicePackOverrides,
 } from './chatter.ts'
 
 describe('StatusVoice', () => {
@@ -139,7 +140,7 @@ describe('WhisperEngine', () => {
   })
 
   it('earns an ambient whisper from output volume alone', () => {
-    const engine = new WhisperEngine(0, 10)
+    const engine = new WhisperEngine(undefined, 0, 10)
     expect(engine.feed('aaaaaaaa', 0)).toBeUndefined()
     expect(engine.feed('bbbb', 1)).toBe(WHISPER_GENERIC_POOL[0])
     // The counter resets after speaking: another budget must accumulate.
@@ -148,7 +149,82 @@ describe('WhisperEngine', () => {
   })
 
   it('ignores empty chunks', () => {
-    const engine = new WhisperEngine(0, 0)
+    const engine = new WhisperEngine(undefined, 0, 0)
     expect(engine.feed('', 0)).toBeUndefined()
+  })
+})
+
+describe('voice-pack overrides (pet-center M4)', () => {
+  const PACK = (): VoicePackOverrides => ({
+    status: {
+      done: ['自定义完工', '第二句完工'],
+      thinking: [],
+    },
+    tools: {
+      shell: ['敲命令 {hint}', '再来一次 {tool}'],
+    },
+    toolRemaining: ['后台还有 {n} 个'],
+    whispers: {
+      generic: ['自定义碎碎念 A', '自定义碎碎念 B'],
+      rules: [{ keywords: ['测试通过'], pool: ['自定义全绿'] }],
+    },
+  })
+
+  it('replaces a scene pool and keeps untouched scenes on the built-in pools', () => {
+    const voice = new StatusVoice(PACK)
+    expect(voice.scene('done', 0)).toBe('自定义完工')
+    expect(voice.scene('done', 5000)).toBe('第二句完工')
+    expect(voice.scene('thinking', 0)).toBe(STATUS_POOLS.thinking[0])
+  })
+
+  it('falls back to the built-in pool when the override pool is empty', () => {
+    const voice = new StatusVoice(PACK)
+    // PACK.thinking is an empty array: a scene line always renders.
+    expect(voice.scene('thinking', 0)).toBe(STATUS_POOLS.thinking[0])
+  })
+
+  it('interpolates placeholders from an overridden tool pool', () => {
+    const voice = new StatusVoice(PACK)
+    expect(voice.tool('bash', 'bash', 'npm test', 0)).toBe('敲命令 npm test')
+    const rotated = voice.tool('bash', 'bash', 'npm test', 5000)
+    expect(rotated).toBe('再来一次 bash')
+  })
+
+  it('uses an overridden remaining-tools pool', () => {
+    const voice = new StatusVoice(PACK)
+    expect(voice.toolRemaining(4, 0)).toBe('后台还有 4 个')
+  })
+
+  it('follows a provider swap on the next draw without rebuilding the engine', () => {
+    let pack: ReturnType<typeof PACK> = PACK()
+    const voice = new StatusVoice(() => pack)
+    expect(voice.scene('done', 0)).toBe('自定义完工')
+    pack = { ...PACK(), status: { done: ['换声了'] } }
+    expect(voice.scene('done', 5000)).toBe('换声了')
+  })
+
+  it('replaces the whisper rules as a whole', () => {
+    const engine = new WhisperEngine(PACK)
+    expect(engine.feed('这里有一个错误', 0)).toBeUndefined()
+    // The built-in error rule is gone; only the pack's rule fires.
+    expect(engine.feed('测试通过', 1000)).toBe('自定义全绿')
+  })
+
+  it('replaces the ambient generic pool', () => {
+    const engine = new WhisperEngine(PACK, 0, 3)
+    expect(engine.feed('aaaa', 0)).toBe('自定义碎碎念 A')
+    expect(engine.feed('bbbb', 1)).toBe('自定义碎碎念 B')
+  })
+
+  it('mutes ambient whispers when the generic pool is explicitly empty', () => {
+    const engine = new WhisperEngine(() => ({ whispers: { generic: [] } }), 0, 3)
+    expect(engine.feed('aaaa', 0)).toBeUndefined()
+    expect(engine.feed('bbbb', 1)).toBeUndefined()
+  })
+
+  it('disables keyword rules when the rules array is explicitly empty', () => {
+    const engine = new WhisperEngine(() => ({ whispers: { rules: [] } }), 0, 3)
+    // No keyword rule matches anymore; volume still earns a built-in ambient.
+    expect(engine.feed('测试通过', 0)).toBe(WHISPER_GENERIC_POOL[0])
   })
 })

--- a/packages/dsh-pet/src/chatter.ts
+++ b/packages/dsh-pet/src/chatter.ts
@@ -17,6 +17,11 @@
  * plugin has always shown, so existing installs keep their wording until the
  * scene cycles. No emoji anywhere (repository rule); ～ is the whale-girl's
  * signature.
+ *
+ * Since pet-center M4 (issue #677) every pool is overridable through a
+ * {@link VoicePoolsProvider}: the built-in pools are the fallback layer, and
+ * voice packs (per-pet voice.json / the global .voice.json) layer their
+ * pools on top at draw time.
  * @module @linxin666/dsh-pet/chatter
  */
 
@@ -438,7 +443,10 @@ export class StatusVoice {
   private lastLine = ''
   private lastLineAt = Number.NEGATIVE_INFINITY
 
-  constructor(private readonly rotateMs: number = STATUS_ROTATE_MS) {}
+  constructor(
+    private readonly pools: VoicePoolsProvider = () => BUILTIN_VOICE_PACK,
+    private readonly rotateMs: number = STATUS_ROTATE_MS,
+  ) {}
 
   /** Draw the next line of one pool, advancing its round-robin cursor. */
   private draw(poolKey: string, pool: readonly string[]): string {
@@ -456,15 +464,27 @@ export class StatusVoice {
     return this.lastLine
   }
 
+  /**
+   * A scene's effective pool: the voice-pack override when it carries lines,
+   * else the built-in pool. Empty overrides fall back rather than blank the
+   * bubble — a scene line always renders.
+   */
+  private scenePool(scene: StatusScene): readonly string[] {
+    const override = this.pools().status?.[scene]
+    return override !== undefined && override.length > 0 ? override : STATUS_POOLS[scene]
+  }
+
   /** Status line for a phase scene. */
   scene(scene: StatusScene, nowMs: number): string {
-    return this.voice('scene:' + scene, 'pool:' + scene, STATUS_POOLS[scene], nowMs)
+    return this.voice('scene:' + scene, 'pool:' + scene, this.scenePool(scene), nowMs)
   }
 
   /** Status line for a tool call, with the real-argument hint when known. */
   tool(toolName: string, displayName: string, hint: string | undefined, nowMs: number): string {
     const category = toolCategory(toolName)
-    const line = this.voice('tool:' + category, 'tool:' + category, TOOL_POOLS[category], nowMs)
+    const override = this.pools().tools?.[category]
+    const pool = override !== undefined && override.length > 0 ? override : TOOL_POOLS[category]
+    const line = this.voice('tool:' + category, 'tool:' + category, pool, nowMs)
     return line
       .replace('{tool}', displayName)
       .replace('{hint}', hint ?? displayName)
@@ -472,7 +492,9 @@ export class StatusVoice {
 
   /** Status line while sibling tools still run (always reflects the count). */
   toolRemaining(count: number, nowMs: number): string {
-    return this.voice('toolRemaining', 'toolRemaining', TOOL_REMAINING_POOL, nowMs)
+    const override = this.pools().toolRemaining
+    const pool = override !== undefined && override.length > 0 ? override : TOOL_REMAINING_POOL
+    return this.voice('toolRemaining', 'toolRemaining', pool, nowMs)
       .replace('{n}', String(count))
   }
 }
@@ -735,12 +757,54 @@ export const WHISPER_RULES: readonly WhisperRule[] = [
 ]
 
 /**
+ * Voice-pack overrides (pet-center M4, issue #677): the content a voice
+ * pack can replace, one pool at a time. Every field is optional — missing
+ * keys inherit the built-in pools. Resolution happens at draw time through
+ * a provider function, so swapping pets (or editing the global file) re-
+ * voices live engines without rebuilding them.
+ *
+ * Override semantics:
+ *  - status/tools/toolRemaining: a non-empty override replaces the built-in
+ *    pool for that key; an empty override falls back to the built-in pool
+ *    (a scene line always renders, so it can never be blanked).
+ *  - whispers.generic / whispers.rules: the override REPLACES the built-in
+ *    section; an empty array mutes that channel (ambient or keyword).
+ */
+export interface VoicePackOverrides {
+  /** Status copy pools by scene; each key replaces that scene's pool. */
+  status?: Partial<Record<StatusScene, readonly string[]>>
+  /** Tool copy pools by family; each key replaces that family's pool. */
+  tools?: Partial<Record<ToolCategory, readonly string[]>>
+  /** The parallel-tools count line pool ({n} interpolates the count). */
+  toolRemaining?: readonly string[]
+  /** Murmur pools; each section replaces the built-in one as a whole. */
+  whispers?: {
+    /** Ambient inner-whisper pool (empty mutes ambient whispers). */
+    generic?: readonly string[]
+    /** Ordered keyword rules (empty disables keyword-triggered whispers). */
+    rules?: readonly WhisperRule[]
+  }
+}
+
+/** Read the current effective voice-pack overrides (draw-time resolution). */
+export type VoicePoolsProvider = () => VoicePackOverrides
+
+/** The built-in voice pack: the plugin's default copy, unchanged since v1. */
+export const BUILTIN_VOICE_PACK: VoicePackOverrides = {
+  status: STATUS_POOLS,
+  tools: TOOL_POOLS,
+  toolRemaining: TOOL_REMAINING_POOL,
+  whispers: { generic: WHISPER_GENERIC_POOL, rules: WHISPER_RULES },
+}
+
+/**
  * The murmur engine (碎碎念): watches the model's own output and lets the pet
  * whisper its inner voice. Two ways to earn a whisper:
  *  - a keyword rule matches the fresh chunk text (themed whisper);
  *  - enough output volume flowed by without one (ambient whisper).
  * A cooldown keeps whispers occasional; all picks are round-robin so tests
- * reproduce exact lines.
+ * reproduce exact lines. The voice-pack provider (pet-center M4) swaps the
+ * pools at draw time, so a pet switch re-voices live engines in place.
  */
 export class WhisperEngine {
   private readonly counters = new Map<number, number>()
@@ -749,9 +813,25 @@ export class WhisperEngine {
   private charsSinceWhisper = 0
 
   constructor(
+    private readonly pools: VoicePoolsProvider = () => BUILTIN_VOICE_PACK,
     private readonly cooldownMs: number = WHISPER_COOLDOWN_MS,
     private readonly charBudget: number = WHISPER_CHAR_BUDGET,
   ) {}
+
+  /**
+   * Effective keyword rules: an override replaces the built-in rules as a
+   * whole; an explicit empty array disables keyword-triggered whispers.
+   */
+  private rules(): readonly WhisperRule[] {
+    const override = this.pools().whispers?.rules
+    return override === undefined ? WHISPER_RULES : override
+  }
+
+  /** Effective ambient pool (an explicit empty array mutes ambient whispers). */
+  private generic(): readonly string[] {
+    const override = this.pools().whispers?.generic
+    return override === undefined ? WHISPER_GENERIC_POOL : override
+  }
 
   /**
    * Feed one model-output chunk (reasoning or text). Returns the whisper to
@@ -765,8 +845,9 @@ export class WhisperEngine {
       return undefined
     }
     const haystack = text.toLowerCase()
-    for (let ruleIndex = 0; ruleIndex < WHISPER_RULES.length; ruleIndex += 1) {
-      const rule = WHISPER_RULES[ruleIndex]!
+    const rules = this.rules()
+    for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex += 1) {
+      const rule = rules[ruleIndex]!
       if (!rule.keywords.some(keyword => haystack.includes(keyword))) continue
       const index = (this.counters.get(ruleIndex) ?? 0) % rule.pool.length
       this.counters.set(ruleIndex, index + 1)
@@ -774,7 +855,9 @@ export class WhisperEngine {
     }
     this.charsSinceWhisper += text.length
     if (this.charsSinceWhisper < this.charBudget) return undefined
-    const line = WHISPER_GENERIC_POOL[this.genericCursor % WHISPER_GENERIC_POOL.length]!
+    const generic = this.generic()
+    if (generic.length === 0) return undefined
+    const line = generic[this.genericCursor % generic.length]!
     this.genericCursor += 1
     return this.speak(line, nowMs)
   }

--- a/packages/dsh-pet/src/event-projection.ts
+++ b/packages/dsh-pet/src/event-projection.ts
@@ -13,7 +13,7 @@
 
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import type { PetStateInput } from './state.ts'
-import { StatusVoice, toolArgHint, WhisperEngine } from './chatter.ts'
+import { StatusVoice, toolArgHint, WhisperEngine, type VoicePoolsProvider } from './chatter.ts'
 
 /** Runtime shape of the optional legacy activity event. */
 export interface ActivityStatusEventLike {
@@ -41,14 +41,19 @@ export interface PetActivityTransition {
   whisper?: string
 }
 
-/** Fresh projection runtime for a newly seen session. */
-export function emptyProjectionRuntime(): ProjectionRuntime {
+/**
+ * Fresh projection runtime for a newly seen session. The optional voice-pack
+ * provider (pet-center M4, issue #677) hands both chatter engines their
+ * pools; engines resolve overrides at draw time, so swapping the provider's
+ * pack re-voices live runtimes without rebuilding them.
+ */
+export function emptyProjectionRuntime(pools?: VoicePoolsProvider): ProjectionRuntime {
   return {
     activeTools: new Set(),
     officialEventsSeen: false,
     stepHadFailure: false,
-    voice: new StatusVoice(),
-    whispers: new WhisperEngine(),
+    voice: new StatusVoice(pools),
+    whispers: new WhisperEngine(pools),
   }
 }
 


### PR DESCRIPTION
## 摘要（Summary）

#677（宠物中心 M4 内容 DIY）第一层：把 `chatter.ts` 的状态池 / 工具池 / 碎碎念池抽成可注入的语音包层。内置文案逐字不变（仍是默认回落层），`StatusVoice` / `WhisperEngine` 构造器新增 voice-pack provider，绘制时解析覆盖池，为后续 voice.json / .voice.json 注入铺路。本 PR 无用户可见行为变更。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin main && git merge origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek-V3.2

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。（本 PR 未改 README，文档随 PR2/PR3 落地）

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-pet && pnpm typecheck && pnpm test
```

结果摘要：

- typecheck：通过（tsc -b + tsconfig.test.json）
- test：27 个文件 251 个用例全绿（chatter.test.ts 新增 9 个 provider 覆盖用例；既有用例未改期望值，证明内置文案零回归）

## 用户可见变更证据（Local Feature Evidence）

N/A（纯内部改动：默认 provider 指向内置池，无用户可见行为变更；用户可见部分在 #677 的 PR2/PR3 提供 GUI 证据）