### PR TITLE
perf(pet): schedule the status decoration by frame duration

### DIFF
--- a/packages/dsh-pet/src/client/PetSprite.test.tsx
+++ b/packages/dsh-pet/src/client/PetSprite.test.tsx
@@ -687,7 +687,7 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
     expect(ornament()).toBeNull()
   })
 
-  it('advances the ornament frames on the rAF loop and wraps when looping', () => {
+  it('advances the ornament frames on the duration timer and wraps when looping', () => {
     vi.spyOn(window, 'matchMedia').mockReturnValue({
       matches: false,
       media: '(prefers-reduced-motion: reduce)',
@@ -698,7 +698,17 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
       removeListener: () => {},
       dispatchEvent: () => false,
     })
-    vi.spyOn(performance, 'now').mockReturnValue(0)
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    // The ornament schedules by frame duration (setTimeout), the sprite
+    // still uses rAF; capture both so stepping advances both loops.
+    const timers: { at: number; callback: () => void }[] = []
+    let timerId = 0
+    vi.spyOn(window, 'setTimeout').mockImplementation(((callback: () => void, delay = 0) => {
+      timers.push({ at: now + delay, callback })
+      return ++timerId
+    }) as typeof window.setTimeout)
+    vi.spyOn(window, 'clearTimeout').mockImplementation(() => {})
     const frames: FrameRequestCallback[] = []
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
       frames.push(callback)
@@ -707,18 +717,31 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
     vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
     renderPet({ snapshot: { ...snapshot, bubble: '正在思考', phase: 'thinking', decoration } })
     const el = ornament()!
-    // Both the sprite loop and the ornament loop schedule frames; step every
-    // pending callback together (the sprite's idle track never moves).
-    const step = (ts: number): void => { for (const callback of frames.splice(0)) callback(ts) }
+    // Run the sprite rAF callbacks immediately (its idle track never moves);
+    // run ornament timers as the clock reaches them, repeatedly, because a
+    // due timer reschedules the next one at now + duration.
+    const step = (ms: number): void => {
+      for (const callback of frames.splice(0)) callback(now)
+      now += ms
+      for (;;) {
+        const due = timers.filter(t => t.at <= now)
+        if (due.length === 0) break
+        for (const t of due) {
+          const idx = timers.indexOf(t)
+          if (idx >= 0) timers.splice(idx, 1)
+          t.callback()
+        }
+      }
+    }
     // frameWidth = round(64 * 18 / 48) = 24 px; thinking binds frames 0..3.
     expect(el.style.backgroundPosition).toBe('0px 0px')
     act(() => { step(161) })
     expect(el.style.backgroundPosition).toBe('-24px 0px')
-    act(() => { step(322) })
+    act(() => { step(161) })
     expect(el.style.backgroundPosition).toBe('-48px 0px')
-    act(() => { step(483) })
+    act(() => { step(161) })
     expect(el.style.backgroundPosition).toBe('-72px 0px')
-    act(() => { step(644) })
+    act(() => { step(161) })
     // The looping segment wraps back to its first frame.
     expect(el.style.backgroundPosition).toBe('0px 0px')
   })
@@ -734,7 +757,15 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
       removeListener: () => {},
       dispatchEvent: () => false,
     })
-    vi.spyOn(performance, 'now').mockReturnValue(0)
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    const timers: { at: number; callback: () => void }[] = []
+    let timerId = 0
+    vi.spyOn(window, 'setTimeout').mockImplementation(((callback: () => void, delay = 0) => {
+      timers.push({ at: now + delay, callback })
+      return ++timerId
+    }) as typeof window.setTimeout)
+    vi.spyOn(window, 'clearTimeout').mockImplementation(() => {})
     const frames: FrameRequestCallback[] = []
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
       frames.push(callback)
@@ -743,13 +774,25 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
     vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
     renderPet({ snapshot: { ...snapshot, bubble: '完成', phase: 'done', decoration: { ...decoration, loop: false } } })
     const el = ornament()!
-    const step = (ts: number): void => { for (const callback of frames.splice(0)) callback(ts) }
+    const step = (ms: number): void => {
+      for (const callback of frames.splice(0)) callback(now)
+      now += ms
+      for (;;) {
+        const due = timers.filter(t => t.at <= now)
+        if (due.length === 0) break
+        for (const t of due) {
+          const idx = timers.indexOf(t)
+          if (idx >= 0) timers.splice(idx, 1)
+          t.callback()
+        }
+      }
+    }
     // done binds frames 2..3; the segment starts on frame 2.
     expect(el.style.backgroundPosition).toBe('-48px 0px')
     act(() => { step(161) })
     expect(el.style.backgroundPosition).toBe('-72px 0px')
-    // The ornament stopped scheduling (only the sprite loop remains pending).
-    expect(frames).toHaveLength(1)
+    // The ornament stopped scheduling timers (only the sprite rAF remains).
+    expect(timers).toHaveLength(0)
     act(() => { step(161) })
     // The last frame holds.
     expect(el.style.backgroundPosition).toBe('-72px 0px')
@@ -767,6 +810,13 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
       dispatchEvent: () => false,
     })
     vi.spyOn(performance, 'now').mockReturnValue(0)
+    const timers: { at: number; callback: () => void }[] = []
+    let timerId = 0
+    vi.spyOn(window, 'setTimeout').mockImplementation(((callback: () => void, delay = 0) => {
+      timers.push({ at: delay, callback })
+      return ++timerId
+    }) as typeof window.setTimeout)
+    vi.spyOn(window, 'clearTimeout').mockImplementation(() => {})
     const frames: FrameRequestCallback[] = []
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
       frames.push(callback)
@@ -784,15 +834,15 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
     })
     const el = ornament()!
     // The ornament settles on its only frame, exactly like the reduced-motion
-    // hold — no rAF loop may start, so only the sprite's idle loop is pending.
+    // hold — no timer may start (only the sprite's idle rAF is pending).
     expect(el.style.backgroundPosition).toBe('-72px 0px')
-    expect(frames).toHaveLength(1)
+    expect(timers).toHaveLength(0)
     const step = (ts: number): void => { for (const callback of frames.splice(0)) callback(ts) }
     act(() => { step(161) })
     act(() => { step(322) })
     // The frame never moves and the ornament never reschedules itself.
     expect(el.style.backgroundPosition).toBe('-72px 0px')
-    expect(frames).toHaveLength(1)
+    expect(timers).toHaveLength(0)
   })
 
   it('does not advance the background while a frame is still in play', () => {
@@ -806,7 +856,15 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
       removeListener: () => {},
       dispatchEvent: () => false,
     })
-    vi.spyOn(performance, 'now').mockReturnValue(0)
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    const timers: { at: number; callback: () => void }[] = []
+    let timerId = 0
+    vi.spyOn(window, 'setTimeout').mockImplementation(((callback: () => void, delay = 0) => {
+      timers.push({ at: now + delay, callback })
+      return ++timerId
+    }) as typeof window.setTimeout)
+    vi.spyOn(window, 'clearTimeout').mockImplementation(() => {})
     const frames: FrameRequestCallback[] = []
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
       frames.push(callback)
@@ -815,7 +873,19 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
     vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
     renderPet({ snapshot: { ...snapshot, bubble: '正在思考', phase: 'thinking', decoration } })
     const el = ornament()!
-    const step = (ts: number): void => { for (const callback of frames.splice(0)) callback(ts) }
+    const step = (ms: number): void => {
+      for (const callback of frames.splice(0)) callback(now)
+      now += ms
+      for (;;) {
+        const due = timers.filter(t => t.at <= now)
+        if (due.length === 0) break
+        for (const t of due) {
+          const idx = timers.indexOf(t)
+          if (idx >= 0) timers.splice(idx, 1)
+          t.callback()
+        }
+      }
+    }
     // thinking binds frames 0..3 at 160 ms/frame. The effect holds frame 0;
     // a step at 80 ms — inside the first frame — must not move the ornament,
     // and only crossing the 160 ms boundary advances to the next frame.
@@ -824,6 +894,58 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
     expect(el.style.backgroundPosition).toBe('0px 0px')
     act(() => { step(161) })
     expect(el.style.backgroundPosition).toBe('-24px 0px')
+  })
+
+  it('catches up every due frame after a long idle gap', () => {
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: false,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    const timers: { at: number; callback: () => void }[] = []
+    let timerId = 0
+    vi.spyOn(window, 'setTimeout').mockImplementation(((callback: () => void, delay = 0) => {
+      timers.push({ at: now + delay, callback })
+      return ++timerId
+    }) as typeof window.setTimeout)
+    vi.spyOn(window, 'clearTimeout').mockImplementation(() => {})
+    const frames: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      frames.push(callback)
+      return frames.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    renderPet({ snapshot: { ...snapshot, bubble: '正在思考', phase: 'thinking', decoration } })
+    const el = ornament()!
+    const step = (ms: number): void => {
+      for (const callback of frames.splice(0)) callback(now)
+      now += ms
+      for (;;) {
+        const due = timers.filter(t => t.at <= now)
+        if (due.length === 0) break
+        for (const t of due) {
+          const idx = timers.indexOf(t)
+          if (idx >= 0) timers.splice(idx, 1)
+          t.callback()
+        }
+      }
+    }
+    // A 500 ms gap (jank / background tab) spans three 160 ms frames; the
+    // ornament must advance through all of them (0 -> 1 -> 2 -> 3), not
+    // drop the surplus time.
+    expect(el.style.backgroundPosition).toBe('0px 0px')
+    act(() => { step(500) })
+    expect(el.style.backgroundPosition).toBe('-72px 0px')
+    act(() => { step(161) })
+    // The next frame tick wraps the looping segment back to its first frame.
+    expect(el.style.backgroundPosition).toBe('0px 0px')
   })
 
   it('does not restart the frame loop when an equal-content decoration re-renders', () => {
@@ -837,21 +959,41 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
       removeListener: () => {},
       dispatchEvent: () => false,
     })
-    vi.spyOn(performance, 'now').mockReturnValue(0)
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    const timers: { at: number; callback: () => void }[] = []
+    let timerId = 0
+    const timerSpy = vi.spyOn(window, 'setTimeout').mockImplementation(((callback: () => void, delay = 0) => {
+      timers.push({ at: now + delay, callback })
+      return ++timerId
+    }) as typeof window.setTimeout)
+    const clearSpy = vi.spyOn(window, 'clearTimeout').mockImplementation(() => {})
     const frames: FrameRequestCallback[] = []
-    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
       frames.push(callback)
       return frames.length
     })
-    const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
     // The definition comes from '/api/pet/pets', fetched once — a state
     // poll never replaces it, so both renders share one definition object.
     const definition = petDefinition()
     const { result } = renderPet({ definition, snapshot: { ...snapshot, bubble: '正在思考', phase: 'thinking', decoration } })
-    const step = (ts: number): void => { for (const callback of frames.splice(0)) callback(ts) }
+    const step = (ms: number): void => {
+      for (const callback of frames.splice(0)) callback(now)
+      now += ms
+      for (;;) {
+        const due = timers.filter(t => t.at <= now)
+        if (due.length === 0) break
+        for (const t of due) {
+          const idx = timers.indexOf(t)
+          if (idx >= 0) timers.splice(idx, 1)
+          t.callback()
+        }
+      }
+    }
     act(() => { step(161) })
     expect(ornament()!.style.backgroundPosition).toBe('-24px 0px')
-    const schedulesBefore = rafSpy.mock.calls.length
+    const schedulesBefore = timerSpy.mock.calls.length
     // The 2 s poll delivers a fresh JSON round-trip: identical content, new
     // object identities everywhere. The loop must not cancel/restart.
     const repolled: DecorationView = {
@@ -861,10 +1003,10 @@ describe('PetSprite status decoration (pet-center M5, #567)', () => {
       phases: { ...decoration.phases },
     }
     result.rerender(<PetSprite {...petProps({ definition, snapshot: { ...snapshot, bubble: '正在思考', phase: 'thinking', decoration: repolled } })} />)
-    act(() => { step(322) })
+    act(() => { step(161) })
     expect(ornament()!.style.backgroundPosition).toBe('-48px 0px')
-    expect(cancelSpy).not.toHaveBeenCalled()
-    // One reschedule per loop tick; no effect restart added new schedules.
-    expect(rafSpy.mock.calls.length).toBe(schedulesBefore + 2)
+    expect(clearSpy).not.toHaveBeenCalled()
+    // One reschedule per frame tick; no effect restart added new timers.
+    expect(timerSpy.mock.calls.length).toBe(schedulesBefore + 1)
   })
 })

--- a/packages/dsh-pet/src/client/PetSprite.tsx
+++ b/packages/dsh-pet/src/client/PetSprite.tsx
@@ -98,32 +98,38 @@ function StatusOrnament(props: { decoration: DecorationView; phase: ActivityPhas
     // tick would keep rescheduling a no-op rAF forever. Settle on the one
     // frame instead — same as the reduced-motion static hold.
     if (reduceMotion || segment.from === segment.to) return
-    let raf = 0
+    let timer = 0
     let index = segment.from
     let elapsed = 0
     let last = performance.now()
-    const tick = (ts: number): void => {
-      const delta = ts - last
-      last = ts
+    const tick = (): void => {
+      const now = performance.now()
+      const delta = now - last
+      last = now
       elapsed += delta
-      const duration = decoration.durations[index] ?? 160
+      const duration = decoration.durations[index] ?? 120
+      // The segment's frame rate (duration ms, typically 90-160) is far
+      // below the rAF cadence, so a 60fps loop would spend ~90% of its
+      // ticks doing nothing. Schedule by the remaining time to the next
+      // frame instead — the ornament wakes once per frame, not once per
+      // screen refresh. A late wake (background tab, jank) carries extra
+      // elapsed time, so catch up every due frame like the sprite loop.
       if (elapsed >= duration) {
-        elapsed = 0
-        if (index < segment.to) index += 1
-        else if (decoration.loop) index = segment.from
-        // Only advance the background when the frame actually changes:
-        // the segment's frame rate (duration ms, typically 90-160) is far
-        // below the rAF cadence, so writing the same position every frame
-        // would churn style recalculations for no visual change.
+        do {
+          elapsed -= duration
+          if (index < segment.to) index += 1
+          else if (decoration.loop) index = segment.from
+        } while (elapsed >= duration)
+        // Only advance the background when the frame actually changes.
         el.style.backgroundPosition = position(index)
       }
       // A non-looping segment settles on its last frame; stop scheduling
       // instead of repainting the same position every frame.
       if (!decoration.loop && index === segment.to) return
-      raf = requestAnimationFrame(tick)
+      timer = window.setTimeout(tick, Math.max(1, duration - elapsed))
     }
-    raf = requestAnimationFrame(tick)
-    return () => cancelAnimationFrame(raf)
+    timer = window.setTimeout(tick, 0)
+    return () => window.clearTimeout(timer)
   }, [shown, segmentKey, frameWidth, decoration.loop, durationsKey])
   if (!shown) return null
   return (


### PR DESCRIPTION
## 摘要（Summary）

修复状态装饰动画的两个代码/性能缺陷：

1. **rAF 空转**：装饰帧时长 90-160ms（约 6-11fps），但 tick 用 rAF（60fps）调度——每个帧周期约 10 次 tick 空转（只做 delta 计算 + 重新调度，不推进不写入）。改为按「到下一帧的剩余时间」用 setTimeout 调度，装饰每帧只醒一次。
2. **丢帧**：`elapsed >= duration` 时 `elapsed = 0` 归零丢弃多余时间、`index += 1` 只推进一帧——页面卡顿/后台切回（如 500ms 对应 3 帧）时动画只前进 1 帧。改为 `while` 循环追帧（镜像宠物主循环）。

附带：duration fallback 从 160 统一为解析器默认 120。

## 涉及包（Affected Packages）

- [x] 宠物 `packages/dsh-pet`

## PR 类型（PR Type）

- [x] Bug 修复（性能 + 行为）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin dev && git merge-base --is-ancestor origin/dev HEAD` 通过；分支基于 `9a226632`（最新 dev）创建。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

本地测试证据（提交 d37bf95a 后、同步最新 dev 前）：

```bash
pnpm --filter @linxin666/dsh-pet typecheck     # 通过
pnpm vitest run src/client/PetSprite.test.tsx  # 42 passed（含新增追帧测试）
pnpm vitest run packages/dsh-pet                # 356 passed
pnpm typecheck                                  # 全仓通过
pnpm test                                       # 全仓通过（dsh-ssh sftp 集成测试在干净 dev 上同样失败，属既有环境问题）
pnpm test:scripts                               # 142 pass
pnpm docs:check                                 # 通过
```

上游同步后重新测试证据（`git fetch origin dev`，确认分支已包含最新 dev `9a226632` 后重跑）：

```bash
pnpm vitest run packages/dsh-pet                # 356 passed（33 test files）
pnpm exec tsc -b                                # 通过
```

新增测试 `catches up every due frame after a long idle gap` 已验证：旧实现下失败（丢帧）、修复后通过。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek- V4-flash

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符（已用 CI 同款码点范围扫描）。
- [x] 改动包 README 时同步维护中英双语三件套（本次未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-pet typecheck     # 通过
pnpm vitest run packages/dsh-pet                # 356 passed（含新增追帧测试）
pnpm typecheck                                  # 全仓通过
pnpm test                                       # 全仓通过（dsh-ssh 的 sftp 集成测试在干净 dev 上同样失败，属既有环境问题，与本改动无关）
pnpm test:scripts                               # 142 pass
pnpm docs:check                                 # 通过
```

结果摘要：全绿（除上述既有的 dsh-ssh 环境失败）。新增测试 `catches up every due frame after a long idle gap` 已验证在旧实现下失败（丢帧）、修复后通过。

## 用户可见变更证据（Local Feature Evidence）

本修复是性能/行为修复：装饰动画不再 60fps 空转、卡顿后不再丢帧变慢。用户可见行为不变（动画照常播放，节奏不变）；证据为测试断言（旧实现丢帧失败 / 新实现追帧通过）。