### PR TITLE
fix(shared): never leave the shell stuck saving, and keep the badge honest

### DIFF
--- a/packages/dsh-aionui-panel/src/client/settings-form.ts
+++ b/packages/dsh-aionui-panel/src/client/settings-form.ts
@@ -294,7 +294,9 @@ export class CardForm<T> {
     const write = staged.clear ? { kind: 'clear' as const } : spec.parse(staged.text)
     return {
       text: staged.text,
-      overridden: write?.kind === 'set',
+      // Overridden only when the save would actually write: a draft equal to
+      // the effective value is skipped by plan(), so it must not show the badge.
+      overridden: write?.kind === 'set' && staged.text !== spec.format(this.sectionValue(field)),
       invalid: write === undefined,
     }
   }
@@ -341,27 +343,32 @@ export class CardForm<T> {
     this.failedReason = undefined
     this.publish()
     const landed = new Set<string>()
-    const batch = this.batchedScope()
-    if (batch !== undefined) {
-      const result = await batch.mutate(plannedWrites)
-      if (result.ok) {
-        for (const field of result.fields) {
-          if (field.landed) landed.add(field.field)
+    try {
+      const batch = this.batchedScope()
+      if (batch !== undefined) {
+        const result = await batch.mutate(plannedWrites)
+        if (result.ok) {
+          for (const field of result.fields) {
+            if (field.landed) landed.add(field.field)
+          }
+        } else {
+          this.failedReason = result.message
         }
       } else {
-        this.failedReason = result.message
+        for (const item of valid) {
+          if (await item.run!()) landed.add(item.field)
+        }
       }
-    } else {
-      for (const item of valid) {
-        if (await item.run!()) landed.add(item.field)
+      for (const field of fields) {
+        if (landed.has(field)) this.staged.delete(field)
       }
+      this.failed = landed.size !== fields.size
+    } finally {
+      // An exceptional write rejection must never leave the shell stuck
+      // saving (a rejected write keeps its drafts staged for a retry).
+      this.saving = false
+      this.publish()
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
-    }
-    this.saving = false
-    this.failed = landed.size !== fields.size
-    this.publish()
   }
 
   /** The scope's batch surface when it supports one; undefined conservatively otherwise. */

--- a/packages/dsh-community-plugins/src/client/settings-form.ts
+++ b/packages/dsh-community-plugins/src/client/settings-form.ts
@@ -294,7 +294,9 @@ export class CardForm<T> {
     const write = staged.clear ? { kind: 'clear' as const } : spec.parse(staged.text)
     return {
       text: staged.text,
-      overridden: write?.kind === 'set',
+      // Overridden only when the save would actually write: a draft equal to
+      // the effective value is skipped by plan(), so it must not show the badge.
+      overridden: write?.kind === 'set' && staged.text !== spec.format(this.sectionValue(field)),
       invalid: write === undefined,
     }
   }
@@ -341,27 +343,32 @@ export class CardForm<T> {
     this.failedReason = undefined
     this.publish()
     const landed = new Set<string>()
-    const batch = this.batchedScope()
-    if (batch !== undefined) {
-      const result = await batch.mutate(plannedWrites)
-      if (result.ok) {
-        for (const field of result.fields) {
-          if (field.landed) landed.add(field.field)
+    try {
+      const batch = this.batchedScope()
+      if (batch !== undefined) {
+        const result = await batch.mutate(plannedWrites)
+        if (result.ok) {
+          for (const field of result.fields) {
+            if (field.landed) landed.add(field.field)
+          }
+        } else {
+          this.failedReason = result.message
         }
       } else {
-        this.failedReason = result.message
+        for (const item of valid) {
+          if (await item.run!()) landed.add(item.field)
+        }
       }
-    } else {
-      for (const item of valid) {
-        if (await item.run!()) landed.add(item.field)
+      for (const field of fields) {
+        if (landed.has(field)) this.staged.delete(field)
       }
+      this.failed = landed.size !== fields.size
+    } finally {
+      // An exceptional write rejection must never leave the shell stuck
+      // saving (a rejected write keeps its drafts staged for a retry).
+      this.saving = false
+      this.publish()
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
-    }
-    this.saving = false
-    this.failed = landed.size !== fields.size
-    this.publish()
   }
 
   /** The scope's batch surface when it supports one; undefined conservatively otherwise. */

--- a/packages/dsh-pet/src/client/settings-form.ts
+++ b/packages/dsh-pet/src/client/settings-form.ts
@@ -294,7 +294,9 @@ export class CardForm<T> {
     const write = staged.clear ? { kind: 'clear' as const } : spec.parse(staged.text)
     return {
       text: staged.text,
-      overridden: write?.kind === 'set',
+      // Overridden only when the save would actually write: a draft equal to
+      // the effective value is skipped by plan(), so it must not show the badge.
+      overridden: write?.kind === 'set' && staged.text !== spec.format(this.sectionValue(field)),
       invalid: write === undefined,
     }
   }
@@ -341,27 +343,32 @@ export class CardForm<T> {
     this.failedReason = undefined
     this.publish()
     const landed = new Set<string>()
-    const batch = this.batchedScope()
-    if (batch !== undefined) {
-      const result = await batch.mutate(plannedWrites)
-      if (result.ok) {
-        for (const field of result.fields) {
-          if (field.landed) landed.add(field.field)
+    try {
+      const batch = this.batchedScope()
+      if (batch !== undefined) {
+        const result = await batch.mutate(plannedWrites)
+        if (result.ok) {
+          for (const field of result.fields) {
+            if (field.landed) landed.add(field.field)
+          }
+        } else {
+          this.failedReason = result.message
         }
       } else {
-        this.failedReason = result.message
+        for (const item of valid) {
+          if (await item.run!()) landed.add(item.field)
+        }
       }
-    } else {
-      for (const item of valid) {
-        if (await item.run!()) landed.add(item.field)
+      for (const field of fields) {
+        if (landed.has(field)) this.staged.delete(field)
       }
+      this.failed = landed.size !== fields.size
+    } finally {
+      // An exceptional write rejection must never leave the shell stuck
+      // saving (a rejected write keeps its drafts staged for a retry).
+      this.saving = false
+      this.publish()
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
-    }
-    this.saving = false
-    this.failed = landed.size !== fields.size
-    this.publish()
   }
 
   /** The scope's batch surface when it supports one; undefined conservatively otherwise. */

--- a/packages/dsh-remote-web-ui/src/client/settings-form.ts
+++ b/packages/dsh-remote-web-ui/src/client/settings-form.ts
@@ -294,7 +294,9 @@ export class CardForm<T> {
     const write = staged.clear ? { kind: 'clear' as const } : spec.parse(staged.text)
     return {
       text: staged.text,
-      overridden: write?.kind === 'set',
+      // Overridden only when the save would actually write: a draft equal to
+      // the effective value is skipped by plan(), so it must not show the badge.
+      overridden: write?.kind === 'set' && staged.text !== spec.format(this.sectionValue(field)),
       invalid: write === undefined,
     }
   }
@@ -341,27 +343,32 @@ export class CardForm<T> {
     this.failedReason = undefined
     this.publish()
     const landed = new Set<string>()
-    const batch = this.batchedScope()
-    if (batch !== undefined) {
-      const result = await batch.mutate(plannedWrites)
-      if (result.ok) {
-        for (const field of result.fields) {
-          if (field.landed) landed.add(field.field)
+    try {
+      const batch = this.batchedScope()
+      if (batch !== undefined) {
+        const result = await batch.mutate(plannedWrites)
+        if (result.ok) {
+          for (const field of result.fields) {
+            if (field.landed) landed.add(field.field)
+          }
+        } else {
+          this.failedReason = result.message
         }
       } else {
-        this.failedReason = result.message
+        for (const item of valid) {
+          if (await item.run!()) landed.add(item.field)
+        }
       }
-    } else {
-      for (const item of valid) {
-        if (await item.run!()) landed.add(item.field)
+      for (const field of fields) {
+        if (landed.has(field)) this.staged.delete(field)
       }
+      this.failed = landed.size !== fields.size
+    } finally {
+      // An exceptional write rejection must never leave the shell stuck
+      // saving (a rejected write keeps its drafts staged for a retry).
+      this.saving = false
+      this.publish()
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
-    }
-    this.saving = false
-    this.failed = landed.size !== fields.size
-    this.publish()
   }
 
   /** The scope's batch surface when it supports one; undefined conservatively otherwise. */

--- a/packages/dsh-task-board/src/client/settings-form.ts
+++ b/packages/dsh-task-board/src/client/settings-form.ts
@@ -294,7 +294,9 @@ export class CardForm<T> {
     const write = staged.clear ? { kind: 'clear' as const } : spec.parse(staged.text)
     return {
       text: staged.text,
-      overridden: write?.kind === 'set',
+      // Overridden only when the save would actually write: a draft equal to
+      // the effective value is skipped by plan(), so it must not show the badge.
+      overridden: write?.kind === 'set' && staged.text !== spec.format(this.sectionValue(field)),
       invalid: write === undefined,
     }
   }
@@ -341,27 +343,32 @@ export class CardForm<T> {
     this.failedReason = undefined
     this.publish()
     const landed = new Set<string>()
-    const batch = this.batchedScope()
-    if (batch !== undefined) {
-      const result = await batch.mutate(plannedWrites)
-      if (result.ok) {
-        for (const field of result.fields) {
-          if (field.landed) landed.add(field.field)
+    try {
+      const batch = this.batchedScope()
+      if (batch !== undefined) {
+        const result = await batch.mutate(plannedWrites)
+        if (result.ok) {
+          for (const field of result.fields) {
+            if (field.landed) landed.add(field.field)
+          }
+        } else {
+          this.failedReason = result.message
         }
       } else {
-        this.failedReason = result.message
+        for (const item of valid) {
+          if (await item.run!()) landed.add(item.field)
+        }
       }
-    } else {
-      for (const item of valid) {
-        if (await item.run!()) landed.add(item.field)
+      for (const field of fields) {
+        if (landed.has(field)) this.staged.delete(field)
       }
+      this.failed = landed.size !== fields.size
+    } finally {
+      // An exceptional write rejection must never leave the shell stuck
+      // saving (a rejected write keeps its drafts staged for a retry).
+      this.saving = false
+      this.publish()
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
-    }
-    this.saving = false
-    this.failed = landed.size !== fields.size
-    this.publish()
   }
 
   /** The scope's batch surface when it supports one; undefined conservatively otherwise. */

--- a/packages/dsh-tool-describe-image/src/client/settings-form.ts
+++ b/packages/dsh-tool-describe-image/src/client/settings-form.ts
@@ -294,7 +294,9 @@ export class CardForm<T> {
     const write = staged.clear ? { kind: 'clear' as const } : spec.parse(staged.text)
     return {
       text: staged.text,
-      overridden: write?.kind === 'set',
+      // Overridden only when the save would actually write: a draft equal to
+      // the effective value is skipped by plan(), so it must not show the badge.
+      overridden: write?.kind === 'set' && staged.text !== spec.format(this.sectionValue(field)),
       invalid: write === undefined,
     }
   }
@@ -341,27 +343,32 @@ export class CardForm<T> {
     this.failedReason = undefined
     this.publish()
     const landed = new Set<string>()
-    const batch = this.batchedScope()
-    if (batch !== undefined) {
-      const result = await batch.mutate(plannedWrites)
-      if (result.ok) {
-        for (const field of result.fields) {
-          if (field.landed) landed.add(field.field)
+    try {
+      const batch = this.batchedScope()
+      if (batch !== undefined) {
+        const result = await batch.mutate(plannedWrites)
+        if (result.ok) {
+          for (const field of result.fields) {
+            if (field.landed) landed.add(field.field)
+          }
+        } else {
+          this.failedReason = result.message
         }
       } else {
-        this.failedReason = result.message
+        for (const item of valid) {
+          if (await item.run!()) landed.add(item.field)
+        }
       }
-    } else {
-      for (const item of valid) {
-        if (await item.run!()) landed.add(item.field)
+      for (const field of fields) {
+        if (landed.has(field)) this.staged.delete(field)
       }
+      this.failed = landed.size !== fields.size
+    } finally {
+      // An exceptional write rejection must never leave the shell stuck
+      // saving (a rejected write keeps its drafts staged for a retry).
+      this.saving = false
+      this.publish()
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
-    }
-    this.saving = false
-    this.failed = landed.size !== fields.size
-    this.publish()
   }
 
   /** The scope's batch surface when it supports one; undefined conservatively otherwise. */

--- a/shared/client/settings/settings-form.ts
+++ b/shared/client/settings/settings-form.ts
@@ -293,7 +293,9 @@ export class CardForm<T> {
     const write = staged.clear ? { kind: 'clear' as const } : spec.parse(staged.text)
     return {
       text: staged.text,
-      overridden: write?.kind === 'set',
+      // Overridden only when the save would actually write: a draft equal to
+      // the effective value is skipped by plan(), so it must not show the badge.
+      overridden: write?.kind === 'set' && staged.text !== spec.format(this.sectionValue(field)),
       invalid: write === undefined,
     }
   }
@@ -340,27 +342,32 @@ export class CardForm<T> {
     this.failedReason = undefined
     this.publish()
     const landed = new Set<string>()
-    const batch = this.batchedScope()
-    if (batch !== undefined) {
-      const result = await batch.mutate(plannedWrites)
-      if (result.ok) {
-        for (const field of result.fields) {
-          if (field.landed) landed.add(field.field)
+    try {
+      const batch = this.batchedScope()
+      if (batch !== undefined) {
+        const result = await batch.mutate(plannedWrites)
+        if (result.ok) {
+          for (const field of result.fields) {
+            if (field.landed) landed.add(field.field)
+          }
+        } else {
+          this.failedReason = result.message
         }
       } else {
-        this.failedReason = result.message
+        for (const item of valid) {
+          if (await item.run!()) landed.add(item.field)
+        }
       }
-    } else {
-      for (const item of valid) {
-        if (await item.run!()) landed.add(item.field)
+      for (const field of fields) {
+        if (landed.has(field)) this.staged.delete(field)
       }
+      this.failed = landed.size !== fields.size
+    } finally {
+      // An exceptional write rejection must never leave the shell stuck
+      // saving (a rejected write keeps its drafts staged for a retry).
+      this.saving = false
+      this.publish()
     }
-    for (const field of fields) {
-      if (landed.has(field)) this.staged.delete(field)
-    }
-    this.saving = false
-    this.failed = landed.size !== fields.size
-    this.publish()
   }
 
   /** The scope's batch surface when it supports one; undefined conservatively otherwise. */

--- a/shared/tests/settings-form.spec.ts
+++ b/shared/tests/settings-form.spec.ts
@@ -180,6 +180,24 @@ describe('CardForm', () => {
     expect(form.shell()).toMatchObject({ failed: true, dirty: true })
   })
 
+  it('clears saving when a write rejects (no stuck shell)', async () => {
+    const scope = new FakeScope<Record<string, unknown>>({ name: 'old' })
+    scope.set.mockImplementation(async () => { throw new Error('boom') })
+    const form = new CardForm(scope, fields())
+    form.actions().edit('name', 'new')
+    await expect(form.save()).rejects.toThrow('boom')
+    expect(form.shell().saving).toBe(false)
+  })
+
+  it('does not show the overridden badge for a draft equal to the effective value', async () => {
+    const scope = new FakeScope<Record<string, unknown>>({ name: 'inherited' })
+    const form = new CardForm(scope, fields())
+    form.actions().edit('name', 'inherited')
+    // plan() skips this draft (it matches the effective value), so no write
+    // would be staged — the badge must not claim one.
+    expect(form.field('name').overridden).toBe(false)
+  })
+
   it('resets a field back to its base value', () => {
     const scope = new FakeScope<Record<string, unknown>>({ enabled: true })
     const form = new CardForm(scope, fields())


### PR DESCRIPTION
## 摘要（Summary）

修复 shared 设置表单的两个 low 问题：

1. `save()` 只在写完成后才把 `this.saving` 复位——若写 reject（异常路径），shell 会永久停在 `saving`（Save/Discard 按钮禁用），且 rejection 成为未处理异常。把写逻辑包进 `try/finally`，异常时 `saving` 必复位（保留 staged 草稿供重试）。
2. `field()` 只要 staged 草稿能解析成 set 就报 `overridden`，即使草稿等于有效值（`plan()` 会把它当作 no-op 跳过、不会产生写）。让 badge 与 `plan()` 对齐：草稿等于有效值时不再显示「已覆盖」。

同步 shared 副本到所有消费者，补测试（还原修复时用例失败）。

> 注：`[43]`（matrix 数字雨）因 `348314c1` 移除了 matrix 皮肤而失效，不在本 PR 内。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`（settings-form 副本）
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 实时令牌统计 `packages/dsh-live-stats`
- [x] 宠物 `packages/dsh-pet`（settings-form 副本）
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`（settings-form 副本）
- [x] 其他（请说明）：`shared/`（settings-form 事实源）及 `dsh-task-board` / `dsh-tool-describe-image` / `dsh-community-plugins` / `dsh-aionui-panel` 的 settings-form 同步副本

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 仅文档
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 新增包目录以 `dsh-` 前缀命名（本 PR 无新增包，不适用）。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/sync-shared.mjs --check
cd shared && npx vitest run tests/settings-form.spec.ts
pnpm --filter @linxin666/dsh-pet test
```

结果摘要：

- `sync-shared.mjs --check`：all consumer copies in sync。
- shared settings-form 测试：19 个用例全部通过（含新增 saving 复位、badge 诚实用例；还原修复时用例失败）。
- `pnpm --filter @linxin666/dsh-pet test`：22 个测试文件 210 个用例全部通过（settings-form 副本）。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（Bug 修复，无新增功能；修复前后行为差异即：写异常时表单不再卡在 saving；草稿等于继承值时不显示「已覆盖」徽标）。
