### PR TITLE
fix(skin-center): scope theme aliases on body (#646)

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -5,8 +5,10 @@ import { basename, dirname, extname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { transform } from "lightningcss";
+import { readFile, stat } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import { Buffer as Buffer$1 } from "node:buffer";
+import { decode } from "jpeg-js";
 import { deflateSync, inflateSync } from "node:zlib";
 //#region \0rolldown/runtime.js
 var __defProp = Object.defineProperty;
@@ -937,6 +939,10 @@ function deriveFallbackTokens(defined) {
 *    `:root` / `html` merge into the scope; `body` and bare official
 *    `[data-ds-*]` heads (the official dark-theme attribute lives on BODY)
 *    become descendants of the scope; everything else becomes a descendant.
+*  - ROOT THEME TOKENS: per-theme `--dsw-alias-*` and
+*    `--dsw-specific-*` declarations from bare `:root` / `html` are reset
+*    on the scope and cloned to body. Root-level shell variables therefore
+*    cannot capture a light token while its dark variant belongs on body (#646).
 *  - WHITELIST (fail-closed): no `@import`, no remote or protocol-relative
 *    URLs, no absolute paths escaping the skin directory; only relative
 *    in-directory assets (and `data:`, which warns — prefer assets/ files).
@@ -1065,6 +1071,39 @@ function scopeSelectorText(selector, skinId) {
 function scopeSelectorList(selectorText, skinId) {
 	return splitSelectors(selectorText).map((sel) => scopeSelectorText(sel, skinId)).join(",");
 }
+const ROOT_BODY_TOKEN = /^(?:--dsw-alias-|--dsw-specific-)/;
+/** A bare root selector owns custom properties evaluated on html itself. */
+function hasBareRootSelector(selectorText) {
+	return splitSelectors(selectorText).some((selector) => {
+		const trimmed = selector.trim();
+		return trimmed === ":root" || trimmed === "html";
+	});
+}
+function withoutCssComments(value) {
+	return value.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+/** Per-theme root declarations that must instead take effect from body. */
+function rootBodyTokens(block) {
+	const tokens = /* @__PURE__ */ new Map();
+	const declarations = withoutCssComments(block);
+	for (const match of declarations.matchAll(/(?:^|[;{])\s*(--[\w-]+)\s*:\s*([^;}]*)/gm)) {
+		const name = match[1];
+		if (name !== void 0 && ROOT_BODY_TOKEN.test(name)) tokens.set(name, /!\s*important\s*$/i.test(match[2] ?? ""));
+	}
+	return [...tokens].map(([name, important]) => ({
+		name,
+		important
+	}));
+}
+/** Normalize cloned root tokens so dark body declarations can override them. */
+function bodyCloneProperty(line) {
+	const custom = line.match(/^(--[\w-]+)\s*:/);
+	if (custom !== null) {
+		const name = custom[1] ?? "";
+		return ROOT_BODY_TOKEN.test(name) ? line.replace(/\s*!important(?=\s*;?\s*$)/i, "") : line;
+	}
+	return /^background-(color|image)\s*:/.test(line) ? line : null;
+}
 /** Check one url() target against the whitelist. */
 function checkUrl(raw, context, violations, warnings) {
 	const url = raw.trim().replace(/^["']|["']$/g, "");
@@ -1154,8 +1193,12 @@ function transformSkinCss(css, options) {
 		const scoped = scopeSelectorList(selectorText, skinId);
 		const block = close === -1 ? css.slice(span.openBrace) : css.slice(span.openBrace, close + 1);
 		out += scoped + block;
-		if (/^:root\b/.test(selectorText.trim()) && close !== -1) {
-			const props = css.slice(span.openBrace + 1, close).split("\n").map((line) => line.trim()).filter((line) => /^--[\w-]+\s*:/.test(line) || /^background-(color|image)\s*:/.test(line));
+		if (close !== -1 && hasBareRootSelector(selectorText)) {
+			const tokens = rootBodyTokens(block);
+			if (tokens.length > 0) out += `\n${scope} {\n  ${tokens.map(({ name, important }) => `${name}: initial${important ? " !important" : ""};`).join("\n  ")}\n}\n`;
+		}
+		if (hasBareRootSelector(selectorText) && close !== -1) {
+			const props = withoutCssComments(css.slice(span.openBrace + 1, close)).split("\n").map((line) => bodyCloneProperty(line.trim())).filter((line) => line !== null);
 			if (props.length > 0) out += `\n${scope} body {\n  ${props.join("\n  ")}\n}\n`;
 		}
 		cursor = close === -1 ? span.openBrace : close + 1;
@@ -2203,15 +2246,16 @@ function buildInventory(opts = {}) {
 //#endregion
 //#region src/pkg-extract.ts
 /**
-* Wallpaper Engine scene.pkg / .tex resource extraction, dependency-free.
+* Wallpaper Engine scene.pkg / .tex resource extraction.
 *
 * This module is the core of the skin center's "scene wallpaper static frame
 * extraction" feature: it unpacks a Wallpaper Engine scene package (PKG
 * container, magic PKGVxxxx), parses the nested TEX texture containers
 * (TEXV0005 header -> TEXI0001 image info -> TEXB0001..4 mipmap data ->
 * TEXS0001..3 frame animation metadata), decodes the main mipmap to RGBA8888
-* (raw RGBA8888/R8/RG88 plus hand-rolled BC1/BC2/BC3 block decompression for
-* DXT1/DXT3/DXT5), and re-encodes the result as a PNG using only node:zlib.
+* (raw RGBA8888/R8/RG88, FreeImage-embedded JPEG via jpeg-js, plus hand-rolled
+* BC1/BC2/BC3 block decompression for DXT1/DXT3/DXT5), and re-encodes the
+* result as a PNG using only node:zlib.
 *
 * Format facts were cross-checked against the two reference implementations:
 * RePKG (github.com/notscuffed/repkg, PackageReader / TexReader and friends)
@@ -2234,7 +2278,8 @@ function buildInventory(opts = {}) {
 *   (bit 2) pull in a TEXS frame container exposed via TexInfo.frames.
 *
 * LZ4 block decoding follows the official lz4 block format specification;
-* BC1/BC2/BC3 follow the standard public algorithms. No npm dependencies.
+* BC1/BC2/BC3 follow the standard public algorithms. One npm dependency:
+* jpeg-js (pure JavaScript, no native builds) for FreeImage JPEG mipmaps.
 *
 * @module @linxin666/dsh-client-ui-skin-center/pkg-extract
 */
@@ -2898,11 +2943,36 @@ function decodeDxt5(src, width, height) {
 * 2048x2048 mip); the TEXI header's image rect is the real content, anchored
 * top-left, so the result is cropped to it before returning.
 */
+/** Crop the power-of-two padding: the TEXI image rect sits at the top-left of
+* the stored mip (verified by render probe), anything beyond it is filler. */
+function cropToImageRect(decoded, imageWidth, imageHeight) {
+	const cropW = Math.min(imageWidth, decoded.width);
+	const cropH = Math.min(imageHeight, decoded.height);
+	if (cropW > 0 && cropH > 0 && (cropW < decoded.width || cropH < decoded.height)) {
+		const cropped = new Uint8Array(cropW * cropH * 4);
+		for (let y = 0; y < cropH; y++) cropped.set(decoded.rgba.subarray(y * decoded.width * 4, (y * decoded.width + cropW) * 4), y * cropW * 4);
+		return {
+			width: cropW,
+			height: cropH,
+			rgba: cropped
+		};
+	}
+	return decoded;
+}
 function decodeTex(data) {
 	const parsed = parseTexInternal(data);
 	if (parsed.isVideoMp4) throw new Error("tex: video mp4 textures cannot be decoded to a static frame");
 	const mip = parsed.mipmaps[0];
 	if (isPngBuffer(mip.bytes)) return decodePngToRgba(mip.bytes);
+	if (mip.bytes[0] === 255 && mip.bytes[1] === 216) {
+		const jpeg = decode(Buffer$1.from(mip.bytes), { useTArray: true });
+		const rgba = jpeg.data;
+		return cropToImageRect({
+			width: jpeg.width,
+			height: jpeg.height,
+			rgba
+		}, parsed.width, parsed.height);
+	}
 	const { width, height, bytes } = mip;
 	let decoded;
 	switch (parsed.format) {
@@ -2978,18 +3048,7 @@ function decodeTex(data) {
 		}
 		default: throw new Error("tex: unsupported format " + parsed.format);
 	}
-	const cropW = Math.min(parsed.width, width);
-	const cropH = Math.min(parsed.height, height);
-	if (cropW > 0 && cropH > 0 && (cropW < width || cropH < height)) {
-		const cropped = new Uint8Array(cropW * cropH * 4);
-		for (let y = 0; y < cropH; y++) cropped.set(decoded.rgba.subarray(y * width * 4, (y * width + cropW) * 4), y * cropW * 4);
-		return {
-			width: cropW,
-			height: cropH,
-			rgba: cropped
-		};
-	}
-	return decoded;
+	return cropToImageRect(decoded, parsed.width, parsed.height);
 }
 const CRC_TABLE = (() => {
 	const table = /* @__PURE__ */ new Uint32Array(256);
@@ -6598,6 +6657,10 @@ function serveFile(absPath, req, res) {
 	res.setHeader("Content-Length", String(size));
 	createReadStream(absPath).pipe(res);
 }
+/** Shape-check an entry loaded from the persisted probe cache. */
+function isSceneProbe(value) {
+	return value !== null && typeof value === "object" && typeof value.hasVideo === "boolean" && typeof value.hasSceneWebGL === "boolean";
+}
 /** Build the route family. */
 function makeWeRoutes(deps) {
 	const tokenStorePath = join(deps.storeDir, ".cache", "we-tokens.json");
@@ -6622,46 +6685,23 @@ function makeWeRoutes(deps) {
 		storeDir: deps.storeDir,
 		autoDetect: deps.autoDetect
 	});
-	const sceneProbeCache = /* @__PURE__ */ new Map();
+	const probeCachePath = join(deps.storeDir, ".cache", "we-scene-probes.json");
+	let sceneProbeCache = /* @__PURE__ */ new Map();
+	try {
+		const saved = JSON.parse(readFileSync(probeCachePath, "utf8"));
+		if (saved !== null && typeof saved === "object") {
+			for (const [key, value] of Object.entries(saved)) if (isSceneProbe(value)) sceneProbeCache.set(key, value);
+		}
+	} catch {}
 	const MAX_PROBE_CACHE = 256;
+	const persistProbes = () => {
+		try {
+			mkdirSync(dirname(probeCachePath), { recursive: true });
+			writeFileSync(probeCachePath, JSON.stringify(Object.fromEntries(sceneProbeCache)), "utf8");
+		} catch {}
+	};
 	const entryToJson = (entry) => {
 		const hasFile = existsSync(entry.fileAbs);
-		let hasVideo = false;
-		let hasSceneWebGL = false;
-		if (entry.type === "scene" && hasFile) {
-			let mtimeMs = 0;
-			let size = 0;
-			try {
-				const st = statSync(entry.fileAbs);
-				mtimeMs = st.mtimeMs;
-				size = st.size;
-			} catch {}
-			const key = entry.fileAbs + ":" + mtimeMs + ":" + size;
-			let probe = mtimeMs > 0 ? sceneProbeCache.get(key) : void 0;
-			if (!probe) {
-				let hasVideoNow = false;
-				let hasSceneWebGLNow = false;
-				try {
-					hasVideoNow = entry.fileAbs.toLowerCase().endsWith(".json") ? hasSceneVideoFromDir(dirname(entry.fileAbs)) : hasSceneVideo(new Uint8Array(readFileSync(entry.fileAbs)));
-					if (!hasVideoNow) {
-						const manifest = entry.fileAbs.toLowerCase().endsWith(".json") ? buildSceneManifestFromDir(dirname(entry.fileAbs), "check") : buildSceneManifest(new Uint8Array(readFileSync(entry.fileAbs)), "check");
-						if (manifest && (manifest.layers && manifest.layers.length >= 1 || manifest.is3D && manifest.models && manifest.models.length > 0)) hasSceneWebGLNow = true;
-					}
-				} catch {
-					hasSceneWebGLNow = false;
-				}
-				probe = {
-					hasVideo: hasVideoNow,
-					hasSceneWebGL: hasSceneWebGLNow
-				};
-				if (mtimeMs > 0) {
-					if (sceneProbeCache.size >= MAX_PROBE_CACHE) sceneProbeCache.clear();
-					sceneProbeCache.set(key, probe);
-				}
-			}
-			hasVideo = probe.hasVideo;
-			hasSceneWebGL = probe.hasSceneWebGL;
-		}
 		return {
 			id: entry.id,
 			title: entry.title,
@@ -6669,10 +6709,10 @@ function makeWeRoutes(deps) {
 			source: entry.source,
 			playable: entry.playable,
 			updateAvailable: entry.updateAvailable,
-			videoUrl: entry.type === "video" && hasFile ? "/api/skin-center/we/media/" + tokenFor(entry.fileAbs) : hasVideo ? "/api/skin-center/we/scene-video/" + tokenFor(entry.fileAbs) : null,
+			videoUrl: entry.type === "video" && hasFile ? "/api/skin-center/we/media/" + tokenFor(entry.fileAbs) : null,
 			webUrl: entry.type === "web" && hasFile ? "/api/skin-center/we/web/" + tokenFor(entry.fileAbs) + "/" : null,
 			frameUrl: entry.type === "scene" && hasFile ? "/api/skin-center/we/scene-frame/" + tokenFor(entry.fileAbs) : null,
-			sceneUrl: hasSceneWebGL ? "/api/skin-center/we/scene-runtime/" + tokenFor(entry.fileAbs) : null,
+			sceneUrl: null,
 			previewUrl: entry.previewAbs ? "/api/skin-center/we/preview/" + tokenFor(entry.previewAbs) : null
 		};
 	};
@@ -6721,6 +6761,86 @@ function makeWeRoutes(deps) {
 					total: inventory.total,
 					portableCount: inventory.portableCount,
 					wallpapers
+				});
+			} catch (error) {
+				json(res, 500, {
+					ok: false,
+					error: error instanceof Error ? error.message : String(error)
+				});
+			}
+		}
+	});
+	routes.push({
+		kind: "exact",
+		path: "/api/skin-center/we/scene-probe",
+		handler: async (req, res) => {
+			if (req.method !== "GET") {
+				json(res, 405, {
+					ok: false,
+					error: "method-not-allowed"
+				});
+				return;
+			}
+			if (!requireSameOrigin(req, res)) return;
+			try {
+				const id = new URL(req.url ?? "", "http://localhost").searchParams.get("id");
+				if (!id) {
+					json(res, 400, {
+						ok: false,
+						error: "missing-id"
+					});
+					return;
+				}
+				const entry = freshInventory().wallpapers.find((w) => w.id === id && w.type === "scene");
+				if (!entry || !existsSync(entry.fileAbs)) {
+					json(res, 404, {
+						ok: false,
+						error: "not-found"
+					});
+					return;
+				}
+				let mtimeMs = 0;
+				let size = 0;
+				try {
+					const st = await stat(entry.fileAbs);
+					mtimeMs = st.mtimeMs;
+					size = st.size;
+				} catch {}
+				if (entry.fileAbs.toLowerCase().endsWith(".json")) mtimeMs = 0;
+				const key = entry.fileAbs + ":" + mtimeMs + ":" + size;
+				let probe = mtimeMs > 0 ? sceneProbeCache.get(key) : void 0;
+				if (!probe) {
+					let hasVideo = false;
+					let hasSceneWebGL = false;
+					try {
+						const pkgData = await readFile(entry.fileAbs);
+						hasVideo = entry.fileAbs.toLowerCase().endsWith(".json") ? hasSceneVideoFromDir(dirname(entry.fileAbs)) : hasSceneVideo(pkgData);
+						if (!hasVideo) {
+							const manifest = entry.fileAbs.toLowerCase().endsWith(".json") ? buildSceneManifestFromDir(dirname(entry.fileAbs), "check") : buildSceneManifest(pkgData, "check");
+							hasSceneWebGL = Boolean(manifest && (manifest.layers && manifest.layers.length >= 1 || manifest.is3D && manifest.models && manifest.models.length > 0));
+						}
+					} catch {}
+					probe = {
+						hasVideo,
+						hasSceneWebGL
+					};
+					if (mtimeMs > 0) {
+						sceneProbeCache.set(key, probe);
+						while (sceneProbeCache.size > MAX_PROBE_CACHE) {
+							const oldest = sceneProbeCache.keys().next().value;
+							if (oldest === void 0) break;
+							sceneProbeCache.delete(oldest);
+						}
+						persistProbes();
+					}
+				}
+				const videoToken = probe.hasVideo ? tokenFor(entry.fileAbs) : null;
+				const sceneToken = probe.hasSceneWebGL ? tokenFor(entry.fileAbs) : null;
+				persistTokens();
+				json(res, 200, {
+					ok: true,
+					videoUrl: videoToken !== null ? "/api/skin-center/we/scene-video/" + videoToken : null,
+					sceneUrl: sceneToken !== null ? "/api/skin-center/we/scene-runtime/" + sceneToken : null
 				});
 			} catch (error) {
 				json(res, 500, {

--- a/packages/skins/skin-center/src/core/css-safety/transform.ts
+++ b/packages/skins/skin-center/src/core/css-safety/transform.ts
@@ -10,6 +10,10 @@
  *    `:root` / `html` merge into the scope; `body` and bare official
  *    `[data-ds-*]` heads (the official dark-theme attribute lives on BODY)
  *    become descendants of the scope; everything else becomes a descendant.
+ *  - ROOT THEME TOKENS: per-theme `--dsw-alias-*` and
+ *    `--dsw-specific-*` declarations from bare `:root` / `html` are reset
+ *    on the scope and cloned to body. Root-level shell variables therefore
+ *    cannot capture a light token while its dark variant belongs on body (#646).
  *  - WHITELIST (fail-closed): no `@import`, no remote or protocol-relative
  *    URLs, no absolute paths escaping the skin directory; only relative
  *    in-directory assets (and `data:`, which warns — prefer assets/ files).
@@ -188,6 +192,50 @@ export function scopeSelectorList(selectorText: string, skinId: string): string 
     .join(',')
 }
 
+const ROOT_BODY_TOKEN = /^(?:--dsw-alias-|--dsw-specific-)/
+
+interface RootBodyToken {
+  name: string
+  important: boolean
+}
+
+/** A bare root selector owns custom properties evaluated on html itself. */
+function hasBareRootSelector(selectorText: string): boolean {
+  return splitSelectors(selectorText).some((selector) => {
+    const trimmed = selector.trim()
+    return trimmed === ':root' || trimmed === 'html'
+  })
+}
+
+function withoutCssComments(value: string): string {
+  return value.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
+/** Per-theme root declarations that must instead take effect from body. */
+function rootBodyTokens(block: string): RootBodyToken[] {
+  const tokens = new Map<string, boolean>()
+  const declarations = withoutCssComments(block)
+  for (const match of declarations.matchAll(/(?:^|[;{])\s*(--[\w-]+)\s*:\s*([^;}]*)/gm)) {
+    const name = match[1]
+    if (name !== undefined && ROOT_BODY_TOKEN.test(name)) {
+      tokens.set(name, /!\s*important\s*$/i.test(match[2] ?? ''))
+    }
+  }
+  return [...tokens].map(([name, important]) => ({ name, important }))
+}
+
+/** Normalize cloned root tokens so dark body declarations can override them. */
+function bodyCloneProperty(line: string): string | null {
+  const custom = line.match(/^(--[\w-]+)\s*:/)
+  if (custom !== null) {
+    const name = custom[1] ?? ''
+    return ROOT_BODY_TOKEN.test(name)
+      ? line.replace(/\s*!important(?=\s*;?\s*$)/i, '')
+      : line
+  }
+  return /^background-(color|image)\s*:/.test(line) ? line : null
+}
+
 /** Check one url() target against the whitelist. */
 function checkUrl(raw: string, context: string, violations: string[], warnings: string[]): void {
   const url = raw.trim().replace(/^["']|["']$/g, '')
@@ -294,20 +342,24 @@ export function transformSkinCss(css: string, options: SkinCssTransformOptions):
     const scoped = scopeSelectorList(selectorText, skinId)
     const block = close === -1 ? css.slice(span.openBrace) : css.slice(span.openBrace, close + 1)
     out += scoped + block
-    // The official shell paints its own opaque body background, and its
-    // light alias tokens live on plain body: a body-level definition beats
-    // anything a skin writes on html for every descendant (custom-property
-    // inheritance is tree-based, not specificity-based). :root-derived
-    // custom properties AND background declarations therefore get a
-    // body-level clone so the light remap and the skin's base background
-    // actually reach the shell surfaces. Dark remaps are already body-scoped
-    // (body[data-ds-dark-theme]) and need no clone.
-    if (/^:root\b/.test(selectorText.trim()) && close !== -1) {
+    // Official shell theme variables are consumed by root-level CSS (notably
+    // Shiki), while skins place dark variants on body. Leave those root values
+    // invalid so the body clone below remains the effective skin token scope.
+    if (close !== -1 && hasBareRootSelector(selectorText)) {
+      const tokens = rootBodyTokens(block)
+      if (tokens.length > 0) {
+        out += `\n${scope} {\n  ${tokens.map(({ name, important }) => `${name}: initial${important ? ' !important' : ''};`).join('\n  ')}\n}\n`
+      }
+    }
+    // The reset above restores stock root semantics. Clone root custom
+    // properties and background declarations to body, where normal descendants
+    // and body[data-ds-dark-theme] variants resolve their active skin token.
+    if (hasBareRootSelector(selectorText) && close !== -1) {
       const body = css.slice(span.openBrace + 1, close)
-      const props = body
+      const props = withoutCssComments(body)
         .split('\n')
-        .map((line) => line.trim())
-        .filter((line) => /^--[\w-]+\s*:/.test(line) || /^background-(color|image)\s*:/.test(line))
+        .map((line) => bodyCloneProperty(line.trim()))
+        .filter((line): line is string => line !== null)
       if (props.length > 0) {
         out += `\n${scope} body {\n  ${props.join('\n  ')}\n}\n`
       }

--- a/packages/skins/skin-center/tests/builtin-skins.spec.ts
+++ b/packages/skins/skin-center/tests/builtin-skins.spec.ts
@@ -41,6 +41,30 @@ const skinIds = readdirSync(SKINS_DIR, { withFileTypes: true })
 
 const hookSkinIds = skinIds.filter((id) => existsSync(join(SKINS_DIR, id, 'hooks.mjs')))
 
+function rootThemeTokens(css: string): string[] {
+  const tokens = new Set<string>()
+  for (const block of css.matchAll(/(?:^|\n)\s*(?::root|html)(?:\s*,[^{]+)?\s*\{([^}]*)\}/g)) {
+    const declarations = (block[1] ?? '').replace(/\/\*[\s\S]*?\*\//g, '')
+    for (const match of declarations.matchAll(/(?:^|[;{])\s*(--dsw-(?:alias|specific)-[\w-]+)\s*:/gm)) {
+      const token = match[1]
+      if (token !== undefined) tokens.add(token)
+    }
+  }
+  return [...tokens]
+}
+
+function expectRootThemeTokensBodyScoped(css: string, code: string, skinId: string): void {
+  const scope = `html[data-dsh-skin="${skinId}"]`
+  for (const token of rootThemeTokens(css)) {
+    const reset = code.indexOf(`${token}: initial;`)
+    const bodyCloneStart = code.indexOf(`${scope} body {`, reset)
+    const bodyClone = code.slice(bodyCloneStart, code.indexOf('}', bodyCloneStart) + 1)
+    expect(reset, `${skinId}: ${token} root reset`).toBeGreaterThanOrEqual(0)
+    expect(bodyCloneStart, `${skinId}: ${token} body clone`).toBeGreaterThan(reset)
+    expect(bodyClone, `${skinId}: ${token} cloned token`).toContain(`${token}:`)
+  }
+}
+
 describe('built-in v2 skins: catalog and stylesheets', () => {
   it('loads the catalog with no diagnostics and every skin present', () => {
     const catalog = loadSkinCatalog({ builtinDir: SKINS_DIR, userDir: NO_USER_SKINS })
@@ -58,10 +82,12 @@ describe('built-in v2 skins: catalog and stylesheets', () => {
       expect(manifest).toBeDefined()
       if (!manifest) return
       const css = readFileSync(join(dir, manifest.contributes.stylesheet), 'utf8')
-      expect(() => transformSkinCss(css, { skinId: id, filename: 'skin.css' })).not.toThrow()
+      const transformed = transformSkinCss(css, { skinId: id, filename: 'skin.css' })
+      expectRootThemeTokensBodyScoped(css, transformed.code, id)
       if (manifest.contributes.patches !== undefined) {
         const patches = readFileSync(join(dir, manifest.contributes.patches), 'utf8')
-        expect(() => transformSkinCss(patches, { skinId: id, filename: 'patches.css' })).not.toThrow()
+        const transformedPatches = transformSkinCss(patches, { skinId: id, filename: 'patches.css' })
+        expectRootThemeTokensBodyScoped(patches, transformedPatches.code, id)
       }
     })
   }

--- a/packages/skins/skin-center/tests/css-safety.spec.ts
+++ b/packages/skins/skin-center/tests/css-safety.spec.ts
@@ -3,6 +3,8 @@
  * Scoping is skin-center owned; violations fail closed.
  */
 
+import { readFileSync } from 'node:fs'
+
 import { describe, expect, it } from 'vitest'
 
 import { SkinCssSafetyError, transformSkinCss } from '../src/core/css-safety/transform.ts'
@@ -74,8 +76,65 @@ describe('transformSkinCss scoping', () => {
     expect(bodyClone).toContain('background-color: #eef')
   })
 
-  it('clones custom properties from comma-listed :root heads and skips body-scoped rules', () => {
+  it('resets root-level Shiki aliases while preserving body theme variants (#646)', () => {
     const css = [
+      ':root {',
+      '  --dsw-alias-markdown-code-block: #ecf4fce6;',
+      '  --dsw-specific-input-major: #f0f7fdf0;',
+      '  --dsh-skin-grid-line: #123456;',
+      '}',
+      'body[data-ds-dark-theme] {',
+      '  --dsw-alias-markdown-code-block: #17243ad9;',
+      '}',
+    ].join('\n')
+    const token = '--dsw-alias-markdown-code-block'
+    const { code } = scope(css)
+    const rootValue = code.indexOf(`${token}: #ecf4fce6;`)
+    const rootReset = code.indexOf(`${token}: initial;`)
+    const bodyCloneStart = code.indexOf(`${SCOPE} body {`, rootReset)
+    const bodyClone = code.slice(bodyCloneStart, code.indexOf('}', bodyCloneStart) + 1)
+    expect(rootValue).toBeGreaterThanOrEqual(0)
+    expect(rootReset).toBeGreaterThan(rootValue)
+    expect(bodyCloneStart).toBeGreaterThan(rootReset)
+    expect(bodyClone).toContain(`${token}: #ecf4fce6;`)
+    expect(code).toContain('--dsw-specific-input-major: initial;')
+    expect(code).not.toContain('--dsh-skin-grid-line: initial')
+    expect(code).toContain(`${SCOPE} body[data-ds-dark-theme]`)
+    expect(code).toContain('--dsw-alias-markdown-code-block: #17243ad9;')
+  })
+
+  it('keeps whale mom markdown code aliases body-scoped (#646)', () => {
+    const css = readFileSync(new URL('../skins/whale-mom/skin.css', import.meta.url), 'utf8')
+    const whaleScope = 'html[data-dsh-skin="whale-mom"]'
+    const token = '--dsw-alias-markdown-code-block'
+    const { code } = transformSkinCss(css, { skinId: 'whale-mom', filename: 'skin.css' })
+    const rootReset = code.indexOf(`${token}: initial;`)
+    const bodyCloneStart = code.indexOf(`${whaleScope} body {`, rootReset)
+    const bodyClone = code.slice(bodyCloneStart, code.indexOf('}', bodyCloneStart) + 1)
+    expect(css).toContain(token)
+    expect(rootReset).toBeGreaterThanOrEqual(0)
+    expect(bodyCloneStart).toBeGreaterThan(rootReset)
+    expect(bodyClone).toContain(`${token}:`)
+  })
+
+  it('normalizes commented important html tokens for body themes (#646)', () => {
+    const token = '--dsw-alias-markdown-code-block'
+    const css = [
+      `html { /* light palette */ ${token}: #ecf4fce6 !important; }`,
+      `body[data-ds-dark-theme] { ${token}: #17243ad9; }`,
+    ].join('\n')
+    const { code } = scope(css)
+    const rootReset = code.indexOf(`${token}: initial !important;`)
+    const bodyCloneStart = code.indexOf(`${SCOPE} body {`, rootReset)
+    const bodyClone = code.slice(bodyCloneStart, code.indexOf('}', bodyCloneStart) + 1)
+    expect(rootReset).toBeGreaterThanOrEqual(0)
+    expect(bodyCloneStart).toBeGreaterThan(rootReset)
+    expect(bodyClone).toContain(`${token}: #ecf4fce6;`)
+    expect(bodyClone).not.toContain(`${token}: #ecf4fce6 !important;`)
+    expect(code).toContain(`${token}: #17243ad9;`)
+  })
+
+  it('clones custom properties from comma-listed :root heads and skips body-scoped rules', () => {    const css = [
       ':root, body[data-ds-dark-theme] {',
       '  --dsw-alias-bg-base: #141a2eb3;',
       '}',


### PR DESCRIPTION
## 摘要（Summary）

Closes #646. Keep per-theme skin aliases and specific tokens effective on body rather than on the scoped HTML root, so Shiki root variables cannot retain a light markdown-code value when dark tokens are defined on body. The transform handles comments and root `!important` declarations while preserving dark body overrides.

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步核验：GitHub API 在提交前返回 `dev` = `9a22663232fcc537d18eb2c705918988aebee133`；该提交是本分支的父提交。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

本地验证：

```bash
pnpm exec vitest run tests/css-safety.spec.ts tests/builtin-skins.spec.ts
pnpm skin-center:check
pnpm test
pnpm typecheck
pnpm test:scripts
pnpm docs:check
pnpm runtime-deps:check
pnpm build
```

结果：

- CSS safety + built-in catalog：59 / 59 通过；catalog gate 覆盖每个 built-in skin 与 patches.css 的 root alias/specific reset 和 body clone。
- skin-center 完整套件：19 个测试文件、329 个断言通过。
- 全仓 `pnpm test`、`pnpm typecheck`、`pnpm test:scripts`、`pnpm docs:check`、`pnpm runtime-deps:check` 均通过。
- `pnpm build` 重建了 host `lib/index.js`；`git diff --check` 通过。

## 视觉修复要求（Visual Fix Requirements）

本 PR 修复 CSS token 级联语义，不涉及新的视觉样式设计；下方提供真实 GUI 的 CSS computed-style 证据。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5.6 Terra

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本 PR 未新增包。）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改 README。）

## 本地验证（Local Validation）

执行的命令：见上方测试证据。

结果摘要：所有列出的命令退出码均为 0。

`lib/index.js` 同时同步了当前 `dev` 中此前已合入但未重建的 host-side 输出；相应 source 已在本 PR 基线中存在，未新增任何不相关源码改动。

## 用户可见变更证据（Local Feature Evidence）

在隔离 headless Chrome 中针对现有 `http://127.0.0.1:3080` GUI 进行了 CDP 验证，不写入用户设置：

- 现有 whale-mom stylesheet 的 scoped HTML root 确实包含浅色 `--dsw-alias-markdown-code-block`，与 Issue 报告的 computed value 一致。
- 临时注入与本 PR 相同的 reset/body-clone 级联后，根 alias 变为无效，Shiki-style background 回退为透明，而 body dark alias 解析为 `rgb(23, 36, 58)`。
- 对 root `!important` token 的同一探针也得到相同结果；临时 DOM、样式和属性均在同一脚本中清理。
- 运行中 GUI 的 stylesheet 扫描显示官方 `:root` 的直接 alias consumer 为 Shiki foreground/background 变量；皮肤 scrollbar variables 同时有 body clone。

图像说明端点在本机返回 HTTP 502，因此不对未能视觉读取的截图作超出上述 CSS/DOM 证据的声明。