### PR TITLE
fix(pet): 防止客户端热重载后重复挂载桌宠

### DIFF
--- a/packages/dsh-pet/src/client/apply-guard.ts
+++ b/packages/dsh-pet/src/client/apply-guard.ts
@@ -1,0 +1,27 @@
+/**
+ * Cross-module-instance apply guard for the pet client bundle.
+ *
+ * A stale client factory can overlap a rebuilt one while DSH swaps the
+ * browser bundle.
+ * Both factories otherwise append their own global React root to body, so
+ * the page shows multiple pets until a full refresh clears the orphaned DOM.
+ * The global claim lets the first live fiber win across module instances;
+ * its lifecycle cleanup releases the slot for a later clean re-apply.
+ */
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __dshPetClientApplied: boolean | undefined
+}
+
+/** Claim the page-global pet client slot. */
+export function claimPetClientApply(): boolean {
+  if (globalThis.__dshPetClientApplied === true) return false
+  globalThis.__dshPetClientApplied = true
+  return true
+}
+
+/** Release the claim when the owning client fiber is disposed. */
+export function releasePetClientApply(): void {
+  globalThis.__dshPetClientApplied = undefined
+}

--- a/packages/dsh-pet/src/client/index.test.tsx
+++ b/packages/dsh-pet/src/client/index.test.tsx
@@ -45,18 +45,31 @@ vi.mock('@deepseek-ai/dsh-client-runtime/client', () => ({
   },
 }))
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+import { releasePetClientApply } from './apply-guard.ts'
 import { apply } from './index.ts'
 
 beforeAll(() => {
   document.documentElement.lang = 'zh'
 })
 
+interface FakeClientLifecycle {
+  ctx: ClientContext
+  dispose(): void
+  settingsListenerCount(): number
+}
+
+const activeClients: FakeClientLifecycle[] = []
+
 afterEach(() => {
+  for (const client of activeClients.splice(0).reverse()) client.dispose()
+  releasePetClientApply()
   document.body.replaceChildren()
 })
 
-/** A minimal client root context: ready settings scope, no-op slot system. */
-function fakeContext(): ClientContext {
+/** A minimal client root context with observable fiber disposal. */
+function fakeContext(): FakeClientLifecycle {
+  const disposers: (() => void)[] = []
+  const settingsListeners = new Set<() => void>()
   const scope = {
     getSnapshot: () => ({
       status: 'ready',
@@ -67,29 +80,71 @@ function fakeContext(): ClientContext {
       revision: 1,
       mode: 'host',
     }),
-    subscribe: () => () => {},
+    subscribe: (listener: () => void) => {
+      settingsListeners.add(listener)
+      return () => { settingsListeners.delete(listener) }
+    },
   }
-  return {
+  const ctx = {
     effect: (fn: () => unknown) => {
       const dispose = fn()
-      return typeof dispose === 'function' ? dispose : () => {}
+      if (typeof dispose !== 'function') return () => {}
+      const cleanup = dispose as () => void
+      disposers.push(cleanup)
+      return cleanup
     },
     locale: { register: () => () => {} },
     get: () => undefined,
     settingsScope: { bind: () => scope },
     slots: {
-      inject: (_name: string, callback: () => () => void) => callback(),
+      inject: (_name: string, callback: () => () => void) => {
+        const dispose = callback()
+        disposers.push(dispose)
+        return dispose
+      },
       register: () => () => {},
     },
     sessions: undefined,
   } as unknown as ClientContext
+  let disposed = false
+  const lifecycle: FakeClientLifecycle = {
+    ctx,
+    dispose: () => {
+      if (disposed) return
+      disposed = true
+      for (const dispose of disposers.splice(0).reverse()) dispose()
+    },
+    settingsListenerCount: () => settingsListeners.size,
+  }
+  activeClients.push(lifecycle)
+  return lifecycle
 }
 
-describe('pet client apply L2 semantic attributes (#506)', () => {
-  it('mounts the pet root container with data-dsh-plugin="pet"', () => {
-    apply(fakeContext())
+describe('pet client apply', () => {
+  it('mounts the pet root container with the L2 data-dsh-plugin attribute (#506)', () => {
+    apply(fakeContext().ctx)
     const root = document.body.querySelector('[data-dsh-pet-root]')
     expect(root).not.toBeNull()
     expect(root!.getAttribute('data-dsh-plugin')).toBe('pet')
+  })
+
+  it('keeps one global pet root when two client factories overlap', () => {
+    apply(fakeContext().ctx)
+    apply(fakeContext().ctx)
+
+    expect(document.body.querySelectorAll('[data-dsh-pet-root]')).toHaveLength(1)
+  })
+
+  it('cleans the root and settings subscriptions before a client re-apply', () => {
+    const first = fakeContext()
+    apply(first.ctx)
+    expect(first.settingsListenerCount()).toBeGreaterThan(0)
+
+    first.dispose()
+    expect(first.settingsListenerCount()).toBe(0)
+    expect(document.body.querySelectorAll('[data-dsh-pet-root]')).toHaveLength(0)
+
+    apply(fakeContext().ctx)
+    expect(document.body.querySelectorAll('[data-dsh-pet-root]')).toHaveLength(1)
   })
 })

--- a/packages/dsh-pet/src/client/index.ts
+++ b/packages/dsh-pet/src/client/index.ts
@@ -24,6 +24,7 @@ import type { PetInteraction } from '../affinity.ts'
 import type { PetDefinition } from '../registry.ts'
 import { createElement } from 'react'
 import { createRoot } from 'react-dom/client'
+import { claimPetClientApply, releasePetClientApply } from './apply-guard.ts'
 import { createPetStore, type PetStoreInstance } from './pet-store.ts'
 import { PetDockEntry, type PetInjected } from './PetDockEntry.tsx'
 import { defaultPetRendererRegistry } from './renderers/registry.ts'
@@ -103,6 +104,11 @@ declare module '@deepseek-ai/cordis' {
  * @param ctx - client root context.
  */
 export function apply(ctx: ClientContext): void {
+  // A stale client bundle can overlap a rebuilt one during client reload.
+  // Only one module instance may own the page-global pet root at a time.
+  if (!claimPetClientApply()) return
+  ctx.effect(() => releasePetClientApply, 'pet: apply claim')
+
   ctx.effect(() => ctx.locale.register(NS, { zh, en }), 'pet: dictionaries')
 
   // Built-in renderers dispatch through the plugin-wide registry (pet-center
@@ -314,6 +320,13 @@ export function apply(ctx: ClientContext): void {
       disposeUi = undefined
     }
   }
-  settingsScope.subscribe(syncUi)
+  const unsubscribeSettings = settingsScope.subscribe(syncUi)
+  ctx.effect(() => () => {
+    try {
+      unsubscribeSettings()
+    } finally {
+      disposeUi?.()
+    }
+  }, 'pet: client lifecycle')
   syncUi()
 }


### PR DESCRIPTION
## 摘要（Summary）

修复宠物客户端 bundle 热重载或重复注入后可能遗留旧 React Root，导致页面同时出现多个桌宠的问题。

- 为客户端入口增加跨 bundle 实例的单一挂载保护，重复执行的客户端工厂不再创建第二个桌宠实例。
- 将设置订阅、React Root、DOM 容器和轮询清理接入 Cordis fiber 生命周期。
- 补充重复注入、生命周期释放和重新挂载的回归测试。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [x] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [x] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream main
git fetch upstream dev
git rev-list --count HEAD..upstream/dev
```

分支基线与 `upstream/dev` 同步，提交前落后数为 0；本 PR 仅新增 1 个修复提交。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [x] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [x] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5（Codex，多模态）

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未修改 README，文档检查已通过）。

## 贡献者版权声明（Contributor Copyright）

本 PR 不变更版权声明。

## 新皮肤收录（New Skin）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
corepack pnpm --filter @linxin666/dsh-pet typecheck
corepack pnpm --filter @linxin666/dsh-pet test
corepack pnpm --filter @linxin666/dsh-pet build
corepack pnpm typecheck
corepack pnpm test
corepack pnpm test:scripts
corepack pnpm docs:check
node scripts/runtime-deps-check.mjs
node scripts/aggregate.mjs --check
node scripts/sync-shared.mjs --check
git diff --check
```

结果摘要：

- `dsh-pet` TypeScript 检查通过。
- `dsh-pet` 32 个测试文件、354 项测试全部通过。
- `dsh-pet` 正式构建通过。
- 全仓 TypeScript 检查通过。
- 文档、运行时依赖、聚合清单、共享文件同步和 diff 格式检查全部通过。
- Windows 上执行全仓测试时，`dsh-ssh` 有 7 项既有平台测试失败，涉及 `/usr/sbin/sshd`、POSIX 权限与路径分隔符；在未修改宠物代码的上游工作树中可原样复现。
- Windows 上 `test:scripts` 有 1 项既有 `spawnSync pnpm.cmd EINVAL` 失败；同样已在未修改宠物代码的上游工作树中复现。
- 本 PR 涉及的宠物测试全部通过。

## 用户可见变更证据（Local Feature Evidence）

使用链接到本 PR 最新代码的真实 DSH Web 环境，执行同一套官方客户端 HMR 热替换流程：

- 修复前：`[data-dsh-pet-root]` 与桌宠按钮均由 1 增至 2；拖开重叠角色后确认是两个独立桌宠实例。
- 修复后：相同流程始终保持 1 个根节点、1 个桌宠按钮。
- 修复版没有新增 pet 相关控制台警告或错误。

**修复前：HMR 后出现两个独立桌宠**

![修复前：HMR 后出现两个桌宠](https://github.com/user-attachments/assets/325c74d6-fa8f-4d8c-807e-b1542501ba07)

**修复后：相同 HMR 流程只保留一个桌宠**

![修复后：HMR 后保持单个桌宠](https://github.com/user-attachments/assets/00b85ef8-8219-46ec-9eb7-cc7e41f44561)
