### PR TITLE
fix(scripts): resolve pnpm.cmd on win32 in e2e-mount-rewrite (#763)

### DIFF
--- a/scripts/e2e-mount-rewrite
+++ b/scripts/e2e-mount-rewrite
@@ -48,7 +48,10 @@ async function checkPublished(name, version) {
  */
 function packWorkspace(pkgDir, outDir) {
   const dest = fs.mkdtempSync(path.join(outDir, 'pack-'))
-  execFileSync('pnpm', ['pack', '--pack-destination', dest], { cwd: pkgDir, stdio: 'pipe' })
+  // win32: CreateProcess only appends .exe to bare names, so the pnpm.cmd
+  // shim must be named explicitly (libuv runs .cmd via cmd.exe).
+  const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+  execFileSync(pnpm, ['pack', '--pack-destination', dest], { cwd: pkgDir, stdio: 'pipe' })
   const names = fs.readdirSync(dest).filter(name => name.endsWith('.tgz'))
   if (names.length !== 1) {
     throw new Error('pnpm pack 未产出唯一 tarball（' + pkgDir + '）: ' + names.join(', '))


### PR DESCRIPTION
## 摘要（Summary）

#763 的后续报告：Windows 上 pnpm test:scripts 失败——scripts/e2e-mount-rewrite.test.mjs 的 packWorkspace 用例报 spawnSync pnpm ENOENT。

根因：node:child_process execFileSync 以「应用名」方式启动时，Windows CreateProcess 对无扩展名只会补 .exe，不会走 PATHEXT 找 pnpm.cmd，因此裸 'pnpm' 在 win32 上必然 ENOENT。

改动：packWorkspace 在 win32 上显式使用 pnpm.cmd（libuv 对 .cmd 经 cmd.exe 执行），其余平台保持 pnpm。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：scripts/e2e-mount-rewrite（仓库维护脚本）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

git fetch origin && git rebase origin/dev

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [x] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [x] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

纯脚本改动，无截图要求。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 新增包目录以 dsh- 前缀命名（如 packages/dsh-xxx）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 pnpm docs:check。

## 本地验证（Local Validation）

执行的命令：

node --test scripts/e2e-mount-rewrite.test.mjs

结果摘要：

macOS 本地 9/9 通过（改动不影响 POSIX 路径）；win32 行为依据 CreateProcess 语义（无扩展名仅补 .exe）与 libuv 对 .cmd 的处理（经 cmd.exe 执行）推断，请求报告人在 Windows 上复核 pnpm test:scripts。

## 用户可见变更证据（Local Feature Evidence）

N/A（维护脚本改动，无用户可见变更）。