### PR TITLE
fix(pet): warn on decoration strip geometry mismatch

### DIFF
--- a/packages/dsh-pet/src/image-dimensions.test.ts
+++ b/packages/dsh-pet/src/image-dimensions.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { imageDimensions } from './image-dimensions.ts'
+
+/** Minimal PNG header (signature + IHDR) for the given size. */
+function pngHeader(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(26)
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buf, 0)
+  buf.writeUInt32BE(13, 8)
+  buf.write('IHDR', 12)
+  buf.writeUInt32BE(width, 16)
+  buf.writeUInt32BE(height, 20)
+  return buf
+}
+
+/** Minimal extended WebP header (RIFF + VP8X) for the given size. */
+function webpExtendedHeader(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(30)
+  buf.write('RIFF', 0)
+  buf.writeUInt32LE(30 - 8, 4)
+  buf.write('WEBP', 8)
+  buf.write('VP8X', 12)
+  buf[20] = 0 // flags: none
+  buf.writeUIntLE(width - 1, 24, 3)
+  buf.writeUIntLE(height - 1, 27, 3)
+  return buf
+}
+
+/** Minimal lossless WebP header (RIFF + VP8L). */
+function webpLosslessHeader(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(25)
+  buf.write('RIFF', 0)
+  buf.writeUInt32LE(25 - 8, 4)
+  buf.write('WEBP', 8)
+  buf.write('VP8L', 12)
+  buf[20] = 0x2f
+  const bits = (width - 1) | ((height - 1) << 14)
+  buf.writeUInt32LE(bits, 21)
+  return buf
+}
+
+/** Minimal lossy WebP header (RIFF + VP8 ) — low 14 bits carry the size. */
+function webpLossyHeader(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(30)
+  buf.write('RIFF', 0)
+  buf.writeUInt32LE(30 - 8, 4)
+  buf.write('WEBP', 8)
+  buf.write('VP8 ', 12)
+  buf.writeUInt16LE(width & 0x3fff, 26)
+  buf.writeUInt16LE(height & 0x3fff, 28)
+  return buf
+}
+
+describe('imageDimensions (decoration strip geometry)', () => {
+  it('reads a PNG header', () => {
+    expect(imageDimensions(pngHeader(256, 48))).toEqual({ width: 256, height: 48 })
+    expect(imageDimensions(pngHeader(64, 48))).toEqual({ width: 64, height: 48 })
+  })
+
+  it('reads an extended WebP header (VP8X)', () => {
+    expect(imageDimensions(webpExtendedHeader(128, 64))).toEqual({ width: 128, height: 64 })
+  })
+
+  it('reads a lossless WebP header (VP8L)', () => {
+    expect(imageDimensions(webpLosslessHeader(300, 200))).toEqual({ width: 300, height: 200 })
+  })
+
+  it('reads a lossy WebP header (VP8 )', () => {
+    expect(imageDimensions(webpLossyHeader(80, 40))).toEqual({ width: 80, height: 40 })
+  })
+
+  it('returns undefined for non-image bytes and truncated headers', () => {
+    expect(imageDimensions(Buffer.from('not-an-image'))).toBeUndefined()
+    expect(imageDimensions(Buffer.alloc(0))).toBeUndefined()
+    expect(imageDimensions(Buffer.from([0x89, 0x50]))).toBeUndefined()
+    // PNG magic but truncated before IHDR width/height.
+    expect(imageDimensions(pngHeader(10, 10).subarray(0, 10))).toBeUndefined()
+  })
+
+  it('returns undefined for a RIFF buffer that is not WebP', () => {
+    const riff = Buffer.alloc(16)
+    riff.write('RIFF', 0)
+    riff.write('AVI ', 8)
+    expect(imageDimensions(riff)).toBeUndefined()
+  })
+})

--- a/packages/dsh-pet/src/image-dimensions.ts
+++ b/packages/dsh-pet/src/image-dimensions.ts
@@ -1,0 +1,76 @@
+/**
+ * Minimal PNG/WebP dimension reader — header-only, no decoding, no
+ * dependencies. Used by the decoration registry to verify a strip's actual
+ * pixel geometry matches its descriptor (single-row sprite strip; the client
+ * renders by frame-column offsets, so a mismatched strip silently shows the
+ * wrong frames). Parsing is best-effort: an unrecognized or truncated header
+ * returns undefined (the caller decides whether to warn).
+ *
+ * PNG: signature (8) + IHDR chunk — length (4) + 'IHDR' (4) + width (4) +
+ * height (4), both big-endian uint32 at fixed offsets 16/20.
+ * WebP: RIFF header (12) + chunk — 'VP8X' extended (width-1/height-1 as
+ * little-endian uint24 at 24/27), 'VP8L' lossless (packed 14-bit dims at
+ * 21), or 'VP8 ' lossy (frame header, low 14 bits of the uint16 at 26/28).
+ * @module @linxin666/dsh-pet/image-dimensions
+ */
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+export interface ImageDimensions {
+  width: number
+  height: number
+}
+
+/** Read the pixel size of a PNG buffer, or undefined when unrecognized. */
+function pngDimensions(buf: Buffer): ImageDimensions | undefined {
+  if (buf.length < 24) return undefined
+  if (!buf.subarray(0, 8).equals(PNG_SIGNATURE)) return undefined
+  if (buf.toString('ascii', 12, 16) !== 'IHDR') return undefined
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) }
+}
+
+/** Read the pixel size of a WebP buffer, or undefined when unrecognized. */
+function webpDimensions(buf: Buffer): ImageDimensions | undefined {
+  if (buf.length < 21) return undefined
+  if (buf.toString('ascii', 0, 4) !== 'RIFF') return undefined
+  if (buf.toString('ascii', 8, 12) !== 'WEBP') return undefined
+  const fourcc = buf.toString('ascii', 12, 16)
+  if (fourcc === 'VP8X') {
+    // Extended header: 1-byte flags at 20, then width-1/height-1 uint24 LE.
+    if (buf.length < 30) return undefined
+    return {
+      width: 1 + buf.readUIntLE(24, 3),
+      height: 1 + buf.readUIntLE(27, 3),
+    }
+  }
+  if (fourcc === 'VP8L') {
+    // Lossless header: 0x2f marker at 20, then 14-bit width / 14-bit height
+    // packed into the little-endian uint32 at 21.
+    if (buf.length < 25) return undefined
+    const bits = buf.readUInt32LE(21)
+    return {
+      width: 1 + (bits & 0x3fff),
+      height: 1 + ((bits >>> 14) & 0x3fff),
+    }
+  }
+  if (fourcc === 'VP8 ') {
+    // Lossy frame header: 3-byte tag + 3-byte start code, then width/height
+    // as uint16 LE whose low 14 bits carry the dimension.
+    if (buf.length < 30) return undefined
+    return {
+      width: buf.readUInt16LE(26) & 0x3fff,
+      height: buf.readUInt16LE(28) & 0x3fff,
+    }
+  }
+  return undefined
+}
+
+/**
+ * Read image pixel dimensions from a PNG or WebP buffer. Returns undefined
+ * for formats this reader does not recognize (never throws). Callers treat
+ * undefined as "cannot verify", not as an error.
+ */
+export function imageDimensions(buf: Buffer): ImageDimensions | undefined {
+  if (buf.length >= 12 && buf.toString('ascii', 0, 4) === 'RIFF') return webpDimensions(buf)
+  return pngDimensions(buf)
+}

--- a/packages/dsh-pet/src/registry.test.ts
+++ b/packages/dsh-pet/src/registry.test.ts
@@ -597,10 +597,26 @@ describe('voice packs (pet-center M4, issue #677)', () => {
   })
 })
 describe('status decorations (pet-center M5, #567)', () => {
-  function writeDecoration(dir: string, name: string, manifest: Record<string, unknown>, strip = 'whale-frames.png'): void {
+  /** A minimal valid PNG header (signature + IHDR) with the given size. */
+  function pngHeader(width: number, height: number): Buffer {
+    const buf = Buffer.alloc(26)
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buf, 0)
+    buf.writeUInt32BE(13, 8)      // IHDR chunk length
+    buf.write('IHDR', 12)         // chunk type
+    buf.writeUInt32BE(width, 16)  // width
+    buf.writeUInt32BE(height, 20) // height
+    return buf
+  }
+
+  /** A strip whose pixel geometry matches baseManifest() (64x48 cell, 4 cols). */
+  function matchingStrip(): Buffer {
+    return pngHeader(64 * 4, 48)
+  }
+
+  function writeDecoration(dir: string, name: string, manifest: Record<string, unknown>, strip: Buffer | string = 'whale-frames.png'): void {
     mkdirSync(join(dir, name), { recursive: true })
     writeFileSync(join(dir, name, 'decoration.json'), JSON.stringify(manifest), 'utf8')
-    writeFileSync(join(dir, name, strip), 'png', 'utf8')
+    writeFileSync(join(dir, name, manifest.entry as string), strip)
   }
 
   const baseManifest = () => ({
@@ -618,7 +634,7 @@ describe('status decorations (pet-center M5, #567)', () => {
     const root = tempDir()
     try {
       const assets = join(root, 'assets')
-      writeDecoration(join(assets, 'decorations'), 'whale', baseManifest())
+      writeDecoration(join(assets, 'decorations'), 'whale', baseManifest(), matchingStrip())
       const registry = loadPetRegistry({ packageRoot: root, petsDir: '', dshPetsDir: '' })
       const entry = registry.decorationById?.('whale')
       expect(entry).toBeDefined()
@@ -635,9 +651,9 @@ describe('status decorations (pet-center M5, #567)', () => {
   it('lets a user decoration override the built-in by id', () => {
     const root = tempDir()
     try {
-      writeDecoration(join(root, 'assets', 'decorations'), 'whale', baseManifest())
+      writeDecoration(join(root, 'assets', 'decorations'), 'whale', baseManifest(), matchingStrip())
       const dsh = join(root, 'dsh')
-      writeDecoration(join(dsh, 'decorations'), 'whale', { ...baseManifest(), displayName: '家用鲸鱼' })
+      writeDecoration(join(dsh, 'decorations'), 'whale', { ...baseManifest(), displayName: '家用鲸鱼' }, matchingStrip())
       const registry = loadPetRegistry({ packageRoot: root, petsDir: '', dshPetsDir: dsh })
       expect(registry.decorationById?.('whale')?.id).toBe('whale')
       expect(registry.warnings.some(w => w.includes('user decoration whale overrides'))).toBe(true)
@@ -683,6 +699,43 @@ describe('status decorations (pet-center M5, #567)', () => {
       // The entry id comes from the descriptor (the directory name is free).
       expect(registry.decorationById?.('whale')).toBeDefined()
       expect(registry.warnings.some(w => w.includes('strip file missing'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('warns and keeps a decoration whose strip geometry mismatches the descriptor', () => {
+    const root = tempDir()
+    try {
+      // Declared 64x48 cell x 4 columns = 256x48; the file is only 128x48
+      // (2 frames worth) — the client would silently render half the frames.
+      const dir = join(root, 'assets', 'decorations', 'short')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'decoration.json'), JSON.stringify(baseManifest()), 'utf8')
+      writeFileSync(join(dir, 'whale-frames.png'), pngHeader(128, 48))
+      const registry = loadPetRegistry({ packageRoot: root, petsDir: '', dshPetsDir: '' })
+      // Warn-and-keep: the entry still lists (mirroring the missing-strip
+      // discipline) and the warning names the mismatch.
+      expect(registry.decorationById?.('whale')).toBeDefined()
+      expect(registry.warnings.some(w => w.includes('does not match cell'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not warn when a matching strip is undecodable (non-image bytes)', () => {
+    const root = tempDir()
+    try {
+      const dir = join(root, 'assets', 'decorations', 'opaque')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'decoration.json'), JSON.stringify(baseManifest()), 'utf8')
+      // Unrecognized bytes: the header reader returns undefined, so the scan
+      // stays silent (cannot verify != mismatch). Only the missing-file check
+      // applies.
+      writeFileSync(join(dir, 'whale-frames.png'), Buffer.from('not-an-image'))
+      const registry = loadPetRegistry({ packageRoot: root, petsDir: '', dshPetsDir: '' })
+      expect(registry.decorationById?.('whale')).toBeDefined()
+      expect(registry.warnings.some(w => w.includes('does not match cell'))).toBe(false)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/packages/dsh-pet/src/registry.ts
+++ b/packages/dsh-pet/src/registry.ts
@@ -27,7 +27,7 @@
  * @module @linxin666/dsh-pet/registry
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { closeSync, existsSync, openSync, readFileSync, readSync, readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -35,6 +35,7 @@ import type { ActivityPhase, PetAnimation } from './state.ts'
 import { normalizePetRemarks, type PetRemarks, type PetRemarksManifest } from './remarks.ts'
 import { mergeVoicePacks, normalizeVoicePack, type PetPanelView, type VoicePack } from './voice-pack.ts'
 import { parseDecorationManifest } from './decoration.ts'
+import { imageDimensions } from './image-dimensions.ts'
 import { PET_DECORATION_API_VERSION, type DecorationView } from './contracts/status-decoration.ts'
 import { dshHome } from './dsh-home.ts'
 import { parsePetManifest, type PetManifestLive2d, type PetManifestV2, type PetRendererKind } from './manifest-v2.ts'
@@ -687,6 +688,27 @@ function loadVoicePackFile(
 /** Decoration asset URL prefix (served by the decoration route, M5). */
 export const DECORATION_ASSET_PREFIX = '/api/pet/decoration'
 
+/** Read the pixel dimensions of a decoration strip (PNG/WebP), if decodable. */
+function readImageDimensions(file: string): { width: number; height: number } | undefined {
+  let header: Buffer
+  try {
+    // Only the header is needed for dimensions; cap the read so a huge or
+    // corrupt strip cannot balloon memory during the registry scan.
+    const fd = openSync(file, 'r')
+    try {
+      header = Buffer.alloc(64)
+      const read = readSync(fd, header, 0, header.length, 0)
+      if (read < 0) return undefined
+      header = header.subarray(0, read)
+    } finally {
+      closeSync(fd)
+    }
+  } catch {
+    return undefined
+  }
+  return imageDimensions(header)
+}
+
 /**
  * Scan one directory of decoration folders ('decoration.json' + strip).
  * Later scans override earlier ones on id collision; a bad descriptor warns
@@ -730,6 +752,23 @@ function scanDecorationDir(dir: string, options: { warnings?: string[]; diagnost
       const message = 'decoration ' + manifest.id + ': strip file missing: ' + manifest.entry
       options.warnings?.push(message)
       options.diagnostics?.push({ level: 'warning', source: entryDir, message })
+    } else {
+      // Geometry check: the client renders the strip as a single row of
+      // 'columns' frames (background-position advances by frame width only),
+      // so the strip must be exactly cell.width * columns wide and cell.height
+      // tall. A mismatched strip silently shows the wrong/partial frames —
+      // warn-and-keep, mirroring the missing-strip discipline (never throw).
+      const actual = readImageDimensions(join(entryDir, manifest.entry))
+      if (actual !== undefined) {
+        const expectedWidth = manifest.cell.width * manifest.columns
+        if (actual.width !== expectedWidth || actual.height !== manifest.cell.height) {
+          const message = 'decoration ' + manifest.id + ': strip ' + actual.width + 'x' + actual.height
+            + ' does not match cell ' + manifest.cell.width + 'x' + manifest.cell.height + ' x ' + manifest.columns
+            + ' columns (expected ' + expectedWidth + 'x' + manifest.cell.height + '); frames will render wrong'
+          options.warnings?.push(message)
+          options.diagnostics?.push({ level: 'warning', source: entryDir, message })
+        }
+      }
     }
     entries.push({
       apiVersion: PET_DECORATION_API_VERSION,


### PR DESCRIPTION
## 摘要（Summary）

状态装饰（#567/#623 的 status-decoration）的客户端把条带按**单行 `columns` 帧**渲染（`background-position` 只按帧宽推进 X 轴），但注册表扫描只检查条带文件**存在**，从不读取 PNG/WebP 头校验实际像素尺寸。尺寸不匹配的条带（如声明 64x48 x 4 列、实际只有 2 帧宽的条带，或多行条带）会**静默渲染错误/缺失的帧，无任何诊断**。

修复：注册表扫描时读取条带文件头（纯 node 解析 PNG IHDR / WebP VP8X/VP8L/VP8），校验 `width === cell.width * columns` 且 `height === cell.height`；不匹配时 **warn-and-keep**（镜像 missing-strip 纪律，不拒绝条目、不抛异常）；无法解析的头保持静默。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：分支基于 `40374260`（最新 main）创建。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek-V3.2

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符（已用 CI 同款码点范围扫描）。
- [x] 改动包 README 时同步维护中英双语三件套（本次未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-pet typecheck
pnpm vitest run packages/dsh-pet    # 340 passed（含新增 8 个）
pnpm typecheck                       # 全仓通过
pnpm test                            # 全仓通过
pnpm test:scripts                    # 131 pass
pnpm docs:check                      # 通过
```

结果摘要：全绿。新增 `image-dimensions` 6 个单测（PNG/WebP 三格式 + 边界）+ registry 尺寸不匹配 2 个用例；用真实双行条带（528x248 vs 声明 528x124）验证会触发告警。

## 用户可见变更证据（Local Feature Evidence）

本修复是诊断增强：尺寸不匹配的装饰条带现在会在注册表诊断中给出警告（原来静默渲染错误帧）。用户可见行为不变（合法条带照常渲染）；证据为测试断言 + 真实条带验证输出。