### PR TITLE
fix(skin-center): re-bind shiki background to the code-block alias on body (#826)

### DIFF
--- a/packages/skins/skin-center/contracts/README.md
+++ b/packages/skins/skin-center/contracts/README.md
@@ -45,6 +45,13 @@ first-class in v2.
   (`[class*=...]`) warns. Only relative in-directory assets.
 - Every file reference in the manifest is a relative path inside the skin
   directory (no leading slash, no `..`, no protocol URLs).
+- The loader re-binds the official shell's `--shiki-background` variable to
+  `var(--dsw-alias-markdown-code-block)` on the skin-scoped body, because
+  the shell declares it on `:root` where the dark code-block alias (scoped
+  to `body[data-ds-dark-theme]`) cannot reach it — without the re-bind,
+  Shiki code blocks paint the fixed light background in dark mode (issue
+  #826). Skins keep owning the alias values; the loader only restores
+  theme-awareness.
 
 ## Automatic token fallbacks
 

--- a/packages/skins/skin-center/src/core/css-safety/transform.ts
+++ b/packages/skins/skin-center/src/core/css-safety/transform.ts
@@ -375,6 +375,13 @@ export function transformSkinCss(css: string, options: SkinCssTransformOptions):
   // tokens are unaffected: the shell surfaces keep their colors, and the
   // body clone above keeps the same base color behind transparent areas.
   out += `\n${scope} [id="root"] { background: transparent; }\n`
+  // The official shell declares --shiki-background: var(--dsw-alias-markdown-code-block)
+  // on :root, but skins (and the official dark theme) place the dark code-block
+  // alias on body — the root-level declaration therefore captures the light
+  // alias, and Shiki highlights paint a fixed light background in dark mode.
+  // Re-bind the variable on body, where the active-theme alias resolves, so
+  // the highlight layer follows the skin in both themes (issue #826).
+  out += `\n${scope} body { --shiki-background: var(--dsw-alias-markdown-code-block); }\n`
   if (options.deriveFallbacks === true) {
     const fallbacks = deriveFallbackTokens(defined)
     if (fallbacks.length > 0) {

--- a/packages/skins/skin-center/tests/css-safety.spec.ts
+++ b/packages/skins/skin-center/tests/css-safety.spec.ts
@@ -155,6 +155,22 @@ describe('transformSkinCss scoping', () => {
     expect(code).toContain(`${SCOPE} [id="root"] { background: transparent; }`)
   })
 
+  it('re-binds --shiki-background to the code-block alias on body (issue #826)', () => {
+    const css = [
+      ':root {',
+      '  --dsw-alias-markdown-code-block: #ecf4fce6;',
+      '}',
+      'body[data-ds-dark-theme] {',
+      '  --dsw-alias-markdown-code-block: #17243ad9;',
+      '}',
+    ].join('\n')
+    const { code } = scope(css)
+    expect(code).toContain(`${SCOPE} body { --shiki-background: var(--dsw-alias-markdown-code-block); }`)
+    // The dark alias itself stays body-scoped so the re-bound variable
+    // resolves the dark value in dark mode and the light value in light mode.
+    expect(code).toContain(`${SCOPE} body[data-ds-dark-theme]`)
+  })
+
   it('scopes :root token remaps to the skin scope', () => {
     const { code } = scope(':root { --dsw-primary: #ff9d5c; }')
     expect(code).toContain(`${SCOPE} {`)


### PR DESCRIPTION
## 摘要（Summary）

修复 #826：shiki 代码高亮层在深色模式下不再使用固定的浅色背景。

根因：官方 shell 在 `:root` 上声明 `--shiki-background: var(--dsw-alias-markdown-code-block)`，而皮肤（以及官方深色主题）把深色 alias 放在 `body[data-ds-dark-theme]` 上——:root 级声明永远捕获浅色 alias，导致 shiki 高亮层在深色模式下仍画浅色（#f4f8fd94 一类的固定浅灰），出现「先黑后灰」的闪烁与叠加壁纸后的发灰。

修复：皮肤中心加载器（css-safety transform）在输出中为每个皮肤重新绑定

```css
html[data-dsh-skin="<id>"] body { --shiki-background: var(--dsw-alias-markdown-code-block); }
```

变量改在 body 上解析（active 主题 alias 所在层），亮/暗两种主题都跟随皮肤自身的 alias；皮肤继续全权拥有 alias 值，加载器只恢复主题感知。该机制与加载器既有能力一致（#646 的 root token 重置 / body 克隆、#root 透明化、token fallback 派生），16 个内置皮肤与用户目录皮肤（$DSH_HOME/skins）全部受益，无需逐皮肤改文件。

## 涉及包（Affected Packages）

- [ ] 任务看板 packages/dsh-task-board
- [ ] Git 图谱 packages/dsh-git-graph
- [ ] 右侧面板 packages/dsh-aionui-panel
- [ ] 远程 Web UI packages/dsh-remote-web-ui
- [ ] SSH 远程运维 packages/dsh-ssh
- [ ] 宠物 packages/dsh-pet
- [x] 皮肤 / 皮肤中心 packages/dsh-skins / packages/skins
- [ ] 聚合包 / 设置 packages/dsh-web-ui-all / packages/dsh-web-ui-settings
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [x] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：git worktree add -b fix/826-skin-code-block-background origin/dev（基于 8f8f426fa，即 dev 最新提交）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据。

证据：皮肤中心包测试 19 个文件 332 个测试全部通过（新增 issue #826 的 re-bind 断言）；pnpm skin-center:check 通过（16 内置皮肤）；pnpm gallery:check 通过；全仓门禁 pnpm typecheck && pnpm test && pnpm test:scripts && pnpm docs:check && pnpm runtime-deps:check && git diff --check 全部通过（ALL_GATES_PASS）。

## 视觉修复要求（Visual Fix Requirements）

- [x] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [x] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

说明：本会话的视觉端点（describe-image）当前返回 502，无法对截图做多模态复核；已用真实运行中的 GUI（127.0.0.1:3080，whale-song 皮肤）做 DOM 计算值级验证：深色模式下 `var(--shiki-background)` 计算值 修复前 #f4f8fd94（浅灰 rgba(244,248,253,0.58)）→ 修复后 #0c1a3ea8（深蓝 rgba(12,26,62,0.66)），与皮肤深色 alias 一致。前后对比截图存于 /tmp/gui-826-dark-before.png 与 /tmp/gui-826-dark-after.png（本机，未上传附件）。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek（deepseek-v4-pro，经 DeepSeek Harness）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 本 PR 未新增包目录。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 本 PR 未改动包 README（仅契约文档 contracts/README.md，英文技术文档，无需 i18n 配对）。

## 贡献者版权声明（Contributor Copyright）

维持现有版权归属。

## 本地验证（Local Validation）

执行的命令：

```bash
cd /tmp/dsh-web-ui-826
pnpm --filter @linxin666/dsh-client-ui-skin-center test
pnpm skin-center:check
pnpm gallery:check
pnpm typecheck && pnpm test && pnpm test:scripts && pnpm docs:check && pnpm runtime-deps:check
git diff --check
```

结果摘要：全部通过。皮肤中心 332 个测试通过；skin-center:check（16 内置皮肤）与 gallery:check 通过；全仓门禁 ALL_GATES_PASS；diff --check 无空白错误。

## 用户可见变更证据（Local Feature Evidence）

证据（计算值级，真实运行 GUI）：在运行中的 GUI（http://127.0.0.1:3080，当前应用 whale-song 皮肤）上以深色模式实测——修复前 shiki 层 `var(--shiki-background)` 计算为浅色 #f4f8fd94；注入本修复规则后计算为皮肤深色 alias #0c1a3ea8。截图已存 /tmp/gui-826-dark-before.png、/tmp/gui-826-dark-after.png（视觉端点 502，未能多模态复核，以计算值证据为准）。