### PR TITLE
test(liangshen): normalize custom bash path assertions

### DIFF
--- a/packages/dsh-liangshen/tests/custom-bash.test.ts
+++ b/packages/dsh-liangshen/tests/custom-bash.test.ts
@@ -49,6 +49,10 @@ function execFace(partial: Record<string, unknown> = {}): never {
   } as never
 }
 
+function portablePath(path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
 /** The registered tool spec + its execute function. */
 function toolOf(ctx: ReturnType<typeof makeCtx>) {
   expect(ctx.registered).toHaveLength(1)
@@ -58,9 +62,7 @@ function toolOf(ctx: ReturnType<typeof makeCtx>) {
 
 describe('bashCandidates', () => {
   it('derives Git Bash roots from the git executable path', () => {
-    // node:path follows the runner platform, so probe with a POSIX-style
-    // git path: <root>/cmd/git.exe -> <root>/bin/bash.exe.
-    const candidates = bashCandidates({}, '/opt/git/cmd/git.exe')
+    const candidates = bashCandidates({}, '/opt/git/cmd/git.exe').map(portablePath)
     expect(candidates).toContain('/opt/git/bin/bash.exe')
     expect(candidates).toContain('/opt/git/cmd/bash.exe')
     expect(candidates).toContain('/opt/bin/bash.exe')
@@ -74,9 +76,8 @@ describe('bashCandidates', () => {
       USERPROFILE: 'C:\\Users\\me',
     }
     const candidates = bashCandidates(env, undefined)
-    // Platform-agnostic tails: each well-known root must appear
-    // (separator varies with the runner, which is what the probe chain
-    // actually uses on Windows).
+    // Platform-agnostic tails: each well-known root must appear.
+    const normalized = candidates.map(portablePath)
     const tails = [
       'Git/bin/bash.exe',
       'Program Files/Git/bin/bash.exe',
@@ -85,7 +86,7 @@ describe('bashCandidates', () => {
       'scoop/apps/git/current/bin/bash.exe',
     ]
     for (const tail of tails) {
-      expect(candidates.some(c => c.includes(tail))).toBe(true)
+      expect(normalized.some(c => c.includes(tail))).toBe(true)
     }
   })
 


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；
> 提交信息用 Conventional Commits（`type(scope): subject`），禁止 emoji。
> 本仓库接受修复、增强与优化类 PR（bug 修复、现有功能的增强、性能 / 体验优化、维护）；新皮肤始终欢迎。全新特性 / 新功能的 PR 暂不接受，请先提 Issue 讨论。
> 仅文档类 PR（标题以 `docs:` 开头或勾选「仅文档」）不接受，会被自动关闭；文档改动请先提 Issue 讨论。

## 摘要（Summary）

修复 #763：`dsh-liangshen` 的 `custom-bash` 测试在 Windows runner 下会因为路径分隔符不同而失败。

本 PR 只在测试断言侧把候选路径规范化为 `/` 后再比较，保留 runtime 继续使用 `node:path` 生成当前平台路径。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）：梁神预设 `packages/dsh-liangshen`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch origin dev
git worktree add -b codex/fix-issue-763 D:\Code\dsh-web-ui-issue-763 origin/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

同步最新 `dev` 后，本地先复现失败：

```bash
pnpm --filter @linxin666/dsh-liangshen test -- --run tests/custom-bash.test.ts
# before fix on Windows: 1 failed file, 2 failed tests
```

修复后重新验证：

```bash
pnpm --filter @linxin666/dsh-liangshen test -- --run tests/custom-bash.test.ts
# Test Files  1 passed (1)
# Tests       8 passed (8)

pnpm --filter @linxin666/dsh-liangshen test
# Test Files  7 passed (7)
# Tests       96 passed (96)

pnpm --filter @linxin666/dsh-liangshen typecheck
# passed

pnpm --filter @linxin666/dsh-liangshen build
# passed

git diff --check
# passed
```

## 视觉修复要求（Visual Fix Requirements）

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

不适用：本 PR 不是视觉修复。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5 Codex

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

说明：本 PR 未新增包目录，未改 README。

## 贡献者版权声明（Contributor Copyright）

N/A

## 新皮肤收录（New Skin）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-liangshen test -- --run tests/custom-bash.test.ts
pnpm --filter @linxin666/dsh-liangshen test
pnpm --filter @linxin666/dsh-liangshen typecheck
pnpm --filter @linxin666/dsh-liangshen build
git diff --check
```

结果摘要：

- #763 复现用例修复前在 Windows 下失败，修复后通过。
- dsh-liangshen 全部单测通过：7 files, 96 tests passed。
- typecheck 通过。
- build 通过；仅有 tsdown 关于 `external` 的既有 deprecation warning。
- `git diff --check` 通过。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A。该改动只修复 Windows 下测试断言的跨平台路径比较，不改变用户可见行为。