### PR TITLE
fix(skin-center): report JPEG-encoded TEX mipmaps explicitly and pin the TEXB0003 layout (#756)

### DIFF
--- a/packages/skins/skin-center/src/pkg-extract.ts
+++ b/packages/skins/skin-center/src/pkg-extract.ts
@@ -823,6 +823,11 @@ export function decodeTex(data: Uint8Array): DecodedImage {
   if (isPngBuffer(mip.bytes)) {
     return decodePngToRgba(mip.bytes)
   }
+  // FreeImage-embedded JPEG mipmaps (FF D8) have no pure-JS decoder; report
+  // that truthfully instead of failing later as an RGBA size mismatch (#756).
+  if (mip.bytes[0] === 0xff && mip.bytes[1] === 0xd8) {
+    throw new Error('tex: JPEG-encoded mipmaps are not supported (no pure-JS JPEG decoder)')
+  }
   const { width, height, bytes } = mip
   let decoded: DecodedImage
   switch (parsed.format) {

--- a/packages/skins/skin-center/tests/pkg-extract.spec.ts
+++ b/packages/skins/skin-center/tests/pkg-extract.spec.ts
@@ -1494,3 +1494,53 @@ describe('scene robustness (#717 follow-up)', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// JPEG-embedded TEX (issue #756): the TEXB0003 layout is imageCount ->
+// FreeImage format -> per-image mipmapCount; FreeImage FIF_JPEG = 2. Such
+// mipmaps carry JPEG bytes (FF D8) with a TEXI format of RGBA8888, which has
+// no pure-JS decoder — the failure must be explicit, not an RGBA size mismatch.
+// ---------------------------------------------------------------------------
+
+const jpegBytes = (size: number): Uint8Array => {
+  const bytes = new Uint8Array(size)
+  bytes[0] = 0xff
+  bytes[1] = 0xd8
+  bytes[2] = 0xff
+  bytes[3] = 0xe0
+  return bytes
+}
+
+describe('JPEG-embedded TEX (issue #756)', () => {
+  it('parses imageCount -> FreeImage format -> mipmapCount without misalignment', () => {
+    const tex = buildTex({
+      format: TexFormat.RGBA8888,
+      width: 2704,
+      height: 1520,
+      containerVersion: 3,
+      freeImageFormat: 2, // FIF_JPEG
+      mipmaps: [
+        { width: 2704, height: 1520, data: jpegBytes(350_695) },
+        { width: 1352, height: 760, data: jpegBytes(90_000) },
+        { width: 676, height: 380, data: jpegBytes(24_000) },
+        { width: 338, height: 190, data: jpegBytes(7_000) },
+      ],
+    })
+    const parsed = parseTex(tex)
+    expect(parsed.width).toBe(2704)
+    expect(parsed.height).toBe(1520)
+    expect(parsed.mipLevels).toBe(4)
+  })
+
+  it('reports JPEG-encoded mipmaps explicitly instead of an RGBA size mismatch', () => {
+    const tex = buildTex({
+      format: TexFormat.RGBA8888,
+      width: 2704,
+      height: 1520,
+      containerVersion: 3,
+      freeImageFormat: 2,
+      mipmaps: [{ width: 2704, height: 1520, data: jpegBytes(350_695) }],
+    })
+    expect(() => decodeTex(tex)).toThrow(/JPEG-encoded mipmaps are not supported/)
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

针对 #756 的核实结果与最小修复：

1. **布局核实**：对照 RePKG 权威源码（TexImageContainerReader.cs / TexImageReader.cs，notscuffed/repkg master）确认 TEXB0003 布局为 imageCount -> FreeImage format -> 每图 mipmapCount。Issue 描述的「imageHeaderField=2」实为 FreeImageFormat 字段（FIF_JPEG = 2），当前解析顺序与 RePKG 一致、无错位。新增回归测试按该真实结构（imageCount=1 -> freeImageFormat=2 -> mipmapCount=4，2704x1520 起 4 级 JPEG mip）验证 parseTex 解析正确。
2. **显式报错**：FreeImage 嵌入的 JPEG mipmap（FF D8 开头、TEXI format 为 RGBA8888）此前会落入 RGBA 尺寸校验并报误导性的 mipmap size mismatch；现在 decodeTex 检测 JPEG 魔数并抛出明确的 tex: JPEG-encoded mipmaps are not supported (no pure-JS JPEG decoder)。

JPEG 解码器本身（纯 JS 零依赖约束下的基线 JPEG 解码，或引入成熟解码依赖）需要维护者决策，不在本 PR 范围；Issue #756 保持开放直到解码能力落地。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

基线：origin/dev @ 18d978663（本 PR 创建时最新）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据。

分支基于最新 origin/dev 创建，见下节本地验证。

## 视觉修复要求（Visual Fix Requirements）

未勾选「视觉修复」，本节不适用。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek V4（本会话运行时 agent）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本次未改动 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/skins/skin-center
pnpm typecheck
pnpm test
```

结果摘要：

- typecheck 通过（0 错误）；
- vitest 19 个测试文件全绿，313/313 通过（含新增 2 个 #756 回归用例）；
- 新增用例覆盖：真实 TEXB0003 布局（imageCount -> freeImageFormat=2 -> mipmapCount=4）解析无误、JPEG mipmap 报错显式化。

## 用户可见变更证据（Local Feature Evidence）

纯内部修复（解析核实 + 错误信息显式化），无用户可见视觉变更，填 N/A。