### PR TITLE
test(liangshen): make custom-bash tests win32-safe and hermetic (#763)

### DIFF
--- a/packages/dsh-liangshen/tests/custom-bash.test.ts
+++ b/packages/dsh-liangshen/tests/custom-bash.test.ts
@@ -2,12 +2,31 @@
  * custom-bash behavior tests (issue #283): the win32 `bash` tool must
  * register the Minimal-compatible schema, spawn `bash -c` through the
  * ordinary cross-platform subprocess seam, and fail with actionable errors
- * instead of silently switching shells. All checks run on POSIX — no real
- * Windows binary is involved.
+ * instead of silently switching shells. Path assertions are separator-
+ * normalized so they hold on win32 runners, and the executable-existence
+ * probe is mocked so the suite is hermetic (issue #763): results no longer
+ * depend on whether the runner has Git for Windows installed.
  */
 
 import { describe, expect, it, vi } from 'vitest'
 import { apply, bashCandidates } from '../presets/liangshen/custom-bash.mjs'
+
+/** Normalize path separators so assertions are runner-platform independent. */
+const normSep = (p: string): string => p.replaceAll('\\', '/')
+
+// The implementation probes candidate executables on the real filesystem
+// (access resolves when the file exists). Mock the probe to reject like
+// ENOENT so tests behave identically with or without Git for Windows on the
+// runner (issue #763).
+const { accessMock } = vi.hoisted(() => ({
+  accessMock: vi.fn(async () => {
+    throw new Error('ENOENT')
+  }),
+}))
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, access: accessMock }
+})
 
 type SpawnFace = { argv: readonly string[]; cwd?: string }
 
@@ -59,8 +78,9 @@ function toolOf(ctx: ReturnType<typeof makeCtx>) {
 describe('bashCandidates', () => {
   it('derives Git Bash roots from the git executable path', () => {
     // node:path follows the runner platform, so probe with a POSIX-style
-    // git path: <root>/cmd/git.exe -> <root>/bin/bash.exe.
-    const candidates = bashCandidates({}, '/opt/git/cmd/git.exe')
+    // git path: <root>/cmd/git.exe -> <root>/bin/bash.exe; separators are
+    // normalized before asserting so the expectations hold on win32 too.
+    const candidates = bashCandidates({}, '/opt/git/cmd/git.exe').map(normSep)
     expect(candidates).toContain('/opt/git/bin/bash.exe')
     expect(candidates).toContain('/opt/git/cmd/bash.exe')
     expect(candidates).toContain('/opt/bin/bash.exe')
@@ -73,10 +93,9 @@ describe('bashCandidates', () => {
       LOCALAPPDATA: 'C:\\Users\\me\\AppData\\Local',
       USERPROFILE: 'C:\\Users\\me',
     }
-    const candidates = bashCandidates(env, undefined)
+    const candidates = bashCandidates(env, undefined).map(normSep)
     // Platform-agnostic tails: each well-known root must appear
-    // (separator varies with the runner, which is what the probe chain
-    // actually uses on Windows).
+    // (separators are normalized, so the same tails hold on win32).
     const tails = [
       'Git/bin/bash.exe',
       'Program Files/Git/bin/bash.exe',


### PR DESCRIPTION
## 摘要（Summary）

修复 #763：Windows 11 上 pnpm test 在 dsh-liangshen 的 custom-bash.test.ts 确定性失败 4 个用例。

根因分两类：

1. **路径分隔符假设**：bashCandidates 用 node:path join（跟随运行平台），win32 上产出反斜杠路径，而两个用例的断言用正斜杠字面量 / 尾部匹配，win32 上必然失败。
2. **测试不封闭**：实现里 exists() 用 node:fs/promises access 探测运行机真实文件系统。装有 Git for Windows 的机器上，env 派生候选真实存在，短路掉 mock 链，导致 spawn argv 与 discovery error 两个用例行为漂移（与 issue 报错 received 完全一致）。

## 涉及包（Affected Packages）

- [ ] 任务看板 packages/dsh-task-board
- [ ] Git 图谱 packages/dsh-git-graph
- [ ] 右侧面板 packages/dsh-aionui-panel
- [ ] 远程 Web UI packages/dsh-remote-web-ui
- [ ] SSH 远程运维 packages/dsh-ssh
- [ ] 宠物 packages/dsh-pet
- [ ] 皮肤 / 皮肤中心 packages/dsh-skins / packages/skins
- [ ] 聚合包 / 设置 packages/dsh-web-ui-all / packages/dsh-web-ui-settings
- [x] 其他（请说明）：packages/dsh-liangshen 测试

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

git fetch origin && git rebase origin/dev

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 dev 分支（git fetch origin && git rebase origin/dev），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [x] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [x] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

纯文本类改动，无截图要求。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 新增包目录以 dsh- 前缀命名（如 packages/dsh-xxx）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 pnpm docs:check。

## 本地验证（Local Validation）

执行的命令：

pnpm --filter @linxin666/dsh-liangshen test
pnpm --filter @linxin666/dsh-liangshen typecheck

结果摘要：

- macOS 本地：test 96/96 通过；typecheck 通过。
- win32 行为用 node path.win32 逐一实测归一化结果与断言匹配（正斜杠输入下 join 产出反斜杠形态，归一化后与原期望逐字一致）。
- CI（ubuntu）为唯一作业平台，win32 失败长期不可见——这正是本 issue 未被 CI 拦截的原因。

## 用户可见变更证据（Local Feature Evidence）

N/A（测试代码改动，无用户可见变更）。

Fixes #763
