### PR TITLE
fix(pet): 清理 Live2D 失败挂载残留资源

### DIFF
--- a/packages/dsh-pet/src/client/renderers/live2d.test.ts
+++ b/packages/dsh-pet/src/client/renderers/live2d.test.ts
@@ -20,7 +20,10 @@ import { createPhaseStream, type PhaseStream } from '../phase-stream.ts'
 import type { PetRendererContext } from '../../contracts/renderer.ts'
 
 interface FakeModel {
+  automator: { autoUpdate: boolean }
   calls: unknown[][]
+  destroyCalls: Record<string, unknown>[]
+  destroyed: number
   listeners: Record<string, () => void>
   width: number
   height: number
@@ -32,6 +35,7 @@ interface FakeModel {
   expression(name?: string): void
   hitTest(x: number, y: number): string[]
   on(event: string, fn: () => void): void
+  destroy(options?: Record<string, unknown>): void
 }
 
 interface FakeApp {
@@ -39,14 +43,18 @@ interface FakeApp {
   stage: { addChild(child: unknown): void }
   renderer: { width: number; height: number }
   init(options: Record<string, unknown>): Promise<void>
-  destroy(): void
+  destroy(rendererOptions?: boolean | { removeView?: boolean; releaseGlobalResources?: boolean }, options?: Record<string, unknown>): void
   destroyed: number
+  destroyCalls: unknown[][]
   added: unknown
 }
 
 function fakeModel(motions: Record<string, unknown[]> = { Idle: [{}, {}], TapBody: [{}] }): FakeModel {
   const model: FakeModel = {
+    automator: { autoUpdate: false },
     calls: [],
+    destroyCalls: [],
+    destroyed: 0,
     listeners: {},
     width: 1000,
     height: 1200,
@@ -58,6 +66,11 @@ function fakeModel(motions: Record<string, unknown[]> = { Idle: [{}, {}], TapBod
     expression: (name) => { model.calls.push(['expression', name]) },
     hitTest: (x, y) => { model.calls.push(['hitTest', x, y]); return ['Body'] },
     on: (event, fn) => { model.listeners[event] = fn },
+    destroy: (options = {}) => {
+      model.destroyed += 1
+      model.destroyCalls.push(options)
+      model.automator.autoUpdate = false
+    },
   }
   return model
 }
@@ -68,8 +81,16 @@ function fakeApp(): FakeApp {
     stage: { addChild: (child) => { app.added = child } },
     renderer: { width: 160, height: 174 },
     init: () => Promise.resolve(),
-    destroy: () => { app.destroyed += 1 },
+    destroy: (rendererOptions, options) => {
+      app.destroyed += 1
+      app.destroyCalls.push([rendererOptions, options])
+      if (rendererOptions === true || (typeof rendererOptions === 'object' && rendererOptions.removeView === true)) app.canvas.remove()
+      if (options?.children === true && typeof (app.added as { destroy?: unknown } | undefined)?.destroy === 'function') {
+        ;(app.added as { destroy(options?: Record<string, unknown>): void }).destroy(options)
+      }
+    },
     destroyed: 0,
+    destroyCalls: [],
     added: undefined,
   }
   return app
@@ -78,7 +99,10 @@ function fakeApp(): FakeApp {
 function fakeVendor(
   model: FakeModel,
   app: FakeApp,
-  from: (source: string, options?: Record<string, unknown>) => Promise<FakeModel> = () => Promise.resolve(model),
+  from: (source: string, options?: Record<string, unknown>) => Promise<FakeModel> = (_source, options) => {
+    model.calls.push(['from', options])
+    return Promise.resolve(model)
+  },
 ): unknown {
   return {
     Application: class { constructor() { return app } },
@@ -131,6 +155,8 @@ describe('live2dRenderer', () => {
     await flush()
     expect(container.querySelector('canvas')).toBeTruthy()
     expect(app.added).toBe(model)
+    expect(model.calls).toContainEqual(['from', expect.objectContaining({ autoUpdate: false, autoHitTest: false, autoFocus: false })])
+    expect(model.automator.autoUpdate).toBe(true)
     // idle plays on boot: group 'Idle', random index floor(0.99 * 2) = 1.
     expect(model.calls).toContainEqual(['motion', 'Idle', 1])
     // auto-fit: min(160/1000, 174/1200) * 0.92 = 0.1334
@@ -142,8 +168,14 @@ describe('live2dRenderer', () => {
     expect(model.calls.filter(call => call[0] === 'motion').at(-1)).toEqual(['motion', 'Idle', 1])
     handle.dispose()
     expect(app.destroyed).toBe(1)
+    expect(app.destroyCalls[0]?.[0]).toEqual({ removeView: true })
+    expect(model.destroyed).toBe(1)
+    expect(model.destroyCalls).toContainEqual({ children: true })
+    expect(model.automator.autoUpdate).toBe(false)
     handle.dispose() // idempotent
     expect(app.destroyed).toBe(1)
+    expect(app.destroyCalls[0]?.[0]).toEqual({ removeView: true })
+    expect(model.destroyed).toBe(1)
   })
 
   it('uses one automatic texture LOD instead of the default full mip chain', async () => {
@@ -157,6 +189,7 @@ describe('live2dRenderer', () => {
     await flush()
 
     expect(from).toHaveBeenCalledWith(CONFIG.modelUrl, {
+      autoUpdate: false,
       autoHitTest: false,
       autoFocus: false,
       textureOptions: { lod: 'single-auto' },
@@ -239,7 +272,43 @@ describe('live2dRenderer', () => {
     handle.onError((next) => { code = next })
     await flush()
     expect(code).toBe('load-failed')
+    expect(app.destroyed).toBe(1)
+    expect(ctx.container.querySelector('canvas')).toBeNull()
     handle.dispose()
+    expect(app.destroyed).toBe(1)
+  })
+
+  it('destroys both sides exactly once when disposed while model loading is pending', async () => {
+    const model = fakeModel()
+    const app = fakeApp()
+    let resolveModel!: (value: FakeModel) => void
+    const pendingModel = new Promise<FakeModel>((resolve) => { resolveModel = resolve })
+    const from = vi.fn(() => pendingModel)
+    runtime.vendor = {
+      Application: class { constructor() { return app } },
+      extensions: { add: () => {} },
+      Live2DPlugin: {},
+      configureCubismSDK: () => {},
+      Live2DModel: { from },
+    }
+    const { ctx, container } = makeCtx()
+    const handle = live2dRenderer.mount(ctx, live2dRenderer.validateConfig(CONFIG))
+    let error: string | undefined
+    ;(handle as Live2dRendererHandle).onError((code) => { error = code })
+    await flush()
+    expect(from).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('canvas')).toBeTruthy()
+    handle.dispose()
+    expect(app.destroyed).toBe(1)
+    expect(container.querySelector('canvas')).toBeNull()
+    resolveModel(model)
+    await flush()
+    expect(app.destroyed).toBe(1)
+    expect(model.destroyed).toBe(1)
+    expect(model.destroyCalls).toContainEqual({ children: true })
+    expect(model.automator.autoUpdate).toBe(false)
+    expect(app.added).toBeUndefined()
+    expect(error).toBeUndefined()
   })
 
   it('never appends a canvas when disposed mid-boot', async () => {

--- a/packages/dsh-pet/src/client/renderers/live2d.ts
+++ b/packages/dsh-pet/src/client/renderers/live2d.ts
@@ -68,6 +68,10 @@ const TAP_GROUP = 'TapBody'
  * downsampled atlas only when the effective on-screen scale warrants it.
  */
 const TEXTURE_OPTIONS = { lod: 'single-auto' } as const
+/** Recursively release the activation without invalidating shared texture caches. */
+const DESTROY_OPTIONS = { children: true } as const
+/** Remove only this activation's canvas; `true` would release Pixi globals. */
+const RENDERER_DESTROY_OPTIONS = { removeView: true } as const
 
 let vendorConfigured = false
 
@@ -105,11 +109,29 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
     let disposed = false
     let app: Live2dVendorApp | undefined
     let model: Live2dVendorModel | undefined
+    let modelAttached = false
     let errorListener: ((code: Live2dErrorCode) => void) | undefined
     let unsubscribe: (() => void) | undefined
     /** The motion group the current phase maps to (resume target after taps). */
     let phaseGroup: string = config.motions.idle
     let tapPlaying = false
+
+    /** Release every resource currently owned by this activation exactly once. */
+    const destroyResources = (): void => {
+      unsubscribe?.()
+      unsubscribe = undefined
+      const currentApp = app
+      const currentModel = model
+      const modelOwnedByApp = currentApp !== undefined && modelAttached
+      app = undefined
+      model = undefined
+      modelAttached = false
+      try {
+        if (currentModel !== undefined && !modelOwnedByApp) currentModel.destroy(DESTROY_OPTIONS)
+      } finally {
+        currentApp?.destroy(RENDERER_DESTROY_OPTIONS, DESTROY_OPTIONS)
+      }
+    }
 
     const playGroup = (group: string): void => {
       if (model === undefined) return
@@ -143,33 +165,43 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
       }
       configureOnce(vendor)
       const pixiApp = new vendor.Application()
-      await pixiApp.init({
-        width: Math.max(1, ctx.container.clientWidth || 160),
-        height: Math.max(1, ctx.container.clientHeight || 174),
-        backgroundAlpha: 0,
-        antialias: true,
-        autoDensity: true,
-        preference: 'webgl',
-      })
+      try {
+        await pixiApp.init({
+          width: Math.max(1, ctx.container.clientWidth || 160),
+          height: Math.max(1, ctx.container.clientHeight || 174),
+          backgroundAlpha: 0,
+          antialias: true,
+          autoDensity: true,
+          preference: 'webgl',
+        })
+      } catch (error) {
+        // init() can fail after allocating a partial renderer; cleanup is
+        // best-effort because Pixi may not consider that partial app ready.
+        try { pixiApp.destroy(RENDERER_DESTROY_OPTIONS, DESTROY_OPTIONS) } catch {}
+        throw error
+      }
       if (disposed) {
-        pixiApp.destroy(true, { children: true })
+        pixiApp.destroy(RENDERER_DESTROY_OPTIONS, DESTROY_OPTIONS)
         return
       }
+      app = pixiApp
       pixiApp.canvas.style.display = 'block'
       pixiApp.canvas.style.width = '100%'
       pixiApp.canvas.style.height = '100%'
       ctx.container.appendChild(pixiApp.canvas)
+      // Keep a model that rejects during setup off Ticker.shared; from()
+      // does not expose that partial instance to callers for disposal.
       const loaded = await vendor.Live2DModel.from(config.modelUrl, {
+        autoUpdate: false,
         autoHitTest: false,
         autoFocus: false,
         textureOptions: TEXTURE_OPTIONS,
       })
+      model = loaded
       if (disposed) {
-        pixiApp.destroy(true, { children: true })
+        destroyResources()
         return
       }
-      app = pixiApp
-      model = loaded
       // Auto-fit the model into the container; the manifest scale multiplies
       // the fit and translate offsets from the center anchor.
       const fit = Math.min(
@@ -183,6 +215,8 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
         pixiApp.renderer.height / 2 + (config.translate?.y ?? 0),
       )
       pixiApp.stage.addChild(loaded)
+      modelAttached = true
+      loaded.automator.autoUpdate = true
       // Resume the phase group once a tap motion finishes playing.
       loaded.on('motionFinish', () => {
         if (tapPlaying) {
@@ -195,19 +229,18 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
     }
 
     void boot().catch(() => {
-      if (!disposed) errorListener?.('load-failed')
+      try {
+        destroyResources()
+      } finally {
+        if (!disposed) errorListener?.('load-failed')
+      }
     })
 
     return {
       dispose() {
         if (disposed) return
         disposed = true
-        unsubscribe?.()
-        model = undefined
-        if (app !== undefined) {
-          app.destroy(true, { children: true })
-          app = undefined
-        }
+        destroyResources()
       },
       tap(x: number, y: number) {
         const current = model

--- a/packages/dsh-pet/src/client/renderers/live2d/Live2dVisualMount.test.tsx
+++ b/packages/dsh-pet/src/client/renderers/live2d/Live2dVisualMount.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PropsLocale } from '@deepseek-ai/dsh-client-ui-slots'
+import type { PetRenderer, PetRendererContext } from '../../../contracts/renderer.ts'
+import type { PetDefinition } from '../../../registry.ts'
+import { defaultPetRendererRegistry } from '../registry.ts'
+import type { Live2dErrorCode } from '../live2d.ts'
+import { Live2dVisualMount } from './Live2dVisualMount.tsx'
+
+const t = ((key: string) => key) as PropsLocale<'pet'>['t']
+const noop = (): void => {}
+
+function definition(id: string): PetDefinition {
+  return {
+    id,
+    displayName: id,
+    description: '',
+    renderer: 'live2d',
+    live2d: { modelPath: id + '.model3.json', modelUrl: '/pet/' + id + '/' + id + '.model3.json', motions: { idle: 'Idle' } },
+  } as unknown as PetDefinition
+}
+
+describe('Live2dVisualMount', () => {
+  afterEach(() => {
+    cleanup()
+    defaultPetRendererRegistry.clear()
+  })
+
+  it('clears a failed activation error when switching to another pet', () => {
+    const errorSinks: ((code: Live2dErrorCode) => void)[] = []
+    const disposes: ReturnType<typeof vi.fn>[] = []
+    defaultPetRendererRegistry.register({
+      id: 'live2d',
+      apiVersion: 'test',
+      validateConfig: (config) => config,
+      mount: (ctx: PetRendererContext) => {
+        const canvas = document.createElement('canvas')
+        ctx.container.appendChild(canvas)
+        const dispose = vi.fn(() => { canvas.remove() })
+        disposes.push(dispose)
+        return {
+          dispose,
+          tap: () => {},
+          onError: (listener: (code: Live2dErrorCode) => void) => { errorSinks.push(listener) },
+        }
+      },
+    } as PetRenderer)
+
+    const first = definition('broken')
+    const second = definition('healthy')
+    const { container, rerender, unmount } = render(<Live2dVisualMount definition={first} phase="idle" onPet={noop} t={t} />)
+    expect(container.querySelectorAll('canvas')).toHaveLength(1)
+    act(() => { errorSinks[0]?.('load-failed') })
+    expect(container.querySelector('[data-dsh-pet-live2d-error="load-failed"]')).toBeTruthy()
+
+    rerender(<Live2dVisualMount definition={second} phase="idle" onPet={noop} t={t} />)
+    expect(disposes[0]).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-dsh-pet-live2d="healthy"]')).toBeTruthy()
+    expect(container.querySelector('[data-dsh-pet-live2d-error]')).toBeNull()
+    expect(container.querySelectorAll('canvas')).toHaveLength(1)
+
+    rerender(<Live2dVisualMount definition={first} phase="idle" onPet={noop} t={t} />)
+    expect(disposes[1]).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-dsh-pet-live2d="broken"]')).toBeTruthy()
+    expect(container.querySelector('[data-dsh-pet-live2d-error]')).toBeNull()
+    expect(container.querySelectorAll('canvas')).toHaveLength(1)
+    unmount()
+    expect(disposes[2]).toHaveBeenCalledTimes(1)
+    expect(container.querySelectorAll('canvas')).toHaveLength(0)
+  })
+})

--- a/packages/dsh-pet/src/client/renderers/live2d/Live2dVisualMount.tsx
+++ b/packages/dsh-pet/src/client/renderers/live2d/Live2dVisualMount.tsx
@@ -33,6 +33,7 @@ export function Live2dVisualMount(props: {
 
   // One activation per pet definition: build the contract context and mount.
   useEffect(() => {
+    setError(null)
     const container = containerRef.current
     const live2d = props.definition.live2d
     if (container === null || live2d === undefined) return undefined

--- a/packages/dsh-pet/src/client/renderers/live2d/runtime.ts
+++ b/packages/dsh-pet/src/client/renderers/live2d/runtime.ts
@@ -23,11 +23,12 @@ export interface Live2dVendorApp {
   stage: { addChild(child: unknown): unknown }
   renderer: { readonly width: number; readonly height: number }
   init(options: Record<string, unknown>): Promise<void>
-  destroy(removeView?: boolean, options?: Record<string, unknown>): void
+  destroy(rendererOptions?: boolean | { removeView?: boolean; releaseGlobalResources?: boolean }, options?: Record<string, unknown>): void
 }
 
 /** The Live2DModel slice the renderer uses. */
 export interface Live2dVendorModel {
+  automator: { autoUpdate: boolean }
   anchor: { set(x: number, y?: number): void }
   position: { set(x: number, y: number): void }
   scale: { set(x: number, y?: number): void }
@@ -43,6 +44,7 @@ export interface Live2dVendorModel {
   expression(name?: string): unknown
   hitTest(x: number, y: number): string[]
   on(event: string, fn: () => void): unknown
+  destroy(options?: { children?: boolean; texture?: boolean; baseTexture?: boolean }): void
 }
 
 /** The vendor bundle global (window.__dshPetLive2d). */


### PR DESCRIPTION
## 摘要（Summary）

修复 Live2D 模型加载失败，或在模型仍加载时切换、卸载宠物后遗留 Pixi Application、Canvas、未挂载模型和共享 Ticker 引用的问题。

根因是 Application 的所有权直到模型加载完成后才交给 renderer，失败分支无法清理已创建的 Canvas；同时 `Live2DModel.from()` 默认会在异步初始化完成前注册共享 Ticker。现在加载期间禁用自动更新，成功挂入 stage 后再启用；释放时区分已挂载和未挂载模型，并只销毁当前 Application，避免影响页面中的其他 Pixi 实例。切换宠物时也会清除上一激活遗留的错误状态。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [x] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream main
git rebase upstream/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README），并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

本 PR 不变更现有版权声明。

## 新皮肤收录（New Skin）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
corepack pnpm@11.7.0 --filter @linxin666/dsh-pet test
corepack pnpm@11.7.0 --filter @linxin666/dsh-pet typecheck
corepack pnpm@11.7.0 --filter @linxin666/dsh-pet build
corepack pnpm@11.7.0 typecheck
node scripts/verify-docs.mjs
node scripts/aggregate.mjs --check
node scripts/sync-shared.mjs --check
node scripts/runtime-deps-check.mjs
```

结果摘要：

- dsh-pet：30 个测试文件、308 项测试全部通过；冲突相关的 2 个定向文件共 12 项回归测试通过。
- dsh-pet 类型检查、三项 bundle 构建和全仓类型检查通过。
- 文档、聚合、共享同步、运行时依赖门禁通过。
- 真实页面故障注入：失败挂载后 `Live2D roots=1 / Canvas=0 / errors=1`；切回内置宠物后 `Live2D roots=0 / Canvas=0 / errors=0`。
- 补充运行的全仓 `pnpm test` 在未改动的 `dsh-liangshen` Windows 路径断言处失败；`pnpm test:scripts` 也有当前主线的 Windows 路径与 skin CLI 本地加载失败。当前 `main` 的 GitHub `CI checks` 为绿色，本 PR 改动包的完整测试全部通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

- 真实页面故障注入后：`Live2D roots=1 / Canvas=0 / errors=1`，说明失败提示正常呈现，同时已创建的 Canvas 被移除。
- 切回内置宠物后：`Live2D roots=0 / Canvas=0 / errors=0 / renderer fallback=0`，说明旧错误与失败挂载均未残留。
- `Live2DModel.from()` 拒绝回归测试断言 Application 只销毁一次、Canvas 被移除，随后重复 `dispose()` 不会二次销毁。
- 加载中释放回归测试断言延迟返回的未挂载模型只销毁一次、不会加入 stage、不会恢复共享 Ticker，也不会产生过期错误。
- `broken → healthy → broken` 切换测试断言每个旧 handle 只释放一次、错误状态在新激活开始时清零，容器始终至多保留一个 Canvas。
- dsh-pet 完整测试：30 个文件、308 项测试通过；冲突相关定向回归：2 个文件、12 项测试通过。

本地 Live2D 模型与 Cubism Core 仅用于故障注入，均未打包、未提交、未上传。
