### PR TITLE
fix(chat-recovery): 防止已取消的自动重试再次激活

### DIFF
--- a/packages/dsh-chat-recovery/src/core/retry-supervisor.ts
+++ b/packages/dsh-chat-recovery/src/core/retry-supervisor.ts
@@ -18,6 +18,7 @@ import type { ConversationSnapshot, SessionId } from '@deepseek-ai/dsh-client-ru
 import { assistantFinalizedInTurn, lastTurnOf, userNodeCount, userNodeCountBefore } from './transcript.ts'
 import {
   BACKOFF_DELAYS_MS,
+  failureOfLastTurn,
   isRetryableError,
   MAX_EXTRA_RETRIES,
   planForTurn,
@@ -92,6 +93,14 @@ export class RetrySupervisor {
   private expectedUserCount = 0
   /** Last turn/end seq seen when the cycle reached a terminal phase (reset guard). */
   private settledEndSeq = 0
+  /** Last failure explicitly handled per session; the same turn must never auto-arm twice. */
+  private readonly suppressedFailureEnds = new Map<SessionId, number>()
+  /** Monotonic owner for an in-flight fork/prompt continuation. */
+  private operationGeneration = 0
+  private attemptInFlight = false
+  private disposed = false
+  /** Last completed event inherited by the current retry child before its replayed turn. */
+  private attemptStartEndSeq = 0
 
   constructor(private readonly ports: RetryPorts) {}
 
@@ -111,6 +120,7 @@ export class RetrySupervisor {
    * Running: settle the child — success, next attempt, or final failure.
    */
   review(): void {
+    if (this.disposed) return
     const current = this.ports.currentId()
     switch (this.state.phase) {
       case 'idle': {
@@ -118,7 +128,12 @@ export class RetrySupervisor {
         const snapshot = this.ports.snapshot(current)
         if (snapshot === undefined) return
         const verdict = verdictFor(snapshot)
-        if (verdict.action === 'auto') this.startAuto(current, verdict.plan)
+        if (verdict.action === 'auto') {
+          const suppressedEnd = this.suppressedFailureEnds.get(current) ?? -1
+          if (verdict.failure.turnEndSeq <= suppressedEnd) return
+          this.suppressedFailureEnds.delete(current)
+          this.startAuto(current, verdict.plan)
+        }
         return
       }
       case 'waiting': {
@@ -175,7 +190,21 @@ export class RetrySupervisor {
         this.finish('failed', verdict.failure.message ?? '')
         return
       }
-      case 'cancelled':
+      case 'cancelled': {
+        if (current === undefined) return
+        const snapshot = this.ports.snapshot(current)
+        if (snapshot === undefined) return
+        const target = this.state.targetId
+        if (target !== null && current === target) {
+          // Cancelling the supervisor cannot abort a prompt already accepted by
+          // the host. Keep this target quarantined until that replayed turn has
+          // settled, then suppress its failure before returning to idle.
+          if (snapshot.running || latestTurnEnd(snapshot) <= this.attemptStartEndSeq) return
+          this.suppressFailure(snapshot)
+        }
+        this.reset()
+        return
+      }
       case 'exhausted':
       case 'failed':
       case 'done': {
@@ -198,6 +227,7 @@ export class RetrySupervisor {
 
   /** Manual one-shot retry from the transcript button (never auto-repeats). */
   manualRetry(sourceId: SessionId): void {
+    if (this.disposed) return
     if (this.state.phase === 'waiting' || this.state.phase === 'running') return
     const snapshot = this.ports.snapshot(sourceId)
     if (snapshot === undefined) return
@@ -205,6 +235,7 @@ export class RetrySupervisor {
     if (verdict.action === 'none') return
     const plan = verdict.action === 'auto' ? verdict.plan : planForTurn(snapshot, verdict.failure.turn)
     if (plan === null) return
+    this.invalidateAttempt()
     this.plan = plan
     this.userBaseline = userNodeCount(snapshot)
     this.publish({ phase: 'waiting', kind: 'manual', attempt: 0, maxAttempts: 1, delayMs: 0, sourceId, targetId: null, reason: null })
@@ -213,24 +244,37 @@ export class RetrySupervisor {
 
   /** User-initiated cancel: no further attempts, ever (until a new failure arms one). */
   cancel(): void {
+    if (this.disposed) return
+    this.invalidateAttempt()
     this.clearTimer()
     if (this.state.phase === 'idle' || this.state.phase === 'cancelled') return
+    const source = this.state.sourceId
+    if (source !== null) {
+      const end = this.suppressFailure(this.ports.snapshot(source))
+      if (end !== undefined) this.settledEndSeq = end
+    }
+    const target = this.state.targetId
+    if (target !== null) this.suppressFailure(this.ports.snapshot(target))
     this.publish({ phase: 'cancelled', delayMs: null, reason: null })
   }
 
   /** UI "retry now": skip the remaining backoff wait. */
   retryNow(): void {
-    if (this.state.phase !== 'waiting') return
+    if (this.disposed || this.state.phase !== 'waiting' || this.attemptInFlight) return
     this.clearTimer()
     void this.runAttempt()
   }
 
   dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.invalidateAttempt()
     this.clearTimer()
     this.listeners.clear()
   }
 
   private startAuto(sourceId: SessionId, plan: RetryPlan): void {
+    this.invalidateAttempt()
     const snapshot = this.ports.snapshot(sourceId)
     this.plan = plan
     this.userBaseline = snapshot === undefined ? 0 : userNodeCount(snapshot)
@@ -248,20 +292,29 @@ export class RetrySupervisor {
   }
 
   private scheduleNext(): void {
+    if (this.disposed) return
+    // A session event may settle the running child before prompt() returns.
+    // Transfer ownership to the next timer now so that the late prompt result
+    // cannot overwrite or block the next attempt.
+    this.invalidateAttempt()
     this.clearTimer()
     const attempt = this.state.attempt + 1
     const delay = this.state.kind === 'manual'
       ? 0
       : BACKOFF_DELAYS_MS[Math.min(attempt - 1, BACKOFF_DELAYS_MS.length - 1)]
     this.publish({ phase: 'waiting', attempt, delayMs: delay })
+    const generation = this.operationGeneration
     this.timer = this.ports.schedule(() => {
+      if (this.disposed || generation !== this.operationGeneration) return
       this.timer = null
       void this.runAttempt()
     }, delay)
   }
 
   private async runAttempt(): Promise<void> {
-    if (this.state.phase !== 'waiting') return
+    if (this.disposed || this.state.phase !== 'waiting' || this.attemptInFlight) return
+    const generation = ++this.operationGeneration
+    this.attemptInFlight = true
     const sourceId = this.state.sourceId
     const plan = this.plan
     if (sourceId === null || plan === null) {
@@ -274,11 +327,12 @@ export class RetrySupervisor {
         ? await this.ports.connectBlank(this.ports.cwdOf(sourceId))
         : await this.ports.fork({ sessionId: sourceId, atSeq: plan.forkAtSeq, increaseTitle: false })
     } catch (error) {
+      if (!this.ownsAttempt(generation)) return
       this.finish('failed', messageOf(error))
       return
     }
     // Cancel raced a slow fork: do not open or prompt a cancelled cycle.
-    if (this.state.phase !== 'waiting') return
+    if (!this.ownsAttempt(generation) || this.state.phase !== 'waiting') return
     // The child carries the source's history prefix (user messages at or
     // before the fork anchor) plus exactly one replayed message. Takeover
     // detection compares against this expected count, never an absolute one.
@@ -286,9 +340,25 @@ export class RetrySupervisor {
     this.expectedUserCount = plan.forkAtSeq === null
       ? 1
       : (sourceSnapshot === undefined ? 0 : userNodeCountBefore(sourceSnapshot, plan.forkAtSeq)) + 1
-    this.ports.open(targetId)
+    this.attemptStartEndSeq = latestTurnEnd(this.ports.snapshot(targetId))
+    if (this.attemptStartEndSeq === 0) this.attemptStartEndSeq = plan.forkAtSeq ?? 0
     this.publish({ phase: 'running', targetId })
-    const outcome = await this.ports.prompt(targetId, plan.text)
+    if (!this.ownsRunningAttempt(generation, targetId)) return
+    this.ports.open(targetId)
+    if (!this.ownsRunningAttempt(generation, targetId)) return
+    let outcome: PromptOutcome
+    try {
+      outcome = await this.ports.prompt(targetId, plan.text)
+    } catch (error) {
+      if (!this.ownsAttempt(generation)) return
+      this.finish('failed', messageOf(error))
+      return
+    }
+    if (!this.ownsRunningAttempt(generation, targetId)) {
+      if (this.ownsAttempt(generation)) this.attemptInFlight = false
+      return
+    }
+    this.attemptInFlight = false
     if (!outcome.ok) {
       const reason = `${outcome.code ?? 'error'}: ${outcome.message ?? ''}`
       if (this.state.kind === 'auto' && isRetryableError(outcome.code, outcome.message) && this.state.attempt < this.state.maxAttempts) {
@@ -303,7 +373,12 @@ export class RetrySupervisor {
   }
 
   private finish(phase: 'done' | 'exhausted' | 'failed', reason: string | null = null): void {
+    this.invalidateAttempt()
     this.clearTimer()
+    if (phase !== 'done' && this.state.sourceId !== null) {
+      const end = this.suppressFailure(this.ports.snapshot(this.state.sourceId))
+      if (end !== undefined) this.settledEndSeq = end
+    }
     this.publish({ phase, delayMs: null, targetId: null, ...(reason === null ? {} : { reason }) })
     if (phase !== 'done' && this.state.sourceId !== null) {
       // Return the user to the original failed turn instead of leaving them
@@ -313,10 +388,36 @@ export class RetrySupervisor {
   }
 
   private reset(): void {
+    this.invalidateAttempt()
     this.clearTimer()
     this.plan = null
     this.settledEndSeq = 0
+    this.attemptStartEndSeq = 0
     this.publish({ ...IDLE })
+  }
+
+  /** Invalidate every late continuation owned by the previous attempt/cycle. */
+  private invalidateAttempt(): void {
+    this.operationGeneration += 1
+    this.attemptInFlight = false
+  }
+
+  private ownsAttempt(generation: number): boolean {
+    return !this.disposed && generation === this.operationGeneration
+  }
+
+  private ownsRunningAttempt(generation: number, targetId: SessionId): boolean {
+    return this.ownsAttempt(generation) && this.state.phase === 'running' && this.state.targetId === targetId
+  }
+
+  /** Record one terminal failure so ordinary subscription churn cannot re-arm it. */
+  private suppressFailure(snapshot: ConversationSnapshot | undefined): number | undefined {
+    if (snapshot === undefined) return undefined
+    const failure = failureOfLastTurn(snapshot)
+    if (failure === null) return undefined
+    const previous = this.suppressedFailureEnds.get(snapshot.sessionId) ?? -1
+    if (failure.turnEndSeq > previous) this.suppressedFailureEnds.set(snapshot.sessionId, failure.turnEndSeq)
+    return failure.turnEndSeq
   }
 
   private clearTimer(): void {
@@ -335,4 +436,12 @@ export class RetrySupervisor {
 function messageOf(error: unknown): string {
   if (error instanceof Error) return error.message
   return String(error)
+}
+
+/** Highest completed turn/end seq in one snapshot (0 for blank/unavailable). */
+function latestTurnEnd(snapshot: ConversationSnapshot | undefined): number {
+  if (snapshot === undefined) return 0
+  let latest = 0
+  for (const end of snapshot.turnEnds.values()) if (end > latest) latest = end
+  return latest
 }

--- a/packages/dsh-chat-recovery/tests/retry-supervisor.spec.ts
+++ b/packages/dsh-chat-recovery/tests/retry-supervisor.spec.ts
@@ -12,6 +12,23 @@ function failedSource(over: Record<string, unknown> = {}): ConversationSnapshot 
   })
 }
 
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve(value: T): void
+  reject(error: unknown): void
+}
+
+/** A controllable async result for lifecycle race tests. */
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
 class FakePorts implements RetryPorts {
   current: SessionId | undefined = SRC
   snaps = new Map<string, ConversationSnapshot>()
@@ -21,7 +38,9 @@ class FakePorts implements RetryPorts {
   opened: string[] = []
   prompts: Array<{ id: SessionId; text: string }> = []
   promptResult: PromptOutcome = { ok: true }
-  timers: Array<{ fn: () => void; ms: number }> = []
+  promptDeferred: Deferred<PromptOutcome> | undefined
+  forkDeferred: Deferred<SessionId> | undefined
+  timers: Array<{ fn: () => void; ms: number; cancelled: boolean }> = []
   failFork = false
 
   currentId = (): SessionId | undefined => this.current
@@ -30,6 +49,7 @@ class FakePorts implements RetryPorts {
   fork = async (opts: { sessionId: SessionId; atSeq?: number; increaseTitle?: boolean }): Promise<SessionId> => {
     if (this.failFork) throw new Error('fork failed')
     this.forked.push({ sessionId: opts.sessionId, atSeq: opts.atSeq })
+    if (this.forkDeferred !== undefined) return this.forkDeferred.promise
     return (`child${this.forked.length}`) as SessionId
   }
   connectBlank = async (cwd: string | undefined): Promise<SessionId> => {
@@ -42,15 +62,25 @@ class FakePorts implements RetryPorts {
   }
   prompt = async (id: SessionId, text: string): Promise<PromptOutcome> => {
     this.prompts.push({ id, text })
+    if (this.promptDeferred !== undefined) return this.promptDeferred.promise
     return this.promptResult
   }
   schedule = (fn: () => void, ms: number): (() => void) => {
-    this.timers.push({ fn, ms })
-    return () => {}
+    const timer = { fn, ms, cancelled: false }
+    this.timers.push(timer)
+    return () => { timer.cancelled = true }
   }
 
   fireTimers(): void {
-    for (const timer of this.timers.splice(0)) timer.fn()
+    for (const timer of this.timers.splice(0)) {
+      if (timer.cancelled) continue
+      timer.cancelled = true
+      timer.fn()
+    }
+  }
+
+  activeTimerCount(): number {
+    return this.timers.filter((timer) => !timer.cancelled).length
   }
 
   /** The retry child: turn 2 = the replayed prompt, still failing recoverably. */
@@ -134,6 +164,33 @@ describe('auto retry cycle', () => {
     expect(ports.opened[ports.opened.length - 1]).toBe(SRC)
   })
 
+  it('starts the next attempt when the child settles before the previous prompt call returns', async () => {
+    const { supervisor, ports } = make(new FakePorts())
+    ports.snaps.set(SRC, failedSource())
+    const firstPrompt = deferred<PromptOutcome>()
+    ports.promptDeferred = firstPrompt
+    supervisor.review()
+    ports.fireTimers()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    ports.setChildFailing('child1' as SessionId)
+    supervisor.review()
+    expect(supervisor.getSnapshot().phase).toBe('waiting')
+
+    ports.promptDeferred = undefined
+    ports.fireTimers()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(supervisor.getSnapshot()).toMatchObject({ phase: 'running', targetId: 'child2' })
+
+    firstPrompt.resolve({ ok: false, code: 'timeout', message: 'late result' })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(supervisor.getSnapshot()).toMatchObject({ phase: 'running', targetId: 'child2' })
+    expect(ports.activeTimerCount()).toBe(0)
+  })
+
   it('finishes done once the child turn settles with a finalized assistant message', async () => {
     const { supervisor, ports } = make(new FakePorts())
     ports.snaps.set(SRC, failedSource())
@@ -205,6 +262,147 @@ describe('cancel semantics', () => {
     supervisor.review()
     expect(supervisor.getSnapshot().phase).toBe('cancelled')
   })
+
+  it('does not re-arm the same failed turn after subscription reviews a cancelled wait', () => {
+    const { supervisor, ports } = make(new FakePorts())
+    ports.snaps.set(SRC, failedSource())
+    supervisor.review()
+
+    supervisor.cancel()
+    supervisor.review()
+    supervisor.review()
+
+    expect(supervisor.getSnapshot().phase).toBe('idle')
+    expect(ports.activeTimerCount()).toBe(0)
+
+    // A genuinely newer failed turn remains eligible for automatic recovery.
+    ports.snaps.set(SRC, failedSource({
+      nodes: [
+        userMsg(1, 'a'),
+        assistantMsg(3, 1),
+        userMsg(5, 'b'),
+        turnErr(9, 2, 'request timed out', 'timeout'),
+        userMsg(11, 'new turn'),
+        turnErr(14, 3, 'request timed out', 'timeout'),
+      ],
+      turnEnds: new Map([[1, 3], [2, 9], [3, 14]]),
+    }))
+    supervisor.review()
+    expect(supervisor.getSnapshot()).toMatchObject({ phase: 'waiting', sourceId: SRC, attempt: 1 })
+    expect(ports.activeTimerCount()).toBe(1)
+  })
+
+  it('ignores a retryable prompt result that arrives after cancel', async () => {
+    const { supervisor, ports } = make(new FakePorts())
+    ports.snaps.set(SRC, failedSource())
+    ports.promptDeferred = deferred<PromptOutcome>()
+    supervisor.review()
+    ports.fireTimers()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(supervisor.getSnapshot().phase).toBe('running')
+
+    supervisor.cancel()
+    ports.promptDeferred.resolve({ ok: false, code: 'timeout', message: 'request timed out' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(supervisor.getSnapshot().phase).toBe('cancelled')
+    expect(ports.activeTimerCount()).toBe(0)
+  })
+
+  it('absorbs a prompt rejection that arrives after cancel', async () => {
+    const { supervisor, ports } = make(new FakePorts())
+    ports.snaps.set(SRC, failedSource())
+    ports.promptDeferred = deferred<PromptOutcome>()
+    supervisor.review()
+    ports.fireTimers()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    supervisor.cancel()
+    ports.promptDeferred.reject(new Error('prompt transport failed'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(supervisor.getSnapshot().phase).toBe('cancelled')
+    expect(ports.activeTimerCount()).toBe(0)
+  })
+
+  it('keeps a late fork failure from overwriting cancel', async () => {
+    const { supervisor, ports } = make(new FakePorts())
+    ports.snaps.set(SRC, failedSource())
+    ports.forkDeferred = deferred<SessionId>()
+    supervisor.review()
+    ports.fireTimers()
+    await Promise.resolve()
+
+    supervisor.cancel()
+    ports.forkDeferred.reject(new Error('fork transport failed'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(supervisor.getSnapshot().phase).toBe('cancelled')
+    expect(ports.opened).toHaveLength(0)
+    expect(ports.activeTimerCount()).toBe(0)
+  })
+
+  it('quarantines the running retry child until its cancelled attempt settles', async () => {
+    const { supervisor, ports } = make(new FakePorts())
+    ports.snaps.set(SRC, failedSource())
+    supervisor.review()
+    ports.fireTimers()
+    await Promise.resolve()
+    await Promise.resolve()
+    const child = 'child1' as SessionId
+    ports.setChildRunning(child)
+    supervisor.review()
+
+    supervisor.cancel()
+    supervisor.review()
+    expect(supervisor.getSnapshot().phase).toBe('cancelled')
+
+    ports.setChildFailing(child)
+    supervisor.review()
+    supervisor.review()
+    expect(supervisor.getSnapshot().phase).toBe('idle')
+    expect(ports.activeTimerCount()).toBe(0)
+
+    ports.snaps.set(child, snapshot({
+      sessionId: child,
+      nodes: [
+        userMsg(1, 'a'),
+        assistantMsg(3, 1),
+        userMsg(5, 'b'),
+        turnErr(9, 2, 'request timed out', 'timeout'),
+        userMsg(11, 'new turn'),
+        turnErr(14, 3, 'request timed out', 'timeout'),
+      ],
+      turnEnds: new Map([[1, 3], [2, 9], [3, 14]]),
+    }))
+    supervisor.review()
+    expect(supervisor.getSnapshot()).toMatchObject({ phase: 'waiting', sourceId: child, attempt: 1 })
+  })
+
+  it('does not schedule work when a prompt settles after dispose', async () => {
+    const { supervisor, ports } = make(new FakePorts())
+    ports.snaps.set(SRC, failedSource())
+    ports.promptDeferred = deferred<PromptOutcome>()
+    supervisor.review()
+    ports.fireTimers()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(supervisor.getSnapshot().phase).toBe('running')
+
+    supervisor.dispose()
+    ports.promptDeferred.resolve({ ok: false, code: 'timeout', message: 'request timed out' })
+    await Promise.resolve()
+    await Promise.resolve()
+    supervisor.review()
+
+    expect(ports.activeTimerCount()).toBe(0)
+    expect(ports.opened).toEqual(['child1'])
+  })
 })
 
 describe('non-retryable and manual paths', () => {
@@ -253,6 +451,24 @@ describe('non-retryable and manual paths', () => {
     await Promise.resolve()
     expect(supervisor.getSnapshot().phase).toBe('failed')
     expect(ports.opened[ports.opened.length - 1]).toBe(SRC)
+  })
+
+  it('settles an exceptional prompt rejection as a failed cycle', async () => {
+    const { supervisor, ports } = make(new FakePorts())
+    ports.snaps.set(SRC, failedSource())
+    ports.promptDeferred = deferred<PromptOutcome>()
+    supervisor.review()
+    ports.fireTimers()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    ports.promptDeferred.reject(new Error('prompt transport failed'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(supervisor.getSnapshot()).toMatchObject({ phase: 'failed', reason: 'prompt transport failed' })
+    expect(ports.opened[ports.opened.length - 1]).toBe(SRC)
+    expect(ports.activeTimerCount()).toBe(0)
   })
 
   it('a fork failure ends the cycle without touching the original session', async () => {


### PR DESCRIPTION
## 摘要（Summary）

修复聊天恢复插件中“取消自动重试后，原失败任务可能再次复活”的问题。

- 为已处理的失败轮次记录会话级水位，避免重复的会话订阅刷新再次激活同一轮失败。
- 使用执行代际隔离定时器、fork 和 prompt 异步结果，取消或销毁后到达的旧结果不再改变状态或安排重试。
- 正在执行的重试子会话会保持隔离至该轮结束，且不会阻止真正的新失败触发后续自动恢复。
- 同时处理会话事件先于旧 prompt 返回时，下一轮定时任务可能被旧执行锁阻塞的竞态。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他：`packages/dsh-chat-recovery`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream dev
git rebase upstream/dev
```

提交基于 `dev@0c668c82`，同步后重新完成包测试、构建和全仓类型检查。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

不适用：本 PR 不修改视觉或 UI 样式。

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5（Codex）

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未修改 README，文档门禁通过）。

## 贡献者版权声明（Contributor Copyright）

不适用。

## 新皮肤收录（New Skin）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-chat-recovery test
pnpm --filter @linxin666/dsh-chat-recovery build
pnpm typecheck
pnpm docs:check
pnpm runtime-deps:check
pnpm test
pnpm test:scripts
```

结果摘要：

- 同步最新 `dev` 后，`dsh-chat-recovery` 的 4 个测试文件、65 个测试全部通过。
- `dsh-chat-recovery` 构建通过。
- 全仓 18 个项目类型检查通过。
- 文档门禁通过。
- 13 个受检包的运行时依赖检查通过。
- 全仓测试中 `dsh-chat-recovery` 的 65 个测试全部通过；根命令仍受当前 Windows 环境下 `dsh-ssh`、`dsh-remote-web-ui` 的 POSIX 路径和文件权限断言影响。
- `test:scripts` 为 141 项通过、4 项跳过、1 项失败；失败是当前 Windows 环境中的 `spawnSync pnpm.cmd EINVAL`，与本 PR 修改的包和文件无关。

## 用户可见变更证据（Local Feature Evidence）

非视觉状态机测试证据：

- 修复前：同一失败轮次可出现 `waiting → cancelled → idle → waiting`，并重新产生活动定时器。
- 修复后：取消并重复触发订阅审查后保持 `waiting → cancelled → idle`，活动定时器数量为 `0`，同一失败轮次不会再次激活。
- 延迟返回的 fork、prompt 成功结果、可重试失败及 Promise rejection 均不能覆盖取消状态或创建新定时器。
- 后续真正的新失败轮次仍可正常进入 `waiting`，证明修复没有永久关闭自动恢复。
- 会话事件先于旧 prompt 返回时，下一次重试仍会按计划启动，旧结果不会覆盖新执行。