### PR TITLE
fix(describe-image): clear input after send on rewrite path

### DIFF
--- a/packages/dsh-tool-describe-image/src/client/send-hook.ts
+++ b/packages/dsh-tool-describe-image/src/client/send-hook.ts
@@ -113,12 +113,13 @@ export function installSendHook(conversation: unknown, isEnabled?: () => boolean
       return original.call(face, session, text, imageIds, mode, signal)
     }
     const fullText = [text.trim(), ...refs].filter(part => part !== '').join('\n')
-    const result = await session.prompt([{ type: 'text', text: fullText }], mode, signal)
-    if (!result.ok) {
-      throw new Error(`conversation.send failed: ${result.error?.code ?? 'unknown'}: ${result.error?.message ?? ''}`)
-    }
     for (const id of imageIds) face.releaseDraftImage(id)
-    return { kind: 'success' }
+    // Delegate to the original sendSession with the rewritten text and no
+    // image IDs so the conversation service manages its state (clears the
+    // input, updates the transcript, etc.) exactly as it would for a normal
+    // text-only send.  Calling session.prompt directly would bypass that
+    // state management and leave the input uncleared.
+    return original.call(face, session, fullText, [], mode, signal)
   }
   ;(face as unknown as Record<string, unknown>)[HOOK_MARKER] = true
 }

--- a/packages/dsh-tool-describe-image/src/client/send-hook.ts
+++ b/packages/dsh-tool-describe-image/src/client/send-hook.ts
@@ -113,13 +113,14 @@ export function installSendHook(conversation: unknown, isEnabled?: () => boolean
       return original.call(face, session, text, imageIds, mode, signal)
     }
     const fullText = [text.trim(), ...refs].filter(part => part !== '').join('\n')
-    for (const id of imageIds) face.releaseDraftImage(id)
-    // Delegate to the original sendSession with the rewritten text and no
-    // image IDs so the conversation service manages its state (clears the
-    // input, updates the transcript, etc.) exactly as it would for a normal
-    // text-only send.  Calling session.prompt directly would bypass that
-    // state management and leave the input uncleared.
-    return original.call(face, session, fullText, [], mode, signal)
+    // Delegate to the original sendSession with the rewritten text and no image
+    // IDs so the conversation service manages its state (clears the input, updates
+    // the transcript, etc.) exactly as it would for a normal text-only send.
+    // Only release draft images after a successful send so a failure preserves
+    // the user's pasted images for retry.
+    const outcome = await original.call(face, session, fullText, [], mode, signal)
+    if (outcome.kind === 'success') for (const id of imageIds) face.releaseDraftImage(id)
+    return outcome
   }
   ;(face as unknown as Record<string, unknown>)[HOOK_MARKER] = true
 }

--- a/packages/dsh-tool-describe-image/tests/send-hook.spec.ts
+++ b/packages/dsh-tool-describe-image/tests/send-hook.spec.ts
@@ -30,7 +30,7 @@ function stubFileReader(payload: string): void {
 
 /** One fake conversation surface recording what the hook did with it. */
 function makeConversation() {
-  const original = vi.fn(async (_session: unknown, _text: string, _ids: readonly string[], _mode: string, _signal?: AbortSignal): Promise<unknown> => { log.push('original'); return undefined })
+  const original = vi.fn(async (_session: unknown, _text: string, _ids: readonly string[], _mode: string, _signal?: AbortSignal): Promise<unknown> => { log.push('original'); return { kind: 'success' } })
   const log: string[] = []
   const face = {
     send: vi.fn(async () => { log.push('send') }),
@@ -43,6 +43,8 @@ function makeConversation() {
 
     }))),
     releaseDraftImage: vi.fn(() => { log.push('release') }),
+    /** Exposed for tests: the original sendSession spy, still reachable after the hook wraps sendSession. */
+    _original: original,
   }
   return { face, log }
 }
@@ -62,12 +64,18 @@ describe('installSendHook', () => {
     const prompt = vi.fn(async () => ({ ok: true }))
     installSendHook(face)
     await face.sendSession({ prompt } as never, 'look', ['id1'], 'queue')
-    expect(log).toEqual(['release'])
-    expect(prompt).toHaveBeenCalledTimes(1)
-    const blocks = (prompt.mock.calls[0] as unknown as [{ type: string; text: string }[]])[0]
-    expect(blocks).toHaveLength(1)
-    expect(blocks[0].type).toBe('text')
-    expect(blocks[0].text).toBe(`look\n${DURABLE_MARKDOWN}`)
+    // The rewritten text is submitted through the original sendSession with
+    // empty image IDs, so the conversation service manages its state (clears
+    // input, updates transcript, etc.) exactly like a normal text-only send.
+    expect(log).toEqual(['release', 'original'])
+    expect(prompt).not.toHaveBeenCalled()
+    expect(face._original).toHaveBeenCalledWith(
+      { prompt },
+      `look\n${DURABLE_MARKDOWN}`,
+      [],
+      'queue',
+      undefined,
+    )
   })
 
   it('falls back to the original send when the upload fails', async () => {
@@ -90,12 +98,11 @@ describe('installSendHook', () => {
   it('is idempotent across repeated installs', async () => {
     stubFileReader('QUJD')
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: true, value: { note: 'N', markdown: 'R' } }), { status: 200 })))
-    const { face } = makeConversation()
-    const prompt = vi.fn(async () => ({ ok: true }))
+    const { face, log } = makeConversation()
     installSendHook(face)
     installSendHook(face)
-    await face.sendSession({ prompt } as never, 'look', ['id1'], 'queue')
-    expect(prompt).toHaveBeenCalledTimes(1)
+    await face.sendSession({ prompt: vi.fn() } as never, 'look', ['id1'], 'queue')
+    expect(log).toEqual(['release', 'original'])
   })
 
   it('passes image-bearing sends through untouched when the live switch is off', async () => {
@@ -122,10 +129,13 @@ describe('installSendHook', () => {
     // Flipped on between sends: the very next send is rewritten.
     enabled = true
     await face.sendSession({ prompt } as never, 'look', ['id1'], 'queue')
-    expect(log).toEqual(['original', 'release'])
-    expect(prompt).toHaveBeenCalledTimes(1)
-    const blocks = (prompt.mock.calls[0] as unknown as [{ type: string; text: string }[]])[0]
-    expect(blocks[0].type).toBe('text')
+    expect(log).toEqual(['original', 'release', 'original'])
+    expect(prompt).not.toHaveBeenCalled()
+    // Both sends went through the original sendSession: the first one passed
+    // through untouched (live switch off), the second was rewritten.
+    expect(face._original).toHaveBeenCalledTimes(2)
+    expect(face._original).toHaveBeenNthCalledWith(1, { prompt }, 'look', ['id1'], 'queue', undefined)
+    expect(face._original).toHaveBeenNthCalledWith(2, { prompt }, expect.any(String), [], 'queue', undefined)
   })
 })
 
@@ -149,8 +159,8 @@ describe('installSendHook capability gating', () => {
     const prompt = vi.fn(async () => ({ ok: true }))
     installSendHook(face, undefined, async () => false)
     await face.sendSession({ prompt, sessionId: 's1' } as never, 'look', ['id1'], 'queue')
-    expect(log).toEqual(['release'])
-    expect(prompt).toHaveBeenCalledTimes(1)
+    expect(log).toEqual(['release', 'original'])
+    expect(prompt).not.toHaveBeenCalled()
   })
 
   it('rewrites when the checker throws, failing closed to the legacy path', async () => {
@@ -160,8 +170,8 @@ describe('installSendHook capability gating', () => {
     const prompt = vi.fn(async () => ({ ok: true }))
     installSendHook(face, undefined, async () => { throw new Error('probe down') })
     await face.sendSession({ prompt, sessionId: 's1' } as never, 'look', ['id1'], 'queue')
-    expect(log).toEqual(['release'])
-    expect(prompt).toHaveBeenCalledTimes(1)
+    expect(log).toEqual(['release', 'original'])
+    expect(prompt).not.toHaveBeenCalled()
   })
 
   it('still honors the disabled switch ahead of the capability check', async () => {
@@ -196,7 +206,7 @@ describe('installSendHook rc.8 signal and outcome contract', () => {
     expect(original).toHaveBeenCalledWith(expect.anything(), 'look', ['id1'], 'queue', signal)
   })
 
-  it('forwards the signal into the session prompt on the rewritten path', async () => {
+  it('forwards the signal and returns SubmitOutcome on the rewritten path', async () => {
     stubFileReader('QUJD')
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: true, value: { note: 'N', markdown: DURABLE_MARKDOWN } }), { status: 200 })))
     const { face, log } = makeConversation()
@@ -205,9 +215,9 @@ describe('installSendHook rc.8 signal and outcome contract', () => {
     const signal = new AbortController().signal
     const outcome = await face.sendSession({ prompt } as never, 'look', ['id1'], 'queue', signal)
     expect(outcome).toEqual({ kind: 'success' })
-    expect(log).toEqual(['release'])
-    const call = prompt.mock.calls[0] as unknown as [unknown, unknown, AbortSignal]
-    expect(call[2]).toBe(signal)
+    expect(log).toEqual(['release', 'original'])
+    // The signal is forwarded to the original sendSession (not to session.prompt).
+    expect(face._original).toHaveBeenCalledWith({ prompt }, expect.any(String), [], 'queue', signal)
   })
 
   it('forwards the signal on the upload-shortfall fallback', async () => {

--- a/packages/dsh-tool-describe-image/tests/send-hook.spec.ts
+++ b/packages/dsh-tool-describe-image/tests/send-hook.spec.ts
@@ -67,7 +67,7 @@ describe('installSendHook', () => {
     // The rewritten text is submitted through the original sendSession with
     // empty image IDs, so the conversation service manages its state (clears
     // input, updates transcript, etc.) exactly like a normal text-only send.
-    expect(log).toEqual(['release', 'original'])
+    expect(log).toEqual(['original', 'release'])
     expect(prompt).not.toHaveBeenCalled()
     expect(face._original).toHaveBeenCalledWith(
       { prompt },
@@ -102,7 +102,7 @@ describe('installSendHook', () => {
     installSendHook(face)
     installSendHook(face)
     await face.sendSession({ prompt: vi.fn() } as never, 'look', ['id1'], 'queue')
-    expect(log).toEqual(['release', 'original'])
+    expect(log).toEqual(['original', 'release'])
   })
 
   it('passes image-bearing sends through untouched when the live switch is off', async () => {
@@ -129,7 +129,7 @@ describe('installSendHook', () => {
     // Flipped on between sends: the very next send is rewritten.
     enabled = true
     await face.sendSession({ prompt } as never, 'look', ['id1'], 'queue')
-    expect(log).toEqual(['original', 'release', 'original'])
+    expect(log).toEqual(['original', 'original', 'release'])
     expect(prompt).not.toHaveBeenCalled()
     // Both sends went through the original sendSession: the first one passed
     // through untouched (live switch off), the second was rewritten.
@@ -159,7 +159,7 @@ describe('installSendHook capability gating', () => {
     const prompt = vi.fn(async () => ({ ok: true }))
     installSendHook(face, undefined, async () => false)
     await face.sendSession({ prompt, sessionId: 's1' } as never, 'look', ['id1'], 'queue')
-    expect(log).toEqual(['release', 'original'])
+    expect(log).toEqual(['original', 'release'])
     expect(prompt).not.toHaveBeenCalled()
   })
 
@@ -170,7 +170,7 @@ describe('installSendHook capability gating', () => {
     const prompt = vi.fn(async () => ({ ok: true }))
     installSendHook(face, undefined, async () => { throw new Error('probe down') })
     await face.sendSession({ prompt, sessionId: 's1' } as never, 'look', ['id1'], 'queue')
-    expect(log).toEqual(['release', 'original'])
+    expect(log).toEqual(['original', 'release'])
     expect(prompt).not.toHaveBeenCalled()
   })
 
@@ -215,11 +215,26 @@ describe('installSendHook rc.8 signal and outcome contract', () => {
     const signal = new AbortController().signal
     const outcome = await face.sendSession({ prompt } as never, 'look', ['id1'], 'queue', signal)
     expect(outcome).toEqual({ kind: 'success' })
-    expect(log).toEqual(['release', 'original'])
+    expect(log).toEqual(['original', 'release'])
     // The signal is forwarded to the original sendSession (not to session.prompt).
     expect(face._original).toHaveBeenCalledWith({ prompt }, expect.any(String), [], 'queue', signal)
   })
 
+
+  it('does not release draft images when the rewritten send fails', async () => {
+    stubFileReader('QUJD')
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: true, value: { note: 'N', markdown: DURABLE_MARKDOWN } }), { status: 200 })))
+    const { face, log } = makeConversation()
+    // Make the original sendSession return an error outcome so the rewritten
+    // path does not release draft images — the user keeps them for retry.
+    face.sendSession = vi.fn(async () => ({ kind: 'error' }))
+    const prompt = vi.fn()
+    installSendHook(face)
+    const outcome = await face.sendSession({ prompt } as never, 'look', ['id1'], 'queue')
+    expect(outcome).toEqual({ kind: 'error' })
+    expect(log).toEqual([])
+    expect(face.releaseDraftImage).not.toHaveBeenCalled()
+  })
   it('forwards the signal on the upload-shortfall fallback', async () => {
     const { face, log } = makeConversation()
     const original = face.sendSession


### PR DESCRIPTION
## 摘要（Summary）

当输入框粘贴了图片和输入了描述后点击发送，输入框的图片和文字未被清空。原因是 `send-hook` 的重写路径直接调用了 `session.prompt()` 发送消息，跳过了原始的 `conversation.sendSession`，而对话服务的状态清理逻辑（清空输入框文字、清除 draft images 的 UI 展示）在后者中。修复将重写路径改为委托给原始的 `sendSession` 处理。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（`packages/dsh-tool-describe-image`）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch origin && git rebase origin/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

N/A（纯逻辑修复，非视觉修复）

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 未新增包。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 未改动 README。

## 贡献者版权声明（Contributor Copyright）

N/A（Bug 修复，非插件或皮肤贡献）

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-tool-describe-image && npx vitest run
```

结果摘要：17 files, 284 tests passed（全绿）

## 用户可见变更证据（Local Feature Evidence）

N/A（纯逻辑修复，非用户可见 UI 变更）
