### PR TITLE
fix(skin-center): lazy scene probing and capture-video release

### DIFF
--- a/packages/skins/skin-center/src/client/wallpaper.ts
+++ b/packages/skins/skin-center/src/client/wallpaper.ts
@@ -261,6 +261,13 @@ export class WallpaperController implements WallpaperHandle {
   /** Shell surfaces tagged with data-dsh-wallpaper-surface during this mount. */
   private taggedSurfaces: HTMLElement[] = []
   private disposed = false
+  /** In-flight scene probes by wallpaper id; overlapping entry points
+   *  (applySelection / tryOn / sync / fetchAndSync) must not re-read the
+   *  same packed scene concurrently. */
+  private probePending = new Map<string, Promise<void>>()
+  /** Detached frame-capture video; released on error/abort/loadeddata and on
+   *  teardown so it never keeps buffering the source file. */
+  private captureVideo: HTMLVideoElement | null = null
 
   constructor(scope: SettingsScope<WallpaperSection>, options: WallpaperControllerOptions = {}) {
     this.scope = scope
@@ -307,12 +314,75 @@ export class WallpaperController implements WallpaperHandle {
             this.applied = item
             this.render()
             this.publish()
+            this.probeSceneCapabilitiesIfNeeded(item)
           }
         }
       })
       .catch(() => {
         // Fail-silent on network errors
       })
+  }
+
+  /**
+   * Lazily probe a scene's video/WebGL capabilities: the inventory never
+   * reads packed scene payloads, so only the wallpaper the user actually
+   * selects (apply, try-on or boot sync) asks the probe route. The response
+   * is merged into every slot (previewing and applied) that holds the id.
+   */
+  private probeSceneCapabilitiesIfNeeded(descriptor: WallpaperDescriptor): void {
+    if (this.disposed || descriptor.type !== 'scene' || descriptor.videoUrl !== null || descriptor.sceneUrl != null) return
+    const targetId = descriptor.id
+    if (this.probePending.has(targetId)) return
+    const fetchFn = this.options.fetchImpl ?? (typeof fetch !== 'undefined' ? fetch.bind(this.doc.defaultView ?? globalThis) : undefined)
+    if (!fetchFn) return
+    const apiBase = this.options.apiBase ?? '/api/skin-center/we'
+    const pending = fetchFn(apiBase + '/scene-probe?id=' + encodeURIComponent(targetId))
+      .then(async (response) => {
+        if (this.disposed || !response.ok) return
+        const payload = (await response.json().catch(() => null)) as {
+          ok?: boolean
+          videoUrl?: string | null
+          sceneUrl?: string | null
+        } | null
+        if (!payload || payload.ok !== true) return
+        // Merge the capabilities into every slot holding the id: a probe
+        // issued by try-on may land while sync/apply has already installed
+        // the same wallpaper as applied, and exiting the try-on must not
+        // fall back to a static frame without capabilities.
+        let changed = false
+        if (this.previewing?.id === targetId) {
+          const merged: WallpaperDescriptor = {
+            ...this.previewing,
+            videoUrl: payload.videoUrl ?? this.previewing.videoUrl,
+            sceneUrl: payload.sceneUrl ?? this.previewing.sceneUrl,
+          }
+          if (merged.videoUrl !== this.previewing.videoUrl || merged.sceneUrl !== this.previewing.sceneUrl) {
+            this.previewing = merged
+            changed = true
+          }
+        }
+        if (this.applied?.id === targetId) {
+          const merged: WallpaperDescriptor = {
+            ...this.applied,
+            videoUrl: payload.videoUrl ?? this.applied.videoUrl,
+            sceneUrl: payload.sceneUrl ?? this.applied.sceneUrl,
+          }
+          if (merged.videoUrl !== this.applied.videoUrl || merged.sceneUrl !== this.applied.sceneUrl) {
+            this.applied = merged
+            changed = true
+          }
+        }
+        if (!changed) return
+        this.render()
+        this.publish()
+      })
+      .catch(() => {
+        // Fail-silent on network errors
+      })
+      .finally(() => {
+        this.probePending.delete(targetId)
+      })
+    this.probePending.set(targetId, pending)
   }
 
   enabled = (): boolean => this.enabledValue
@@ -415,6 +485,7 @@ export class WallpaperController implements WallpaperHandle {
     this.render()
     this.publish()
     void this.scope.set('selection', descriptor.id)
+    this.probeSceneCapabilitiesIfNeeded(descriptor)
   }
 
   clearSelection(): void {
@@ -429,12 +500,14 @@ export class WallpaperController implements WallpaperHandle {
   sync(descriptor: WallpaperDescriptor | null): void {
     this.applied = descriptor
     this.render()
+    if (descriptor !== null) this.probeSceneCapabilitiesIfNeeded(descriptor)
   }
 
   tryOn(descriptor: WallpaperDescriptor): void {
     this.previewing = descriptor
     this.render()
     this.publish()
+    this.probeSceneCapabilitiesIfNeeded(descriptor)
   }
 
   exitTryOn(): void {
@@ -578,9 +651,17 @@ export class WallpaperController implements WallpaperHandle {
       styleLayer(this.scrimLayer, -2)
       this.doc.body.appendChild(this.scrimLayer)
     }
+    // Capabilities (videoUrl/sceneUrl) participate in the key: the lazy
+    // scene probe merges them into the same descriptor id after the first
+    // render, and the static frame must be rebuilt as live media.
     const mediaKey = descriptor.id + ':' + this.modeValue
+      + ':' + (descriptor.videoUrl ?? '') + ':' + (descriptor.sceneUrl ?? '')
     if (this.mediaLayer.dataset.mediaKey !== mediaKey) {
       this.mediaLayer.dataset.mediaKey = mediaKey
+      // A media transition (frame->live, mode switch) abandons the current
+      // capture: release its src before replacing, otherwise the detached
+      // video keeps buffering until teardown or the next capture.
+      this.releaseCaptureVideo()
       this.mediaLayer.replaceChildren()
       this.videoElement = null
       const child = this.buildMedia(descriptor)
@@ -722,6 +803,17 @@ export class WallpaperController implements WallpaperHandle {
     video.playsInline = true
     video.preload = 'auto'
     video.src = url
+    // The capture video is owned by the controller: it is released on
+    // error/abort, on a successful capture, and on teardown, so a decode
+    // failure or an early mode switch cannot leave it buffering detached.
+    this.releaseCaptureVideo()
+    this.captureVideo = video
+    const release = (): void => {
+      video.removeAttribute('src')
+      video.load()
+    }
+    video.addEventListener('error', release, { once: true })
+    video.addEventListener('abort', release, { once: true })
     video.addEventListener('loadeddata', () => {
       try {
         const scale = Math.min(1, FRAME_MAX_EDGE / Math.max(video.videoWidth, video.videoHeight))
@@ -729,18 +821,27 @@ export class WallpaperController implements WallpaperHandle {
         canvas.width = Math.max(1, Math.round(video.videoWidth * scale))
         canvas.height = Math.max(1, Math.round(video.videoHeight * scale))
         const context = canvas.getContext('2d')
-        if (context === null) return
-        context.drawImage(video, 0, 0, canvas.width, canvas.height)
-        image.src = canvas.toDataURL('image/jpeg', 0.85)
-        // Stop buffering: the capture is done, the hidden video must not
-        // keep streaming the file.
-        video.removeAttribute('src')
-        video.load()
+        if (context !== null) {
+          context.drawImage(video, 0, 0, canvas.width, canvas.height)
+          image.src = canvas.toDataURL('image/jpeg', 0.85)
+        }
       } catch {
         // Capture failed (codec/format): the preview image stays.
+      } finally {
+        // Stop buffering whether the capture succeeded or not (a missing 2d
+        // context or a decode failure must not leave the hidden video
+        // streaming the file).
+        release()
       }
     }, { once: true })
     return image
+  }
+
+  private releaseCaptureVideo(): void {
+    if (this.captureVideo === null) return
+    this.captureVideo.removeAttribute('src')
+    this.captureVideo.load()
+    this.captureVideo = null
   }
 
   private buildImage(url: string | null, fallbackUrl: string | null = null): HTMLElement | null {
@@ -805,6 +906,7 @@ export class WallpaperController implements WallpaperHandle {
   }
 
   private teardownLayers(): void {
+    this.releaseCaptureVideo()
     this.untagSurfaces()
     delete this.doc.body.dataset.dshWallpaperActive
     delete this.doc.documentElement.dataset.dshWallpaperActive

--- a/packages/skins/skin-center/src/we-routes.ts
+++ b/packages/skins/skin-center/src/we-routes.ts
@@ -276,41 +276,9 @@ export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
 
   const entryToJson = (entry: WallpaperEntry): WallpaperJson => {
     const hasFile = existsSync(entry.fileAbs)
-    let hasVideo = false
-    let hasSceneWebGL = false
-    if (entry.type === 'scene' && hasFile) {
-      let mtimeMs = 0
-      let size = 0
-      try { const st = statSync(entry.fileAbs); mtimeMs = st.mtimeMs; size = st.size } catch { /* probe once without a key */ }
-      const key = entry.fileAbs + ':' + mtimeMs + ':' + size
-      let probe = mtimeMs > 0 ? sceneProbeCache.get(key) : undefined
-      if (!probe) {
-        let hasVideoNow = false
-        let hasSceneWebGLNow = false
-        try {
-          hasVideoNow = entry.fileAbs.toLowerCase().endsWith('.json')
-            ? hasSceneVideoFromDir(dirname(entry.fileAbs))
-            : hasSceneVideo(new Uint8Array(readFileSync(entry.fileAbs)))
-          if (!hasVideoNow) {
-            const manifest = entry.fileAbs.toLowerCase().endsWith('.json')
-              ? buildSceneManifestFromDir(dirname(entry.fileAbs), 'check')
-              : buildSceneManifest(new Uint8Array(readFileSync(entry.fileAbs)), 'check')
-            if (manifest && ((manifest.layers && manifest.layers.length >= 1) || (manifest.is3D && manifest.models && manifest.models.length > 0))) {
-              hasSceneWebGLNow = true
-            }
-          }
-        } catch {
-          hasSceneWebGLNow = false
-        }
-        probe = { hasVideo: hasVideoNow, hasSceneWebGL: hasSceneWebGLNow }
-        if (mtimeMs > 0) {
-          if (sceneProbeCache.size >= MAX_PROBE_CACHE) sceneProbeCache.clear()
-          sceneProbeCache.set(key, probe)
-        }
-      }
-      hasVideo = probe.hasVideo
-      hasSceneWebGL = probe.hasSceneWebGL
-    }
+    // Scene video/WebGL capabilities are probed lazily by the scene-probe
+    // route for the selected wallpaper only; probing every scene here would
+    // read the whole packed payload of a large library on every inventory.
     return {
       id: entry.id,
       title: entry.title,
@@ -318,15 +286,10 @@ export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
       source: entry.source,
       playable: entry.playable,
       updateAvailable: entry.updateAvailable,
-      videoUrl:
-        entry.type === 'video' && hasFile
-          ? WE_API_PREFIX + '/media/' + tokenFor(entry.fileAbs)
-          : hasVideo
-            ? WE_API_PREFIX + '/scene-video/' + tokenFor(entry.fileAbs)
-            : null,
+      videoUrl: entry.type === 'video' && hasFile ? WE_API_PREFIX + '/media/' + tokenFor(entry.fileAbs) : null,
       webUrl: entry.type === 'web' && hasFile ? WE_API_PREFIX + '/web/' + tokenFor(entry.fileAbs) + '/' : null,
       frameUrl: entry.type === 'scene' && hasFile ? WE_API_PREFIX + '/scene-frame/' + tokenFor(entry.fileAbs) : null,
-      sceneUrl: hasSceneWebGL ? WE_API_PREFIX + '/scene-runtime/' + tokenFor(entry.fileAbs) : null,
+      sceneUrl: null,
       previewUrl: entry.previewAbs ? WE_API_PREFIX + '/preview/' + tokenFor(entry.previewAbs) : null,
     }
   }
@@ -370,6 +333,72 @@ export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
           total: inventory.total,
           portableCount: inventory.portableCount,
           wallpapers,
+        })
+      } catch (error) {
+        json(res, 500, { ok: false, error: error instanceof Error ? error.message : String(error) })
+      }
+    },
+  })
+
+  // GET /scene-probe?id=<id> — lazy per-item capability probe. Inventory
+  // stays cheap by never reading scene payloads; the client asks this route
+  // only for the wallpaper the user actually selects. The probe reads the
+  // whole packed scene file once (cached by path+mtime+size), so a large
+  // library is never scanned up front.
+  routes.push({
+    kind: 'exact',
+    path: WE_API_PREFIX + '/scene-probe',
+    handler: (req, res) => {
+      if (req.method !== 'GET') { json(res, 405, { ok: false, error: 'method-not-allowed' }); return }
+      if (!requireSameOrigin(req, res)) return
+      try {
+        const url = new URL(req.url ?? '', 'http://localhost')
+        const id = url.searchParams.get('id')
+        if (!id) { json(res, 400, { ok: false, error: 'missing-id' }); return }
+        const entry = freshInventory().wallpapers.find((w) => w.id === id && w.type === 'scene')
+        if (!entry || !existsSync(entry.fileAbs)) { json(res, 404, { ok: false, error: 'not-found' }); return }
+        let mtimeMs = 0
+        let size = 0
+        try { const st = statSync(entry.fileAbs); mtimeMs = st.mtimeMs; size = st.size } catch { /* probe once without a key */ }
+        // Loose .json scenes probe the whole directory (video/manifest
+        // siblings), which a single-file stat key cannot fingerprint; skip
+        // the cache for them so sibling changes never serve stale results.
+        const isLooseScene = entry.fileAbs.toLowerCase().endsWith('.json')
+        if (isLooseScene) mtimeMs = 0
+        const key = entry.fileAbs + ':' + mtimeMs + ':' + size
+        let probe = mtimeMs > 0 ? sceneProbeCache.get(key) : undefined
+        if (!probe) {
+          let hasVideo = false
+          let hasSceneWebGL = false
+          try {
+            const pkgData = readFileSync(entry.fileAbs)
+            const u8 = new Uint8Array(pkgData.buffer, pkgData.byteOffset, pkgData.byteLength)
+            hasVideo = entry.fileAbs.toLowerCase().endsWith('.json')
+              ? hasSceneVideoFromDir(dirname(entry.fileAbs))
+              : hasSceneVideo(u8)
+            if (!hasVideo) {
+              const manifest = entry.fileAbs.toLowerCase().endsWith('.json')
+                ? buildSceneManifestFromDir(dirname(entry.fileAbs), 'check')
+                : buildSceneManifest(u8, 'check')
+              hasSceneWebGL = Boolean(manifest && ((manifest.layers && manifest.layers.length >= 1) || (manifest.is3D && manifest.models && manifest.models.length > 0)))
+            }
+          } catch {
+            // probe failure: capabilities stay negative
+          }
+          probe = { hasVideo, hasSceneWebGL }
+          if (mtimeMs > 0) {
+            if (sceneProbeCache.size >= MAX_PROBE_CACHE) sceneProbeCache.clear()
+            sceneProbeCache.set(key, probe)
+          }
+        }
+        const videoToken = probe.hasVideo ? tokenFor(entry.fileAbs) : null
+        const sceneToken = probe.hasSceneWebGL ? tokenFor(entry.fileAbs) : null
+        // Persist after issuing so freshly minted tokens survive a restart.
+        persistTokens()
+        json(res, 200, {
+          ok: true,
+          videoUrl: videoToken !== null ? WE_API_PREFIX + '/scene-video/' + videoToken : null,
+          sceneUrl: sceneToken !== null ? WE_API_PREFIX + '/scene-runtime/' + sceneToken : null,
         })
       } catch (error) {
         json(res, 500, { ok: false, error: error instanceof Error ? error.message : String(error) })

--- a/packages/skins/skin-center/tests/wallpaper.spec.ts
+++ b/packages/skins/skin-center/tests/wallpaper.spec.ts
@@ -214,6 +214,222 @@ describe('WallpaperController', () => {
     controller.dispose()
   })
 
+  it('applySelection probes scene capabilities lazily and mounts live video', async () => {
+    const fetchImpl = vi.fn(async (input: string) => {
+      if (input.includes('/scene-probe')) {
+        return { ok: true, json: async () => ({ ok: true, videoUrl: '/api/skin-center/we/scene-video/lazy', sceneUrl: null }) }
+      }
+      return { ok: true, json: async () => ({ ok: true, wallpapers: [] }) }
+    }) as unknown as typeof fetch
+    const { scope } = fakeScope()
+    let controller: WallpaperController | null = null
+    try {
+      controller = new WallpaperController(scope, { fetchImpl, doc: document })
+      controller.applySelection({ ...scene, id: 'lazy', frameUrl: '/api/skin-center/we/scene-frame/lazy' })
+      // Before the probe resolves, the static frame is mounted.
+      expect(document.body.querySelector('img')).not.toBeNull()
+      await new Promise((r) => setTimeout(r, 10))
+      expect(fetchImpl).toHaveBeenCalledWith('/api/skin-center/we/scene-probe?id=lazy')
+      const [media] = layers()
+      const vid = media.querySelector('video')
+      expect(vid).not.toBeNull()
+      expect(vid?.src).toContain('/api/skin-center/we/scene-video/lazy')
+    } finally {
+      controller?.dispose()
+    }
+  })
+
+  it('tryOn probes scene capabilities and mounts live video for the preview', async () => {
+    const fetchImpl = vi.fn(async (input: string) => {
+      if (input.includes('/scene-probe')) {
+        return { ok: true, json: async () => ({ ok: true, videoUrl: '/api/skin-center/we/scene-video/preview', sceneUrl: null }) }
+      }
+      return { ok: true, json: async () => ({ ok: true, wallpapers: [] }) }
+    }) as unknown as typeof fetch
+    const { scope } = fakeScope()
+    let controller: WallpaperController | null = null
+    try {
+      controller = new WallpaperController(scope, { fetchImpl, doc: document })
+      controller.tryOn({ ...scene, id: 'preview', frameUrl: '/api/skin-center/we/scene-frame/preview' })
+      await new Promise((r) => setTimeout(r, 10))
+      expect(fetchImpl).toHaveBeenCalledWith('/api/skin-center/we/scene-probe?id=preview')
+      const [media] = layers()
+      const vid = media.querySelector('video')
+      expect(vid).not.toBeNull()
+      expect(vid?.src).toContain('/api/skin-center/we/scene-video/preview')
+    } finally {
+      controller?.dispose()
+    }
+  })
+
+  it('stale probe responses never overwrite a newer selection', async () => {
+    const probes = new Map<string, (value: unknown) => void>()
+    const fetchImpl = vi.fn(async (input: string) => {
+      if (input.includes('/scene-probe')) {
+        const id = input.split('id=')[1]
+        return new Promise((resolve) => { probes.set(id, resolve) })
+      }
+      return { ok: true, json: async () => ({ ok: true, wallpapers: [] }) }
+    }) as unknown as typeof fetch
+    const { scope } = fakeScope()
+    let controller: WallpaperController | null = null
+    try {
+      controller = new WallpaperController(scope, { fetchImpl, doc: document })
+      controller.tryOn({ ...scene, id: 'slow-a', frameUrl: '/api/skin-center/we/scene-frame/slow-a' })
+      await new Promise((r) => setTimeout(r, 5))
+      // Switch to a different wallpaper before slow-a's probe answers.
+      controller.tryOn({ ...scene, id: 'slow-b', frameUrl: '/api/skin-center/we/scene-frame/slow-b' })
+      probes.get('slow-b')?.({ ok: true, json: async () => ({ ok: true, videoUrl: '/api/skin-center/we/scene-video/slow-b', sceneUrl: null }) })
+      await new Promise((r) => setTimeout(r, 5))
+      const [media] = layers()
+      expect(media.querySelector('video')?.src).toContain('/api/skin-center/we/scene-video/slow-b')
+      // slow-a's stale probe resolves late: the preview now belongs to slow-b,
+      // so the response must be dropped, not merged.
+      probes.get('slow-a')?.({ ok: true, json: async () => ({ ok: true, videoUrl: '/api/skin-center/we/scene-video/stale', sceneUrl: null }) })
+      await new Promise((r) => setTimeout(r, 10))
+      expect(media.querySelector('video')?.src).toContain('/api/skin-center/we/scene-video/slow-b')
+      expect(media.querySelector('video')?.src).not.toContain('/api/skin-center/we/scene-video/stale')
+    } finally {
+      controller?.dispose()
+    }
+  })
+
+  it('dedupes concurrent scene probes for the same id across entry points', async () => {
+    let probeCalls = 0
+    const fetchImpl = vi.fn(async (input: string) => {
+      if (input.includes('/scene-probe')) {
+        probeCalls++
+        await new Promise((r) => setTimeout(r, 30))
+        return { ok: true, json: async () => ({ ok: true, videoUrl: '/api/skin-center/we/scene-video/dedup', sceneUrl: null }) }
+      }
+      return { ok: true, json: async () => ({ ok: true, wallpapers: [] }) }
+    }) as unknown as typeof fetch
+    const { scope } = fakeScope()
+    let controller: WallpaperController | null = null
+    try {
+      controller = new WallpaperController(scope, { fetchImpl, doc: document })
+      controller.tryOn({ ...scene, id: 'dedup', frameUrl: '/api/skin-center/we/scene-frame/dedup' })
+      controller.applySelection({ ...scene, id: 'dedup', frameUrl: '/api/skin-center/we/scene-frame/dedup' })
+      controller.sync({ ...scene, id: 'dedup', frameUrl: '/api/skin-center/we/scene-frame/dedup' })
+      await new Promise((r) => setTimeout(r, 10))
+      expect(probeCalls).toBe(1)
+      await new Promise((r) => setTimeout(r, 50))
+      controller.tryOn({ ...scene, id: 'dedup', videoUrl: '/api/skin-center/we/scene-video/dedup', frameUrl: '/api/skin-center/we/scene-frame/dedup' })
+      await new Promise((r) => setTimeout(r, 10))
+      expect(probeCalls).toBe(1)
+      const [media] = layers()
+      expect(media.querySelector('video')?.src).toContain('/api/skin-center/we/scene-video/dedup')
+    } finally {
+      controller?.dispose()
+    }
+  })
+
+  it('applied capabilities survive exiting a try-on that probed the same wallpaper', async () => {
+    const fetchImpl = vi.fn(async (input: string) => {
+      if (input.includes('/scene-probe')) {
+        return { ok: true, json: async () => ({ ok: true, videoUrl: '/api/skin-center/we/scene-video/shared', sceneUrl: null }) }
+      }
+      return { ok: true, json: async () => ({ ok: true, wallpapers: [] }) }
+    }) as unknown as typeof fetch
+    const { scope } = fakeScope()
+    let controller: WallpaperController | null = null
+    try {
+      controller = new WallpaperController(scope, { fetchImpl, doc: document })
+      const desc = { ...scene, id: 'shared', frameUrl: '/api/skin-center/we/scene-frame/shared' }
+      controller.applySelection(desc)
+      controller.tryOn(desc)
+      await new Promise((r) => setTimeout(r, 10))
+      controller.exitTryOn()
+      await new Promise((r) => setTimeout(r, 10))
+      const [media] = layers()
+      const vid = media.querySelector('video')
+      expect(vid).not.toBeNull()
+      expect(vid?.src).toContain('/api/skin-center/we/scene-video/shared')
+    } finally {
+      controller?.dispose()
+    }
+  })
+
+  it('releases the capture video on error before loadeddata', () => {
+    const { scope } = fakeScope()
+    const origCreate = document.createElement.bind(document)
+    const createdVideos: HTMLVideoElement[] = []
+    const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = origCreate(tag)
+      if (tag === 'video') createdVideos.push(el as HTMLVideoElement)
+      return el
+    })
+    let controller: WallpaperController | null = null
+    try {
+      controller = new WallpaperController(scope)
+      controller.setMode('frame')
+      controller.applySelection({ ...video, id: 'cap-err', previewUrl: '/api/skin-center/we/preview/cap-err' })
+      const capture = createdVideos.find((v) => v.getAttribute('src') !== null)
+      expect(capture).not.toBeNull()
+      // A decode/network failure fires error before loadeddata: the src must
+      // still be released instead of keeping preload=auto buffering.
+      capture?.dispatchEvent(new Event('error'))
+      expect(capture?.hasAttribute('src')).toBe(false)
+    } finally {
+      controller?.dispose()
+      createSpy.mockRestore()
+    }
+  })
+
+  it('releases the capture video on teardown when loadeddata never fires', () => {
+    const { scope } = fakeScope()
+    const origCreate = document.createElement.bind(document)
+    const createdVideos: HTMLVideoElement[] = []
+    const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = origCreate(tag)
+      if (tag === 'video') createdVideos.push(el as HTMLVideoElement)
+      return el
+    })
+    let controller: WallpaperController | null = null
+    try {
+      controller = new WallpaperController(scope)
+      controller.setMode('frame')
+      controller.applySelection({ ...video, id: 'cap-teardown', previewUrl: '/api/skin-center/we/preview/cap-teardown' })
+      const capture = createdVideos.find((v) => v.getAttribute('src') !== null)
+      expect(capture).not.toBeNull()
+      // Mode switch / dispose before any media event: teardown must release.
+      controller.dispose()
+      controller = null
+      expect(capture?.hasAttribute('src')).toBe(false)
+    } finally {
+      controller?.dispose()
+      createSpy.mockRestore()
+    }
+  })
+
+  it('releases the capture video on a media-key transition before loadeddata', () => {
+    const { scope } = fakeScope()
+    const origCreate = document.createElement.bind(document)
+    const createdVideos: HTMLVideoElement[] = []
+    const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = origCreate(tag)
+      if (tag === 'video') createdVideos.push(el as HTMLVideoElement)
+      return el
+    })
+    let controller: WallpaperController | null = null
+    try {
+      controller = new WallpaperController(scope)
+      controller.setMode('frame')
+      controller.applySelection({ ...video, id: 'cap-switch', previewUrl: '/api/skin-center/we/preview/cap-switch' })
+      const capture = createdVideos.find((v) => v.getAttribute('src') !== null)
+      expect(capture).not.toBeNull()
+      // frame -> live rebuilds the media layer and must release the
+      // abandoned capture instead of leaving it buffering.
+      controller.setMode('live')
+      expect(capture?.hasAttribute('src')).toBe(false)
+      const [media] = layers()
+      expect(media.querySelector('video')).not.toBeNull()
+    } finally {
+      controller?.dispose()
+      createSpy.mockRestore()
+    }
+  })
+
   it('keeps videos muted by default and applies sound/volume live (#580)', () => {
     const { scope, calls } = fakeScope()
     const controller = new WallpaperController(scope)

--- a/packages/skins/skin-center/tests/we-routes.spec.ts
+++ b/packages/skins/skin-center/tests/we-routes.spec.ts
@@ -162,6 +162,23 @@ describe('inventory', () => {
     expect(String(scene?.frameUrl)).toContain(WE_API_PREFIX + '/scene-frame/')
   })
 
+  it('probes scene capabilities lazily and fails closed on unreadable pkg', async () => {
+    const inv = await call('GET', WE_API_PREFIX + '/inventory')
+    const scene = (inv.body.wallpapers as Array<Record<string, unknown>>).find(w => w.id === '333')
+    expect(scene?.videoUrl).toBe(null)
+    expect(scene?.sceneUrl).toBe(null)
+    // scene.pkg in the fixture is not a real PKG: the probe fails closed.
+    const probe = await call('GET', WE_API_PREFIX + '/scene-probe?id=333')
+    expect(probe.status).toBe(200)
+    expect(probe.body.ok).toBe(true)
+    expect(probe.body.videoUrl).toBe(null)
+    expect(probe.body.sceneUrl).toBe(null)
+    // Unknown id 404s; missing id 400s; cross-site is fenced.
+    expect((await call('GET', WE_API_PREFIX + '/scene-probe?id=999')).status).toBe(404)
+    expect((await call('GET', WE_API_PREFIX + '/scene-probe')).status).toBe(400)
+    expect((await call('GET', WE_API_PREFIX + '/scene-probe?id=333', { headers: { 'sec-fetch-site': 'cross-site' } })).status).toBe(403)
+  })
+
   it('rejects cross-site requests', async () => {
     const res = await call('GET', WE_API_PREFIX + '/inventory', { headers: { 'sec-fetch-site': 'cross-site' } })
     expect(res.status).toBe(403)
@@ -359,16 +376,23 @@ describe('scene container resolution (#521)', () => {
 
     const inventory = await call('GET', WE_API_PREFIX + '/inventory')
     const entry = (inventory.body.wallpapers as Array<Record<string, unknown>>).find(w => w.id === '666')
-    expect(String(entry?.sceneUrl)).toContain(WE_API_PREFIX + '/scene-runtime/')
+    // Scene capabilities are probed lazily: the inventory never reads packed
+    // payloads, so the selected wallpaper asks the probe route.
+    expect(entry?.sceneUrl).toBe(null)
+    const probe = await call('GET', WE_API_PREFIX + '/scene-probe?id=666')
+    expect(probe.status).toBe(200)
+    expect(probe.body.ok).toBe(true)
+    expect(probe.body.videoUrl).toBe(null)
+    expect(String(probe.body.sceneUrl)).toContain(WE_API_PREFIX + '/scene-runtime/')
 
     // Scene runtime HTML
-    const runtimeRes = await call('GET', String(entry?.sceneUrl))
+    const runtimeRes = await call('GET', String(probe.body.sceneUrl))
     expect(runtimeRes.status).toBe(200)
     expect(String(runtimeRes.headers['content-type'])).toContain('text/html')
     expect(runtimeRes.raw).toContain('<canvas id="canvas"></canvas>')
 
     // Scene manifest JSON
-    const token = String(entry?.sceneUrl).split('/').pop()
+    const token = String(probe.body.sceneUrl).split('/').pop()
     const manifestRes = await call('GET', WE_API_PREFIX + '/scene-manifest/' + token)
     expect(manifestRes.status).toBe(200)
     expect(manifestRes.body.ok).toBe(true)


### PR DESCRIPTION
## 摘要（Summary）
惰性 scene 能力探测与捕获视频资源释放：修复皮肤中心 Wallpaper Engine 面板的 inventory 全量读盘与帧捕获 video 资源泄漏。

## 涉及包（Affected Packages）
- `packages/skins/skin-center`

## PR 类型（PR Type）
- [x] 修复（Bug Fix）
- [ ] 新功能（Feature）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

（本 PR 基于当前 dev（e858f80），仅改 4 个文件，无冲突、MERGEABLE。）

## 变更内容
- **惰性探测**：`GET /we/inventory` 不再同步读取每个 scene 包的完整内容（真实本地库约 550 个 scene 包、约 19 GB，单次 inventory 曾耗时数分钟并阻塞 HTTP 服务）。新增 `GET /we/scene-probe?id=<id>`，仅对用户选中的壁纸探测一次，按 `path+mtime+size` 缓存；松散 `.json` 场景跳过缓存（其探测读取目录兄弟文件，单文件 stat 无法指纹）；不可读包失败闭合；token 在发放后持久化，新签发的 `scene-video`/`scene-runtime` token 重启后仍有效。
- **客户端**：`applySelection` / `tryOn` / `sync` / `fetchAndSync` 对同一壁纸共享一次 in-flight 探测；探测响应合并到持有该 id 的所有槽位（previewing 与 applied），退出试穿不会丢失已应用的 live 能力；`mediaKey` 纳入能力字段，探测完成后静态帧重建为 live 媒体。
- **捕获释放**：帧模式的捕获 video 由 controller 持有，在 `error`/`abort`/`loadeddata`、teardown 与媒体切换（media-key 变更）时均释放 `src`，解码失败或提前切换模式不会遗留 detached `preload=auto` 视频继续缓冲。
- **测试**：probe 端点（失败闭合、404/400/同源围栏）、惰性 apply/try-on、stale probe 竞态、in-flight 去重、apply+tryOn 共享探测、捕获释放（error/teardown/媒体切换）。

## 本地验证（Local Validation）

执行的命令：在 `packages/skins/skin-center` 下运行 `pnpm vitest run`（基于最新 dev 分支）。
结果摘要：`pnpm vitest run` 输出 Test Files 20 passed (20)、Tests 316 passed (316)；新增 9 个用例全部通过（probe 端点失败闭合/404/400/同源围栏、applySelection/tryOn 惰性探测、stale probe 竞态、in-flight 去重、apply+tryOn 共享探测、捕获释放 error/teardown/媒体切换）。运行态冒烟：746 条库存 inventory `0.5s`（此前分钟级/卡死）；662 MB 最大 scene 探测 `0.7s`，二次命中缓存。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

（上述输出即基于最新 dev rebase 后的测试结果，316/316 全绿。）

## 用户可见变更证据（Local Feature Evidence）
- 皮肤中心 Wallpaper Engine 列表对 746 条库存秒开（此前页面挂起数分钟）。
- 选中 scene 壁纸后探测一次并正常播放（视频层 / WebGL runtime），行为与之前一致；其余 UI 无可见变化。
