### PR TITLE
chore(contributors): remove manual acknowledgement override

### DIFF
--- a/scripts/update-contributors.mjs
+++ b/scripts/update-contributors.mjs
@@ -39,26 +39,6 @@ const EXCLUDED_LOGINS = new Set([
   'github-actions[bot]', // auto-commits README syncs; not a human contributor
 ])
 
-/**
- * External contributors recognized for substantive work that did not become a
- * commit on main. Keep this explicit list so GitHub's /contributors endpoint
- * does not erase that acknowledgement.
- */
-const ACKNOWLEDGED_CONTRIBUTORS = [
-  { login: 'Twelveeee', html_url: 'https://github.com/Twelveeee' }, // PR #102
-]
-
-function buildContributors(githubContributors) {
-  const byLogin = new Map()
-  for (const contributor of githubContributors) {
-    if (!EXCLUDED_LOGINS.has(contributor.login)) byLogin.set(contributor.login, contributor)
-  }
-  for (const contributor of ACKNOWLEDGED_CONTRIBUTORS) {
-    if (!byLogin.has(contributor.login)) byLogin.set(contributor.login, contributor)
-  }
-  return [...byLogin.values()]
-}
-
 async function fetchContributors() {
   let page = 1
   const all = []
@@ -103,7 +83,7 @@ function replaceSection(text, section) {
   return text.slice(0, i) + section + text.slice(j + END.length)
 }
 
-const contributors = buildContributors(await fetchContributors())
+const contributors = (await fetchContributors()).filter((c) => !EXCLUDED_LOGINS.has(c.login))
 for (const { rel, viewAllLabel } of files) {
   const path = join(root, rel)
   const original = readFileSync(path, 'utf8')


### PR DESCRIPTION
## 摘要（Summary）

移除 PR #407 人工贡献者兜底名单，让贡献者同步重新只依赖 GitHub `/contributors` 接口与既有排除列表。README 不做改动；

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他：贡献者同步脚本 `scripts/update-contributors.mjs`

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch --prune upstream
git rebase upstream/dev
```

同步基线：`37ae632c`。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支，并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

N/A（非视觉改动）。

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5.6-sol

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未修改 README）。

## 贡献者版权声明（Contributor Copyright）

N/A（未贡献插件或皮肤）。

## 新皮肤收录（New Skin）

N/A（未新增皮肤）。

## 社区插件索引登记（Community Plugin Index）

N/A（未修改社区插件索引）。

## 本地验证（Local Validation）

执行的命令：

```bash
node --check scripts/update-contributors.mjs
git diff --check upstream/dev...HEAD
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
gh api repos/zhu1090093659/dsh-web-ui/contributors --paginate \
  --jq '.[] | select(.login == "Twelveeee") | {login, contributions}'
```

结果摘要：

- 脚本语法检查与 diff 检查通过。
- 全仓类型检查通过。
- 全仓单测通过。
- 脚本测试共 146 项：142 项通过，4 项按预期跳过，0 项失败。
- 文档门禁全部通过。

## 用户可见变更证据（Local Feature Evidence）

N/A（内部维护改动，无用户可见界面变化）。