### PR TITLE
fix(skin-center): crop scene frames to the declared projection ratio

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -3156,6 +3156,57 @@ function hasContent(rgba, width, height) {
 	}
 	return sampleCount === 0 || visibleCount / sampleCount >= .01;
 }
+/**
+* Read the scene's declared projection size (the viewport the author
+* designed the scene for). Scenes without an explicit projection default to
+* null so the extractor keeps the texture's native dimensions.
+*/
+function sceneProjectionSize(scene) {
+	const general = scene.general;
+	const rawW = general?.orthogonalprojection?.width;
+	const rawH = general?.orthogonalprojection?.height;
+	const width = typeof rawW === "number" && Number.isFinite(rawW) && rawW > 0 ? Math.floor(rawW) : 0;
+	const height = typeof rawH === "number" && Number.isFinite(rawH) && rawH > 0 ? Math.floor(rawH) : 0;
+	if (width <= 0 || height <= 0) return null;
+	return {
+		width,
+		height
+	};
+}
+/**
+* Center-crop RGBA pixels to the scene's projection aspect ratio (cover
+* semantics). Scene textures are authored at the full projection canvas
+* (e.g. 2048x2048) while the viewport is 16:9; returning the raw square
+* makes the wallpaper stretch or crop wrongly on a widescreen display.
+* Returns null when no projection is declared or the ratio already matches.
+*/
+function cropToProjection(rgba, width, height, projection) {
+	if (!projection) return null;
+	const sourceRatio = width / height;
+	const targetRatio = projection.width / projection.height;
+	if (Math.abs(sourceRatio - targetRatio) < .005) return null;
+	let outWidth = width;
+	let outHeight = height;
+	if (sourceRatio > targetRatio) {
+		outWidth = Math.floor(height * targetRatio);
+		if (outWidth >= width) return null;
+	} else {
+		outHeight = Math.floor(width / targetRatio);
+		if (outHeight >= height) return null;
+	}
+	const startX = Math.max(0, Math.floor((width - outWidth) / 2));
+	const startY = Math.max(0, Math.floor((height - outHeight) / 2));
+	const out = new Uint8Array(outWidth * outHeight * 4);
+	for (let y = 0; y < outHeight; y++) {
+		const srcStart = ((startY + y) * width + startX) * 4;
+		out.set(rgba.subarray(srcStart, srcStart + outWidth * 4), y * outWidth * 4);
+	}
+	return {
+		width: outWidth,
+		height: outHeight,
+		rgba: out
+	};
+}
 function getTextureScore(path) {
 	const lower = path.toLowerCase();
 	if (isLikelyMaskOrHelper(path)) return -100;
@@ -3260,6 +3311,7 @@ function extractSceneMainImageVia(access, label) {
 		if (project && typeof project.file === "string" && project.file.endsWith(".json")) scene = access.readJson(project.file);
 	}
 	if (!scene || !Array.isArray(scene.objects)) throw new Error(label + ": scene.json not found or invalid");
+	const projection = sceneProjectionSize(scene);
 	if (scene.objects.some((obj) => obj && typeof obj === "object" && typeof obj.model === "string" && obj.model.length > 0)) throw new Error(label + ": 3D scene cannot be extracted as 2D frame");
 	const composite = tryCompositeMultiLayerScene(scene, access);
 	if (composite !== null) return composite;
@@ -3305,17 +3357,37 @@ function extractSceneMainImageVia(access, label) {
 			const parsed = parseTexInternal(file.bytes);
 			if (parsed.isVideoMp4) throw new Error("tex: video mp4 textures cannot be decoded to a static frame");
 			const mip0 = parsed.mipmaps[0];
-			if (isPngBuffer(mip0.bytes)) return {
-				width: mip0.width,
-				height: mip0.height,
-				png: Buffer$1.from(mip0.bytes),
-				texturePath: file.path
-			};
+			if (isPngBuffer(mip0.bytes)) {
+				const png = Buffer$1.from(mip0.bytes);
+				if (projection) {
+					const decoded = decodePngToRgba(mip0.bytes);
+					const cropped = cropToProjection(decoded.rgba, decoded.width, decoded.height, projection);
+					if (cropped) return {
+						width: cropped.width,
+						height: cropped.height,
+						png: encodePng(cropped.width, cropped.height, cropped.rgba),
+						texturePath: file.path
+					};
+				}
+				return {
+					width: mip0.width,
+					height: mip0.height,
+					png,
+					texturePath: file.path
+				};
+			}
 			const { width, height, rgba } = decodeTex(file.bytes);
 			if (!hasContent(rgba, width, height)) {
 				lastError = /* @__PURE__ */ new Error(label + ": texture '" + path + "' is a shader mask or partial layer");
 				continue;
 			}
+			const cropped = cropToProjection(rgba, width, height, projection);
+			if (cropped) return {
+				width: cropped.width,
+				height: cropped.height,
+				png: encodePng(cropped.width, cropped.height, cropped.rgba),
+				texturePath: file.path
+			};
 			return {
 				width,
 				height,

--- a/packages/skins/skin-center/src/pkg-extract.ts
+++ b/packages/skins/skin-center/src/pkg-extract.ts
@@ -1192,6 +1192,57 @@ function hasContent(rgba: Uint8Array, width: number, height: number): boolean {
   return sampleCount === 0 || (visibleCount / sampleCount) >= 0.01
 }
 
+/**
+ * Read the scene's declared projection size (the viewport the author
+ * designed the scene for). Scenes without an explicit projection default to
+ * null so the extractor keeps the texture's native dimensions.
+ */
+function sceneProjectionSize(scene: Record<string, unknown>): { width: number; height: number } | null {
+  const general = scene.general as { orthogonalprojection?: { width?: unknown; height?: unknown } } | undefined
+  const rawW = general?.orthogonalprojection?.width
+  const rawH = general?.orthogonalprojection?.height
+  const width = typeof rawW === 'number' && Number.isFinite(rawW) && rawW > 0 ? Math.floor(rawW) : 0
+  const height = typeof rawH === 'number' && Number.isFinite(rawH) && rawH > 0 ? Math.floor(rawH) : 0
+  if (width <= 0 || height <= 0) return null
+  return { width, height }
+}
+
+/**
+ * Center-crop RGBA pixels to the scene's projection aspect ratio (cover
+ * semantics). Scene textures are authored at the full projection canvas
+ * (e.g. 2048x2048) while the viewport is 16:9; returning the raw square
+ * makes the wallpaper stretch or crop wrongly on a widescreen display.
+ * Returns null when no projection is declared or the ratio already matches.
+ */
+function cropToProjection(
+  rgba: Uint8Array,
+  width: number,
+  height: number,
+  projection: { width: number; height: number } | null,
+): { width: number; height: number; rgba: Uint8Array } | null {
+  if (!projection) return null
+  const sourceRatio = width / height
+  const targetRatio = projection.width / projection.height
+  if (Math.abs(sourceRatio - targetRatio) < 0.005) return null
+  let outWidth = width
+  let outHeight = height
+  if (sourceRatio > targetRatio) {
+    outWidth = Math.floor(height * targetRatio)
+    if (outWidth >= width) return null
+  } else {
+    outHeight = Math.floor(width / targetRatio)
+    if (outHeight >= height) return null
+  }
+  const startX = Math.max(0, Math.floor((width - outWidth) / 2))
+  const startY = Math.max(0, Math.floor((height - outHeight) / 2))
+  const out = new Uint8Array(outWidth * outHeight * 4)
+  for (let y = 0; y < outHeight; y++) {
+    const srcStart = ((startY + y) * width + startX) * 4
+    out.set(rgba.subarray(srcStart, srcStart + outWidth * 4), y * outWidth * 4)
+  }
+  return { width: outWidth, height: outHeight, rgba: out }
+}
+
 function getTextureScore(path: string): number {
   const lower = path.toLowerCase()
   if (isLikelyMaskOrHelper(path)) return -100
@@ -1348,6 +1399,11 @@ function extractSceneMainImageVia(access: SceneAccess, label: string): SceneMain
     throw new Error(label + ': scene.json not found or invalid')
   }
 
+  // The scene's declared viewport (e.g. 1920x1080). Scene textures are often
+  // authored larger or square; the final frame must match the projection so
+  // the wallpaper keeps its aspect on widescreen displays.
+  const projection = sceneProjectionSize(scene)
+
   // 3D model scenes use UV maps on 3D meshes rather than 2D desktop backgrounds
   const has3dModels = (scene.objects as Array<{ model?: unknown }>).some(
     (obj) => obj && typeof obj === 'object' && typeof obj.model === 'string' && obj.model.length > 0,
@@ -1413,12 +1469,29 @@ function extractSceneMainImageVia(access: SceneAccess, label: string): SceneMain
       }
       const mip0 = parsed.mipmaps[0]
       if (isPngBuffer(mip0.bytes)) {
-        return { width: mip0.width, height: mip0.height, png: Buffer.from(mip0.bytes), texturePath: file.path }
+        const png = Buffer.from(mip0.bytes)
+        if (projection) {
+          const decoded = decodePngToRgba(mip0.bytes)
+          const cropped = cropToProjection(decoded.rgba, decoded.width, decoded.height, projection)
+          if (cropped) {
+            return {
+              width: cropped.width,
+              height: cropped.height,
+              png: encodePng(cropped.width, cropped.height, cropped.rgba),
+              texturePath: file.path,
+            }
+          }
+        }
+        return { width: mip0.width, height: mip0.height, png, texturePath: file.path }
       }
       const { width, height, rgba } = decodeTex(file.bytes)
       if (!hasContent(rgba, width, height)) {
         lastError = new Error(label + ": texture '" + path + "' is a shader mask or partial layer")
         continue
+      }
+      const cropped = cropToProjection(rgba, width, height, projection)
+      if (cropped) {
+        return { width: cropped.width, height: cropped.height, png: encodePng(cropped.width, cropped.height, cropped.rgba), texturePath: file.path }
       }
       return { width, height, png: encodePng(width, height, rgba), texturePath: file.path }
     } catch (err) {

--- a/packages/skins/skin-center/tests/pkg-extract.spec.ts
+++ b/packages/skins/skin-center/tests/pkg-extract.spec.ts
@@ -744,6 +744,73 @@ describe('extractSceneMainImageFromDir', () => {
     }
   })
 
+  it('crops a square texture to the scene projection ratio (16:9 cover)', () => {
+    const wide = 8
+    const tall = 8
+    const pixels = solidPixels(wide, tall, 40, 80, 120)
+    // Two distinct horizontal bands so a vertical crop is observable: top
+    // half stays opaque dark, bottom half stays opaque light; the center
+    // crop keeps both (an all-same solid would mask an off-center crop bug).
+    for (let y = 0; y < tall; y++) {
+      const band = y < tall / 2 ? 200 : 40
+      for (let x = 0; x < wide; x++) {
+        const i = (y * wide + x) * 4
+        pixels[i] = band
+        pixels[i + 1] = band
+        pixels[i + 2] = band
+        pixels[i + 3] = 255
+      }
+    }
+    const squareTex = buildTex({
+      width: wide,
+      height: tall,
+      containerVersion: 3,
+      mipmaps: [{ width: wide, height: tall, data: pixels }],
+    })
+    const dir = makeSceneDir({
+      // Scene declares a 16:9 viewport while the texture is square.
+      'scene.json': JSON.stringify({
+        general: { orthogonalprojection: { width: 1920, height: 1080 } },
+        objects: [{ id: 1, name: 'background', image: 'materials/bg.tex' }],
+      }),
+      'materials/bg.tex': squareTex,
+    })
+    try {
+      const result = extractSceneMainImageFromDir(dir)
+      // 8x8 square cropped to 16:9 cover keeps full width and floor(8 / (16/9)) height.
+      expect(result.width).toBe(8)
+      expect(result.height).toBe(Math.floor(8 / (1920 / 1080))) // 4
+      const out = decodePng(result.png)
+      expect(out.width).toBe(8)
+      expect(out.height).toBe(4)
+      // Vertical center crop: source rows 2..5 remain (startY = floor((8-4)/2) = 2).
+      const row = (y: number): number => out.rgba[(y * out.width) * 4]
+      expect(row(0)).toBe(200) // source row 2 (top half band)
+      expect(row(out.height - 1)).toBe(40) // source row 5 (bottom half band)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the native ratio when the scene declares no projection', () => {
+    const dir = makeSceneDir({
+      'scene.json': sceneJson('materials/bg.tex'),
+      'materials/bg.tex': buildTex({
+        width: 4,
+        height: 4,
+        containerVersion: 3,
+        mipmaps: [{ width: 4, height: 4, data: solidPixels(4, 4, 7, 7, 7) }],
+      }),
+    })
+    try {
+      const result = extractSceneMainImageFromDir(dir)
+      expect(result.width).toBe(4)
+      expect(result.height).toBe(4)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('falls back to the largest .tex found in the directory tree', () => {
     const dir = makeSceneDir({
       'scene.json': sceneJson('materials/missing.json'),


### PR DESCRIPTION
## 摘要（Summary）

Wallpaper Engine 场景声明视口（如 1920x1080），但源纹理常为正方形（2048x2048）。静态帧提取器直接返回原始纹理，导致 deep_space 等 3D 场景在宽屏上渲染成正方形拉伸——比例错误、内容错位。修复：读取场景 general.orthogonalprojection 声明，解码后按该比例居中裁剪（cover 语义）；未声明投影的场景保持原生尺寸。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 packages/skins

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [x] 视觉修复（UI / 视觉类问题的修复）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch origin && git rebase origin/dev
```

已执行：分支已 rebase 到 origin/dev（a57312f），HEAD 为 af76bf3。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

本地测试证据（packages/skins/skin-center）：

```bash
pnpm typecheck        # pass
pnpm exec vitest run tests/pkg-extract.spec.ts   # 54/55 passed
```

- 唯一失败为 symlinks escaping 测试：Windows 上 symlinkSync 触发 EPERM（环境权限限制，未改动代码的 dev 分支同样失败）。
- 新增两个测试（投影裁剪、无投影保持原生比例）均通过。
- 同步 origin/dev（rebase 到 a57312f）后重新运行，结果一致（54/55）。

## 视觉修复要求（Visual Fix Requirements）

- [x] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [x] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

视觉证据（deep_space：投影 1920x1080、纹理 2048x2048）：

- 修复前：帧 2048x2048 正方形，16:9 屏幕上下各裁切约 420px，变形错位
- 修复后：帧 2048x1152（16:9），等比铺满

![deep_space frame after fix](https://raw.githubusercontent.com/Xeehho/dsh-web-ui/docs/pr751-evidence/docs/archive/pr751-evidence/deep_space-frame-after-2048x1152.png)

![before vs after](https://raw.githubusercontent.com/Xeehho/dsh-web-ui/docs/pr751-evidence/docs/archive/pr751-evidence/before-vs-after.png)

验证：重启 DSH 后请求 /api/skin-center/we/scene-frame/<token>，读取尺寸 2048x1152（比例 1.778）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码
- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（多模态验证：describe_image 工具读取视觉证据图确认修复效果；模型支持图像输入）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 新增 / 修改文件不含任何 emoji 字符。
- [x] 未改动 README。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/skins/skin-center
pnpm typecheck
pnpm exec vitest run tests/pkg-extract.spec.ts
```

结果摘要：typecheck 通过；pkg-extract.spec.ts 54/55 通过，唯一失败为 Windows symlink EPERM 环境限制（dev 分支同样失败）。新增两个投影裁剪测试均通过。

## 用户可见变更证据（Local Feature Evidence）

deep_space（1920x1080 视口、2048x2048 纹理）修复前后对比：

- 修复前：帧 2048x2048（正方形），16:9 屏幕上下各裁切约 420px，变形错位
- 修复后：帧 2048x1152（16:9），等比铺满

![deep_space frame after fix](https://raw.githubusercontent.com/Xeehho/dsh-web-ui/docs/pr751-evidence/docs/archive/pr751-evidence/deep_space-frame-after-2048x1152.png)

真实帧截图见「视觉修复要求」节。