### PR TITLE
test(remote-web-ui): skip POSIX file-mode assertion on win32 (#772)

### DIFF
--- a/packages/dsh-remote-web-ui/src/pairing.persist.test.ts
+++ b/packages/dsh-remote-web-ui/src/pairing.persist.test.ts
@@ -54,7 +54,11 @@ describe('PairingService device persistence', () => {
     const deviceId = pairDevice(first)
     expect(readFileSync(file, 'utf8')).toContain(deviceId)
     // Device ids are session credentials: the persisted file is 0600.
-    expect(statSync(file).mode & 0o777).toBe(0o600)
+    // win32: NTFS has no POSIX mode bits and Node ignores the writeFileSync
+    // mode option there, so the mode assertion only applies on POSIX (#772).
+    if (process.platform !== 'win32') {
+      expect(statSync(file).mode & 0o777).toBe(0o600)
+    }
 
     // Simulated restart: a brand-new service instance reading the same file.
     const second = new PairingService({ ...BASE_CONFIG, devicesFile: file }, makeClock())


### PR DESCRIPTION
## 摘要（Summary）

修复 #772 的 pnpm test 部分：Windows 上 packages/dsh-remote-web-ui/src/pairing.persist.test.ts 失败——期望文件模式 0600（384），实际 438（0o666）。

根因：实现本身正确（pairing.ts:281 writeFileSync 带 mode: 0o600），但 NTFS 没有 POSIX 模式位，Node 在 win32 上忽略 mode 参数，statSync().mode 恒为 0o666。断言只在 POSIX 平台成立。

改动：模式断言包在 process.platform !== 'win32' 分支内（win32 上跳过，其余断言不变）。

注：issue 中的 pnpm test:scripts 报错（packWorkspace pnpm ENOENT）是修复 #771 合入前的旧报告——该部分已由 #771（68f2c0846）修复，报告人未拉取最新 dev 所致。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：packages/dsh-remote-web-ui 测试

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

git fetch origin && git rebase origin/dev

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [x] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [x] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

纯测试改动，无截图要求。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 新增包目录以 dsh- 前缀命名（如 packages/dsh-xxx）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 pnpm docs:check。

## 本地验证（Local Validation）

执行的命令：

pnpm --filter @linxin666/dsh-remote-web-ui test

结果摘要：

macOS 本地 33 文件 316 测试全部通过（POSIX 分支断言仍生效，验证无回归）；win32 行为依据 Node 文档（NTFS 无 POSIX 模式位、mode 参数被忽略）与报告人实测（438=0o666）判断，请求报告人在 Windows 上复核。

## 用户可见变更证据（Local Feature Evidence）

N/A（测试代码改动，无用户可见变更）。

Fixes #772