### PR TITLE
perf(pet): 降低高分辨率 Live2D 纹理开销

### DIFF
--- a/packages/dsh-pet/src/client/renderers/live2d.test.ts
+++ b/packages/dsh-pet/src/client/renderers/live2d.test.ts
@@ -75,13 +75,17 @@ function fakeApp(): FakeApp {
   return app
 }
 
-function fakeVendor(model: FakeModel, app: FakeApp): unknown {
+function fakeVendor(
+  model: FakeModel,
+  app: FakeApp,
+  from: (source: string, options?: Record<string, unknown>) => Promise<FakeModel> = () => Promise.resolve(model),
+): unknown {
   return {
     Application: class { constructor() { return app } },
     extensions: { add: () => {} },
     Live2DPlugin: {},
     configureCubismSDK: () => {},
-    Live2DModel: { from: () => Promise.resolve(model) },
+    Live2DModel: { from },
   }
 }
 
@@ -140,6 +144,23 @@ describe('live2dRenderer', () => {
     expect(app.destroyed).toBe(1)
     handle.dispose() // idempotent
     expect(app.destroyed).toBe(1)
+  })
+
+  it('uses one automatic texture LOD instead of the default full mip chain', async () => {
+    const model = fakeModel()
+    const app = fakeApp()
+    const from = vi.fn(async () => model)
+    runtime.vendor = fakeVendor(model, app, from)
+    const { ctx } = makeCtx()
+
+    live2dRenderer.mount(ctx, live2dRenderer.validateConfig(CONFIG))
+    await flush()
+
+    expect(from).toHaveBeenCalledWith(CONFIG.modelUrl, {
+      autoHitTest: false,
+      autoFocus: false,
+      textureOptions: { lod: 'single-auto' },
+    })
   })
 
   it('falls back to the idle group when a mapped group is absent from the model', async () => {

--- a/packages/dsh-pet/src/client/renderers/live2d.ts
+++ b/packages/dsh-pet/src/client/renderers/live2d.ts
@@ -60,6 +60,15 @@ export interface Live2dRendererHandle extends PetRendererHandle {
 /** The de-facto tap-motion group of Cubism sample models. */
 const TAP_GROUP = 'TapBody'
 
+/**
+ * Keep one screen-appropriate atlas LOD instead of asking Pixi for the
+ * engine's default full mip chain. A user model can legitimately carry an
+ * 8192px texture while the pet itself is only a few hundred pixels tall;
+ * `single-auto` preserves the source for larger renders and generates one
+ * downsampled atlas only when the effective on-screen scale warrants it.
+ */
+const TEXTURE_OPTIONS = { lod: 'single-auto' } as const
+
 let vendorConfigured = false
 
 /** Configure pixi extensions + the Cubism SDK once per page. */
@@ -150,7 +159,11 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
       pixiApp.canvas.style.width = '100%'
       pixiApp.canvas.style.height = '100%'
       ctx.container.appendChild(pixiApp.canvas)
-      const loaded = await vendor.Live2DModel.from(config.modelUrl, { autoHitTest: false, autoFocus: false })
+      const loaded = await vendor.Live2DModel.from(config.modelUrl, {
+        autoHitTest: false,
+        autoFocus: false,
+        textureOptions: TEXTURE_OPTIONS,
+      })
       if (disposed) {
         pixiApp.destroy(true, { children: true })
         return


### PR DESCRIPTION
## 摘要（Summary）

Live2D 模型加载时显式使用引擎提供的 `single-auto` 纹理 LOD 策略，避免高分辨率模型默认生成完整 mip 链。

该策略继续保留原始纹理供较大尺寸渲染，并仅在模型实际显示较小时按需生成一个匹配屏幕尺度的降采样图集。新增回归测试，确保 Live2D 加载参数不会退回引擎默认的 `full` LOD。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [x] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream main
git merge --ff-only upstream/main
```

同步基线：`main@1316b49f`。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未修改 README，文档门禁已通过）。

## 贡献者版权声明（Contributor Copyright）

N/A。本 PR 只修改现有宠物包的 Live2D 加载策略与回归测试，不新增资产或版权声明。

## 新皮肤收录（New Skin）

N/A。本 PR 不涉及皮肤。

## 社区插件索引登记（Community Plugin Index）

N/A。本 PR 不涉及社区插件索引。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-pet exec vitest run src/client/renderers/live2d.test.ts

node node_modules/.pnpm/typescript@6.0.3/node_modules/typescript/bin/tsc \
  -b packages/dsh-pet --pretty false

node node_modules/.pnpm/typescript@6.0.3/node_modules/typescript/bin/tsc \
  -p packages/dsh-pet/tsconfig.test.json --pretty false

pnpm --filter @linxin666/dsh-pet exec vitest run
pnpm --filter @linxin666/dsh-pet exec tsdown

pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm runtime-deps:check
pnpm aggregate:check
pnpm sync-shared:check
git diff --check
```

结果摘要：

- Live2D 定向测试：`10 / 10` 通过。
- `dsh-pet` 全量测试：`28 / 28` 个测试文件、`281 / 281` 个测试通过。
- `dsh-pet` 源码及测试类型检查通过。
- `dsh-pet` 服务端、客户端和 Live2D vendor 三个入口构建通过。
- 工作区 `pnpm typecheck` 通过。
- `docs:check`、`runtime-deps:check`、`aggregate:check`、`sync-shared:check` 和 `git diff --check` 通过。
- Windows 本地执行 `pnpm test` 时，未修改的 `dsh-liangshen/tests/custom-bash.test.ts` 仍有 2 个路径分隔符断言失败。
- Windows 本地执行 `pnpm test:scripts` 时，现有 aggregate ID collision、skin-center 的 Windows `file:` URL 加载及 e2e 路径分隔符测试共 9 项失败；均不位于本 PR 的两个改动文件中。

## 用户可见变更证据（Local Feature Evidence）

本次是内部 GPU 纹理策略优化，没有适合通过普通 UI 截图比较的视觉差异，因此使用源码、回归断言和纹理测量数据作为证据。

实际修改与回归断言：

<img width="1440" height="1028" alt="Live2D LOD 代码与测试证据" src="https://github.com/user-attachments/assets/87128f07-1db0-4890-b05d-872a95dde138" />

本地 Yumi 模型的 `texture_00.png` 实测为 `8192×8192`，PNG 文件大小为 `14.68 MiB`。按照 RGBA8 texel 计算：

- 原始基级理论大小：`256 MiB`；
- 默认完整 mip 链理论总量：`341.33 MiB`；
- 完整 mip 链理论额外层级：约 `85.33 MiB`。

实际 GPU 分配可能因图形后端而异；上述数值用于说明完整 mip 链的理论 texel 开销。锁定依赖 `untitled-pixi-live2d-engine@1.3.5` 明确以 `lod: full` 为默认值，而 `single-auto` 会保留原始图集，并在模型显示较小时只生成一个按需 LOD。

测量与验证汇总：

<img width="1440" height="1000" alt="Live2D 纹理测量与验证" src="https://github.com/user-attachments/assets/4df5def5-809d-4514-a1e4-05e977bbcbb0" />


