### PR TITLE
Fix/describe image send outcome

### DIFF
--- a/packages/dsh-tool-describe-image/src/client/send-hook.ts
+++ b/packages/dsh-tool-describe-image/src/client/send-hook.ts
@@ -31,6 +31,9 @@ interface SessionPromptFace {
   prompt(content: readonly TextBlock[], mode: string, signal?: AbortSignal): Promise<PromptResult>
 }
 
+/** Submission result consumed by the conversation input state machine. */
+interface SubmitOutcome { kind: 'success' | 'error'; text?: string }
+
 /**
  * The conversation-service surface this hook wraps. rc.8 added the optional
  * AbortSignal (send cancellation) and a SubmitOutcome return on sendSession;
@@ -40,7 +43,7 @@ interface SessionPromptFace {
  */
 interface ConversationSendFace {
   send(text: string): Promise<void>
-  sendSession(session: SessionPromptFace, text: string, imageIds: readonly string[], mode: string, signal?: AbortSignal): Promise<unknown>
+  sendSession(session: SessionPromptFace, text: string, imageIds: readonly string[], mode: string, signal?: AbortSignal): Promise<SubmitOutcome>
   draftImages(ids: readonly string[]): readonly DraftImageFace[]
   releaseDraftImage(id: string): void
 }
@@ -72,7 +75,7 @@ export function installSendHook(conversation: unknown, isEnabled?: () => boolean
   if ((face as unknown as Record<string, unknown>)[HOOK_MARKER] === true) return
 
   const original = face.sendSession
-  face.sendSession = async (session, text, imageIds, mode, signal): Promise<unknown> => {
+  face.sendSession = async (session, text, imageIds, mode, signal): Promise<SubmitOutcome> => {
     if (isEnabled !== undefined && !isEnabled()) {
       return original.call(face, session, text, imageIds, mode, signal)
     }
@@ -115,6 +118,7 @@ export function installSendHook(conversation: unknown, isEnabled?: () => boolean
       throw new Error(`conversation.send failed: ${result.error?.code ?? 'unknown'}: ${result.error?.message ?? ''}`)
     }
     for (const id of imageIds) face.releaseDraftImage(id)
+    return { kind: 'success' }
   }
   ;(face as unknown as Record<string, unknown>)[HOOK_MARKER] = true
 }

--- a/packages/dsh-tool-describe-image/tests/send-hook.spec.ts
+++ b/packages/dsh-tool-describe-image/tests/send-hook.spec.ts
@@ -203,7 +203,8 @@ describe('installSendHook rc.8 signal and outcome contract', () => {
     const prompt = vi.fn(async () => ({ ok: true }))
     installSendHook(face)
     const signal = new AbortController().signal
-    await face.sendSession({ prompt } as never, 'look', ['id1'], 'queue', signal)
+    const outcome = await face.sendSession({ prompt } as never, 'look', ['id1'], 'queue', signal)
+    expect(outcome).toEqual({ kind: 'success' })
     expect(log).toEqual(['release'])
     const call = prompt.mock.calls[0] as unknown as [unknown, unknown, AbortSignal]
     expect(call[2]).toBe(signal)
@@ -220,4 +221,3 @@ describe('installSendHook rc.8 signal and outcome contract', () => {
     expect(original).toHaveBeenCalledWith(expect.anything(), 'look', ['id1'], 'queue', signal)
   })
 })
-


### PR DESCRIPTION
## 摘要（Summary）

修复 describe-image 图片发送拦截器未返回 DSH rc.8 `SubmitOutcome` 的兼容性问题。图片成功发送后现在返回 `{ kind: "success" }`，避免输入框永久停留在 `submitting` 状态，以及已释放图片残留并导致原图预览损坏。

关联 Issue：无（本次为本地运行时现场发现并复现的回归）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他：识图插件 `packages/dsh-tool-describe-image`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream dev
git rebase upstream/dev
```

当前分支已同步到最新 `upstream/dev` 提交 `85862966`，并在同步后重新完成测试；分支仅包含一个修复提交：

```text
29c32032 fix(describe-image): return successful send outcome
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

已同步到 `upstream/dev` 的 `85862966`，随后重新运行 describe-image 全包测试、构建、全仓类型检查、全仓测试、脚本测试、文档检查、运行时依赖检查与 `git diff --check`，结果均通过。

## 视觉修复要求（Visual Fix Requirements）

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

不适用：本 PR 类型未勾选「视觉修复」。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5.6 Sol

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本次未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本次未修改 README），并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

本次未新增插件或皮肤，不追加版权声明。

## 新皮肤收录（New Skin）

不适用，本次未新增或修改皮肤。

## 社区插件索引登记（Community Plugin Index）

不适用，本次未登记社区插件。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-tool-describe-image exec vitest run tests/send-hook.spec.ts
pnpm --filter @linxin666/dsh-tool-describe-image test
pnpm --filter @linxin666/dsh-tool-describe-image build
pnpm runtime-deps:check
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm aggregate:check
pnpm gallery:check
pnpm skin-center:check
pnpm community:check
pnpm sync-shared:check
git diff --check
```

结果摘要：

- describe-image 聚焦回归测试：15 项通过。
- describe-image 全包测试：284 项通过。
- describe-image 构建通过。
- 全仓类型检查与测试通过。
- 脚本、文档、聚合、画廊、皮肤中心、社区索引、共享源码同步和运行时依赖检查全部通过。
- `git diff --check` 通过。
- 全仓 Git 测试使用仅对测试子进程生效的配置关闭提交与标签签名，避免继承本机 GPG 设置；未修改用户 Git 配置。

## 用户可见变更证据（Local Feature Evidence）

证据：

故障已在真实 DSH Web GUI 中复现并定位：

- 输入框停留在 `data-phase="submitting"`，处于只读状态且发送按钮禁用。
- 控制台错误为：

```text
TypeError: Cannot read properties of undefined (reading 'kind')
```

- describe-image 拦截器成功发送并释放图片后返回 `undefined`，导致 DSH 输入状态机无法完成提交结算。
- 残留待发送图片引用了已撤销的 Blob URL；打开原图预览时，图片的 `naturalWidth` 和 `naturalHeight` 均为 `0`。
- rc.8 专用契约测试现已直接断言重写发送路径返回 `{ kind: "success" }`，并同时验证 `AbortSignal` 继续透传。