### PR TITLE
fix(describe-image): give attachment guidance for a bare stale attachment id

### DIFF
--- a/packages/dsh-tool-describe-image/src/vision-client.ts
+++ b/packages/dsh-tool-describe-image/src/vision-client.ts
@@ -129,6 +129,12 @@ export async function loadImage(ctx: Context, input: string, signal: AbortSignal
     const bytes = await readAttachment(ctx, JSON.stringify(registered), signal)
     return finishLoad(bytes, trimmed, maxBytes)
   }
+  // A bare content-addressed attachment id no longer in the registry (host
+  // restart or FIFO eviction) must not fall through to a filesystem stat,
+  // which surfaces a misleading ENOENT for a non-path string.
+  if (/^sha256:[0-9a-f]{64}$/i.test(trimmed)) {
+    throw new Error(ATTACHMENT_REF_GUIDANCE)
+  }
   const info = await stat(trimmed, { bigint: false })
   if (!info.isFile()) throw new Error(`describe-image: image path is not a file: ${trimmed}`)
   if (info.size > maxBytes) {


### PR DESCRIPTION
## 摘要（Summary）

修复 `dsh-tool-describe-image` 的裸附件 id 在注册表缺失时产生误导性 ENOENT 的问题。

根因：`loadImage` 对裸 `sha256:…` 附件 id 会先在内存注册表 `attachmentRefById` 解析；当注册表条目因 host 重启或 FIFO 驱逐（上限 128）而消失时，输入会落到最后的 `stat(trimmed)`——对一个非路径字符串做文件系统 stat，抛出 `ENOENT: no such file or directory, stat 'sha256:…'`，误导用户。

修复：检测 content-addressed 的裸附件 id（`sha256:` + 64 位 hex）且不在注册表时，直接抛出「附件引用已不可用」的引导信息（`ATTACHMENT_REF_GUIDANCE`），而非落到文件系统 stat。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）：`packages/dsh-tool-describe-image`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-tool-describe-image test
pnpm --filter @linxin666/dsh-tool-describe-image typecheck
```

结果摘要：

- `pnpm --filter @linxin666/dsh-tool-describe-image test`：15 个测试文件 267 个用例全部通过。
- `pnpm --filter @linxin666/dsh-tool-describe-image typecheck`：通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：裸附件 id 在注册表缺失时给出「附件引用已不可用，请重新附加」的引导，而非文件系统 ENOENT）。
