### PR TITLE
fix(settings-card): keep select options at natural height in flex popup

### DIFF
--- a/packages/dsh-aionui-panel/src/client/settings-card.module.css
+++ b/packages/dsh-aionui-panel/src/client/settings-card.module.css
@@ -354,6 +354,8 @@
 }
 
 .selectOption {
+  /* 弹层是 max-height 受限的 flex 列：选项必须保持自然行高，超出交给弹层滚动 */
+  flex-shrink: 0;
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 13px;

--- a/packages/dsh-community-plugins/src/client/settings-card.module.css
+++ b/packages/dsh-community-plugins/src/client/settings-card.module.css
@@ -354,6 +354,8 @@
 }
 
 .selectOption {
+  /* 弹层是 max-height 受限的 flex 列：选项必须保持自然行高，超出交给弹层滚动 */
+  flex-shrink: 0;
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 13px;

--- a/packages/dsh-desktop-launcher/src/client/settings-card.module.css
+++ b/packages/dsh-desktop-launcher/src/client/settings-card.module.css
@@ -354,6 +354,8 @@
 }
 
 .selectOption {
+  /* 弹层是 max-height 受限的 flex 列：选项必须保持自然行高，超出交给弹层滚动 */
+  flex-shrink: 0;
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 13px;

--- a/packages/dsh-pet/src/client/settings-card.module.css
+++ b/packages/dsh-pet/src/client/settings-card.module.css
@@ -354,6 +354,8 @@
 }
 
 .selectOption {
+  /* 弹层是 max-height 受限的 flex 列：选项必须保持自然行高，超出交给弹层滚动 */
+  flex-shrink: 0;
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 13px;

--- a/packages/dsh-remote-web-ui/src/client/settings-card.module.css
+++ b/packages/dsh-remote-web-ui/src/client/settings-card.module.css
@@ -354,6 +354,8 @@
 }
 
 .selectOption {
+  /* 弹层是 max-height 受限的 flex 列：选项必须保持自然行高，超出交给弹层滚动 */
+  flex-shrink: 0;
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 13px;

--- a/packages/dsh-task-board/src/client/settings-card.module.css
+++ b/packages/dsh-task-board/src/client/settings-card.module.css
@@ -354,6 +354,8 @@
 }
 
 .selectOption {
+  /* 弹层是 max-height 受限的 flex 列：选项必须保持自然行高，超出交给弹层滚动 */
+  flex-shrink: 0;
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 13px;

--- a/packages/dsh-tool-describe-image/src/client/settings-card.module.css
+++ b/packages/dsh-tool-describe-image/src/client/settings-card.module.css
@@ -354,6 +354,8 @@
 }
 
 .selectOption {
+  /* 弹层是 max-height 受限的 flex 列：选项必须保持自然行高，超出交给弹层滚动 */
+  flex-shrink: 0;
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 13px;

--- a/shared/client/settings/settings-card.module.css
+++ b/shared/client/settings/settings-card.module.css
@@ -353,6 +353,8 @@
 }
 
 .selectOption {
+  /* 弹层是 max-height 受限的 flex 列：选项必须保持自然行高，超出交给弹层滚动 */
+  flex-shrink: 0;
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 13px;


### PR DESCRIPTION
## 摘要（Summary）

修复设置页 SelectField 下拉弹层在选项过多时把选项压缩成乱码碎片的问题：弹层是 max-height 受限的 flex 列，选项默认 flex-shrink: 1 且因 overflow: hidden 使 min-height: auto 计算为 0，选项总高超过 240px 时被整体压缩，文字被裁成碎片。给 .selectOption 加 flex-shrink: 0，选项保持自然行高、弹层正常滚动。首个实际触发点是宠物选择器（~/.codex/pets 自定义宠物可积累到数十个选项）。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`
- [x] 其他（请说明）

改动共享源 `shared/client/settings/settings-card.module.css` 一行（+注释），并用 `node scripts/sync-shared.mjs` 重新生成全部 7 个消费方副本（dsh-pet / dsh-task-board / dsh-remote-web-ui / dsh-aionui-panel / dsh-tool-describe-image / dsh-community-plugins / dsh-desktop-launcher），这些包的同一控件同等受益。

## PR 类型（PR Type）

- [x] Bug 修复
- [x] 视觉修复（UI / 视觉类问题的修复）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

git clone --branch dev（fork 自 dev HEAD 0c668c8，修复分支直接从其切出）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [x] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [x] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

说明：使用的 Kimi K3 为支持图像输入的多模态模型，本 PR 的修复前后截图证据均由该模型在真实浏览器中截图并核对（门禁的纯文本模型名单按名字前缀匹配 kimi，实际该模型具备视觉能力，请人工复核）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：Kimi K3-256K（Moonshot，多模态，支持图像输入）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本次无新增包目录）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改动 README）

## 贡献者版权声明（Contributor Copyright）

N/A（一行 CSS 修复，不追加版权表）

## 新皮肤收录（New Skin）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/sync-shared.mjs          # 重新生成 7 个消费方副本
node scripts/sync-shared.mjs --check  # 通过：all consumer copies in sync
cd packages/dsh-pet && pnpm test      # vitest run
```

结果摘要：

packages/dsh-pet 全部 32 个测试文件 352 个测试通过。注意 jsdom 不做真实布局，单测无法覆盖本问题，因此另在运行中的真实实例（dsh 0.1.0-rc.7 + dsh-pet 0.2.2，以及升级后 0.1.0-rc.8 + dsh-pet 0.2.5 复现确认）用无头 Chrome 实测：修复前选项计算高度仅 12px（应为 31.5px，flexShrink=1 / min-height=auto / overflow=hidden），页面实时注入 flex-shrink: 0 后恢复 31.5px 且弹层正常滚动（scrollHeight 1174 / clientHeight 248）。dev 分支共享源已确认仍缺该属性。

## 用户可见变更证据（Local Feature Evidence）

证据：

修复前（设置 → 宠物 → 打开宠物下拉框，37 个选项全部压缩成碎片）：

![修复前：选项乱码](https://raw.githubusercontent.com/xiaobin/dsh-web-ui/evidence/select-flex-shrink/evidence/pet-select-garbled-before.png)

修复后（同一页面实时应用本补丁，选项恢复自然行高、弹层滚动正常）：

![修复后：选项正常](https://raw.githubusercontent.com/xiaobin/dsh-web-ui/evidence/select-flex-shrink/evidence/pet-select-fixed-after.png)
