### PR TITLE
fix(pet): 同步 Live2D Canvas 与桌宠尺寸

### DIFF
--- a/packages/dsh-pet/src/client/renderers/live2d.test.ts
+++ b/packages/dsh-pet/src/client/renderers/live2d.test.ts
@@ -41,12 +41,44 @@ interface FakeModel {
 interface FakeApp {
   canvas: HTMLCanvasElement
   stage: { addChild(child: unknown): void }
-  renderer: { width: number; height: number }
+  renderer: { width: number; height: number; resize(width: number, height: number): void }
   init(options: Record<string, unknown>): Promise<void>
   destroy(rendererOptions?: boolean | { removeView?: boolean; releaseGlobalResources?: boolean }, options?: Record<string, unknown>): void
   destroyed: number
   destroyCalls: unknown[][]
   added: unknown
+  resizeCalls: [number, number][]
+}
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+
+  readonly targets = new Set<Element>()
+  disconnected = false
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this)
+  }
+
+  observe(target: Element): void {
+    this.targets.add(target)
+  }
+
+  unobserve(target: Element): void {
+    this.targets.delete(target)
+  }
+
+  disconnect(): void {
+    this.disconnected = true
+    this.targets.clear()
+  }
+
+  emit(target: Element, width: number, height: number): void {
+    this.callback([{
+      target,
+      contentRect: { width, height },
+    } as ResizeObserverEntry], this as unknown as ResizeObserver)
+  }
 }
 
 function fakeModel(motions: Record<string, unknown[]> = { Idle: [{}, {}], TapBody: [{}] }): FakeModel {
@@ -76,11 +108,28 @@ function fakeModel(motions: Record<string, unknown[]> = { Idle: [{}, {}], TapBod
 }
 
 function fakeApp(): FakeApp {
+  const canvas = document.createElement('canvas')
   const app: FakeApp = {
-    canvas: document.createElement('canvas'),
+    canvas,
     stage: { addChild: (child) => { app.added = child } },
-    renderer: { width: 160, height: 174 },
-    init: () => Promise.resolve(),
+    renderer: {
+      width: 160,
+      height: 174,
+      resize: (width, height) => {
+        app.renderer.width = width
+        app.renderer.height = height
+        canvas.width = width
+        canvas.height = height
+        app.resizeCalls.push([width, height])
+      },
+    },
+    init: (options) => {
+      app.renderer.width = Number(options.width)
+      app.renderer.height = Number(options.height)
+      canvas.width = app.renderer.width
+      canvas.height = app.renderer.height
+      return Promise.resolve()
+    },
     destroy: (rendererOptions, options) => {
       app.destroyed += 1
       app.destroyCalls.push([rendererOptions, options])
@@ -92,6 +141,7 @@ function fakeApp(): FakeApp {
     destroyed: 0,
     destroyCalls: [],
     added: undefined,
+    resizeCalls: [],
   }
   return app
 }
@@ -115,12 +165,27 @@ function fakeVendor(
 
 const CONFIG = { modelUrl: '/pet/haru/haru.model3.json', motions: { idle: 'Idle', thinking: 'TapBody' } }
 
-function makeCtx(): { ctx: PetRendererContext; stream: PhaseStream; container: HTMLDivElement } {
+function makeCtx(width = 0, height = 0): {
+  ctx: PetRendererContext
+  stream: PhaseStream
+  container: HTMLDivElement
+  setSize(nextWidth: number, nextHeight: number): void
+} {
   const container = document.createElement('div')
+  let clientWidth = width
+  let clientHeight = height
+  Object.defineProperties(container, {
+    clientWidth: { configurable: true, get: () => clientWidth },
+    clientHeight: { configurable: true, get: () => clientHeight },
+  })
   const stream = createPhaseStream('idle')
   return {
     container,
     stream,
+    setSize(nextWidth, nextHeight) {
+      clientWidth = nextWidth
+      clientHeight = nextHeight
+    },
     ctx: {
       petId: 'haru',
       assetBase: '/pet/haru',
@@ -139,9 +204,12 @@ async function flush(): Promise<void> {
 describe('live2dRenderer', () => {
   beforeEach(() => {
     runtime.core = true
+    FakeResizeObserver.instances = []
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver)
     resetLive2dRenderer()
   })
   afterEach(() => {
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -194,6 +262,72 @@ describe('live2dRenderer', () => {
       autoFocus: false,
       textureOptions: { lod: 'single-auto' },
     })
+  })
+
+  it('keeps the Pixi canvas and model layout in sync with display-size changes', async () => {
+    const model = fakeModel()
+    const app = fakeApp()
+    runtime.vendor = fakeVendor(model, app)
+    const { ctx, container, setSize } = makeCtx(148, 160)
+
+    const handle = live2dRenderer.mount(ctx, live2dRenderer.validateConfig(CONFIG)) as Live2dRendererHandle
+    await flush()
+    expect(app.canvas.width).toBe(148)
+    expect(app.canvas.height).toBe(160)
+    expect(model.calls).toContainEqual(['position', 74, 80])
+
+    model.calls.length = 0
+    setSize(295, 320)
+    FakeResizeObserver.instances[0]?.emit(container, 295, 320)
+
+    expect(app.resizeCalls).toEqual([[295, 320]])
+    expect(app.canvas.width).toBe(295)
+    expect(app.canvas.height).toBe(320)
+    expect(model.calls).toContainEqual(['scale', expect.closeTo(0.245333, 5)])
+    expect(model.calls).toContainEqual(['position', 147.5, 160])
+    handle.tap(147.5, 160)
+    expect(model.calls).toContainEqual(['hitTest', 147.5, 160])
+
+    handle.dispose()
+    expect(FakeResizeObserver.instances[0]?.disconnected).toBe(true)
+  })
+
+  it('uses the latest renderer size when the model finishes loading', async () => {
+    const model = fakeModel()
+    const app = fakeApp()
+    let resolveModel!: (value: FakeModel) => void
+    const pendingModel = new Promise<FakeModel>((resolve) => { resolveModel = resolve })
+    runtime.vendor = fakeVendor(model, app, () => pendingModel)
+    const { ctx, container, setSize } = makeCtx(148, 160)
+
+    live2dRenderer.mount(ctx, live2dRenderer.validateConfig(CONFIG))
+    await flush()
+    setSize(295, 320)
+    FakeResizeObserver.instances[0]?.emit(container, 295, 320)
+    resolveModel(model)
+    await flush()
+
+    expect(app.resizeCalls).toEqual([[295, 320]])
+    expect(model.calls).toContainEqual(['position', 147.5, 160])
+    expect(model.calls).toContainEqual(['scale', expect.closeTo(0.245333, 5)])
+  })
+
+  it('ignores zero-size observations and stops resizing after disposal', async () => {
+    const model = fakeModel()
+    const app = fakeApp()
+    runtime.vendor = fakeVendor(model, app)
+    const { ctx, container } = makeCtx(148, 160)
+    const handle = live2dRenderer.mount(ctx, live2dRenderer.validateConfig(CONFIG))
+    await flush()
+    const observer = FakeResizeObserver.instances[0]
+
+    observer?.emit(container, 0, 0)
+    observer?.emit(container, 148, 160)
+    expect(app.resizeCalls).toEqual([])
+
+    handle.dispose()
+    observer?.emit(container, 295, 320)
+    expect(app.resizeCalls).toEqual([])
   })
 
   it('falls back to the idle group when a mapped group is absent from the model', async () => {

--- a/packages/dsh-pet/src/client/renderers/live2d.ts
+++ b/packages/dsh-pet/src/client/renderers/live2d.ts
@@ -73,6 +73,39 @@ const DESTROY_OPTIONS = { children: true } as const
 /** Remove only this activation's canvas; `true` would release Pixi globals. */
 const RENDERER_DESTROY_OPTIONS = { removeView: true } as const
 
+interface Live2dModelSize {
+  width: number
+  height: number
+}
+
+/** Ignore hidden/zero boxes and keep Pixi dimensions stable and integral. */
+function normalizeRendererSize(width: number, height: number): Live2dModelSize | undefined {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return undefined
+  return {
+    width: Math.max(1, Math.round(width)),
+    height: Math.max(1, Math.round(height)),
+  }
+}
+
+/** Fit the model from its unscaled dimensions into the current Pixi screen. */
+function layoutModel(
+  app: Live2dVendorApp,
+  model: Live2dVendorModel,
+  sourceSize: Live2dModelSize,
+  config: PetLive2dConfig,
+): void {
+  const fit = Math.min(
+    app.renderer.width / sourceSize.width,
+    app.renderer.height / sourceSize.height,
+  ) * 0.92
+  model.scale.set(fit * (config.scale ?? 1))
+  model.anchor.set(0.5)
+  model.position.set(
+    app.renderer.width / 2 + (config.translate?.x ?? 0),
+    app.renderer.height / 2 + (config.translate?.y ?? 0),
+  )
+}
+
 let vendorConfigured = false
 
 /** Configure pixi extensions + the Cubism SDK once per page. */
@@ -110,14 +143,47 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
     let app: Live2dVendorApp | undefined
     let model: Live2dVendorModel | undefined
     let modelAttached = false
+    let modelSourceSize: Live2dModelSize | undefined
+    let resizeObserver: ResizeObserver | undefined
+    let resizeTracking = false
     let errorListener: ((code: Live2dErrorCode) => void) | undefined
     let unsubscribe: (() => void) | undefined
     /** The motion group the current phase maps to (resume target after taps). */
     let phaseGroup: string = config.motions.idle
     let tapPlaying = false
 
+    const stopResizeTracking = (): void => {
+      resizeTracking = false
+      resizeObserver?.disconnect()
+      resizeObserver = undefined
+    }
+
+    const resizeRenderer = (pixiApp: Live2dVendorApp, width: number, height: number): void => {
+      const next = normalizeRendererSize(width, height)
+      if (disposed || !resizeTracking || next === undefined) return
+      if (pixiApp.renderer.width === next.width && pixiApp.renderer.height === next.height) return
+      pixiApp.renderer.resize(next.width, next.height)
+      if (model !== undefined && modelSourceSize !== undefined) {
+        layoutModel(pixiApp, model, modelSourceSize, config)
+      }
+    }
+
+    const trackContainerSize = (pixiApp: Live2dVendorApp): void => {
+      if (typeof ResizeObserver === 'undefined') return
+      resizeTracking = true
+      resizeObserver = new ResizeObserver((entries) => {
+        const entry = entries.find(candidate => candidate.target === ctx.container)
+        if (entry === undefined) return
+        resizeRenderer(pixiApp, entry.contentRect.width, entry.contentRect.height)
+      })
+      resizeObserver.observe(ctx.container)
+      // Catch a synchronous layout change between init() and observe().
+      resizeRenderer(pixiApp, ctx.container.clientWidth, ctx.container.clientHeight)
+    }
+
     /** Release every resource currently owned by this activation exactly once. */
     const destroyResources = (): void => {
+      stopResizeTracking()
       unsubscribe?.()
       unsubscribe = undefined
       const currentApp = app
@@ -125,6 +191,7 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
       const modelOwnedByApp = currentApp !== undefined && modelAttached
       app = undefined
       model = undefined
+      modelSourceSize = undefined
       modelAttached = false
       try {
         if (currentModel !== undefined && !modelOwnedByApp) currentModel.destroy(DESTROY_OPTIONS)
@@ -165,10 +232,14 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
       }
       configureOnce(vendor)
       const pixiApp = new vendor.Application()
+      const initialSize = normalizeRendererSize(ctx.container.clientWidth, ctx.container.clientHeight) ?? {
+        width: 160,
+        height: 174,
+      }
       try {
         await pixiApp.init({
-          width: Math.max(1, ctx.container.clientWidth || 160),
-          height: Math.max(1, ctx.container.clientHeight || 174),
+          width: initialSize.width,
+          height: initialSize.height,
           backgroundAlpha: 0,
           antialias: true,
           autoDensity: true,
@@ -191,6 +262,7 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
       ctx.container.appendChild(pixiApp.canvas)
       // Keep a model that rejects during setup off Ticker.shared; from()
       // does not expose that partial instance to callers for disposal.
+      trackContainerSize(pixiApp)
       const loaded = await vendor.Live2DModel.from(config.modelUrl, {
         autoUpdate: false,
         autoHitTest: false,
@@ -202,18 +274,13 @@ export const live2dRenderer: PetRenderer<PetLive2dConfig> = {
         destroyResources()
         return
       }
+      modelSourceSize = {
+        width: Math.max(1, loaded.width),
+        height: Math.max(1, loaded.height),
+      }
       // Auto-fit the model into the container; the manifest scale multiplies
       // the fit and translate offsets from the center anchor.
-      const fit = Math.min(
-        pixiApp.renderer.width / Math.max(1, loaded.width),
-        pixiApp.renderer.height / Math.max(1, loaded.height),
-      ) * 0.92
-      loaded.scale.set(fit * (config.scale ?? 1))
-      loaded.anchor.set(0.5)
-      loaded.position.set(
-        pixiApp.renderer.width / 2 + (config.translate?.x ?? 0),
-        pixiApp.renderer.height / 2 + (config.translate?.y ?? 0),
-      )
+      layoutModel(pixiApp, loaded, modelSourceSize, config)
       pixiApp.stage.addChild(loaded)
       modelAttached = true
       loaded.automator.autoUpdate = true

--- a/packages/dsh-pet/src/client/renderers/live2d/runtime.ts
+++ b/packages/dsh-pet/src/client/renderers/live2d/runtime.ts
@@ -21,7 +21,11 @@ const VENDOR_URL = '/api/pet/runtime/live2d-vendor.js'
 export interface Live2dVendorApp {
   canvas: HTMLCanvasElement
   stage: { addChild(child: unknown): unknown }
-  renderer: { readonly width: number; readonly height: number }
+  renderer: {
+    readonly width: number
+    readonly height: number
+    resize(width: number, height: number): void
+  }
   init(options: Record<string, unknown>): Promise<void>
   destroy(rendererOptions?: boolean | { removeView?: boolean; releaseGlobalResources?: boolean }, options?: Record<string, unknown>): void
 }


### PR DESCRIPTION
## 摘要（Summary）

修复 Live2D 桌宠尺寸调整后，Canvas 内部分辨率没有随显示尺寸更新的问题。

此前桌宠从 160px 调整到 320px 后，Canvas 的 CSS 显示尺寸会变为 295×320，但内部分辨率仍停留在 148×160，导致画面被放大约两倍，同时 CSS 点击坐标与渲染坐标不再一致。

本次改动：

- 监听 Live2D 容器尺寸变化，同步调用 Pixi renderer.resize。
- 使用模型加载时记录的原始尺寸重新计算缩放和居中位置。
- 忽略隐藏状态产生的零尺寸通知。
- 加载失败、卸载或销毁时，通过统一资源清理入口断开 ResizeObserver。
- 保留 #686 引入的失败挂载清理和 Pixi 安全销毁逻辑。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [x] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：

```bash
git fetch upstream main
git rebase --autostash upstream/main
```

同步基线：`main@3a45cfed`

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 本 PR 未修改包 README，并已运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

不追加新的版权声明。

## 新皮肤收录（New Skin）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
corepack pnpm@11.7.0 --filter @linxin666/dsh-pet typecheck
corepack pnpm@11.7.0 --filter @linxin666/dsh-pet test
corepack pnpm@11.7.0 --filter @linxin666/dsh-pet build
corepack pnpm@11.7.0 typecheck
corepack pnpm@11.7.0 test
corepack pnpm@11.7.0 test:scripts
corepack pnpm@11.7.0 docs:check
node scripts/runtime-deps-check.mjs
node scripts/aggregate.mjs --check
node scripts/sync-shared.mjs --check
git diff --check
```

结果摘要：

- Live2D 定向回归：14/14 通过。
- `dsh-pet`：31 个测试文件、342/342 通过。
- `dsh-pet` TypeScript 检查与构建通过。
- 仓库级 typecheck、文档、runtime dependencies、aggregate、shared sync 和 diff 检查通过。
- 真实 DSH Web 验证：
  - 修复前：从 160px 动态调整到 320px 后，CSS 为 295×320，Canvas 内部分辨率仍为 148×160。
  - 修复后：相同操作下，CSS 与 Canvas 内部分辨率均为 295×320。
  - 点击桌宠能够正常触发互动。
  - 浏览器控制台 0 error / 0 warning。

Windows 本地仓库级基线问题：

- `pnpm test` 在未修改的 `dsh-liangshen/tests/custom-bash.test.ts` 中有两个路径断言失败。
- `pnpm test:scripts` 在最新 main 的 `e2e-mount-rewrite` Windows 用例中因 `spawnSync pnpm ENOENT` 失败。
- 本 PR 未修改上述包或脚本。

## 用户可见变更证据（Local Feature Evidence）

以下画面来自真实 DSH Web。两次验证均先以 160px 加载同一 Live2D 模型，再在不刷新页面的情况下调整到 320px。

### 修复前

Canvas 被 CSS 放大，模型边缘和面部细节明显模糊。

![修复前实机画面](https://github.com/user-attachments/assets/0583bdfb-8c13-401d-a8a3-88ea9cba33aa)

### 修复后

Canvas 内部分辨率同步更新，模型细节恢复清晰。

![修复后实机画面](https://github.com/user-attachments/assets/a6fc681f-99a7-47fc-a092-09803730f575)


