### PR TITLE
fix(skins): fold WE scene parent transforms and drive water reflection from scene data (#742)

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -4079,9 +4079,72 @@ function buildSceneManifestVia(access, token) {
 	if (meteorTexPath) manifest.meteorTex = resourceBase + meteorTexPath;
 	const sparkleTexPath = allTex.find((p) => p.toLowerCase().includes("sparkle") || p.toLowerCase().includes("halo") || p.toLowerCase().includes("star"));
 	if (sparkleTexPath) manifest.sparkleTex = resourceBase + sparkleTexPath;
-	for (const obj of scene.objects) {
+	const sceneObjects = scene.objects;
+	const resolveObjectTransform = (obj) => {
+		const chain = [obj];
+		let cur = obj;
+		while (cur.parent != null && chain.length <= 32) {
+			const parent = sceneObjects.find((o) => o.id === cur.parent);
+			if (!parent || chain.includes(parent)) break;
+			chain.push(parent);
+			cur = parent;
+		}
+		const root = chain[chain.length - 1];
+		let origin = parseVec3(root.origin, [
+			width / 2,
+			height / 2,
+			0
+		]);
+		let scale = parseVec3(root.scale, [
+			1,
+			1,
+			1
+		]);
+		let angle = parseVec3(root.angles, [
+			0,
+			0,
+			0
+		])[2];
+		for (let i = chain.length - 2; i >= 0; i--) {
+			const localOrigin = parseVec3(chain[i].origin, [
+				0,
+				0,
+				0
+			]);
+			const localScale = parseVec3(chain[i].scale, [
+				1,
+				1,
+				1
+			]);
+			const localAngle = parseVec3(chain[i].angles, [
+				0,
+				0,
+				0
+			])[2];
+			const c = Math.cos(angle);
+			const s = Math.sin(angle);
+			origin = [
+				origin[0] + localOrigin[0] * scale[0] * c - localOrigin[1] * scale[1] * s,
+				origin[1] + localOrigin[0] * scale[0] * s + localOrigin[1] * scale[1] * c,
+				origin[2] + localOrigin[2] * scale[2]
+			];
+			scale = [
+				scale[0] * localScale[0],
+				scale[1] * localScale[1],
+				scale[2] * localScale[2]
+			];
+			angle += localAngle;
+		}
+		return {
+			origin,
+			scale,
+			angle
+		};
+	};
+	const hasReflectionEffect = (obj) => (Array.isArray(obj.effects) ? obj.effects : []).some((e) => typeof e?.file === "string" && e.file.toLowerCase().includes("effects/reflection"));
+	for (const obj of sceneObjects) {
 		if (!obj.image || typeof obj.image !== "string" || obj.image.startsWith("models/util/")) {
-			if (typeof obj.name === "string" && obj.name.toLowerCase() === "reflection") {
+			if (typeof obj.name === "string" && obj.name.toLowerCase() === "reflection" || hasReflectionEffect(obj)) {
 				const reflTex = allTex.find((p) => p.toLowerCase().includes("reflection_mask"));
 				if (reflTex) manifest.layers.push({
 					name: "Reflection",
@@ -4160,21 +4223,14 @@ function buildSceneManifestVia(access, token) {
 		} catch {
 			decoded = null;
 		}
-		const objOrigin = parseVec3(obj.origin, [
-			width / 2,
-			height / 2,
-			0
-		]);
-		const objScale = parseVec3(obj.scale, [
-			1,
-			1,
-			1
-		]);
-		const objAngles = parseVec3(obj.angles, [
+		const resolvedTransform = resolveObjectTransform(obj);
+		const objOrigin = [...resolvedTransform.origin];
+		const objScale = resolvedTransform.scale;
+		const objAngles = [
 			0,
 			0,
-			0
-		]);
+			resolvedTransform.angle
+		];
 		let lw = 0;
 		let lh = 0;
 		if (typeof modelJson.width === "number" && typeof modelJson.height === "number") {
@@ -4203,6 +4259,13 @@ function buildSceneManifestVia(access, token) {
 			objOrigin[1] = height / 2;
 			objAngles[2] = 0;
 		}
+		const alignment = typeof obj.alignment === "string" ? obj.alignment.toLowerCase() : "";
+		let alignDx = 0;
+		let alignDy = 0;
+		if (alignment.includes("left")) alignDx = lw / 2;
+		else if (alignment.includes("right")) alignDx = -lw / 2;
+		if (alignment.includes("top")) alignDy = -lh / 2;
+		else if (alignment.includes("bottom")) alignDy = lh / 2;
 		let ox = 0;
 		let oy = 0;
 		if (typeof modelJson.cropoffset === "string") {
@@ -4225,11 +4288,26 @@ function buildSceneManifestVia(access, token) {
 			];
 		}
 		const isGround = nameLower.includes("land") || nameLower.includes("grass") || nameLower.includes("railing") || nameLower.includes("betong") || nameLower.includes("sign") || nameLower.includes("cabinet") || nameLower.includes("bush") || nameLower.includes("fence");
+		const layerX = objOrigin[0] + alignDx;
+		const layerY = objOrigin[1] + alignDy;
+		if (hasReflectionEffect(obj) || nameLower === "reflection") {
+			const reflTex = allTex.find((p) => p.toLowerCase().includes("reflection_mask"));
+			if (reflTex) manifest.layers.push({
+				name: "Reflection",
+				isReflection: true,
+				texUrl: resourceBase + reflTex,
+				x: layerX,
+				y: layerY,
+				w: lw,
+				h: lh,
+				waterLine: Math.min(1, Math.max(0, 1 - (layerY + lh / 2) / height))
+			});
+		}
 		manifest.layers.push({
 			name: typeof obj.name === "string" ? obj.name : "layer",
 			texUrl: resourceBase + texPath,
-			x: objOrigin[0] + ox,
-			y: objOrigin[1] + oy,
+			x: layerX,
+			y: layerY,
 			w: lw,
 			h: lh,
 			alpha,
@@ -4756,13 +4834,21 @@ const WE_SCENE_PLAYER_HTML = `<!DOCTYPE html>
     uniform sampler2D u_mask;
     uniform float u_time;
     uniform float u_alpha;
+    // Scene-uv rect of the reflection quad: (leftU, topV, scaleU, scaleV);
+    // (0,0,1,1) for a fullscreen layer. Scene v grows downward (0 at the top).
+    uniform vec4 u_rect;
+    // Data-driven water surface from the scene object (legacy default 0.65).
+    uniform float u_waterLine;
+    // Reflection sample window: start + puddleDepth * span (legacy 0.42/0.38).
+    uniform vec2 u_reflectRange;
     void main() {
       float mask = texture2D(u_mask, v_uv).r;
-      if (mask < 0.05 || v_uv.y < 0.65) {
+      vec2 sceneUv = u_rect.xy + v_uv * u_rect.zw;
+      if (mask < 0.05 || sceneUv.y < u_waterLine) {
         discard;
       }
-      float puddleDepth = (v_uv.y - 0.65) / 0.35;
-      vec2 uvReflect = vec2(v_uv.x, 0.42 + puddleDepth * 0.38);
+      float puddleDepth = (sceneUv.y - u_waterLine) / max(1.0 - u_waterLine, 0.0001);
+      vec2 uvReflect = vec2(sceneUv.x, u_reflectRange.x + puddleDepth * u_reflectRange.y);
       // water wave ripple perturbation
       float wave = sin(v_uv.y * 120.0 + u_time * 2.8) * 0.002 +
                    cos(v_uv.x * 90.0 + u_time * 1.9) * 0.0015;
@@ -6009,12 +6095,27 @@ const WE_SCENE_PLAYER_HTML = `<!DOCTYPE html>
         gl.vertexAttribPointer(rPos, 2, gl.FLOAT, false, 16, 0);
         gl.vertexAttribPointer(rUv, 2, gl.FLOAT, false, 16, 8);
 
-        const model = mat4Transform2D(sceneW / 2, sceneH / 2, sceneW, sceneH, 0);
+        // Draw the reflection quad at the layer's own rect (fullscreen for
+        // legacy scene-wide reflection layers).
+        const model = mat4Transform2D(layer.x, layer.y, layer.w, layer.h, layer.angle || 0);
         gl.uniformMatrix4fv(gl.getUniformLocation(progReflection, 'u_proj'), false, proj);
         gl.uniformMatrix4fv(gl.getUniformLocation(progReflection, 'u_model'), false, model);
         gl.uniform4f(gl.getUniformLocation(progReflection, 'u_uvRect'), 0, 0, 1, 1);
         gl.uniform1f(gl.getUniformLocation(progReflection, 'u_time'), elapsed);
         gl.uniform1f(gl.getUniformLocation(progReflection, 'u_alpha'), 0.85);
+
+        // Scene-uv rect of the quad (scene v grows downward, 0 at the top).
+        const rectLeftU = (layer.x - layer.w / 2) / sceneW;
+        const rectTopV = 1 - (layer.y + layer.h / 2) / sceneH;
+        gl.uniform4f(gl.getUniformLocation(progReflection, 'u_rect'),
+          rectLeftU, rectTopV, layer.w / sceneW, layer.h / sceneH);
+        // Water line follows the scene data when the parser resolved one;
+        // otherwise keep the legacy 0.65 / 0.42 / 0.38 window.
+        const waterLine = typeof layer.waterLine === 'number' ? layer.waterLine : 0.65;
+        const depthScale = (1 - waterLine) / 0.35;
+        gl.uniform1f(gl.getUniformLocation(progReflection, 'u_waterLine'), waterLine);
+        gl.uniform2f(gl.getUniformLocation(progReflection, 'u_reflectRange'),
+          waterLine - 0.23 * depthScale, 0.38 * depthScale);
 
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, fboTex);

--- a/packages/skins/skin-center/src/pkg-extract.ts
+++ b/packages/skins/skin-center/src/pkg-extract.ts
@@ -1515,6 +1515,9 @@ export interface SceneManifestLayer {
   userColors?: Record<string, [number, number, number]>
   isGround?: boolean
   isReflection?: boolean
+  /** Water surface height as screen v (0 at the top); player falls back to its
+   *  legacy default when absent. */
+  waterLine?: number
   sway?: number
   swaySpeed?: number
 }
@@ -2311,11 +2314,58 @@ function buildSceneManifestVia(access: SceneAccess, token: string): SceneManifes
   const sparkleTexPath = allTex.find((p) => p.toLowerCase().includes('sparkle') || p.toLowerCase().includes('halo') || p.toLowerCase().includes('star'))
   if (sparkleTexPath) manifest.sparkleTex = resourceBase + sparkleTexPath
 
-  for (const obj of scene.objects as Array<Record<string, unknown>>) {
+  const sceneObjects = scene.objects as Array<Record<string, unknown>>
+
+  // Fold the parent transform chain (linux-wallpaperengine CImage::resolveTransform):
+  // a child's origin/scale/angles are relative to the already-resolved parent, so
+  // grouped objects (props like utility poles) only land correctly after folding.
+  // Walk leaf-first with a visited check + depth cap against cycles, then
+  // accumulate root-down: offset = rotate(childOrigin * parentScale, parentAngle).
+  const resolveObjectTransform = (obj: Record<string, unknown>) => {
+    const chain = [obj]
+    let cur = obj
+    while (cur.parent != null && chain.length <= 32) {
+      const parent = sceneObjects.find((o) => o.id === cur.parent)
+      if (!parent || chain.includes(parent)) break
+      chain.push(parent)
+      cur = parent
+    }
+    const root = chain[chain.length - 1]
+    let origin = parseVec3(root.origin, [width / 2, height / 2, 0])
+    let scale = parseVec3(root.scale, [1, 1, 1])
+    let angle = parseVec3(root.angles, [0, 0, 0])[2]
+    for (let i = chain.length - 2; i >= 0; i--) {
+      const localOrigin = parseVec3(chain[i].origin, [0, 0, 0])
+      const localScale = parseVec3(chain[i].scale, [1, 1, 1])
+      const localAngle = parseVec3(chain[i].angles, [0, 0, 0])[2]
+      const c = Math.cos(angle)
+      const s = Math.sin(angle)
+      origin = [
+        origin[0] + localOrigin[0] * scale[0] * c - localOrigin[1] * scale[1] * s,
+        origin[1] + localOrigin[0] * scale[0] * s + localOrigin[1] * scale[1] * c,
+        origin[2] + localOrigin[2] * scale[2],
+      ]
+      scale = [scale[0] * localScale[0], scale[1] * localScale[1], scale[2] * localScale[2]]
+      angle += localAngle
+    }
+    return { origin, scale, angle }
+  }
+
+  // In real WE scenes the water reflection is an object effect
+  // (effects/reflection/effect.json), not only a conventionally named object.
+  const hasReflectionEffect = (obj: Record<string, unknown>) =>
+    (Array.isArray(obj.effects) ? obj.effects : []).some(
+      (e) => typeof (e as Record<string, unknown> | null)?.file === 'string' &&
+        ((e as Record<string, unknown>).file as string).toLowerCase().includes('effects/reflection'),
+    )
+
+  for (const obj of sceneObjects) {
     if (!obj.image || typeof obj.image !== 'string' || obj.image.startsWith('models/util/')) {
-      if (typeof obj.name === 'string' && obj.name.toLowerCase() === 'reflection') {
+      if ((typeof obj.name === 'string' && obj.name.toLowerCase() === 'reflection') || hasReflectionEffect(obj)) {
         const reflTex = allTex.find((p) => p.toLowerCase().includes('reflection_mask'))
         if (reflTex) {
+          // No image means no own rect: keep the legacy fullscreen layer and
+          // let the player fall back to its default water line.
           manifest.layers.push({
             name: 'Reflection',
             isReflection: true,
@@ -2428,10 +2478,12 @@ function buildSceneManifestVia(access: SceneAccess, token: string): SceneManifes
     // Layer geometry follows the scene object (open-wallpaper-engine
     // ImageObject::FromJson): size comes from the image json width/height,
     // then the object size, then the decoded texture; the object origin is
-    // the quad center and scale/angles/alpha apply on top.
-    const objOrigin = parseVec3(obj.origin, [width / 2, height / 2, 0])
-    const objScale = parseVec3(obj.scale, [1, 1, 1])
-    const objAngles = parseVec3(obj.angles, [0, 0, 0])
+    // the quad center and scale/angles/alpha apply on top. Grouped objects
+    // resolve their transform through the parent chain first.
+    const resolvedTransform = resolveObjectTransform(obj)
+    const objOrigin: [number, number, number] = [...resolvedTransform.origin]
+    const objScale = resolvedTransform.scale
+    const objAngles: [number, number, number] = [0, 0, resolvedTransform.angle]
     let lw = 0
     let lh = 0
     if (typeof modelJson.width === 'number' && typeof modelJson.height === 'number') {
@@ -2460,6 +2512,17 @@ function buildSceneManifestVia(access: SceneAccess, token: string): SceneManifes
       objOrigin[1] = height / 2
       objAngles[2] = 0
     }
+
+    // alignment anchors the quad by half its scaled size per side
+    // (linux-wallpaperengine CImage::updateScenePosition); default 'center'
+    // leaves the origin at the quad center.
+    const alignment = typeof obj.alignment === 'string' ? obj.alignment.toLowerCase() : ''
+    let alignDx = 0
+    let alignDy = 0
+    if (alignment.includes('left')) alignDx = lw / 2
+    else if (alignment.includes('right')) alignDx = -lw / 2
+    if (alignment.includes('top')) alignDy = -lh / 2
+    else if (alignment.includes('bottom')) alignDy = lh / 2
 
     let ox = 0
     let oy = 0
@@ -2498,11 +2561,36 @@ function buildSceneManifestVia(access: SceneAccess, token: string): SceneManifes
       nameLower.includes('bush') ||
       nameLower.includes('fence')
 
+    const layerX = objOrigin[0] + alignDx
+    const layerY = objOrigin[1] + alignDy
+
+    // Reflection carried as an object effect (effects/reflection/effect.json):
+    // emit the reflection layer anchored to this object's own rect with the
+    // water line at its top edge (screen v, 0 at the top). The object itself
+    // still renders as a normal layer below.
+    if (hasReflectionEffect(obj) || nameLower === 'reflection') {
+      const reflTex = allTex.find((p) => p.toLowerCase().includes('reflection_mask'))
+      if (reflTex) {
+        manifest.layers.push({
+          name: 'Reflection',
+          isReflection: true,
+          texUrl: resourceBase + reflTex,
+          x: layerX,
+          y: layerY,
+          w: lw,
+          h: lh,
+          waterLine: Math.min(1, Math.max(0, 1 - (layerY + lh / 2) / height)),
+        })
+      }
+    }
+
     manifest.layers.push({
       name: typeof obj.name === 'string' ? obj.name : 'layer',
       texUrl: resourceBase + texPath,
-      x: objOrigin[0] + ox,
-      y: objOrigin[1] + oy,
+      // cropoffset (ox/oy) only crops the sampled UV rect; it must not move
+      // the quad in world space.
+      x: layerX,
+      y: layerY,
       w: lw,
       h: lh,
       alpha,

--- a/packages/skins/skin-center/src/we-player-source.ts
+++ b/packages/skins/skin-center/src/we-player-source.ts
@@ -409,13 +409,21 @@ export const WE_SCENE_PLAYER_HTML = `<!DOCTYPE html>
     uniform sampler2D u_mask;
     uniform float u_time;
     uniform float u_alpha;
+    // Scene-uv rect of the reflection quad: (leftU, topV, scaleU, scaleV);
+    // (0,0,1,1) for a fullscreen layer. Scene v grows downward (0 at the top).
+    uniform vec4 u_rect;
+    // Data-driven water surface from the scene object (legacy default 0.65).
+    uniform float u_waterLine;
+    // Reflection sample window: start + puddleDepth * span (legacy 0.42/0.38).
+    uniform vec2 u_reflectRange;
     void main() {
       float mask = texture2D(u_mask, v_uv).r;
-      if (mask < 0.05 || v_uv.y < 0.65) {
+      vec2 sceneUv = u_rect.xy + v_uv * u_rect.zw;
+      if (mask < 0.05 || sceneUv.y < u_waterLine) {
         discard;
       }
-      float puddleDepth = (v_uv.y - 0.65) / 0.35;
-      vec2 uvReflect = vec2(v_uv.x, 0.42 + puddleDepth * 0.38);
+      float puddleDepth = (sceneUv.y - u_waterLine) / max(1.0 - u_waterLine, 0.0001);
+      vec2 uvReflect = vec2(sceneUv.x, u_reflectRange.x + puddleDepth * u_reflectRange.y);
       // water wave ripple perturbation
       float wave = sin(v_uv.y * 120.0 + u_time * 2.8) * 0.002 +
                    cos(v_uv.x * 90.0 + u_time * 1.9) * 0.0015;
@@ -1662,12 +1670,27 @@ export const WE_SCENE_PLAYER_HTML = `<!DOCTYPE html>
         gl.vertexAttribPointer(rPos, 2, gl.FLOAT, false, 16, 0);
         gl.vertexAttribPointer(rUv, 2, gl.FLOAT, false, 16, 8);
 
-        const model = mat4Transform2D(sceneW / 2, sceneH / 2, sceneW, sceneH, 0);
+        // Draw the reflection quad at the layer's own rect (fullscreen for
+        // legacy scene-wide reflection layers).
+        const model = mat4Transform2D(layer.x, layer.y, layer.w, layer.h, layer.angle || 0);
         gl.uniformMatrix4fv(gl.getUniformLocation(progReflection, 'u_proj'), false, proj);
         gl.uniformMatrix4fv(gl.getUniformLocation(progReflection, 'u_model'), false, model);
         gl.uniform4f(gl.getUniformLocation(progReflection, 'u_uvRect'), 0, 0, 1, 1);
         gl.uniform1f(gl.getUniformLocation(progReflection, 'u_time'), elapsed);
         gl.uniform1f(gl.getUniformLocation(progReflection, 'u_alpha'), 0.85);
+
+        // Scene-uv rect of the quad (scene v grows downward, 0 at the top).
+        const rectLeftU = (layer.x - layer.w / 2) / sceneW;
+        const rectTopV = 1 - (layer.y + layer.h / 2) / sceneH;
+        gl.uniform4f(gl.getUniformLocation(progReflection, 'u_rect'),
+          rectLeftU, rectTopV, layer.w / sceneW, layer.h / sceneH);
+        // Water line follows the scene data when the parser resolved one;
+        // otherwise keep the legacy 0.65 / 0.42 / 0.38 window.
+        const waterLine = typeof layer.waterLine === 'number' ? layer.waterLine : 0.65;
+        const depthScale = (1 - waterLine) / 0.35;
+        gl.uniform1f(gl.getUniformLocation(progReflection, 'u_waterLine'), waterLine);
+        gl.uniform2f(gl.getUniformLocation(progReflection, 'u_reflectRange'),
+          waterLine - 0.23 * depthScale, 0.38 * depthScale);
 
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, fboTex);

--- a/packages/skins/skin-center/tests/pkg-extract.spec.ts
+++ b/packages/skins/skin-center/tests/pkg-extract.spec.ts
@@ -1103,6 +1103,155 @@ describe('extractSceneMainImageFromDir', () => {
       rmSync(tmp, { recursive: true, force: true })
     }
   })
+
+  it('folds parent transform chains for grouped objects (#742)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'dsh-2d-parent-'))
+    try {
+      mkdirSync(join(tmp, 'models'), { recursive: true })
+      mkdirSync(join(tmp, 'materials'), { recursive: true })
+      writeFileSync(join(tmp, 'materials', 'pole.tex'), buildTex({
+        width: 128, height: 128,
+        mipmaps: [{ width: 128, height: 128, data: new Uint8Array(128 * 128 * 4) }],
+      }))
+      writeFileSync(join(tmp, 'models', 'pole.json'), JSON.stringify({ material: 'materials/pole.json', width: 128, height: 128 }))
+      writeFileSync(join(tmp, 'materials', 'pole.json'), JSON.stringify({ passes: [{ shader: 'genericimage', textures: ['pole'] }] }))
+      writeFileSync(join(tmp, 'scene.json'), JSON.stringify({
+        general: { orthogonalprojection: { width: 1000, height: 800 } },
+        objects: [
+          // WE editor group: children are relative to the resolved parent.
+          { id: 1, name: 'pole-group', origin: '100 50 0', scale: '2 2 1', angles: '0 0 0.25' },
+          { id: 2, name: 'pole', image: 'models/pole.json', parent: 1, origin: '10 5 0', scale: '0.5 0.5 1', angles: '0 0 0.25' },
+        ],
+      }), 'utf8')
+
+      const manifest = buildSceneManifestFromDir(tmp, 'tok_parent')
+      expect(manifest?.layers.length).toBe(1)
+      const layer = manifest?.layers[0]
+      const c = Math.cos(0.25)
+      const s = Math.sin(0.25)
+      expect(layer?.x).toBeCloseTo(100 + 10 * 2 * c - 5 * 2 * s)
+      expect(layer?.y).toBeCloseTo(50 + 10 * 2 * s + 5 * 2 * c)
+      expect(layer?.w).toBe(128) // folded scale 2 * 0.5
+      expect(layer?.h).toBe(128)
+      expect(layer?.angle).toBeCloseTo(0.5)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('survives parent cycles without hanging (#742)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'dsh-2d-cycle-'))
+    try {
+      mkdirSync(join(tmp, 'models'), { recursive: true })
+      mkdirSync(join(tmp, 'materials'), { recursive: true })
+      writeFileSync(join(tmp, 'materials', 'pole.tex'), buildTex({
+        width: 128, height: 128,
+        mipmaps: [{ width: 128, height: 128, data: new Uint8Array(128 * 128 * 4) }],
+      }))
+      writeFileSync(join(tmp, 'models', 'pole.json'), JSON.stringify({ material: 'materials/pole.json', width: 128, height: 128 }))
+      writeFileSync(join(tmp, 'materials', 'pole.json'), JSON.stringify({ passes: [{ shader: 'genericimage', textures: ['pole'] }] }))
+      writeFileSync(join(tmp, 'scene.json'), JSON.stringify({
+        general: { orthogonalprojection: { width: 1000, height: 800 } },
+        objects: [
+          { id: 1, name: 'a', image: 'models/pole.json', parent: 2, origin: '10 0 0' },
+          { id: 2, name: 'b', parent: 1, origin: '20 0 0' },
+        ],
+      }), 'utf8')
+
+      const manifest = buildSceneManifestFromDir(tmp, 'tok_cycle')
+      expect(manifest?.layers.length).toBe(1)
+      expect(Number.isFinite(manifest?.layers[0].x)).toBe(true)
+      expect(Number.isFinite(manifest?.layers[0].y)).toBe(true)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('applies alignment offsets and keeps cropoffset out of the world position (#742)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'dsh-2d-align-'))
+    try {
+      mkdirSync(join(tmp, 'models'), { recursive: true })
+      mkdirSync(join(tmp, 'materials'), { recursive: true })
+      // 128x128 content padded into a 256x256 tex, sampled from (32, 16).
+      writeFileSync(join(tmp, 'materials', 'photo.tex'), buildTex({
+        width: 256, height: 256,
+        mipmaps: [{ width: 256, height: 256, data: new Uint8Array(256 * 256 * 4) }],
+      }))
+      writeFileSync(join(tmp, 'models', 'photo.json'), JSON.stringify({
+        material: 'materials/photo.json', width: 128, height: 128, cropoffset: '32 16',
+      }))
+      writeFileSync(join(tmp, 'materials', 'photo.json'), JSON.stringify({ passes: [{ shader: 'genericimage', textures: ['photo'] }] }))
+      writeFileSync(join(tmp, 'scene.json'), JSON.stringify({
+        general: { orthogonalprojection: { width: 1000, height: 800 } },
+        objects: [
+          { name: 'photo', image: 'models/photo.json', origin: '500 400 0', alignment: 'left top' },
+        ],
+      }), 'utf8')
+
+      const manifest = buildSceneManifestFromDir(tmp, 'tok_align')
+      expect(manifest?.layers.length).toBe(1)
+      const layer = manifest?.layers[0]
+      // left/top anchor shifts the quad center by half its size; the crop
+      // offset only selects the sampled UV rect and must not move the quad.
+      expect(layer?.x).toBe(500 + 64)
+      expect(layer?.y).toBe(400 - 64)
+      expect(layer?.uvCrop).toEqual([0.125, 0.0625, 0.625, 0.5625])
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('anchors effects-driven reflection layers to the object rect with a data-driven water line (#742)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'dsh-2d-reflect-'))
+    try {
+      mkdirSync(join(tmp, 'models'), { recursive: true })
+      mkdirSync(join(tmp, 'materials'), { recursive: true })
+      mkdirSync(join(tmp, 'masks'), { recursive: true })
+      writeFileSync(join(tmp, 'materials', 'water.tex'), buildTex({
+        width: 128, height: 128,
+        mipmaps: [{ width: 128, height: 128, data: new Uint8Array(128 * 128 * 4) }],
+      }))
+      writeFileSync(join(tmp, 'masks', 'reflection_mask_0.tex'), buildTex({
+        width: 128, height: 128,
+        mipmaps: [{ width: 128, height: 128, data: new Uint8Array(128 * 128 * 4) }],
+      }))
+      writeFileSync(join(tmp, 'models', 'water.json'), JSON.stringify({ material: 'materials/water.json', width: 128, height: 128 }))
+      writeFileSync(join(tmp, 'materials', 'water.json'), JSON.stringify({ passes: [{ shader: 'genericimage', textures: ['water'] }] }))
+      writeFileSync(join(tmp, 'scene.json'), JSON.stringify({
+        general: { orthogonalprojection: { width: 1000, height: 800 } },
+        objects: [
+          {
+            name: 'water', image: 'models/water.json', origin: '500 400 0',
+            effects: [{ file: 'effects/reflection/effect.json' }],
+          },
+          // Legacy form: a conventionally named object without its own image
+          // keeps the fullscreen layer and leaves the water line to the player.
+          { name: 'reflection' },
+        ],
+      }), 'utf8')
+
+      const manifest = buildSceneManifestFromDir(tmp, 'tok_reflect')
+      const reflections = manifest?.layers.filter((l) => l.isReflection)
+      expect(reflections?.length).toBe(2)
+      const anchored = reflections?.find((l) => typeof l.waterLine === 'number')
+      expect(anchored).toBeDefined()
+      expect(anchored?.x).toBe(500)
+      expect(anchored?.y).toBe(400)
+      expect(anchored?.w).toBe(128)
+      expect(anchored?.h).toBe(128)
+      // Water surface at the object top edge: 1 - (400 + 64) / 800.
+      expect(anchored?.waterLine).toBeCloseTo(0.42)
+      expect(anchored?.texUrl).toContain('reflection_mask_0')
+      const legacy = reflections?.find((l) => l.waterLine == null)
+      expect(legacy).toBeDefined()
+      expect(legacy?.w).toBe(1000)
+      expect(legacy?.h).toBe(800)
+      // The water object itself still renders as a normal layer.
+      expect(manifest?.layers.some((l) => l.name === 'water' && !l.isReflection)).toBe(true)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('untrusted input allocation caps (#717 hardening)', () => {

--- a/packages/skins/skin-center/tests/we-player.spec.ts
+++ b/packages/skins/skin-center/tests/we-player.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Source-level guards for the WE scene player runtime (src/we-player-source.ts).
+ * The player is a self-contained HTML string, so these tests pin the
+ * reflection contract that pkg-extract's manifest feeds: the water line and
+ * the reflection quad must follow scene data, not hard-coded constants (#742).
+ * @module @linxin666/dsh-client-ui-skin-center/tests/we-player
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { WE_SCENE_PLAYER_HTML } from '../src/we-player-source.ts'
+
+describe('WE scene player reflection pass (#742)', () => {
+  it('drives the water line and sample window from uniforms, not constants', () => {
+    expect(WE_SCENE_PLAYER_HTML).toContain('uniform float u_waterLine;')
+    expect(WE_SCENE_PLAYER_HTML).toContain('uniform vec2 u_reflectRange;')
+    expect(WE_SCENE_PLAYER_HTML).toContain('uniform vec4 u_rect;')
+    expect(WE_SCENE_PLAYER_HTML).not.toContain('v_uv.y < 0.65')
+    expect(WE_SCENE_PLAYER_HTML).not.toContain('0.42 + puddleDepth * 0.38')
+  })
+
+  it('draws the reflection quad at the layer rect instead of forcing fullscreen', () => {
+    expect(WE_SCENE_PLAYER_HTML).not.toContain('mat4Transform2D(sceneW / 2, sceneH / 2, sceneW, sceneH, 0)')
+    expect(WE_SCENE_PLAYER_HTML).toContain("gl.getUniformLocation(progReflection, 'u_waterLine')")
+    // Legacy manifests without a water line keep the historical default.
+    expect(WE_SCENE_PLAYER_HTML).toContain("typeof layer.waterLine === 'number' ? layer.waterLine : 0.65")
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 #742：WE 场景壁纸（Meteors at Dawn 等多组件场景）经皮肤中心 scene 播放器渲染时，打组对象（电线杆等道具）定位错误、水面反射缺失/错位。解析器补齐 parent 变换链折叠、alignment 偏移与 cropoffset 语义；反射从「名字恰好叫 reflection 的全屏层」改为对象 effect 驱动、锚定对象矩形，播放器水线与采样窗改为场景数据驱动（无数据时保留旧默认值，defaultprojects 零回退）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `main` 分支开发，或在提交前已 rebase / 合并最新 `main`。

同步命令：分支直接从最新 `origin/main` 切出（`git checkout -b fix/742-we-scene-player origin/main`）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：Kimi（kimi-for-coding）

使用的编码 Agent 工具：Kimi Code CLI

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本 PR 未新增包）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改动 README）

## 贡献者版权声明（Contributor Copyright）

维持现有版权归属。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm typecheck                              # 全仓通过
pnpm --filter @linxin666/dsh-client-ui-skin-center test   # 19 文件 287 测试全过（含新增 6 个）
pnpm skin-center:check                      # OK（13 built-in skins）
pnpm docs:check                             # all documentation gates passed
pnpm test                                   # 见下方说明
pnpm test:scripts                           # 见下方说明
```

结果摘要：

- 新增回归测试：parent 链折叠（旋转+缩放复合）、parent 成环防护、alignment 偏移 + cropoffset 不移位、effects 驱动反射层（对象矩形 + waterLine 断言，旧式全屏层回退共存）、播放器源码契约守卫（uniforms 替代硬编码 0.65/0.42/0.38）。
- `pnpm test` 全仓：`dsh-liangshen` 的 `custom-bash` 4 例在本机失败（Git Bash 路径发现的环境相关断言），与本次改动零文件重叠，本机干净 main 上同样失败；其余包全过。
- `pnpm test:scripts`：`scripts/e2e-mount-rewrite.test.mjs` 3 例在本机失败（GNU tar 把 `C:\...` 输出路径当远程主机，Git Bash 环境问题），干净 main 上同样失败；其余脚本测试全过。
- GUI 实测：本机 `dsh web` 以 link 方式挂载本分支全家桶，应用创意工坊壁纸 Meteors at Dawn [4K]（workshop 3413921910），电线杆等分组组件定位与水面反射高度均正常；测试完成后已恢复 npm 正式包并清理本地链接。

## 用户可见变更证据（Local Feature Evidence）

证据：维护者本机 `dsh web` 实测通过（见「本地验证」GUI 实测条）。渲染对比截图建议由 issue 认领人 ForeverのSkywalker 按 #742 约定补充。

---

参考实现：linux-wallpaperengine `src/WallpaperEngine/Render/Objects/CImage.cpp`（`resolveTransform` 父级链折叠、`updateScenePosition` alignment 偏移）。

Closes #742
