### PR TITLE
feat(pet): voice.json packs and panel chrome through registry and service (#677)

### DIFF
--- a/packages/dsh-pet/contracts/voice-pack-v1.schema.json
+++ b/packages/dsh-pet/contracts/voice-pack-v1.schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.linxin666.org/dsh-pet/voice-pack-v1.schema.json",
+  "title": "DSH Pet Voice Pack v1",
+  "description": "Pet-center voice pack (issue #677). Optional voice.json inside a pet directory, or the global $DSH_HOME/pets/.voice.json override — pure JSON content layering status / tool / whisper copy over the built-in pools, plus hover-panel chrome. Structure is fail-closed per file (a non-object root drops the pack); content is warn-and-drop per slot.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "voicePackVersion": {
+      "const": 1,
+      "description": "Optional; absent reads as v1."
+    },
+    "status": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Status copy pools keyed by the eleven StatusScene ids; each key replaces that scene's built-in pool.",
+      "properties": {
+        "prepare": {
+          "$ref": "#/definitions/pool"
+        },
+        "waiting": {
+          "$ref": "#/definitions/pool"
+        },
+        "thinking": {
+          "$ref": "#/definitions/pool"
+        },
+        "review": {
+          "$ref": "#/definitions/pool"
+        },
+        "toolResult": {
+          "$ref": "#/definitions/pool"
+        },
+        "done": {
+          "$ref": "#/definitions/pool"
+        },
+        "failed": {
+          "$ref": "#/definitions/pool"
+        },
+        "toolFailed": {
+          "$ref": "#/definitions/pool"
+        },
+        "maxTokens": {
+          "$ref": "#/definitions/pool"
+        },
+        "interrupted": {
+          "$ref": "#/definitions/pool"
+        },
+        "blocked": {
+          "$ref": "#/definitions/pool"
+        }
+      }
+    },
+    "tools": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Tool copy pools keyed by the seventeen ToolCategory ids; {tool} and {hint} interpolate.",
+      "properties": {
+        "read": {
+          "$ref": "#/definitions/pool"
+        },
+        "write": {
+          "$ref": "#/definitions/pool"
+        },
+        "edit": {
+          "$ref": "#/definitions/pool"
+        },
+        "shell": {
+          "$ref": "#/definitions/pool"
+        },
+        "grep": {
+          "$ref": "#/definitions/pool"
+        },
+        "find": {
+          "$ref": "#/definitions/pool"
+        },
+        "ls": {
+          "$ref": "#/definitions/pool"
+        },
+        "webSearch": {
+          "$ref": "#/definitions/pool"
+        },
+        "webFetch": {
+          "$ref": "#/definitions/pool"
+        },
+        "mcp": {
+          "$ref": "#/definitions/pool"
+        },
+        "memory": {
+          "$ref": "#/definitions/pool"
+        },
+        "subagent": {
+          "$ref": "#/definitions/pool"
+        },
+        "todo": {
+          "$ref": "#/definitions/pool"
+        },
+        "browser": {
+          "$ref": "#/definitions/pool"
+        },
+        "git": {
+          "$ref": "#/definitions/pool"
+        },
+        "ask": {
+          "$ref": "#/definitions/pool"
+        },
+        "generic": {
+          "$ref": "#/definitions/pool"
+        }
+      }
+    },
+    "toolRemaining": {
+      "$ref": "#/definitions/pool",
+      "description": "The parallel-tools count line pool; {n} interpolates the count."
+    },
+    "whispers": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Murmur pools; each section replaces the built-in one as a whole. An explicit empty array mutes that channel.",
+      "properties": {
+        "generic": {
+          "$ref": "#/definitions/pool"
+        },
+        "rules": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "keywords",
+              "pool"
+            ],
+            "properties": {
+              "keywords": {
+                "type": "array",
+                "maxItems": 16,
+                "items": {
+                  "type": "string",
+                  "maxLength": 40,
+                  "minLength": 1
+                },
+                "description": "Lowercase substrings matched against the model's output."
+              },
+              "pool": {
+                "$ref": "#/definitions/pool"
+              }
+            }
+          }
+        }
+      }
+    },
+    "panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Hover-panel chrome; unset slots keep the client's i18n dictionary copy.",
+      "properties": {
+        "labels": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "feed": {
+              "type": "string",
+              "maxLength": 40
+            },
+            "rename": {
+              "type": "string",
+              "maxLength": 40
+            },
+            "hide": {
+              "type": "string",
+              "maxLength": 40
+            },
+            "confirm": {
+              "type": "string",
+              "maxLength": 40
+            }
+          }
+        },
+        "stats": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "{rank} / {n} / {points} interpolate the live values.",
+          "properties": {
+            "rank": {
+              "type": "string",
+              "maxLength": 80
+            },
+            "treats": {
+              "type": "string",
+              "maxLength": 80
+            },
+            "points": {
+              "type": "string",
+              "maxLength": 80
+            }
+          }
+        },
+        "actions": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "feed",
+              "rename",
+              "hide"
+            ]
+          },
+          "description": "Subset of actions to render in canonical order; absent = all three, [] = none."
+        }
+      }
+    }
+  },
+  "definitions": {
+    "pool": {
+      "oneOf": [
+        {
+          "type": "string",
+          "maxLength": 160
+        },
+        {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "maxLength": 160
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/dsh-pet/src/chatter.ts
+++ b/packages/dsh-pet/src/chatter.ts
@@ -198,6 +198,18 @@ export type ToolCategory =
   | 'ask'
   | 'generic'
 
+/** Every status scene key, in declaration order (voice-pack key allow-list). */
+export const STATUS_SCENES: readonly StatusScene[] = [
+  'prepare', 'waiting', 'thinking', 'review', 'toolResult', 'done',
+  'failed', 'toolFailed', 'maxTokens', 'interrupted', 'blocked',
+]
+
+/** Every tool-family key, in declaration order (voice-pack key allow-list). */
+export const TOOL_CATEGORIES: readonly ToolCategory[] = [
+  'read', 'write', 'edit', 'shell', 'grep', 'find', 'ls', 'webSearch',
+  'webFetch', 'mcp', 'memory', 'subagent', 'todo', 'browser', 'git', 'ask', 'generic',
+]
+
 /** Map a raw tool name onto its copy family (working-activity style regexes). */
 export function toolCategory(toolName: string): ToolCategory {
   const name = toolName.toLowerCase()
@@ -438,15 +450,19 @@ export function toolArgHint(toolName: string, argumentsJson: string): string | u
  * stretch keeps changing its wording.
  */
 export class StatusVoice {
+  private readonly pools: VoicePoolsProvider
+  private readonly rotateMs: number
   private readonly counters = new Map<string, number>()
   private lastScene = ''
   private lastLine = ''
   private lastLineAt = Number.NEGATIVE_INFINITY
 
-  constructor(
-    private readonly pools: VoicePoolsProvider = () => BUILTIN_VOICE_PACK,
-    private readonly rotateMs: number = STATUS_ROTATE_MS,
-  ) {}
+  constructor(pools: VoicePoolsProvider = () => BUILTIN_VOICE_PACK, rotateMs: number = STATUS_ROTATE_MS) {
+    // Plain property assignment, not parameter properties: this module is
+    // imported by scripts/ under node's strip-only mode (pet-center M4).
+    this.pools = pools
+    this.rotateMs = rotateMs
+  }
 
   /** Draw the next line of one pool, advancing its round-robin cursor. */
   private draw(poolKey: string, pool: readonly string[]): string {
@@ -807,16 +823,23 @@ export const BUILTIN_VOICE_PACK: VoicePackOverrides = {
  * pools at draw time, so a pet switch re-voices live engines in place.
  */
 export class WhisperEngine {
+  private readonly pools: VoicePoolsProvider
+  private readonly cooldownMs: number
+  private readonly charBudget: number
   private readonly counters = new Map<number, number>()
   private genericCursor = 0
   private lastWhisperAt = Number.NEGATIVE_INFINITY
   private charsSinceWhisper = 0
 
   constructor(
-    private readonly pools: VoicePoolsProvider = () => BUILTIN_VOICE_PACK,
-    private readonly cooldownMs: number = WHISPER_COOLDOWN_MS,
-    private readonly charBudget: number = WHISPER_CHAR_BUDGET,
-  ) {}
+    pools: VoicePoolsProvider = () => BUILTIN_VOICE_PACK,
+    cooldownMs: number = WHISPER_COOLDOWN_MS,
+    charBudget: number = WHISPER_CHAR_BUDGET,
+  ) {
+    this.pools = pools
+    this.cooldownMs = cooldownMs
+    this.charBudget = charBudget
+  }
 
   /**
    * Effective keyword rules: an override replaces the built-in rules as a

--- a/packages/dsh-pet/src/registry.test.ts
+++ b/packages/dsh-pet/src/registry.test.ts
@@ -465,3 +465,76 @@ describe('loadPetRegistry pet-center v2 (issue #623)', () => {
     }
   })
 })
+
+describe('voice packs (pet-center M4, issue #677)', () => {
+  function writeVoice(dir: string, name: string, pack: unknown): void {
+    mkdirSync(join(dir, name), { recursive: true })
+    writeFileSync(join(dir, name, 'pet.json'), JSON.stringify({ id: name, displayName: name, spritesheetPath: 'spritesheet.webp' }), 'utf8')
+    writeFileSync(join(dir, name, 'spritesheet.webp'), 'webp', 'utf8')
+    writeFileSync(join(dir, name, 'voice.json'), JSON.stringify(pack), 'utf8')
+  }
+
+  it('loads a pet voice.json and serves its panel slice to the browser view', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      writeVoice(petsDir, 'talker', {
+        status: { done: ['自定义完工'] },
+        panel: { labels: { feed: '投喂' }, stats: { rank: '好感 {rank}' }, actions: ['feed'] },
+      })
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      const entry = registry.byId('talker')!
+      expect(entry.voice?.overrides.status?.done).toEqual(['自定义完工'])
+      const view = petEntryView(entry)
+      expect(view.panel).toEqual({
+        labels: { feed: '投喂' },
+        stats: { rank: '好感 {rank}' },
+        actions: ['feed'],
+      })
+      // Host-only voice content never reaches the browser half.
+      expect('voice' in view).toBe(false)
+      // A healthy voice pack records no diagnostics of its own.
+      expect(registry.diagnostics.filter(d => d.message.includes('voice'))).toEqual([])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('warns and drops a broken voice.json without rejecting the pet', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      mkdirSync(join(petsDir, 'mumbler'), { recursive: true })
+      writeFileSync(join(petsDir, 'mumbler', 'pet.json'), JSON.stringify({ id: 'mumbler', displayName: 'Mumbler', spritesheetPath: 'spritesheet.webp' }), 'utf8')
+      writeFileSync(join(petsDir, 'mumbler', 'spritesheet.webp'), 'webp', 'utf8')
+      writeFileSync(join(petsDir, 'mumbler', 'voice.json'), '{ not json', 'utf8')
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('mumbler')).toBeDefined()
+      expect(registry.byId('mumbler')!.voice).toBeUndefined()
+      expect(registry.diagnostics.some(d => d.level === 'warning' && d.message.includes('voice pack is not valid JSON'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('loads the global .voice.json override from the DSH_HOME pets dir', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      mkdirSync(join(petsDir, 'plain'), { recursive: true })
+      writeFileSync(join(petsDir, 'plain', 'pet.json'), JSON.stringify({ id: 'plain', displayName: 'Plain', spritesheetPath: 'spritesheet.webp' }), 'utf8')
+      writeFileSync(join(petsDir, 'plain', 'spritesheet.webp'), 'webp', 'utf8')
+      writeFileSync(join(petsDir, '.voice.json'), JSON.stringify({
+        status: { done: ['全局完工'] },
+        panel: { labels: { hide: '全局藏' } },
+      }), 'utf8')
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: petsDir })
+      expect(registry.globalVoice?.overrides.status?.done).toEqual(['全局完工'])
+      expect(registry.globalVoice?.panel?.labels).toEqual({ hide: '全局藏' })
+      // The dotfile itself is never scanned as a pet directory.
+      expect(registry.entries.map(e => e.id)).toEqual(['plain'])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/dsh-pet/src/registry.ts
+++ b/packages/dsh-pet/src/registry.ts
@@ -33,6 +33,7 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ActivityPhase, PetAnimation } from './state.ts'
 import { normalizePetRemarks, type PetRemarks, type PetRemarksManifest } from './remarks.ts'
+import { normalizeVoicePack, type PetPanelView, type VoicePack } from './voice-pack.ts'
 import { dshHome } from './dsh-home.ts'
 import { parsePetManifest, type PetManifestLive2d, type PetManifestV2, type PetRendererKind } from './manifest-v2.ts'
 import { collectModel3References } from './model3.ts'
@@ -212,6 +213,8 @@ export interface PetDefinition {
   atlasUrl: string
   /** Browser URL of the manifest (served by the host asset route). */
   manifestUrl: string
+  /** Hover-panel chrome overrides (voice.json 'panel'; pet-center M4). */
+  panel?: PetPanelView
 }
 
 /** A resolved pet plus its host-side file location. */
@@ -228,6 +231,11 @@ export interface PetEntry extends PetDefinition {
   servable: readonly string[]
   /** Normalized per-pet remark pools (manifest 'remarks'), when declared. */
   remarks?: PetRemarks
+  /**
+   * Normalized per-pet voice pack (the directory's voice.json; pet-center
+   * M4). Host-side only — the browser half receives its 'panel' slice.
+   */
+  voice?: VoicePack
 }
 
 /** Registry load result: resolved entries plus load warnings. */
@@ -239,6 +247,11 @@ export interface PetRegistry {
   byId(id: string): PetEntry | undefined
   /** The pet an installation falls back to when the selection is unknown. */
   defaultEntry(): PetEntry
+  /**
+   * The global voice override ('$DSH_HOME/pets/.voice.json'), when present —
+   * layers under every per-pet pack and over the built-in pools (M4, #677).
+   */
+  globalVoice?: VoicePack
 }
 
 /** One structured registry diagnostic (manifest-v2 era). */
@@ -551,20 +564,23 @@ function scanPetDir(dir: string, options: { assetPrefix?: string; warnings?: str
       options.warnings?.push(diagnostic.message)
     }
     if (!verdict.ok) continue
+    let entry: PetEntry | undefined
     if (verdict.manifest.renderer === 'live2d') {
-      const entry = resolveLive2dEntry(verdict.manifest, entryDir, options)
-      if (entry !== undefined) entries.push(entry)
-      continue
+      entry = resolveLive2dEntry(verdict.manifest, entryDir, options)
+    } else {
+      const legacy = flattenV2Sprite2d(verdict.manifest)
+      if (legacy === undefined) {
+        const note = 'pet ' + verdict.manifest.id + ': sprite2d.atlasRows only supports 9 or 11 under the v1 compat resolver'
+        options.diagnostics?.push({ level: 'error', source: entryDir, message: note })
+        options.warnings?.push(note)
+        continue
+      }
+      entry = resolvePetManifest(legacy, entryDir, options)
     }
-    const legacy = flattenV2Sprite2d(verdict.manifest)
-    if (legacy === undefined) {
-      const note = 'pet ' + verdict.manifest.id + ': sprite2d.atlasRows only supports 9 or 11 under the v1 compat resolver'
-      options.diagnostics?.push({ level: 'error', source: entryDir, message: note })
-      options.warnings?.push(note)
-      continue
-    }
-    const entry = resolvePetManifest(legacy, entryDir, options)
-    if (entry !== undefined) entries.push(entry)
+    if (entry === undefined) continue
+    // Optional voice pack (voice.json) — pure content, warn-and-drop (M4).
+    const voice = loadVoicePackFile(join(entryDir, 'voice.json'), options)
+    entries.push({ ...entry, ...(voice === undefined ? {} : { voice }) })
   }
   return entries
 }
@@ -577,6 +593,30 @@ function readPetJson(file: string, warnings: string[] | undefined): unknown {
     warnings?.push('skipping ' + file + ': ' + (error instanceof Error ? error.message : String(error)))
     return undefined
   }
+}
+
+/**
+ * Load and normalize one optional voice.json (pet-center M4). A missing
+ * file is silent; a broken file warns and drops. The pack is pure content,
+ * so every issue stays a warning — a bad voice.json never rejects a pet.
+ */
+function loadVoicePackFile(
+  file: string,
+  options: { warnings?: string[]; diagnostics?: PetRegistryDiagnostic[] },
+): VoicePack | undefined {
+  if (!existsSync(file)) return undefined
+  const warn = (message: string): void => {
+    options.warnings?.push(file + ': ' + message)
+    options.diagnostics?.push({ level: 'warning', source: file, message: file + ': ' + message })
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(file, 'utf8'))
+  } catch (error) {
+    warn('voice pack is not valid JSON; ignored: ' + (error instanceof Error ? error.message : String(error)))
+    return undefined
+  }
+  return normalizeVoicePack(raw, warn)
 }
 
 /**
@@ -611,11 +651,14 @@ export function loadPetRegistry(options: PetRegistryOptions): PetRegistry {
 
   // The pet-center user directory ranks above the legacy hatch-pet source.
   const dshPetsDir = options.dshPetsDir ?? join(dshHome(), 'pets')
+  let globalVoice: VoicePack | undefined
   if (dshPetsDir !== '') {
     for (const entry of scanPetDir(dshPetsDir, { assetPrefix, warnings, diagnostics })) {
       if (byId.has(entry.id)) warnings.push('user pet ' + entry.id + ' overrides an earlier registration')
       byId.set(entry.id, entry)
     }
+    // The global voice override layers under every per-pet pack (M4, #677).
+    globalVoice = loadVoicePackFile(join(dshPetsDir, '.voice.json'), { warnings, diagnostics })
   }
 
   for (const manifest of options.extra ?? []) {
@@ -643,6 +686,7 @@ export function loadPetRegistry(options: PetRegistryOptions): PetRegistry {
     diagnostics,
     byId: (id: string) => byId.get(id),
     defaultEntry: () => entries.find(entry => builtinIds.has(entry.id)) ?? entries[0]!,
+    ...(globalVoice === undefined ? {} : { globalVoice }),
   }
 }
 
@@ -662,6 +706,7 @@ export function petEntryView(entry: PetEntry): PetDefinition {
     ...(entry.sequences === undefined ? {} : { sequences: entry.sequences }),
     atlasUrl: entry.atlasUrl,
     manifestUrl: entry.manifestUrl,
+    ...(entry.voice?.panel === undefined ? {} : { panel: entry.voice.panel }),
   }
 }
 

--- a/packages/dsh-pet/src/service.ts
+++ b/packages/dsh-pet/src/service.ts
@@ -44,7 +44,8 @@ import {
   type PetRegistry,
   type PetRegistryDiagnostic,
 } from './registry.ts'
-import { WHISPER_TTL_MS } from './chatter.ts'
+import { WHISPER_TTL_MS, type VoicePackOverrides, type VoicePoolsProvider } from './chatter.ts'
+import { mergeVoicePacks } from './voice-pack.ts'
 import {
   defaultPetStateConfig,
   PetStateMachine,
@@ -204,6 +205,12 @@ export class PetService extends Service {
   /** Session whose most recent meaningful event currently drives the global pet. */
   private displaySession: Session | undefined
   /**
+   * Effective voice-pack overrides for the currently selected pet (M4,
+   * #677). Cached per pet id; the registry is an immutable snapshot, so the
+   * global pack and each entry's pack cannot change behind the cache.
+   */
+  private voiceCache: { petId: string; overrides: VoicePackOverrides } | undefined
+  /**
    * Per-session activity, most recent last (Map insertion order). Bounded by
    * MAX_SESSION_BUBBLES so a burst of sessions cannot grow it without bound;
    * disposed sessions are removed by the 'session/disposed' listener.
@@ -239,6 +246,23 @@ export class PetService extends Service {
     this.enabled = config.enabled ?? true
 
     this.syncActivity()
+  }
+
+  /**
+   * The draw-time voice-pool provider handed to every projection runtime.
+   * It re-resolves when the selected pet changes, so live engines re-voice
+   * on the next draw without being rebuilt (M4, #677).
+   */
+  private voicePools(): VoicePoolsProvider {
+    return () => {
+      const entry = this.activeEntry()
+      if (this.voiceCache !== undefined && this.voiceCache.petId === entry.id) {
+        return this.voiceCache.overrides
+      }
+      const overrides = mergeVoicePacks(this.registry.globalVoice, entry.voice)?.overrides ?? {}
+      this.voiceCache = { petId: entry.id, overrides }
+      return overrides
+    }
   }
 
   /** Whether the pet service consumes session activity while enabled. */
@@ -370,7 +394,7 @@ export class PetService extends Service {
     let activity = this.sessionActivity.get(session)
     if (activity === undefined) {
       activity = {
-        runtime: emptyProjectionRuntime(),
+        runtime: emptyProjectionRuntime(this.voicePools()),
         machine: new PetStateMachine(this.stateConfig),
       }
       this.sessionActivity.set(session, activity)

--- a/packages/dsh-pet/src/voice-pack.test.ts
+++ b/packages/dsh-pet/src/voice-pack.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Voice-pack unit tests (pet-center M4, issue #677): normalization rules
+ * (structure fail-closed per file, content warn-and-drop per slot), the
+ * per-kind placeholder whitelists, and the layer merge precedence
+ * (later layers win per slot).
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  mergeVoicePacks,
+  normalizePanel,
+  normalizePool,
+  normalizeVoicePack,
+  normalizeWhisperRules,
+  VOICE_LINE_MAX,
+} from './voice-pack.ts'
+
+function collectWarnings(pack: unknown): { pack: ReturnType<typeof normalizeVoicePack>; warnings: string[] } {
+  const warnings: string[] = []
+  const result = normalizeVoicePack(pack, message => warnings.push(message))
+  return { pack: result, warnings }
+}
+
+describe('normalizeVoicePack structure', () => {
+  it('accepts a minimal pack and drops it when nothing usable remains', () => {
+    expect(normalizeVoicePack({})).toBeUndefined()
+    expect(normalizeVoicePack({ status: { done: ['收工'] } })).toBeDefined()
+  })
+
+  it('rejects a non-object root with a warning (fail-closed per file)', () => {
+    const { pack, warnings } = collectWarnings(['not', 'an', 'object'])
+    expect(pack).toBeUndefined()
+    expect(warnings[0]).toContain('must be a JSON object')
+  })
+
+  it('warns on unknown top-level fields and unknown voicePackVersion', () => {
+    const { pack, warnings } = collectWarnings({
+      voicePackVersion: 99,
+      mystery: true,
+      status: { done: ['收工'] },
+    })
+    expect(pack).toBeDefined()
+    expect(warnings.join('\n')).toContain('mystery')
+    expect(warnings.join('\n')).toContain('voicePackVersion')
+  })
+})
+
+describe('normalizePool', () => {
+  it('accepts a single string and arrays, dropping non-string entries', () => {
+    const warnings: string[] = []
+    expect(normalizePool('一行', 'status', m => warnings.push(m))).toEqual(['一行'])
+    expect(normalizePool(['一', 7, '二'], 'status', m => warnings.push(m))).toEqual(['一', '二'])
+    expect(warnings.join('\n')).toContain('non-string')
+  })
+
+  it('caps pool length and truncates long lines', () => {
+    const lines = Array.from({ length: 80 }, (_, i) => '行' + i)
+    const warnings: string[] = []
+    const pool = normalizePool(lines, 'status', m => warnings.push(m))
+    expect(pool).toHaveLength(64)
+    expect(warnings.join('\n')).toContain('extra lines')
+    expect(normalizePool(['x'.repeat(500)], 'status')?.[0]).toHaveLength(VOICE_LINE_MAX)
+  })
+
+  it('drops lines carrying placeholders the pool kind does not allow', () => {
+    const warnings: string[] = []
+    const pool = normalizePool(['好的 {tool}', '干净的'], 'status', m => warnings.push(m))
+    expect(pool).toEqual(['干净的'])
+    expect(warnings.join('\n')).toContain('unsupported placeholder')
+  })
+
+  it('keeps allowed placeholders per kind', () => {
+    expect(normalizePool(['跑 {hint}', '用 {tool}'], 'tools')![0]).toBe('跑 {hint}')
+    expect(normalizePool(['还有 {n} 个'], 'toolRemaining')![0]).toBe('还有 {n} 个')
+    expect(normalizePool(['好感 {rank}'], 'stat')![0]).toBe('好感 {rank}')
+  })
+
+  it('preserves an explicit empty array (mute semantics) but not absent', () => {
+    expect(normalizePool([], 'whisperGeneric')).toEqual([])
+    expect(normalizePool(undefined, 'whisperGeneric')).toBeUndefined()
+  })
+})
+
+describe('normalizeWhisperRules', () => {
+  it('lowercases and trims keywords, drops unusable rules', () => {
+    const warnings: string[] = []
+    const rules = normalizeWhisperRules([
+      { keywords: ['  测试通过  ', 7], pool: ['全绿'] },
+      { keywords: [], pool: ['没有关键词'] },
+      { keywords: ['有词'], pool: [] },
+    ], m => warnings.push(m))
+    expect(rules).toEqual([{ keywords: ['测试通过'], pool: ['全绿'] }])
+    expect(warnings.length).toBeGreaterThan(0)
+  })
+
+  it('caps the rule count and keyword count', () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({ keywords: ['k' + i], pool: ['p'] }))
+    expect(normalizeWhisperRules(many)).toHaveLength(32)
+    expect(normalizeWhisperRules([{ keywords: Array.from({ length: 20 }, (_, i) => 'k' + i), pool: ['p'] }])![0]!.keywords).toHaveLength(16)
+  })
+
+  it('returns an explicit empty array (disables the keyword channel)', () => {
+    expect(normalizeWhisperRules([])).toEqual([])
+  })
+})
+
+describe('normalizePanel', () => {
+  it('normalizes labels, stats and the action subset', () => {
+    const panel = normalizePanel({
+      labels: { feed: '投喂', confirm: '好的', bogus: 'x' },
+      stats: { rank: '好感 {rank}', points: '{points} 分' },
+      actions: ['hide', 'feed', 'hide', 'bogus'],
+    })
+    expect(panel?.labels).toEqual({ feed: '投喂', confirm: '好的' })
+    expect(panel?.stats).toEqual({ rank: '好感 {rank}', points: '{points} 分' })
+    expect(panel?.actions).toEqual(['feed', 'hide'])
+  })
+
+  it('rejects non-string labels and labels carrying placeholders', () => {
+    const warnings: string[] = []
+    const panel = normalizePanel({ labels: { feed: 3, rename: '改名 {tool}' } }, m => warnings.push(m))
+    expect(panel?.labels).toBeUndefined()
+    expect(warnings.length).toBe(2)
+  })
+
+  it('keeps an explicit empty action list (hides every action)', () => {
+    expect(normalizePanel({ actions: [] })?.actions).toEqual([])
+  })
+})
+
+describe('mergeVoicePacks', () => {
+  it('merges per-key with later layers winning', () => {
+    const global = normalizeVoicePack({
+      status: { done: ['全局收工'], thinking: ['全局思考'] },
+      panel: { labels: { feed: '全局投喂' } },
+    })
+    const pet = normalizeVoicePack({
+      status: { done: ['宠物收工'] },
+      panel: { labels: { feed: '宠物投喂', hide: '宠物藏' } },
+    })
+    const merged = mergeVoicePacks(global, pet)
+    expect(merged?.overrides.status?.done).toEqual(['宠物收工'])
+    expect(merged?.overrides.status?.thinking).toEqual(['全局思考'])
+    expect(merged?.panel?.labels).toEqual({ feed: '宠物投喂', hide: '宠物藏' })
+  })
+
+  it('lets the pet pack replace whisper sections while the global stays', () => {
+    const global = normalizeVoicePack({ whispers: { generic: ['全局碎碎念'] } })
+    const pet = normalizeVoicePack({ whispers: { rules: [{ keywords: ['测试'], pool: ['宠物全绿'] }] } })
+    const merged = mergeVoicePacks(global, pet)
+    expect(merged?.overrides.whispers?.generic).toEqual(['全局碎碎念'])
+    expect(merged?.overrides.whispers?.rules).toEqual([{ keywords: ['测试'], pool: ['宠物全绿'] }])
+  })
+
+  it('returns undefined when every layer is empty', () => {
+    expect(mergeVoicePacks(undefined, undefined)).toBeUndefined()
+  })
+})

--- a/packages/dsh-pet/src/voice-pack.ts
+++ b/packages/dsh-pet/src/voice-pack.ts
@@ -1,0 +1,405 @@
+/**
+ * Voice-pack normalization and merge (pet-center M4, issue #677).
+ *
+ * A voice pack is the optional 'voice.json' inside a pet directory, or the
+ * global '$DSH_HOME/pets/.voice.json' override file — pure JSON content that
+ * layers pet copy over the built-in pools. Two halves:
+ *
+ *  - 'overrides': the chatter pools (status / tools / toolRemaining /
+ *    whispers) handed to the chatter engines through a VoicePoolsProvider;
+ *  - 'panel': the hover-panel chrome (button labels, stat formats, action
+ *    subset) served to the browser half through PetDefinition.panel.
+ *
+ * Discipline split matches the registry: STRUCTURE is fail-closed per file
+ * (a non-object root drops the whole pack with a warning), CONTENT is
+ * warn-and-drop per slot — one bad line never breaks a pet. The JSON Schema
+ * twin lives at contracts/voice-pack-v1.schema.json for documentation and
+ * external tooling; this hand-rolled normalizer is authoritative (the
+ * repository ships no schema-validator runtime).
+ *
+ * Placeholder policy (each pool kind whitelists its own tokens):
+ *  - status / whisper pools / panel labels: no placeholders allowed — a line
+ *    carrying any '{...}' token is dropped with a warning;
+ *  - tools: {tool} and {hint}; toolRemaining: {n}; panel stats:
+ *    {rank} / {n} / {points}.
+ *
+ * This file is imported directly by scripts/dsh-pet under node's strip-only
+ * TypeScript mode: keep it erasable-syntax-only.
+ * @module @linxin666/dsh-pet/voice-pack
+ */
+
+import {
+  STATUS_SCENES,
+  TOOL_CATEGORIES,
+  type VoicePackOverrides,
+  type WhisperRule,
+} from './chatter.ts'
+
+/** Schema version this module normalizes (optional field; missing = 1). */
+export const VOICE_PACK_V1 = 1 as const
+
+/** Hover-panel action buttons a pack can show or hide (canonical order). */
+export const PANEL_ACTIONS = ['feed', 'rename', 'hide'] as const
+export type PanelAction = (typeof PANEL_ACTIONS)[number]
+
+/** Panel label slots (unset slots keep the client's i18n dictionary copy). */
+export const PANEL_LABEL_KEYS = ['feed', 'rename', 'hide', 'confirm'] as const
+export type PanelLabelKey = (typeof PANEL_LABEL_KEYS)[number]
+
+/** Panel stat slots ({rank}/{n}/{points} interpolate the live values). */
+export const PANEL_STAT_KEYS = ['rank', 'treats', 'points'] as const
+export type PanelStatKey = (typeof PANEL_STAT_KEYS)[number]
+
+/** Hover-panel chrome overrides served to the browser half. */
+export interface PetPanelView {
+  /** Button / input labels; unset slots keep the i18n dictionary copy. */
+  labels?: Partial<Record<PanelLabelKey, string>>
+  /** Stat line formats; unset slots keep the i18n dictionary copy. */
+  stats?: Partial<Record<PanelStatKey, string>>
+  /** Actions to render in canonical order; absent = all three; [] = none. */
+  actions?: PanelAction[]
+}
+
+/** One normalized voice pack (a pet's voice.json or the global override). */
+export interface VoicePack {
+  /** Chatter pool overrides (draw-time merged with the built-in pools). */
+  overrides: VoicePackOverrides
+  /** Hover-panel chrome, when the pack declares any. */
+  panel?: PetPanelView
+}
+
+/** Hard caps shared by every pool slot (mirrors the remarks discipline). */
+export const VOICE_POOL_LINES_MAX = 64
+export const VOICE_LINE_MAX = 160
+export const VOICE_KEYWORDS_PER_RULE_MAX = 16
+export const VOICE_KEYWORD_MAX = 40
+export const VOICE_RULES_MAX = 32
+export const VOICE_LABEL_MAX = 40
+export const VOICE_STAT_MAX = 80
+
+/** Any '{token}' placeholder (no nesting, no newlines). */
+const PLACEHOLDER_PATTERN = /{[^{}]*}/g
+
+/** Allowed placeholder tokens per pool kind (absent kind = none allowed). */
+const PLACEHOLDER_WHITELIST: Partial<Record<PoolKind, readonly string[]>> = {
+  tools: ['{tool}', '{hint}'],
+  toolRemaining: ['{n}'],
+  stat: ['{rank}', '{n}', '{points}'],
+}
+
+type PoolKind = 'status' | 'tools' | 'toolRemaining' | 'whisperGeneric' | 'whisperRule' | 'label' | 'stat'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Trim, length-cap and placeholder-check one copy line; undefined to drop. */
+function normalizeLine(raw: string, kind: PoolKind, onWarning: (message: string) => void): string | undefined {
+  const trimmed = raw.trim()
+  if (trimmed === '') return undefined
+  const capped = trimmed.length > VOICE_LINE_MAX ? trimmed.slice(0, VOICE_LINE_MAX) : trimmed
+  const allowed = PLACEHOLDER_WHITELIST[kind]
+  const tokens = capped.match(PLACEHOLDER_PATTERN) ?? []
+  for (const token of tokens) {
+    if (allowed?.includes(token) === true) continue
+    const preview = capped.length > 40 ? capped.slice(0, 40) + '...' : capped
+    onWarning('line dropped (unsupported placeholder ' + token + '): ' + preview)
+    return undefined
+  }
+  return capped
+}
+
+/**
+ * Normalize one pool slot. Accepts a single line or an array; non-string
+ * entries warn and drop, empty lines drop silently, lines over the length
+ * cap truncate, illegal placeholders drop the line, and pools over the line
+ * cap keep their first lines. An explicit empty pool normalizes to [] (the
+ * whisper channels read that as mute) while an absent slot normalizes to
+ * undefined (the slot keeps the built-in pool).
+ */
+export function normalizePool(
+  raw: unknown,
+  kind: PoolKind,
+  onWarning: (message: string) => void = () => {},
+): string[] | undefined {
+  if (raw === undefined) return undefined
+  const entries = typeof raw === 'string' ? [raw] : Array.isArray(raw) ? raw : undefined
+  if (entries === undefined) {
+    onWarning('pool must be a string or an array of strings')
+    return undefined
+  }
+  if (entries.length > VOICE_POOL_LINES_MAX) {
+    onWarning('pool has more than ' + VOICE_POOL_LINES_MAX + ' lines; extra lines are ignored')
+  }
+  const pool: string[] = []
+  for (const entry of entries.slice(0, VOICE_POOL_LINES_MAX)) {
+    if (typeof entry !== 'string') {
+      onWarning('non-string pool entry dropped')
+      continue
+    }
+    const line = normalizeLine(entry, kind, onWarning)
+    if (line !== undefined) pool.push(line)
+  }
+  return pool
+}
+
+/** Normalize the ordered keyword-rule list ([] disables the keyword channel). */
+export function normalizeWhisperRules(
+  raw: unknown,
+  onWarning: (message: string) => void = () => {},
+): WhisperRule[] | undefined {
+  if (raw === undefined) return undefined
+  if (!Array.isArray(raw)) {
+    onWarning('whispers.rules must be an array')
+    return undefined
+  }
+  if (raw.length > VOICE_RULES_MAX) {
+    onWarning('whispers.rules has more than ' + VOICE_RULES_MAX + ' rules; extra rules are ignored')
+  }
+  const rules: WhisperRule[] = []
+  for (const item of raw.slice(0, VOICE_RULES_MAX)) {
+    if (!isRecord(item)) {
+      onWarning('whisper rule must be an object')
+      continue
+    }
+    for (const key of Object.keys(item)) {
+      if (key !== 'keywords' && key !== 'pool') onWarning('unknown whisper rule field ' + key + ' ignored')
+    }
+    const keywordsRaw: unknown = item.keywords
+    const keywords: string[] = []
+    if (Array.isArray(keywordsRaw)) {
+      for (const entry of keywordsRaw.slice(0, VOICE_KEYWORDS_PER_RULE_MAX)) {
+        if (typeof entry !== 'string') {
+          onWarning('non-string keyword dropped')
+          continue
+        }
+        const trimmed = entry.trim().toLowerCase().slice(0, VOICE_KEYWORD_MAX)
+        if (trimmed !== '') keywords.push(trimmed)
+      }
+      if (keywordsRaw.length > VOICE_KEYWORDS_PER_RULE_MAX) {
+        onWarning('rule has more than ' + VOICE_KEYWORDS_PER_RULE_MAX + ' keywords; extra keywords are ignored')
+      }
+    }
+    const pool = normalizePool(item.pool, 'whisperRule', onWarning)
+    if (keywords.length === 0 || pool === undefined || pool.length === 0) {
+      onWarning('whisper rule dropped (needs keywords and a non-empty pool)')
+      continue
+    }
+    rules.push({ keywords, pool })
+  }
+  return rules
+}
+
+/** Normalize the panel block (labels / stats / actions; warn-and-drop). */
+export function normalizePanel(
+  raw: unknown,
+  onWarning: (message: string) => void = () => {},
+): PetPanelView | undefined {
+  if (!isRecord(raw)) {
+    onWarning('panel must be an object')
+    return undefined
+  }
+  const panel: PetPanelView = {}
+  const labelsRaw = raw.labels
+  if (labelsRaw !== undefined) {
+    if (!isRecord(labelsRaw)) {
+      onWarning('panel.labels must be an object')
+    } else {
+      const labels: Record<string, string> = {}
+      for (const key of PANEL_LABEL_KEYS) {
+        const value = labelsRaw[key]
+        if (value === undefined) continue
+        if (typeof value !== 'string') {
+          onWarning('panel.labels.' + key + ' must be a string')
+          continue
+        }
+        const line = normalizeLine(value, 'label', onWarning)
+        if (line !== undefined) labels[key] = line.slice(0, VOICE_LABEL_MAX)
+      }
+      if (Object.keys(labels).length > 0) panel.labels = labels
+    }
+  }
+  const statsRaw = raw.stats
+  if (statsRaw !== undefined) {
+    if (!isRecord(statsRaw)) {
+      onWarning('panel.stats must be an object')
+    } else {
+      const stats: Record<string, string> = {}
+      for (const key of PANEL_STAT_KEYS) {
+        const value = statsRaw[key]
+        if (value === undefined) continue
+        if (typeof value !== 'string') {
+          onWarning('panel.stats.' + key + ' must be a string')
+          continue
+        }
+        const line = normalizeLine(value, 'stat', onWarning)
+        if (line !== undefined) stats[key] = line.slice(0, VOICE_STAT_MAX)
+      }
+      if (Object.keys(stats).length > 0) panel.stats = stats
+    }
+  }
+  const actionsRaw = raw.actions
+  if (actionsRaw !== undefined) {
+    if (!Array.isArray(actionsRaw)) {
+      onWarning('panel.actions must be an array')
+    } else {
+      const seen = new Set<PanelAction>()
+      for (const entry of actionsRaw) {
+        if (typeof entry !== 'string' || !(PANEL_ACTIONS as readonly string[]).includes(entry)) {
+          onWarning('unknown panel action dropped: ' + String(entry))
+          continue
+        }
+        seen.add(entry as PanelAction)
+      }
+      // Canonical order, deduplicated; an explicit empty array hides all.
+      panel.actions = PANEL_ACTIONS.filter(action => seen.has(action))
+    }
+  }
+  if (panel.labels === undefined && panel.stats === undefined && panel.actions === undefined) return undefined
+  return panel
+}
+
+/** Voice-pack top-level fields. */
+const VOICE_PACK_KEYS = new Set(['voicePackVersion', 'status', 'tools', 'toolRemaining', 'whispers', 'panel'])
+
+/** Allowed whisper-section fields. */
+const WHISPER_KEYS = new Set(['generic', 'rules'])
+
+/**
+ * Normalize one raw voice.json document into a VoicePack, or undefined when
+ * the file cannot serve as a pack at all (non-object root — structure is
+ * fail-closed per file). Every slot issue is a warning, never a throw.
+ */
+export function normalizeVoicePack(
+  raw: unknown,
+  onWarning: (message: string) => void = () => {},
+): VoicePack | undefined {
+  if (raw === undefined) return undefined
+  if (!isRecord(raw)) {
+    onWarning('voice.json must be a JSON object; the file is ignored')
+    return undefined
+  }
+  for (const key of Object.keys(raw)) {
+    if (!VOICE_PACK_KEYS.has(key)) onWarning('unknown top-level field ' + key + ' ignored')
+  }
+  const version = raw.voicePackVersion
+  if (version !== undefined && (typeof version !== 'number' || version !== VOICE_PACK_V1)) {
+    onWarning('voicePackVersion ' + String(version) + ' is not supported; reading as v1 best-effort')
+  }
+  const overrides: VoicePackOverrides = {}
+  const statusRaw = raw.status
+  if (statusRaw !== undefined) {
+    if (!isRecord(statusRaw)) {
+      onWarning('status must be an object')
+    } else {
+      for (const key of Object.keys(statusRaw)) {
+        if (!(STATUS_SCENES as readonly string[]).includes(key)) {
+          onWarning('unknown status scene ' + key + ' ignored')
+          continue
+        }
+        const pool = normalizePool(statusRaw[key], 'status', onWarning)
+        if (pool !== undefined && pool.length > 0) {
+          overrides.status = { ...overrides.status, [key]: pool }
+        }
+      }
+    }
+  }
+  const toolsRaw = raw.tools
+  if (toolsRaw !== undefined) {
+    if (!isRecord(toolsRaw)) {
+      onWarning('tools must be an object')
+    } else {
+      for (const key of Object.keys(toolsRaw)) {
+        if (!(TOOL_CATEGORIES as readonly string[]).includes(key)) {
+          onWarning('unknown tool family ' + key + ' ignored')
+          continue
+        }
+        const pool = normalizePool(toolsRaw[key], 'tools', onWarning)
+        if (pool !== undefined && pool.length > 0) {
+          overrides.tools = { ...overrides.tools, [key]: pool }
+        }
+      }
+    }
+  }
+  const remainingRaw = raw.toolRemaining
+  if (remainingRaw !== undefined) {
+    const pool = normalizePool(remainingRaw, 'toolRemaining', onWarning)
+    if (pool !== undefined && pool.length > 0) overrides.toolRemaining = pool
+  }
+  const whispersRaw = raw.whispers
+  if (whispersRaw !== undefined) {
+    if (!isRecord(whispersRaw)) {
+      onWarning('whispers must be an object')
+    } else {
+      for (const key of Object.keys(whispersRaw)) {
+        if (!WHISPER_KEYS.has(key)) onWarning('unknown whispers field ' + key + ' ignored')
+      }
+      const generic = normalizePool(whispersRaw.generic, 'whisperGeneric', onWarning)
+      const rules = normalizeWhisperRules(whispersRaw.rules, onWarning)
+      if (generic !== undefined || rules !== undefined) {
+        overrides.whispers = {
+          ...(generic === undefined ? {} : { generic }),
+          ...(rules === undefined ? {} : { rules }),
+        }
+      }
+    }
+  }
+  const panel = raw.panel === undefined ? undefined : normalizePanel(raw.panel, onWarning)
+  if (
+    overrides.status === undefined && overrides.tools === undefined
+    && overrides.toolRemaining === undefined && overrides.whispers === undefined
+    && panel === undefined
+  ) {
+    return undefined
+  }
+  return {
+    overrides,
+    ...(panel === undefined ? {} : { panel }),
+  }
+}
+
+/**
+ * Merge voice-pack layers into one pack; later layers win per slot. The
+ * built-in pools are NOT a layer here — the chatter engines fall back to
+ * them per key at draw time. Merge order for a selected pet:
+ * mergeVoicePacks(registry.globalVoice, entry.voice).
+ */
+export function mergeVoicePacks(...layers: (VoicePack | undefined)[]): VoicePack | undefined {
+  const overrides: VoicePackOverrides = {}
+  const labels: NonNullable<PetPanelView['labels']> = {}
+  const stats: NonNullable<PetPanelView['stats']> = {}
+  let actions: PanelAction[] | undefined
+  let panelSeen = false
+  let any = false
+  for (const layer of layers) {
+    if (layer === undefined) continue
+    any = true
+    if (layer.overrides.status !== undefined) {
+      overrides.status = { ...overrides.status, ...layer.overrides.status }
+    }
+    if (layer.overrides.tools !== undefined) {
+      overrides.tools = { ...overrides.tools, ...layer.overrides.tools }
+    }
+    if (layer.overrides.toolRemaining !== undefined) overrides.toolRemaining = layer.overrides.toolRemaining
+    if (layer.overrides.whispers !== undefined) {
+      overrides.whispers = { ...overrides.whispers, ...layer.overrides.whispers }
+    }
+    if (layer.panel !== undefined) {
+      panelSeen = true
+      if (layer.panel.labels !== undefined) Object.assign(labels, layer.panel.labels)
+      if (layer.panel.stats !== undefined) Object.assign(stats, layer.panel.stats)
+      if (layer.panel.actions !== undefined) actions = layer.panel.actions
+    }
+  }
+  if (!any) return undefined
+  const panel: PetPanelView = {
+    ...(Object.keys(labels).length > 0 ? { labels } : {}),
+    ...(Object.keys(stats).length > 0 ? { stats } : {}),
+    ...(actions === undefined ? {} : { actions }),
+  }
+  const panelEmpty = panel.labels === undefined && panel.stats === undefined && panel.actions === undefined
+  return {
+    overrides,
+    ...(panelSeen && !panelEmpty ? { panel } : {}),
+  }
+}

--- a/packages/dsh-pet/tests/service-enabled.spec.ts
+++ b/packages/dsh-pet/tests/service-enabled.spec.ts
@@ -7,6 +7,7 @@ import type { Session, SessionEvent, TurnEndReason } from '@deepseek-ai/dsh-sess
 import { loadPetPersist } from '../src/persist.ts'
 import { PetService } from '../src/service.ts'
 import { resolvePetManifest, type PetRegistry } from '../src/registry.ts'
+import { normalizeVoicePack } from '../src/voice-pack.ts'
 
 /** Two-pet registry fixture (whale-girl + otter) for selection/name tests. */
 function fixtureRegistry(): PetRegistry {
@@ -902,6 +903,115 @@ describe('PetService (rc.6 session events)', () => {
       const result = await service.setName('   ')
       expect(result.ok).toBe(false)
       expect(service.petName()).toBe('鲸鱼娘')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('voice packs in PetService (pet-center M4, issue #677)', () => {
+  function voicedRegistry(petId: string, pack: unknown, extra?: Partial<PetRegistry>): PetRegistry {
+    const warnings: string[] = []
+    const base = resolvePetManifest({
+      id: petId,
+      displayName: petId,
+      spritesheetPath: 'spritesheet.webp',
+    }, join(tmpdir(), petId), { warnings })
+    const entry = { ...base!, voice: normalizeVoicePack(pack) }
+    const entries = [entry]
+    return {
+      entries,
+      warnings,
+      diagnostics: [],
+      byId: id => entries.find(e => e.id === id),
+      defaultEntry: () => entries[0]!,
+      ...extra,
+    }
+  }
+
+  it('speaks the selected pet pack for status scenes', async () => {
+    const ctx = new Context()
+    const dir = tempDir()
+    const session = makeSession('s1')
+    try {
+      const service = new PetService(ctx, {
+        persistDir: dir,
+        registry: voicedRegistry('talker', { status: { prepare: ['自定义开工'], done: ['自定义完工'] } }),
+      })
+      ctx.emit('session/event', session, turnStart(1, 1))
+      expect(await service.state()).toMatchObject({ bubble: '自定义开工' })
+      ctx.emit('session/event', session, turnEnd(1, { kind: 'completed' }, 2))
+      expect(await service.state()).toMatchObject({ bubble: '自定义完工' })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('re-voices a live session when the pet switches', async () => {
+    const ctx = new Context()
+    const dir = tempDir()
+    const session = makeSession('s1')
+    try {
+      const warnings: string[] = []
+      const otter = resolvePetManifest({
+        id: 'otter',
+        displayName: '水獭',
+        spritesheetPath: 'spritesheet.webp',
+      }, join(tmpdir(), 'otter'), { warnings })
+      const talker = voicedRegistry('talker', { status: { done: ['自定义完工'] } })
+      const entries = [...talker.entries, otter!]
+      const registry: PetRegistry = {
+        entries,
+        warnings: [],
+        diagnostics: [],
+        byId: id => entries.find(entry => entry.id === id),
+        defaultEntry: () => entries[0]!,
+      }
+      const service = new PetService(ctx, { persistDir: dir, registry })
+      ctx.emit('session/event', session, turnEnd(1, { kind: 'completed' }, 1))
+      expect(await service.state()).toMatchObject({ bubble: '自定义完工' })
+      await service.setPetId('otter')
+      // A new session's runtime resolves the provider against the now-
+      // selected otter (no pack) and draws the built-in pool.
+      const other = makeSession('s2')
+      ctx.emit('session/event', other, turnEnd(2, { kind: 'completed' }, 2))
+      expect(await service.state()).toMatchObject({ bubble: '完成啦' })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to the global override when the pet carries no pack', async () => {
+    const ctx = new Context()
+    const dir = tempDir()
+    const session = makeSession('s1')
+    try {
+      const registry = voicedRegistry('plain', undefined, {
+        globalVoice: normalizeVoicePack({ status: { done: ['全局完工'] } }),
+      })
+      const service = new PetService(ctx, { persistDir: dir, registry })
+      ctx.emit('session/event', session, turnEnd(1, { kind: 'completed' }, 1))
+      expect(await service.state()).toMatchObject({ bubble: '全局完工' })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('wakes a whisper from the pet pack keyword rules', async () => {
+    const ctx = new Context()
+    const dir = tempDir()
+    const session = makeSession('s1')
+    try {
+      const service = new PetService(ctx, {
+        persistDir: dir,
+        registry: voicedRegistry('talker', {
+          whispers: { rules: [{ keywords: ['测试通过'], pool: ['自定义全绿'] }] },
+        }),
+      })
+      ctx.emit('session/event', session, assistantChunk(1, 1, {
+        type: 'reasoning-delta', index: 0, text: '测试通过',
+      }, 1))
+      expect((await service.state()).whisper).toBe('自定义全绿')
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/scripts/dsh-pet
+++ b/scripts/dsh-pet
@@ -12,6 +12,7 @@
  *
  * Commands:
  *   dsh-pet validate <dir>   validate manifest + declared assets + Live2D closure
+ *                            + optional voice.json (pet-center M4, issue #677)
  *   dsh-pet install <dir>    validate, then copy into $DSH_HOME/pets/<id>/
  *                            [--force overwrites an existing same-id install]
  *
@@ -30,7 +31,8 @@ async function loadContracts() {
   const manifest = await import(pathToFileURL(path.join(SRC, 'manifest-v2.ts')).href)
   const model3 = await import(pathToFileURL(path.join(SRC, 'model3.ts')).href)
   const dshHome = await import(pathToFileURL(path.join(SRC, 'dsh-home.ts')).href)
-  return { parsePetManifest: manifest.parsePetManifest, model3, dshHome: dshHome.dshHome }
+  const voicePack = await import(pathToFileURL(path.join(SRC, 'voice-pack.ts')).href)
+  return { parsePetManifest: manifest.parsePetManifest, model3, dshHome: dshHome.dshHome, voicePack }
 }
 
 function printDiagnostics(diagnostics) {
@@ -81,6 +83,27 @@ async function checkAssets(dir, manifest, contracts) {
   return diagnostics
 }
 
+/** Validate an optional voice.json (M4, #677): structure fail-closed, content warn-only. */
+function checkVoicePack(dir, contracts) {
+  const diagnostics = []
+  const file = path.join(dir, 'voice.json')
+  if (!fs.existsSync(file)) return diagnostics
+  let raw
+  try {
+    raw = JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch (e) {
+    diagnostics.push({ level: 'error', message: 'voice.json is not valid JSON: ' + (e && e.message ? e.message : String(e)) })
+    return diagnostics
+  }
+  const warn = (message) => diagnostics.push({ level: 'warning', message: 'voice.json: ' + message })
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    diagnostics.push({ level: 'error', message: 'voice.json must be a JSON object' })
+    return diagnostics
+  }
+  contracts.voicePack.normalizeVoicePack(raw, warn)
+  return diagnostics
+}
+
 async function validate(dir, contracts) {
   const manifestFile = path.join(dir, 'pet.json')
   if (!fs.existsSync(manifestFile)) {
@@ -100,6 +123,7 @@ async function validate(dir, contracts) {
   if (verdict.ok) {
     manifest = verdict.manifest
     diagnostics.push(...await checkAssets(dir, manifest, contracts))
+    diagnostics.push(...checkVoicePack(dir, contracts))
     if (verdict.migrated === 'v1-compat') {
       console.log('note: v1 manifest compat-read as sprite2d; run scripts/dsh-pet-migrate-v2.mjs to migrate')
     }

--- a/scripts/dsh-pet.test.mjs
+++ b/scripts/dsh-pet.test.mjs
@@ -140,3 +140,40 @@ test('usage errors exit 2 with guidance', () => {
   assert.equal(run(['validate']).code, 2)
   assert.equal(run(['bogus', 'x']).code, 2)
 })
+
+test('validate accepts a voice.json and warns on content issues (M4, #677)', () => {
+  const dir = makeSpritePet(join(tmp(), 'voiced'))
+  writeFileSync(join(dir, 'voice.json'), JSON.stringify({
+    status: { done: ['自定义完工'], bogusScene: ['x'] },
+    panel: { labels: { feed: '投喂' }, actions: ['feed', 'bogus'] },
+  }))
+  const result = run(['validate', dir])
+  assert.equal(result.code, 0, result.stderr + result.stdout)
+  assert.match(result.stdout, /unknown status scene bogusScene/)
+  assert.match(result.stdout, /unknown panel action dropped: bogus/)
+})
+
+test('validate rejects a voice.json that is not valid JSON (M4, #677)', () => {
+  const dir = makeSpritePet(join(tmp(), 'broken-voice'))
+  writeFileSync(join(dir, 'voice.json'), '{ nope')
+  const result = run(['validate', dir])
+  assert.equal(result.code, 1)
+  assert.ok((result.stderr + result.stdout).includes('voice.json is not valid JSON'))
+})
+
+test('validate rejects a voice.json whose root is not an object (M4, #677)', () => {
+  const dir = makeSpritePet(join(tmp(), 'array-voice'))
+  writeFileSync(join(dir, 'voice.json'), JSON.stringify([1, 2]))
+  const result = run(['validate', dir])
+  assert.equal(result.code, 1)
+  assert.ok((result.stderr + result.stdout).includes('voice.json must be a JSON object'))
+})
+
+test('install copies voice.json into DSH_HOME/pets (M4, #677)', () => {
+  const dir = makeSpritePet(join(tmp(), 'voiced-install'))
+  writeFileSync(join(dir, 'voice.json'), JSON.stringify({ status: { done: ['装好的'] } }))
+  const home = tmp()
+  const result = run(['install', dir], { DSH_HOME: home })
+  assert.equal(result.code, 0, result.stderr + result.stdout)
+  assert.ok(existsSync(join(home, 'pets', 'test-cat', 'voice.json')))
+})


### PR DESCRIPTION
## 摘要（Summary）

#677（宠物中心 M4 内容 DIY）第二层：voice.json 语音包从文件到投影引擎的全链路。新增 `voice-pack.ts`（归一化 + 逐槽合并，结构 fail-closed / 内容 warn-and-drop），registry 扫描宠物目录 `voice.json` 与全局 `$DSH_HOME/pets/.voice.json`，service 按当前选中宠物逐绘时解析覆盖池（换宠物即换声、存量引擎免重建），`petEntryView` 增发面板 chrome（labels/stats/actions），CLI `scripts/dsh-pet` 校验 voice.json（结构错误拒装、内容问题警告），附 JSON Schema 孪生文件 `contracts/voice-pack-v1.schema.json`。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`
- [x] 其他（请说明）：`scripts/dsh-pet` 校验 CLI + 测试

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin main && git rebase origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek-V3.2

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。（本 PR 未改 README；voice.json 文档随 PR3 落地）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
```

结果摘要：

- typecheck：全仓通过
- test：全仓通过（dsh-pet 28 文件 275 用例，含 voice-pack 17、registry 26、service 34）
- test:scripts：135 用例全绿（含新增 4 个 voice.json CLI 用例）
- docs:check：全部文档门禁通过

## 用户可见变更证据（Local Feature Evidence）

本 PR 为用户可见变更的地基（气泡文案/面板仍默认内置文案，未放 voice.json 的宠物零变化）。真实 GUI 证据（自定义气泡 + 自定义面板 + 诊断）随 PR3 客户端渲染落地一并提供。
