### PR TITLE
fix(skin-center): write the active skin selection atomically (#678)

### DIFF
--- a/packages/skins/skin-center/src/active-state.ts
+++ b/packages/skins/skin-center/src/active-state.ts
@@ -6,8 +6,8 @@
  * @module @linxin666/dsh-client-ui-skin-center/active-state
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
 
 import { userSkinsDir } from './skin-repo.ts'
 
@@ -28,6 +28,18 @@ export function readActiveSelection(path: string): string | null {
 
 /** Persist the active skin id (creates the parent directory). */
 export function writeActiveSelection(path: string, id: string | null): void {
-  mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, JSON.stringify({ active: id }, null, 2) + '\n', 'utf8')
+  const dir = dirname(path)
+  mkdirSync(dir, { recursive: true })
+  // Atomic replace (issue #678): write a sibling temp file then rename over
+  // the target, so a crash mid-write can never leave a half-written JSON that
+  // readActiveSelection would silently discard. The temp dir is cleaned up on
+  // both success and failure.
+  const tmpDir = mkdtempSync(join(dir, `${basename(path)}.tmp-`))
+  const tmp = join(tmpDir, basename(path))
+  try {
+    writeFileSync(tmp, JSON.stringify({ active: id }, null, 2) + '\n', { encoding: 'utf8', flag: 'wx' })
+    renameSync(tmp, path)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
 }

--- a/packages/skins/skin-center/tests/active-state.spec.ts
+++ b/packages/skins/skin-center/tests/active-state.spec.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, readFileSync, readdirSync, renameSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { readActiveSelection, writeActiveSelection } from '../src/active-state.ts'
+
+const { originalRename } = vi.hoisted(() => ({
+  originalRename: { impl: null as unknown as typeof renameSync },
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  originalRename.impl = actual.renameSync
+  return { ...actual, renameSync: vi.fn(actual.renameSync) }
+})
+
+const renameMock = vi.mocked(renameSync)
+
+describe('active-state persistence (issue #678: atomic write)', () => {
+  let dir: string
+  let path: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'active-state-'))
+    path = join(dir, 'skin-center-active.json')
+    renameMock.mockReset()
+    renameMock.mockImplementation(originalRename.impl)
+  })
+
+  it('writes a valid JSON document and reads it back', () => {
+    writeActiveSelection(path, 'skin-a')
+    expect(readActiveSelection(path)).toBe('skin-a')
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ active: 'skin-a' })
+  })
+
+  it('persists null (stock look)', () => {
+    writeActiveSelection(path, null)
+    expect(readActiveSelection(path)).toBeNull()
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ active: null })
+  })
+
+  it('creates the parent directory on demand', () => {
+    const nested = join(dir, 'a', 'b', 'active.json')
+    writeActiveSelection(nested, 'skin-a')
+    expect(readActiveSelection(nested)).toBe('skin-a')
+  })
+
+  it('leaves no temp directories behind after a successful write', () => {
+    writeActiveSelection(path, 'skin-a')
+    expect(readdirSync(dir)).toEqual(['skin-center-active.json'])
+  })
+
+  it('keeps the previous content when the rename fails mid-write', () => {
+    writeActiveSelection(path, 'skin-a')
+    expect(readActiveSelection(path)).toBe('skin-a')
+    renameMock.mockImplementationOnce(() => {
+      throw new Error('simulated crash')
+    })
+    expect(() => writeActiveSelection(path, 'skin-b')).toThrow('simulated crash')
+    // The half-written temp file must never replace the previous document.
+    expect(readActiveSelection(path)).toBe('skin-a')
+    expect(readFileSync(path, 'utf8')).toContain('"skin-a"')
+    // The failed attempt must clean up its temp directory.
+    expect(readdirSync(dir)).toEqual(['skin-center-active.json'])
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

见 PR 描述。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：见 PR 标题

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git worktree add /tmp/fix -b fix origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek（deepseek-v4-pro，经 DeepSeek Harness 会话）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。（本次未改 README）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter <pkg> test
pnpm typecheck
```

结果摘要：

- 受影响包测试全绿（见 PR 描述）
- 全仓 typecheck 通过
