### PR TITLE
fix(pet): wire global voice-pack panel, stabilize ornament loop and harden decoration inputs (#623)

### DIFF
--- a/packages/dsh-pet/contracts/status-decoration-v1.schema.json
+++ b/packages/dsh-pet/contracts/status-decoration-v1.schema.json
@@ -10,8 +10,7 @@
     "license",
     "entry",
     "cell",
-    "columns",
-    "phases"
+    "columns"
   ],
   "additionalProperties": false,
   "properties": {

--- a/packages/dsh-pet/package.json
+++ b/packages/dsh-pet/package.json
@@ -38,7 +38,8 @@
     "lib/**/*.d.ts.map",
     "src",
     "cordis.patch.yml",
-    "assets"
+    "assets",
+    "contracts"
   ],
   "license": "Apache-2.0",
   "dsh": {

--- a/packages/dsh-pet/src/chatter.test.ts
+++ b/packages/dsh-pet/src/chatter.test.ts
@@ -195,6 +195,17 @@ describe('voice-pack overrides (pet-center M4)', () => {
     expect(voice.toolRemaining(4, 0)).toBe('后台还有 4 个')
   })
 
+  it('interpolates every occurrence of a repeated placeholder', () => {
+    const pack: ReturnType<typeof PACK> = {
+      ...PACK(),
+      tools: { shell: ['{tool} 和 {tool} 一起跑 {hint} {hint}'] },
+      toolRemaining: ['{n} 路并进，共 {n} 路'],
+    }
+    const voice = new StatusVoice(() => pack)
+    expect(voice.tool('bash', 'bash', 'npm test', 0)).toBe('bash 和 bash 一起跑 npm test npm test')
+    expect(voice.toolRemaining(2, 5000)).toBe('2 路并进，共 2 路')
+  })
+
   it('follows a provider swap on the next draw without rebuilding the engine', () => {
     let pack: ReturnType<typeof PACK> = PACK()
     const voice = new StatusVoice(() => pack)

--- a/packages/dsh-pet/src/chatter.ts
+++ b/packages/dsh-pet/src/chatter.ts
@@ -502,8 +502,8 @@ export class StatusVoice {
     const pool = override !== undefined && override.length > 0 ? override : TOOL_POOLS[category]
     const line = this.voice('tool:' + category, 'tool:' + category, pool, nowMs)
     return line
-      .replace('{tool}', displayName)
-      .replace('{hint}', hint ?? displayName)
+      .replaceAll('{tool}', displayName)
+      .replaceAll('{hint}', hint ?? displayName)
   }
 
   /** Status line while sibling tools still run (always reflects the count). */
@@ -511,7 +511,7 @@ export class StatusVoice {
     const override = this.pools().toolRemaining
     const pool = override !== undefined && override.length > 0 ? override : TOOL_REMAINING_POOL
     return this.voice('toolRemaining', 'toolRemaining', pool, nowMs)
-      .replace('{n}', String(count))
+      .replaceAll('{n}', String(count))
   }
 }
 

--- a/packages/dsh-pet/src/client/PetSprite.test.tsx
+++ b/packages/dsh-pet/src/client/PetSprite.test.tsx
@@ -92,14 +92,9 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-/** Render the pet with mocked callbacks; returns the rename and open spys. */
-function renderPet(overrides: Partial<PetSpriteProps> = {}): {
-  onRename: ReturnType<typeof vi.fn>
-  onOpenSession: ReturnType<typeof vi.fn>
-} {
-  const onRename = vi.fn()
-  const onOpenSession = vi.fn()
-  const props: PetSpriteProps = {
+/** Build the mocked props for one render. */
+function petProps(overrides: Partial<PetSpriteProps> = {}): PetSpriteProps {
+  return {
     snapshot,
     definition: petDefinition(),
     display: snapshot.display,
@@ -108,14 +103,24 @@ function renderPet(overrides: Partial<PetSpriteProps> = {}): {
     onFeed: vi.fn(),
     onHide: vi.fn(),
     onDragEnd: vi.fn(),
-    onRename,
-    onOpenSession,
+    onRename: vi.fn(),
+    onOpenSession: vi.fn(),
     onFeedbackDone: vi.fn(),
     t,
     ...overrides,
   }
-  render(<PetSprite {...props} />)
-  return { onRename, onOpenSession }
+}
+
+/** Render the pet with mocked callbacks; returns the rename/open spys + the RTL result. */
+function renderPet(overrides: Partial<PetSpriteProps> = {}): {
+  onRename: ReturnType<typeof vi.fn>
+  onOpenSession: ReturnType<typeof vi.fn>
+  result: ReturnType<typeof render>
+} {
+  const onRename = vi.fn()
+  const onOpenSession = vi.fn()
+  const result = render(<PetSprite {...petProps({ onRename, onOpenSession, ...overrides })} />)
+  return { onRename, onOpenSession, result }
 }
 
 /** Hover the sprite to open the panel, then click the rename button. */
@@ -616,9 +621,18 @@ describe('PetSprite panel chrome from the voice pack (pet-center M4)', () => {
     expect(screen.getByText('隐藏')).toBeDefined()
     expect(screen.getByText('亲密度 幼鲸')).toBeDefined()
   })
+
+  it('substitutes cross-slot placeholders in pack stat formats', () => {
+    renderPet({ definition: { ...petDefinition(), panel: { stats: { treats: '鱼干 {n}（{points} 分，{rank}）' } } } })
+    fireEvent.pointerOver(screen.getByRole('button', { name: '鲸鱼娘' }))
+    // The host whitelists {rank}/{n}/{points} in every stat slot, so a pack
+    // format may reference any of them; all three live values substitute.
+    expect(screen.getByText('鱼干 3（0 分，幼鲸）')).toBeDefined()
+  })
 })
 describe('PetSprite status decoration (pet-center M5, #567)', () => {
   const decoration: DecorationView = {
+    apiVersion: 'x-org.linxin666.pet-center/status-decoration-v1',
     id: 'whale',
     assetBase: '/api/pet/decoration/whale',
     entryUrl: '/api/pet/decoration/whale/whale-frames.png',
@@ -671,5 +685,115 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
   it('renders no ornament when the host serves no decoration', () => {
     renderPet({ snapshot: { ...snapshot, bubble: '正在思考', phase: 'thinking' } })
     expect(ornament()).toBeNull()
+  })
+
+  it('advances the ornament frames on the rAF loop and wraps when looping', () => {
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: false,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+    const frames: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      frames.push(callback)
+      return frames.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    renderPet({ snapshot: { ...snapshot, bubble: '正在思考', phase: 'thinking', decoration } })
+    const el = ornament()!
+    // Both the sprite loop and the ornament loop schedule frames; step every
+    // pending callback together (the sprite's idle track never moves).
+    const step = (ts: number): void => { for (const callback of frames.splice(0)) callback(ts) }
+    // frameWidth = round(64 * 18 / 48) = 24 px; thinking binds frames 0..3.
+    expect(el.style.backgroundPosition).toBe('0px 0px')
+    act(() => { step(161) })
+    expect(el.style.backgroundPosition).toBe('-24px 0px')
+    act(() => { step(322) })
+    expect(el.style.backgroundPosition).toBe('-48px 0px')
+    act(() => { step(483) })
+    expect(el.style.backgroundPosition).toBe('-72px 0px')
+    act(() => { step(644) })
+    // The looping segment wraps back to its first frame.
+    expect(el.style.backgroundPosition).toBe('0px 0px')
+  })
+
+  it('holds the segment last frame when the loop is off and stops scheduling', () => {
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: false,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+    const frames: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      frames.push(callback)
+      return frames.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    renderPet({ snapshot: { ...snapshot, bubble: '完成', phase: 'done', decoration: { ...decoration, loop: false } } })
+    const el = ornament()!
+    const step = (ts: number): void => { for (const callback of frames.splice(0)) callback(ts) }
+    // done binds frames 2..3; the segment starts on frame 2.
+    expect(el.style.backgroundPosition).toBe('-48px 0px')
+    act(() => { step(161) })
+    expect(el.style.backgroundPosition).toBe('-72px 0px')
+    // The ornament stopped scheduling (only the sprite loop remains pending).
+    expect(frames).toHaveLength(1)
+    act(() => { step(161) })
+    // The last frame holds.
+    expect(el.style.backgroundPosition).toBe('-72px 0px')
+  })
+
+  it('does not restart the frame loop when an equal-content decoration re-renders', () => {
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: false,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+    const frames: FrameRequestCallback[] = []
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      frames.push(callback)
+      return frames.length
+    })
+    const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    // The definition comes from '/api/pet/pets', fetched once — a state
+    // poll never replaces it, so both renders share one definition object.
+    const definition = petDefinition()
+    const { result } = renderPet({ definition, snapshot: { ...snapshot, bubble: '正在思考', phase: 'thinking', decoration } })
+    const step = (ts: number): void => { for (const callback of frames.splice(0)) callback(ts) }
+    act(() => { step(161) })
+    expect(ornament()!.style.backgroundPosition).toBe('-24px 0px')
+    const schedulesBefore = rafSpy.mock.calls.length
+    // The 2 s poll delivers a fresh JSON round-trip: identical content, new
+    // object identities everywhere. The loop must not cancel/restart.
+    const repolled: DecorationView = {
+      ...decoration,
+      cell: { ...decoration.cell },
+      durations: [...decoration.durations],
+      phases: { ...decoration.phases },
+    }
+    result.rerender(<PetSprite {...petProps({ definition, snapshot: { ...snapshot, bubble: '正在思考', phase: 'thinking', decoration: repolled } })} />)
+    act(() => { step(322) })
+    expect(ornament()!.style.backgroundPosition).toBe('-48px 0px')
+    expect(cancelSpy).not.toHaveBeenCalled()
+    // One reschedule per loop tick; no effect restart added new schedules.
+    expect(rafSpy.mock.calls.length).toBe(schedulesBefore + 2)
   })
 })

--- a/packages/dsh-pet/src/client/PetSprite.tsx
+++ b/packages/dsh-pet/src/client/PetSprite.tsx
@@ -81,6 +81,11 @@ function StatusOrnament(props: { decoration: DecorationView; phase: ActivityPhas
   const scale = 18 / decoration.cell.height
   const frameWidth = Math.round(decoration.cell.width * scale)
   const stripWidth = decoration.columns * frameWidth
+  // Value-stable dependency key: the host serves a fresh DecorationView
+  // object on every state poll (2 s), so the effect must not depend on the
+  // object identity — otherwise each poll would cancel and restart the
+  // frame loop and the animation would jump back to its first frame.
+  const durationsKey = decoration.durations.join(',')
   useEffect(() => {
     if (segment === undefined || segment === 'hide') return
     const el = spanRef.current
@@ -104,11 +109,14 @@ function StatusOrnament(props: { decoration: DecorationView; phase: ActivityPhas
         else if (decoration.loop) index = segment.from
       }
       el.style.backgroundPosition = position(index)
+      // A non-looping segment settles on its last frame; stop scheduling
+      // instead of repainting the same position every frame.
+      if (!decoration.loop && index === segment.to) return
       raf = requestAnimationFrame(tick)
     }
     raf = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(raf)
-  }, [shown, segmentKey, decoration, frameWidth])
+  }, [shown, segmentKey, frameWidth, decoration.loop, durationsKey])
   if (!shown) return null
   return (
     <span
@@ -190,8 +198,17 @@ export function PetSprite(props: PetSpriteProps): ReactPortal {
     values: Record<string, string | number>,
   ): string => {
     const format = panel?.stats?.[slot] ?? props.t(i18nKey, values)
+    if (panel?.stats?.[slot] === undefined) return format
+    // The host whitelists {rank}/{n}/{points} in every stat slot, so a pack
+    // format may reference any of them; substitute all three live values
+    // (the slot's own value plus the siblings) instead of only the slot's.
+    const all: Record<string, string | number> = {
+      rank: snapshot?.affinity.rank ?? '?',
+      n: snapshot?.treats.stocked ?? 0,
+      points: snapshot?.affinity.points ?? 0,
+    }
     let text = format
-    for (const [name, value] of Object.entries(values)) text = text.replaceAll('{' + name + '}', String(value))
+    for (const [name, value] of Object.entries(all)) text = text.replaceAll('{' + name + '}', String(value))
     return text
   }
   const panelShows = (action: 'feed' | 'rename' | 'hide'): boolean =>

--- a/packages/dsh-pet/src/contracts/status-decoration.ts
+++ b/packages/dsh-pet/src/contracts/status-decoration.ts
@@ -58,9 +58,13 @@ export type DecorationManifestParse =
 
 /**
  * The decoration block the host serves inside the pet state view — exactly
- * what the browser half needs to render the ornament, nothing more.
+ * what the browser half needs to render the ornament, nothing more. The
+ * apiVersion rides the wire so a future protocol revision can be detected
+ * and negotiated by clients (review-spd follow-up, pet-center M5).
  */
 export interface DecorationView {
+  /** The protocol version this view speaks (PET_DECORATION_API_VERSION). */
+  apiVersion: typeof PET_DECORATION_API_VERSION
   id: string
   /** Same-origin URL prefix of the decoration's assets. */
   assetBase: string

--- a/packages/dsh-pet/src/decoration.test.ts
+++ b/packages/dsh-pet/src/decoration.test.ts
@@ -4,7 +4,11 @@
  * PNG/WebP entry discipline.
  */
 import { describe, expect, it } from 'vitest'
-import { parseDecorationManifest, safeDecorationEntry } from './decoration.ts'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { KNOWN_DECORATION_TOP_LEVEL, parseDecorationManifest, safeDecorationEntry } from './decoration.ts'
+import { PET_ACTIVITY_PHASES } from './manifest-v2.ts'
+import { petPackageRoot } from './registry.ts'
 
 function parse(raw: unknown) {
   return parseDecorationManifest(raw, 'test/decoration.json')
@@ -116,17 +120,59 @@ describe('parseDecorationManifest content (warn-and-drop)', () => {
     if (!verdict.ok) return
     expect(verdict.manifest.durations).toEqual([120, 130, 140, 150])
   })
+
+  it('warns and defaults to looping when loop is not a boolean', () => {
+    const verdict = parse({ ...valid(), loop: 'yes' })
+    expect(verdict.ok).toBe(true)
+    if (!verdict.ok) return
+    expect(verdict.manifest.loop).toBe(true)
+    expect(verdict.diagnostics.some(d => d.level === 'warning' && d.message.includes('loop'))).toBe(true)
+    const off = parse({ ...valid(), loop: false })
+    expect(off.ok && off.manifest.loop).toBe(false)
+  })
 })
 
 describe('safeDecorationEntry', () => {
   it('accepts safe relative PNG/WebP paths and rejects everything else', () => {
     expect(safeDecorationEntry('frames.webp')).toBe('frames.webp')
-    expect(safeDecorationEntry('img/FRAMES.PNG')).toBe('img/FRAMES.PNG')
     expect(safeDecorationEntry('a/b.png')).toBe('a/b.png')
     expect(safeDecorationEntry('')).toBeUndefined()
     expect(safeDecorationEntry('a/../b.png')).toBeUndefined()
     expect(safeDecorationEntry('/tmp/x.png')).toBeUndefined()
     expect(safeDecorationEntry('x.svg')).toBeUndefined()
     expect(safeDecorationEntry('x')).toBeUndefined()
+  })
+
+  it('rejects case-mismatched extensions (the route serves paths verbatim)', () => {
+    // A lenient case check would pass validation here, but the asset route
+    // matches the declared path exactly and 403s on case-sensitive hosts.
+    expect(safeDecorationEntry('img/FRAMES.PNG')).toBeUndefined()
+    expect(safeDecorationEntry('img/frames.WebP')).toBeUndefined()
+    expect(safeDecorationEntry('img/frames.png')).toBe('img/frames.png')
+  })
+})
+
+describe('status-decoration schema file drift lock', () => {
+  const schema = JSON.parse(readFileSync(
+    join(petPackageRoot(import.meta.url), 'contracts', 'status-decoration-v1.schema.json'),
+    'utf8',
+  )) as {
+    required: string[]
+    properties: Record<string, { const?: number; properties?: Record<string, unknown> }>
+  }
+
+  it('locks the schema top-level fields to the validator allow-list', () => {
+    expect(new Set(Object.keys(schema.properties))).toEqual(KNOWN_DECORATION_TOP_LEVEL)
+  })
+
+  it('locks the required set and the version const', () => {
+    expect([...schema.required].sort()).toEqual([
+      'cell', 'columns', 'decorationManifestVersion', 'entry', 'id', 'license',
+    ])
+    expect(schema.properties.decorationManifestVersion?.const).toBe(1)
+  })
+
+  it('locks the phases key set to the ActivityPhase stream', () => {
+    expect(new Set(Object.keys(schema.properties.phases?.properties ?? {}))).toEqual(new Set(PET_ACTIVITY_PHASES))
   })
 })

--- a/packages/dsh-pet/src/decoration.ts
+++ b/packages/dsh-pet/src/decoration.ts
@@ -64,20 +64,25 @@ function finiteInt(value: unknown, min: number, max: number): number | undefined
 
 /**
  * Validate a descriptor-relative entry path: no absolute paths, no
- * backslashes, no traversal, plain safe segments only, and a PNG/WebP
- * extension (the adopted entry discipline — SVG/CSS are not accepted).
+ * backslashes, no traversal, plain safe segments only, and an exact
+ * lowercase PNG/WebP extension (the adopted entry discipline — SVG/CSS are
+ * not accepted). The extension match is case-sensitive on purpose: the
+ * asset route serves the declared path verbatim, so a case-mismatched
+ * suffix (frames.PNG vs frames.png) would pass a lenient check but 403 on
+ * case-sensitive filesystems.
  * Returns the normalized path or undefined.
  */
 export function safeDecorationEntry(raw: unknown): string | undefined {
   if (typeof raw !== 'string' || raw.trim() === '') return undefined
   const value = raw.trim()
+  if (value.length > 256) return undefined
   if (isAbsolute(value) || value.includes('\\') || /^[a-z][a-z0-9+.-]*:/i.test(value)) return undefined
   const segments = value.split('/').filter(segment => segment !== '')
   if (segments.length === 0) return undefined
   if (segments.some(segment => segment === '.' || segment === '..' || !PATH_SEGMENT_PATTERN.test(segment))) return undefined
   const last = segments[segments.length - 1]!
   const dot = last.lastIndexOf('.')
-  if (dot <= 0 || !(DECORATION_ENTRY_EXTENSIONS as readonly string[]).includes(last.slice(dot).toLowerCase())) return undefined
+  if (dot <= 0 || !(DECORATION_ENTRY_EXTENSIONS as readonly string[]).includes(last.slice(dot))) return undefined
   return segments.join('/')
 }
 
@@ -125,13 +130,22 @@ export function parseDecorationManifest(
   if (!PET_ID_PATTERN.test(id)) {
     diag.error('id must be a lowercase kebab id')
   }
+  if (id.length > 64) {
+    diag.error('id must be at most 64 characters')
+  }
   const license = typeof raw.license === 'string' ? raw.license.trim() : ''
   if (license === '') diag.error('license is required (asset provenance)')
+  if (license.length > 128) {
+    diag.error('license must be at most 128 characters')
+  }
   const entry = safeDecorationEntry(raw.entry)
   if (entry === undefined) {
     diag.error('entry must be a safe relative PNG/WebP path')
   }
   const rawCell = isRecord(raw.cell) ? raw.cell : {}
+  for (const key of Object.keys(rawCell)) {
+    if (key !== 'width' && key !== 'height') diag.warn('unknown cell field ' + JSON.stringify(key) + ' ignored')
+  }
   const cellWidth = finiteInt(rawCell.width, 1, DECORATION_CELL_MAX)
   const cellHeight = finiteInt(rawCell.height, 1, DECORATION_CELL_MAX)
   if (cellWidth === undefined || cellHeight === undefined) {
@@ -147,7 +161,13 @@ export function parseDecorationManifest(
   const displayName = typeof raw.displayName === 'string' && raw.displayName.trim() !== ''
     ? raw.displayName.trim().slice(0, DECORATION_DISPLAY_NAME_MAX)
     : id
-  const loop = typeof raw.loop === 'boolean' ? raw.loop : true
+  let loop: boolean
+  if (raw.loop === undefined || typeof raw.loop === 'boolean') {
+    loop = raw.loop ?? true
+  } else {
+    diag.warn('loop must be a boolean; defaulting to true')
+    loop = true
+  }
   const rawDurations = raw.durations
   let durations: number[]
   if (Array.isArray(rawDurations)) {

--- a/packages/dsh-pet/src/registry.test.ts
+++ b/packages/dsh-pet/src/registry.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import {
   DEFAULT_FRAME_COUNTS,
   DEFAULT_PET_CELL,
+  PET_SCAN_JSON_CAP,
   codexPetsDir,
   loadPetRegistry,
   petAtlasFile,
@@ -537,6 +538,63 @@ describe('voice packs (pet-center M4, issue #677)', () => {
       rmSync(root, { recursive: true, force: true })
     }
   })
+
+  it('serves the merged panel chrome (per-pet over global, per slot)', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      mkdirSync(join(petsDir, 'plain'), { recursive: true })
+      writeFileSync(join(petsDir, 'plain', 'pet.json'), JSON.stringify({ id: 'plain', displayName: 'Plain', spritesheetPath: 'spritesheet.webp' }), 'utf8')
+      writeFileSync(join(petsDir, 'plain', 'spritesheet.webp'), 'webp', 'utf8')
+      writeFileSync(join(petsDir, 'plain', 'voice.json'), JSON.stringify({
+        panel: { labels: { feed: '宠物投喂' }, stats: { treats: '宠物鱼干 {n}' } },
+      }), 'utf8')
+      writeFileSync(join(petsDir, '.voice.json'), JSON.stringify({
+        panel: { labels: { feed: '全局投喂', hide: '全局藏' } },
+      }), 'utf8')
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: petsDir })
+      const entry = registry.byId('plain')
+      expect(entry).toBeDefined()
+      const view = petEntryView(entry!, registry.globalVoice)
+      // The pet's own slot wins; untouched global slots layer underneath.
+      expect(view.panel?.labels).toEqual({ feed: '宠物投喂', hide: '全局藏' })
+      expect(view.panel?.stats?.treats).toBe('宠物鱼干 {n}')
+      // A pack-less pet would receive the global panel as-is.
+      const bare = resolvePetManifest({ id: 'bare', displayName: 'Bare', spritesheetPath: 'spritesheet.webp' }, join(tmpdir(), 'bare'))
+      expect(petEntryView(bare!, registry.globalVoice).panel?.labels).toEqual({ feed: '全局投喂', hide: '全局藏' })
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('skips an oversized voice.json with a warning instead of reading it', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      mkdirSync(join(petsDir, 'loud'), { recursive: true })
+      writeFileSync(join(petsDir, 'loud', 'pet.json'), JSON.stringify({ id: 'loud', displayName: 'Loud', spritesheetPath: 'spritesheet.webp' }), 'utf8')
+      writeFileSync(join(petsDir, 'loud', 'voice.json'), '{ ' + 'x'.repeat(PET_SCAN_JSON_CAP) + ' }', 'utf8')
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('loud')!.voice).toBeUndefined()
+      expect(registry.warnings.some(w => w.includes('scan ceiling'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('skips a non-regular voice.json with a warning', () => {
+    const root = tempDir()
+    try {
+      const petsDir = join(root, 'pets')
+      mkdirSync(join(petsDir, 'odd', 'voice.json'), { recursive: true })
+      writeFileSync(join(petsDir, 'odd', 'pet.json'), JSON.stringify({ id: 'odd', displayName: 'Odd', spritesheetPath: 'spritesheet.webp' }), 'utf8')
+      const registry = loadPetRegistry({ packageRoot: join(root, 'none'), petsDir, dshPetsDir: '' })
+      expect(registry.byId('odd')!.voice).toBeUndefined()
+      expect(registry.warnings.some(w => w.includes('not a regular file'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
 })
 describe('status decorations (pet-center M5, #567)', () => {
   function writeDecoration(dir: string, name: string, manifest: Record<string, unknown>, strip = 'whale-frames.png'): void {
@@ -597,6 +655,34 @@ describe('status decorations (pet-center M5, #567)', () => {
       const registry = loadPetRegistry({ packageRoot: root, petsDir: '', dshPetsDir: '' })
       expect(registry.decorations).toEqual([])
       expect(registry.diagnostics.some(d => d.level === 'error' && d.message.includes('broken'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('skips an oversized decoration.json with a warning instead of reading it', () => {
+    const root = tempDir()
+    try {
+      mkdirSync(join(root, 'assets', 'decorations', 'huge'), { recursive: true })
+      writeFileSync(join(root, 'assets', 'decorations', 'huge', 'decoration.json'), '{ ' + 'x'.repeat(PET_SCAN_JSON_CAP) + ' }', 'utf8')
+      const registry = loadPetRegistry({ packageRoot: root, petsDir: '', dshPetsDir: '' })
+      expect(registry.decorations).toEqual([])
+      expect(registry.warnings.some(w => w.includes('scan ceiling'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('lists a decoration with a missing strip and warns about the file', () => {
+    const root = tempDir()
+    try {
+      const dir = join(root, 'assets', 'decorations', 'ghost')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'decoration.json'), JSON.stringify(baseManifest()), 'utf8')
+      const registry = loadPetRegistry({ packageRoot: root, petsDir: '', dshPetsDir: '' })
+      // The entry id comes from the descriptor (the directory name is free).
+      expect(registry.decorationById?.('whale')).toBeDefined()
+      expect(registry.warnings.some(w => w.includes('strip file missing'))).toBe(true)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/packages/dsh-pet/src/registry.ts
+++ b/packages/dsh-pet/src/registry.ts
@@ -27,15 +27,15 @@
  * @module @linxin666/dsh-pet/registry
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ActivityPhase, PetAnimation } from './state.ts'
 import { normalizePetRemarks, type PetRemarks, type PetRemarksManifest } from './remarks.ts'
-import { normalizeVoicePack, type PetPanelView, type VoicePack } from './voice-pack.ts'
+import { mergeVoicePacks, normalizeVoicePack, type PetPanelView, type VoicePack } from './voice-pack.ts'
 import { parseDecorationManifest } from './decoration.ts'
-import type { DecorationView } from './contracts/status-decoration.ts'
+import { PET_DECORATION_API_VERSION, type DecorationView } from './contracts/status-decoration.ts'
 import { dshHome } from './dsh-home.ts'
 import { parsePetManifest, type PetManifestLive2d, type PetManifestV2, type PetRendererKind } from './manifest-v2.ts'
 import { collectModel3References } from './model3.ts'
@@ -619,6 +619,47 @@ function readPetJson(file: string, warnings: string[] | undefined): unknown {
 }
 
 /**
+ * Scan-time read ceiling for user-authored JSON descriptors (voice.json,
+ * .voice.json, decoration.json): the registry reads these synchronously at
+ * plugin startup, and a pathological file — multi-GB, or a FIFO/device
+ * symlink — must not hang or exhaust the host before the warn-and-drop
+ * discipline can apply (review-spd follow-up, pet-center M4/M5).
+ */
+export const PET_SCAN_JSON_CAP = 64 * 1024
+
+/**
+ * Stat one scanned JSON descriptor with a regular-file + size guard, so a
+ * pathological user file is skipped with a warning instead of stalling or
+ * OOM-ing the host at startup. Returns the Stats, or undefined when the
+ * caller must skip the file (a warning was recorded).
+ */
+function guardedScannedJsonStat(
+  file: string,
+  options: { warnings?: string[]; diagnostics?: PetRegistryDiagnostic[] },
+  what: string,
+): ReturnType<typeof statSync> | undefined {
+  let st: ReturnType<typeof statSync>
+  try {
+    st = statSync(file)
+  } catch {
+    return undefined
+  }
+  const warn = (message: string): void => {
+    options.warnings?.push(file + ': ' + message)
+    options.diagnostics?.push({ level: 'warning', source: file, message: file + ': ' + message })
+  }
+  if (!st.isFile()) {
+    warn(what + ' is not a regular file; ignored')
+    return undefined
+  }
+  if (st.size > PET_SCAN_JSON_CAP) {
+    warn(what + ' exceeds the ' + PET_SCAN_JSON_CAP + '-byte scan ceiling; ignored')
+    return undefined
+  }
+  return st
+}
+
+/**
  * Load and normalize one optional voice.json (pet-center M4). A missing
  * file is silent; a broken file warns and drops. The pack is pure content,
  * so every issue stays a warning — a bad voice.json never rejects a pet.
@@ -628,6 +669,7 @@ function loadVoicePackFile(
   options: { warnings?: string[]; diagnostics?: PetRegistryDiagnostic[] },
 ): VoicePack | undefined {
   if (!existsSync(file)) return undefined
+  if (guardedScannedJsonStat(file, options, 'voice pack') === undefined) return undefined
   const warn = (message: string): void => {
     options.warnings?.push(file + ': ' + message)
     options.diagnostics?.push({ level: 'warning', source: file, message: file + ': ' + message })
@@ -664,6 +706,7 @@ function scanDecorationDir(dir: string, options: { warnings?: string[]; diagnost
     const entryDir = join(dir, name)
     const manifestFile = join(entryDir, 'decoration.json')
     if (!existsSync(manifestFile)) continue
+    if (guardedScannedJsonStat(manifestFile, options, 'decoration descriptor') === undefined) continue
     let raw: unknown
     try {
       raw = JSON.parse(readFileSync(manifestFile, 'utf8'))
@@ -680,7 +723,16 @@ function scanDecorationDir(dir: string, options: { warnings?: string[]; diagnost
     }
     if (!verdict.ok) continue
     const manifest = verdict.manifest
+    // A missing strip keeps the entry listed (mirroring the live2d closure
+    // discipline) but earns a diagnostic: the ornament will silently render
+    // nothing, and the warning names the file to fix.
+    if (!existsSync(join(entryDir, manifest.entry))) {
+      const message = 'decoration ' + manifest.id + ': strip file missing: ' + manifest.entry
+      options.warnings?.push(message)
+      options.diagnostics?.push({ level: 'warning', source: entryDir, message })
+    }
     entries.push({
+      apiVersion: PET_DECORATION_API_VERSION,
       id: manifest.id,
       dir: entryDir,
       entryPath: manifest.entry,
@@ -793,6 +845,7 @@ export const DEFAULT_DECORATION_ID = 'whale'
 /** Strip host-only fields, leaving the browser-visible decoration view. */
 export function decorationView(entry: DecorationEntry): DecorationView {
   return {
+    apiVersion: PET_DECORATION_API_VERSION,
     id: entry.id,
     assetBase: entry.assetBase,
     entryUrl: entry.entryUrl,
@@ -804,8 +857,16 @@ export function decorationView(entry: DecorationEntry): DecorationView {
   }
 }
 
-/** Strip host-only fields, leaving the client-visible definition. */
-export function petEntryView(entry: PetEntry): PetDefinition {
+/**
+ * Strip host-only fields, leaving the client-visible definition. When the
+ * registry carries a global voice pack, its panel chrome layers under the
+ * entry's own pack (per-slot merge, pet > global), mirroring the voice-pool
+ * layering (pet-center M4, issue #677).
+ */
+export function petEntryView(entry: PetEntry, globalVoice?: VoicePack): PetDefinition {
+  const panel = globalVoice === undefined
+    ? entry.voice?.panel
+    : mergeVoicePacks(globalVoice, entry.voice)?.panel
   return {
     id: entry.id,
     displayName: entry.displayName,
@@ -820,7 +881,7 @@ export function petEntryView(entry: PetEntry): PetDefinition {
     ...(entry.sequences === undefined ? {} : { sequences: entry.sequences }),
     atlasUrl: entry.atlasUrl,
     manifestUrl: entry.manifestUrl,
-    ...(entry.voice?.panel === undefined ? {} : { panel: entry.voice.panel }),
+    ...(panel === undefined ? {} : { panel }),
   }
 }
 

--- a/packages/dsh-pet/src/routes.ts
+++ b/packages/dsh-pet/src/routes.ts
@@ -263,7 +263,7 @@ function assetHandler(registry: PetRegistry, caps: PetAssetCaps): WebRoute['hand
       file = existsSync(preview) ? preview : undefined
     }
     if (synthesized) {
-      const body = Buffer.from(JSON.stringify(petEntryView(entry), null, 2), 'utf8')
+      const body = Buffer.from(JSON.stringify(petEntryView(entry, registry.globalVoice), null, 2), 'utf8')
       res.writeHead(200, {
         'content-type': 'application/json; charset=utf-8',
         'content-length': String(body.byteLength),
@@ -504,8 +504,10 @@ function decorationHandler(registry: PetRegistry, caps: PetAssetCaps): WebRoute[
       return
     }
     const cap = rel === 'decoration.json' ? caps.manifest : caps.image
+    let stat: ReturnType<typeof statSync>
     try {
-      if (statSync(resolved).size > cap) {
+      stat = statSync(resolved)
+      if (stat.size > cap) {
         res.writeHead(413)
         res.end()
         return
@@ -515,11 +517,22 @@ function decorationHandler(registry: PetRegistry, caps: PetAssetCaps): WebRoute[
       res.end()
       return
     }
+    // Weak ETag from size + mtime: 'no-cache' forces revalidation, and the
+    // validator lets repeat requests settle as 304 — the ornament remounts
+    // on whisper and display-session flips, and without a validator each
+    // remount would re-download the full strip body.
+    const etag = '"' + stat.size.toString(16) + '-' + Math.round(stat.mtimeMs).toString(16) + '"'
+    if (req.headers['if-none-match'] === etag) {
+      res.writeHead(304, { etag, 'cache-control': 'no-cache' })
+      res.end()
+      return
+    }
     readFile(resolved).then((body) => {
       res.writeHead(200, {
         'content-type': mimeFor(resolved),
         'content-length': String(body.byteLength),
         'cache-control': 'no-cache',
+        etag,
       })
       if (req.method === 'HEAD') {
         res.end()

--- a/packages/dsh-pet/src/service.ts
+++ b/packages/dsh-pet/src/service.ts
@@ -301,7 +301,7 @@ export class PetService extends Service {
 
   /** RPC: the registry entries the browser half renders and selects from. */
   async pets(): Promise<PetDefinition[]> {
-    return this.registry.entries.map(petEntryView)
+    return this.registry.entries.map(entry => petEntryView(entry, this.registry.globalVoice))
   }
 
   /** The loaded registry (the asset routes serve its entries). */

--- a/packages/dsh-pet/src/voice-pack.test.ts
+++ b/packages/dsh-pet/src/voice-pack.test.ts
@@ -5,14 +5,24 @@
  * (later layers win per slot).
  */
 import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   mergeVoicePacks,
   normalizePanel,
   normalizePool,
   normalizeVoicePack,
   normalizeWhisperRules,
+  PANEL_ACTIONS,
+  PANEL_LABEL_KEYS,
+  PANEL_STAT_KEYS,
   VOICE_LINE_MAX,
+  VOICE_PACK_KEYS,
+  VOICE_PACK_V1,
+  WHISPER_KEYS,
 } from './voice-pack.ts'
+import { STATUS_SCENES, TOOL_CATEGORIES } from './chatter.ts'
+import { petPackageRoot } from './registry.ts'
 
 function collectWarnings(pack: unknown): { pack: ReturnType<typeof normalizeVoicePack>; warnings: string[] } {
   const warnings: string[] = []
@@ -153,5 +163,54 @@ describe('mergeVoicePacks', () => {
 
   it('returns undefined when every layer is empty', () => {
     expect(mergeVoicePacks(undefined, undefined)).toBeUndefined()
+  })
+})
+
+describe('normalizeVoicePack schema twin', () => {
+  it('accepts the $schema field without a warning', () => {
+    const { pack, warnings } = collectWarnings({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      status: { done: ['收工'] },
+    })
+    expect(pack).toBeDefined()
+    expect(warnings).toEqual([])
+  })
+
+  it('drops the tail when the length cap cuts a placeholder token in half', () => {
+    const line = 'x'.repeat(155) + '{tool}'
+    const { pack, warnings } = collectWarnings({ tools: { shell: [line] } })
+    expect(pack?.overrides.tools?.shell).toEqual(['x'.repeat(155)])
+    expect(warnings.some(w => w.includes('unterminated placeholder'))).toBe(true)
+  })
+})
+
+describe('voice-pack schema file drift lock', () => {
+  const schema = JSON.parse(readFileSync(
+    join(petPackageRoot(import.meta.url), 'contracts', 'voice-pack-v1.schema.json'),
+    'utf8',
+  )) as {
+    properties: Record<string, { const?: number; properties?: Record<string, unknown>; items?: { enum?: string[] } }>
+  }
+
+  it('locks the schema top-level fields to the validator allow-list', () => {
+    expect(new Set(Object.keys(schema.properties))).toEqual(VOICE_PACK_KEYS)
+  })
+
+  it('locks the scene, tool, whisper and panel key sets', () => {
+    const props = schema.properties
+    expect(new Set(Object.keys(props.status?.properties ?? {}))).toEqual(new Set(STATUS_SCENES))
+    expect(new Set(Object.keys(props.tools?.properties ?? {}))).toEqual(new Set(TOOL_CATEGORIES))
+    expect(new Set(Object.keys(props.whispers?.properties ?? {}))).toEqual(WHISPER_KEYS)
+    const panel = props.panel?.properties ?? {}
+    const labels = (panel.labels as { properties?: Record<string, unknown> } | undefined)?.properties ?? {}
+    const stats = (panel.stats as { properties?: Record<string, unknown> } | undefined)?.properties ?? {}
+    expect(new Set(Object.keys(labels))).toEqual(new Set(PANEL_LABEL_KEYS))
+    expect(new Set(Object.keys(stats))).toEqual(new Set(PANEL_STAT_KEYS))
+    const actions = (panel.actions as { items?: { enum?: string[] } } | undefined)
+    expect(actions?.items?.enum).toEqual([...PANEL_ACTIONS])
+  })
+
+  it('keeps the schema version const in sync', () => {
+    expect(schema.properties.voicePackVersion?.const).toBe(VOICE_PACK_V1)
   })
 })

--- a/packages/dsh-pet/src/voice-pack.ts
+++ b/packages/dsh-pet/src/voice-pack.ts
@@ -97,7 +97,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function normalizeLine(raw: string, kind: PoolKind, onWarning: (message: string) => void): string | undefined {
   const trimmed = raw.trim()
   if (trimmed === '') return undefined
-  const capped = trimmed.length > VOICE_LINE_MAX ? trimmed.slice(0, VOICE_LINE_MAX) : trimmed
+  let capped = trimmed.length > VOICE_LINE_MAX ? trimmed.slice(0, VOICE_LINE_MAX) : trimmed
+  // The length cap may cut a placeholder token in half, leaving a dangling
+  // '{' that would render literally; drop the tail from the unmatched brace.
+  const dangling = capped.lastIndexOf('{')
+  if (dangling !== -1 && capped.indexOf('}', dangling) === -1) {
+    onWarning('line cut at an unterminated placeholder; tail dropped: ' + capped.slice(0, 40) + '...')
+    capped = capped.slice(0, dangling)
+  }
+  if (capped === '') return undefined
   const allowed = PLACEHOLDER_WHITELIST[kind]
   const tokens = capped.match(PLACEHOLDER_PATTERN) ?? []
   for (const token of tokens) {
@@ -259,11 +267,11 @@ export function normalizePanel(
   return panel
 }
 
-/** Voice-pack top-level fields. */
-const VOICE_PACK_KEYS = new Set(['voicePackVersion', 'status', 'tools', 'toolRemaining', 'whispers', 'panel'])
+/** Voice-pack top-level fields ('$schema' mirrors the schema twin; drift-locked in tests). */
+export const VOICE_PACK_KEYS = new Set(['$schema', 'voicePackVersion', 'status', 'tools', 'toolRemaining', 'whispers', 'panel'])
 
-/** Allowed whisper-section fields. */
-const WHISPER_KEYS = new Set(['generic', 'rules'])
+/** Allowed whisper-section fields (drift-locked in tests). */
+export const WHISPER_KEYS = new Set(['generic', 'rules'])
 
 /**
  * Normalize one raw voice.json document into a VoicePack, or undefined when

--- a/packages/dsh-pet/tests/routes.spec.ts
+++ b/packages/dsh-pet/tests/routes.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { createServer, type Server } from 'node:http'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { once } from 'node:events'
@@ -17,6 +17,7 @@ let dir: string
 let server: Server
 let port: number
 let routes: ReturnType<typeof makePetRoutes>
+let service: PetService
 
 beforeAll(async () => {
   dir = mkdtempSync(join(tmpdir(), 'dsh-pet-routes-'))
@@ -50,7 +51,7 @@ beforeAll(async () => {
 
   const ctx = new Context()
   const registry = loadPetRegistry({ packageRoot: dir, petsDir: '', dshPetsDir: '' })
-  const service = new PetService(ctx, { persistDir: join(dir, 'home'), registry })
+  service = new PetService(ctx, { persistDir: join(dir, 'home'), registry })
   routes = makePetRoutes({ service })
   server = createServer((req, res) => {
     const pathname = (req.url ?? '').split('?')[0]!
@@ -215,8 +216,96 @@ describe('decoration routes (pet-center M5, #567)', () => {
   it('serves the decoration block in the state view', async () => {
     const state = await fetch(`http://127.0.0.1:${port}/api/pet/state`)
     const body = await state.json()
+    expect(body.decoration.apiVersion).toBe('x-org.linxin666.pet-center/status-decoration-v1')
     expect(body.decoration.id).toBe('whale')
     expect(body.decoration.entryUrl).toBe('/api/pet/decoration/whale/whale-frames.png')
     expect(body.decoration.phases.thinking).toEqual({ from: 0, to: 3 })
+  })
+
+  it('serves the strip and descriptor with correct content types', async () => {
+    const strip = await fetch('http://127.0.0.1:' + port + '/api/pet/decoration/whale/whale-frames.png')
+    expect(strip.headers.get('content-type')).toBe('image/png')
+    const manifest = await fetch('http://127.0.0.1:' + port + '/api/pet/decoration/whale/decoration.json')
+    expect(manifest.headers.get('content-type')).toContain('application/json')
+  })
+
+  it('answers 405 to POST and 200 with an empty body to HEAD', async () => {
+    const post = await fetch('http://127.0.0.1:' + port + '/api/pet/decoration/whale/whale-frames.png', { method: 'POST' })
+    expect(post.status).toBe(405)
+    const head = await fetch('http://127.0.0.1:' + port + '/api/pet/decoration/whale/whale-frames.png', { method: 'HEAD' })
+    expect(head.status).toBe(200)
+    expect(await head.arrayBuffer()).toHaveProperty('byteLength', 0)
+  })
+
+  it('revalidates with the ETag instead of re-downloading the strip', async () => {
+    const first = await fetch('http://127.0.0.1:' + port + '/api/pet/decoration/whale/whale-frames.png')
+    expect(first.status).toBe(200)
+    const etag = first.headers.get('etag')
+    expect(etag).not.toBeNull()
+    const cached = await fetch('http://127.0.0.1:' + port + '/api/pet/decoration/whale/whale-frames.png', {
+      headers: { 'if-none-match': etag! },
+    })
+    expect(cached.status).toBe(304)
+    expect(await cached.arrayBuffer()).toHaveProperty('byteLength', 0)
+    const stale = await fetch('http://127.0.0.1:' + port + '/api/pet/decoration/whale/whale-frames.png', {
+      headers: { 'if-none-match': '"bogus"' },
+    })
+    expect(stale.status).toBe(200)
+  })
+
+  it('enforces the size ceiling and refuses symlink escapes', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-pet-deco-caps-'))
+    try {
+      mkdirSync(join(root, 'assets', 'pet'), { recursive: true })
+      writeFileSync(join(root, 'assets', 'pet', 'pet.json'), JSON.stringify({
+        id: 'plain-pet', displayName: 'Plain', spritesheetPath: 'spritesheet.webp',
+      }), 'utf8')
+      writeFileSync(join(root, 'assets', 'pet', 'spritesheet.webp'), WEBP_BYTES)
+      const assets = join(root, 'assets', 'decorations', 'whale')
+      mkdirSync(assets, { recursive: true })
+      writeFileSync(join(assets, 'decoration.json'), JSON.stringify({
+        decorationManifestVersion: 1,
+        id: 'whale',
+        license: 'MIT',
+        entry: 'whale-frames.png',
+        cell: { width: 64, height: 48 },
+        columns: 4,
+        phases: { thinking: { from: 0, to: 3 } },
+      }), 'utf8')
+      writeFileSync(join(assets, 'whale-frames.png'), Buffer.alloc(128, 1))
+      const ctx = new Context()
+      const registry = loadPetRegistry({ packageRoot: root, petsDir: '', dshPetsDir: '' })
+      const capped = new PetService(ctx, { persistDir: join(root, 'home'), registry })
+      const tinyRoutes = makePetRoutes({ service: capped, assetCaps: { manifest: 64, image: 64, model: 64 } })
+      const srv = createServer((req, res) => {
+        const pathname = (req.url ?? '').split('?')[0]!
+        for (const route of tinyRoutes) {
+          if (route.kind === 'exact' && pathname === route.path) { void route.handler(req, res); return }
+        }
+        for (const route of tinyRoutes) {
+          if (route.kind === 'prefix' && (pathname === route.path || pathname.startsWith(route.path + '/'))) { void route.handler(req, res); return }
+        }
+        res.writeHead(404)
+        res.end()
+      })
+      srv.listen(0, '127.0.0.1')
+      await once(srv, 'listening')
+      try {
+        const capPort = (srv.address() as AddressInfo).port
+        const oversized = await fetch('http://127.0.0.1:' + capPort + '/api/pet/decoration/whale/whale-frames.png')
+        expect(oversized.status).toBe(413)
+        // A strip symlinked outside the decoration directory is refused.
+        rmSync(join(assets, 'whale-frames.png'))
+        const outside = join(root, 'outside.png')
+        writeFileSync(outside, Buffer.alloc(4, 1))
+        symlinkSync(outside, join(assets, 'whale-frames.png'))
+        const escaped = await fetch('http://127.0.0.1:' + capPort + '/api/pet/decoration/whale/whale-frames.png')
+        expect(escaped.status).toBe(403)
+      } finally {
+        await new Promise<void>((resolve) => srv.close(() => resolve()))
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/dsh-pet/tests/service-enabled.spec.ts
+++ b/packages/dsh-pet/tests/service-enabled.spec.ts
@@ -9,6 +9,7 @@ import { PetService } from '../src/service.ts'
 import { resolvePetManifest, type DecorationEntry, type PetRegistry } from '../src/registry.ts'
 import { normalizeVoicePack } from '../src/voice-pack.ts'
 import { parseDecorationManifest } from '../src/decoration.ts'
+import { PET_DECORATION_API_VERSION } from '../src/contracts/status-decoration.ts'
 
 /** Two-pet registry fixture (whale-girl + otter) for selection/name tests. */
 function fixtureRegistry(): PetRegistry {
@@ -998,6 +999,31 @@ describe('voice packs in PetService (pet-center M4, issue #677)', () => {
     }
   })
 
+  it('serves the global panel chrome on the pets list (pet over global, per slot)', async () => {
+    const ctx = new Context()
+    const dir = tempDir()
+    try {
+      const registry = voicedRegistry('plain', { panel: { labels: { feed: '宠物投喂' } } }, {
+        globalVoice: normalizeVoicePack({ panel: { labels: { feed: '全局投喂', hide: '全局藏' } } }),
+      })
+      const service = new PetService(ctx, { persistDir: dir, registry })
+      const pets = await service.pets()
+      const plain = pets.find(pet => pet.id === 'plain')
+      expect(plain).toBeDefined()
+      expect(plain!.panel?.labels).toEqual({ feed: '宠物投喂', hide: '全局藏' })
+      // A pack-less pet receives the global panel as-is.
+      const registryBare = voicedRegistry('bare', undefined, {
+        globalVoice: normalizeVoicePack({ panel: { labels: { hide: '全局藏' } } }),
+      })
+      const ctxBare = new Context()
+      const serviceBare = new PetService(ctxBare, { persistDir: join(dir, 'bare'), registry: registryBare })
+      const bare = (await serviceBare.pets()).find(pet => pet.id === 'bare')
+      expect(bare!.panel?.labels).toEqual({ hide: '全局藏' })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('wakes a whisper from the pet pack keyword rules', async () => {
     const ctx = new Context()
     const dir = tempDir()
@@ -1038,6 +1064,7 @@ describe('status decorations in PetService (pet-center M5, #567)', () => {
     if (!verdict.ok) throw new Error('fixture decoration must parse')
     const manifest = verdict.manifest
     const entry: DecorationEntry = {
+      apiVersion: PET_DECORATION_API_VERSION,
       id: manifest.id,
       dir: join(tmpdir(), 'whale'),
       entryPath: manifest.entry,


### PR DESCRIPTION
## 摘要（Summary）

针对 pet-center M4/M5 五个合并提交（#681/#685/#687/#691/#693）的 review-spd 评审清单修复（M1/M2/L1-L7 + 残留项）：全局面板接线、装饰 rAF 轮询重启、跨槽占位符、大小写扩展名、扫描期读取上限、ETag/304、apiVersion 上线、schema 孪生漂移锁、contracts 打包等，全部带测试。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [x] Bug 修复
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch origin && git rebase origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek-V3.2（本会话运行时）

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 修复明细

- **M1 全局面板接线**：`petEntryView` 接受 `globalVoice` 层，`$DSH_HOME/pets/.voice.json` 的 `panel` 现在按槽合入 `/api/pet/pets` 与合成 pet.json（宠物包 > 全局包 > i18n 兜底），不再是死代码。
- **M2 装饰 rAF 重启**：`StatusOrnament` effect 依赖改为值稳定原语（segmentKey/frameWidth/loop/durationsKey），2 秒状态轮询不再取消并重建帧循环；`loop:false` 的段走完后停止调度。
- **L1 跨槽占位符**：pack 统计格式代换全部三个值 `{rank}/{n}/{points}`；`StatusVoice` 的 `{tool}/{hint}/{n}` 改为 replaceAll。
- **L2 扫描期上限**：`voice.json`/`.voice.json`/`decoration.json` 读取前 stat 校验（常规文件 + 64KB 上限），超限/非常规文件告警跳过，不再可能卡死或 OOM 宿主启动。
- **L3 ETag/304**：装饰资产路由带 size+mtime 弱 ETag，`If-None-Match` 命中返回 304，饰件重挂载不再全额重传条带。
- **L4 大小写扩展名**：`safeDecorationEntry` 改为大小写敏感（路由按声明路径逐字节服务，`frames.PNG` 校验通过但必然 403 的陷阱关闭）。
- **L5 apiVersion 上线**：`DecorationView` 携带 `apiVersion`，状态路由与测试钉住。
- **L6 schema 孪生**：`$schema` 加入 voice-pack 白名单；两份新 schema 补 drift-lock 测试（顶层键集、版本 const、scene/tool/whisper/panel/phases 键集）；解析器补 id/license/entry 长度上限与 cell 未知键告警，schema 的 phases 改为可选（与解析器一致）。
- **L7 打包**：`package.json` files 增加 `contracts`，三份协议 schema 随 npm 包发布（`npm pack --dry-run` 验证）。
- **残留项**：条带缺失注册时给诊断；截断切半的占位符丢弃悬空 `{` 尾部；非布尔 `loop` 告警并回落 true。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm --filter @linxin666/dsh-pet build
pnpm runtime-deps:check
npm pack --dry-run  # contracts/ 进入 tarball 验证
node /tmp/pet-review-fix-accept.mjs  # scratch harness GUI 验收
```

结果摘要：

全部通过。dsh-pet 330 用例（新增/更新 25）、test:scripts 135、docs:check 三件套一致；GUI 验收 PASS：全局 panel 渲染与 pets 列表合并、apiVersion 上线、ETag 304、设置开关 off/on、多轮询窗口 rAF cancels 为 0、零 pageerror。

## 用户可见变更证据（Local Feature Evidence）

证据：

本地 scratch harness（:61440）Playwright 实测截图：`/tmp/pet-review-fix-A-panel.png`（全局语音包面板按钮「投喂测试/藏起来测」+ 跨槽统计）、`/tmp/pet-review-fix-C-on.png`（设置开启后装饰恢复）。

M2 的「轮询不重启循环」另有 3 个单元测试直接钉住（帧推进/回绕、段尾保持+停调度、等值重渲染不重启）；scratch harness 无 workspace/session/API key，无法驱动真实活动气泡做现场帧采样，已在验收脚本注释说明。

## 已知后续（未纳入本 PR）

- `pet.json` 沿用既有无上限读取（评审范围外的前置模式），如需可与本 PR 的守卫对齐。