### PR TITLE
fix(release): drop the tarball upload step and skip private family packages

### DIFF
--- a/.dsh/skills/dsh-web-ui-release/SKILL.md
+++ b/.dsh/skills/dsh-web-ui-release/SKILL.md
@@ -120,11 +120,10 @@ git push origin "vX.Y.Z"            # 推送 tag 即触发发布管线（唯一�
 
 1. actionlint + pnpm install（frozen lockfile，checkout 用 fetch-depth: 0 取全量历史）；
 2. 全量 gate：typecheck / build / test / test:scripts / aggregate --check；
-3. **版本一致性校验**：tag 版本必须与全部 23 个包的 package.json version 完全一致，不一致直接失败（防止忘 bump 就发版）；
+3. **版本一致性校验**：tag 版本必须与全部 17 个家族包的 package.json version 完全一致（walkFamilyPackages：packages/* 与 packages/skins/* 非递归），不一致直接失败（防止忘 bump 就发版）；
 4. **生成 release notes**：优先使用已提交的 `docs/release-notes/$TAG.md`（v0.2.1 起维护者在发版提交中附带逐条 EN / 中文 双语版，管线直接采用）；文件缺失时兜底跑 `node scripts/release-notes.mjs $TAG` 生成单语草稿（把上一 tag 以来的**全部**常规提交——含合并进来的分支提交，不能只走 --first-parent，v0.1.15 曾因此漏掉整条 perf/refactor 分支——分组为 New Features / Bug Fixes / Other Changes 并链接 issue）。发布前执行，失败即中止，不触碰 npm；
-5. `pnpm -r publish --no-git-checks --access public`（NPM_TOKEN 写入 ~/.npmrc，拓扑序发布，workspace:* 自动转真实版本）；
-6. `gh release create --notes-file` 创建 GitHub Release（notes 即第 4 步生成的内容）；
-7. **上传 npm tarball 资产**：`node scripts/release-assets.mjs $TAG <outDir>` 从 registry 逐包 `npm pack <name>@<version>`（与已发布内容字节一致），再 `gh release upload` 附到 Release——裸 `gh release create` 只有 GitHub 自动源码归档，不带 npm 包。
+5. `pnpm -r publish --no-git-checks --access public`（NPM_TOKEN 写入 ~/.npmrc，拓扑序发布，workspace:* 自动转真实版本；private 包由 pnpm 自动跳过——若某 private 包被聚合依赖引用，先解除引用或改为公开，否则全家桶安装 404）；
+6. `gh release create --notes-file` 创建 GitHub Release（notes 即第 4 步生成的内容）；Release 只保留 GitHub 自动源码归档，不附 npm tarball（与官方 DSH 一致，v0.2.4 起约定）。
 
 关注与排障：
 
@@ -146,7 +145,6 @@ gh run list --workflow=release.yml    # 查历史
 npm view @linxin666/dsh-web-ui-all version          # 期望 = X.Y.Z
 npm view @linxin666/dsh-client-ui-skin-center version
 gh release view "vX.Y.Z" --json body --jq .body    # Release 已创建；v0.2.1 起每个条目必须为 "EN / 中文" 双语（逐条抽查）
-gh release view "vX.Y.Z" --json assets               # 23 个 @linxin666/dsh-* tgz 资产已附上（scripts/release-assets.mjs 上传）
 gh run list --workflow=release.yml                  # 全部成功
 git ls-remote --tags origin | grep "vX.Y.Z"         # tag 已在远端
 ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ name: Release
 # all packages to npm in dependency order. A second job then re-runs the
 # aggregate mount smoke in strict npm mode (every dependency resolves from
 # the registry — the real consumer install path, verified after publish when
-# the assertion holds) and only then creates the GitHub Release with the npm
-# tarball assets.
+# the assertion holds) and only then creates the GitHub Release.
 #
 # Requires the repository secret NPM_TOKEN (npm automation token for the
 # @linxin666 scope) to publish.
@@ -201,13 +200,3 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --notes-file "$RUNNER_TEMP/release-notes.md" \
             --title "dsh-web-ui $GITHUB_REF_NAME"
-
-      # Pack the published tarballs back from the npm registry (byte-identical
-      # to what the publish job pushed) and attach them as real installable
-      # release artifacts.
-      - name: Upload npm tarballs to the release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          node scripts/release-assets.mjs "$GITHUB_REF_NAME" "$RUNNER_TEMP/release-assets"
-          gh release upload "$GITHUB_REF_NAME" "$RUNNER_TEMP"/release-assets/*.tgz --clobber

--- a/scripts/release-assets.mjs
+++ b/scripts/release-assets.mjs
@@ -7,8 +7,10 @@
  *
  * Walks the same package set as verify-version.mjs (packages/* and
  * packages/skins/*, non-recursive), reads each package.json name + version,
- * waits for every version to become readable on the npm registry (fresh
- * publishes are eventually consistent and can 404 briefly), and runs
+ * skips private packages (pnpm -r publish never pushes them, so they would
+ * 404 forever — v0.2.4: dsh-chat-recovery), waits for every publishable
+ * version to become readable on the npm registry (fresh publishes are
+ * eventually consistent and can 404 briefly), and runs
  * `npm pack <name>@<version>` against the registry. Packing from the
  * registry (not the working tree) makes every uploaded tarball
  * byte-identical to what `pnpm -r publish` pushed moments earlier.
@@ -48,6 +50,15 @@ export function packOne(name, version, outDir, run = (file, args, options) => ex
 
 function defaultView(name, version) {
   execFileSync('npm', ['view', name + '@' + version, 'version'], { encoding: 'utf8' })
+}
+
+/**
+ * Family packages that actually reach the registry: private packages are
+ * bundled into a carrier (or referenced as a workspace dep) and `pnpm -r
+ * publish` skips them, so packing them from the registry can never succeed.
+ */
+export function publishablePackages(packages) {
+  return packages.filter(pkg => pkg.private !== true)
 }
 
 /**
@@ -100,9 +111,12 @@ function main() {
     }
     packages.push(pkg)
   }
-  waitForPublished(packages, version)
+  // Version parity above covers every family package; only publishable
+  // packages can ever be packed back from the registry.
+  const publishable = publishablePackages(packages)
+  waitForPublished(publishable, version)
   const packed = []
-  for (const pkg of packages) {
+  for (const pkg of publishable) {
     const tgz = packOne(pkg.name, version, outDir)
     packed.push(tgz)
     console.log(tgz)

--- a/scripts/release-assets.test.mjs
+++ b/scripts/release-assets.test.mjs
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { packageFiles, packOne, waitForPublished } from './release-assets.mjs'
+import { packageFiles, packOne, publishablePackages, waitForPublished } from './release-assets.mjs'
 
 test('packageFiles: walks packages/ and packages/skins/ non-recursively', () => {
   const dir = mkdtempSync(join(tmpdir(), 'dsh-release-assets-'))
@@ -53,6 +53,14 @@ test('packOne: packs the exact published version and resolves the tarball path',
 test('packOne: rejects when npm pack reports no filename', () => {
   const fakeRun = () => JSON.stringify([])
   assert.throws(() => packOne('@linxin666/dsh-ssh', '0.1.15', '/tmp/assets', fakeRun), /no filename/)
+})
+
+test('publishablePackages: drops private family packages', () => {
+  const out = publishablePackages([
+    { name: '@linxin666/dsh-ssh', version: '0.2.4' },
+    { name: '@linxin666/dsh-chat-recovery', version: '0.2.4', private: true },
+  ])
+  assert.deepEqual(out, [{ name: '@linxin666/dsh-ssh', version: '0.2.4' }])
 })
 
 test('waitForPublished: polls until every package version is readable', () => {


### PR DESCRIPTION
## 摘要（Summary）

v0.2.4 发布暴露了发布管线的两处问题，本 PR 一并修复：

1. 用户约定 GitHub Release 不附 npm tarball（与官方 DSH 一致，只保留源码归档）。移除 `.github/workflows/release.yml` 中「Upload npm tarballs to the release」步骤，并同步更新 `.dsh/skills/dsh-web-ui-release/SKILL.md`（管线步骤清单、发布后验证清单，顺带修正家族包计数 23 → 17）。
2. `scripts/release-assets.mjs` 遍历家族包时没有跳过 private 包：v0.2.4 中 `dsh-chat-recovery` 曾被误标 `private: true`，上传步骤对不存在的包 `npm view` 永久 404 直至超时，导致整个 run 挂红。新增 `publishablePackages` 过滤（private 包不进 registry，永远打包不到）+ 对应单测。该脚本保留为手动补传资产的工具（管线不再自动调用）。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：发布管线维护（workflow + scripts + skill 文档），不改任何插件包。

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```sh
git fetch origin && git rebase origin/main
```

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（deepseek-v4-pro）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。（本次未改任何包 README）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm test:scripts
pnpm docs:check
actionlint .github/workflows/release.yml
node scripts/release-assets.mjs v0.2.4 /tmp/rel-assets2
```

结果摘要：

- `pnpm test:scripts`：138 通过 / 0 失败（含新增 publishablePackages 用例）。
- `pnpm docs:check`：全部文档门禁通过。
- `actionlint`：workflow 语法检查通过。
- 修复后的脚本对真实 registry 实测：打包 17 个 tarball 成功（修复前对 v0.2.4 必然 404 超时）。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（纯发布管线内部改动，无用户可见变更）。
