### PR TITLE
fix(plugins): default announceToAgent to false and expose a liangshen settings switch (#839)

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -39,6 +39,14 @@
 - **样式**：CSS Modules（`*.module.css`）经 lightningcss 编译进 bundle；不引入
   UI 框架样式库。
 
+## Agent 公告约定（issue #839）
+
+- 会向 agent 系统提示注入公告（systemPrompt section）的插件必须提供
+  `announceToAgent` 开关：schema 默认 `false`（默认不注入，保持系统提示词干净），
+  用户在设置界面（或 profile patch）按需开启；开关必须经
+  `installSettingsSection`（或等价的自定义设置卡）暴露到 Web 设置界面并即时生效。
+- 公告文本只陈述能力、约束与触发词，不包含与当前任务无关的长段声明。
+
 ## 测试纪律
 
 - 每个包必须有 `vitest run` 可通过的测试（`pnpm test` 全仓门禁）。行为变化必须

--- a/packages/dsh-desktop-launcher/README.i18n.yaml
+++ b/packages/dsh-desktop-launcher/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 17a0860ba4ecf746f44d6736b04f82b014451bd3
-README.zh.md: c5a33d334bb160beb115f606db368bae7ca4ce51
+README.md: a928a0cf523ebbb48a7969f3d72930ccc0e3c90b
+README.zh.md: 6d22cafc3f09092c1d19353d417125e5f45c4b38

--- a/packages/dsh-desktop-launcher/README.md
+++ b/packages/dsh-desktop-launcher/README.md
@@ -52,7 +52,7 @@ All fields live in the plugin settings card (or in the composition entry):
 | Field | Default | Meaning |
 | --- | --- | --- |
 | `enabled` | `true` | Master switch for the plugin. |
-| `announceToAgent` | `true` | Announce the plugin in the system prompt. |
+| `announceToAgent` | `false` | Opt-in: when true, announces the plugin in the system prompt. |
 | `dshCommand` | `dsh` | Command that starts dsh; must be on PATH. |
 | `url` | `http://127.0.0.1:3080` | GUI URL the launcher waits for and opens. |
 | `profile` | unset | Optional `--profile` argument passed to `dsh web`. |

--- a/packages/dsh-desktop-launcher/README.zh.md
+++ b/packages/dsh-desktop-launcher/README.zh.md
@@ -44,7 +44,7 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-desktop-launcher
 | 字段 | 默认值 | 含义 |
 | --- | --- | --- |
 | `enabled` | `true` | 插件总开关。 |
-| `announceToAgent` | `true` | 是否在系统提示词中公告本插件。 |
+| `announceToAgent` | `false` | 按需开启：开启后在系统提示词中公告本插件。 |
 | `dshCommand` | `dsh` | 启动 dsh 的命令，需在 PATH 中。 |
 | `url` | `http://127.0.0.1:3080` | 启动器等待就绪并打开的 GUI 地址。 |
 | `profile` | 未设置 | 可选的 `dsh web` 的 `--profile` 参数。 |

--- a/packages/dsh-desktop-launcher/src/index.ts
+++ b/packages/dsh-desktop-launcher/src/index.ts
@@ -62,7 +62,7 @@ export interface Config {
 }
 
 export const Config: z<Config> = z.object({
-  announceToAgent: z.boolean().default(true),
+  announceToAgent: z.boolean().default(false),
   enabled: z.boolean().default(true),
   dshCommand: z.string().default(DEFAULT_DSH_COMMAND),
   url: z.string().default(DEFAULT_URL),
@@ -72,7 +72,7 @@ export const Config: z<Config> = z.object({
 })
 
 /** Schema default, re-read for hand-built test contexts (the loader applies them normally). */
-const DEFAULT_ANNOUNCE = true
+const DEFAULT_ANNOUNCE = false
 
 /** Order of the announcement section within the tool-guidance band. */
 const SECTION_ORDER = 210

--- a/packages/dsh-desktop-launcher/tests/announce-default.spec.ts
+++ b/packages/dsh-desktop-launcher/tests/announce-default.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * Announcement default (issue #839): announceToAgent resolves to false so
+ * agent system prompts stay clean unless the user opts in.
+ */
+import { describe, expect, it } from 'vitest'
+import { Config } from '../src/index.ts'
+
+describe('announcement default (issue #839)', () => {
+  it('resolves announceToAgent to false by default', () => {
+    const value = Config({}) as { announceToAgent: boolean; enabled: boolean }
+    expect(value.announceToAgent).toBe(false)
+    expect(value.enabled).toBe(true)
+  })
+
+  it('keeps an explicit true override', () => {
+    const value = Config({ announceToAgent: true }) as { announceToAgent: boolean }
+    expect(value.announceToAgent).toBe(true)
+  })
+})

--- a/packages/dsh-liangshen/README.i18n.yaml
+++ b/packages/dsh-liangshen/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 369bb8384a73650063d3d040f1aecc4d7f11f842
-README.zh.md: 96ce3a7db25f7696368b7e0d8440c42df457e571
+README.md: cbce60fdf1c3fc52daea6f2cf6cec6f6fe96ca71
+README.zh.md: c262a22537b68f5c8b1e72ba057470ec7336bedb

--- a/packages/dsh-liangshen/README.md
+++ b/packages/dsh-liangshen/README.md
@@ -63,6 +63,15 @@ Trajectory drift can be measured without reading raw reasoning:
 node tools/analyze-session.mjs ~/.dsh/sessions/<workspace>/<session>/session.jsonl
 ```
 
+## Configuration
+
+| Key | Default | Behavior |
+| --- | --- | --- |
+| `enabled` | `true` | Master switch: when false, neither preset sync nor announcement runs. |
+| `announceToAgent` | `false` | Opt-in: when true, a system-prompt section announces the plugin. Off by default so agent system prompts stay clean. |
+
+Both fields are editable in the web settings surface (plugin config, live) or through the profile patch (`dsh plugin` / `cordis.patch.yml`).
+
 ## Behavior and limits
 
 - A first model response that calls no tool promotes once it has responded; an anchor-gated session also releases when its first turn ends (`turn/end`). The release is decided during prompt assembly, so the new user turn already gets the promoted PTC catalog and its messages are not stripped;

--- a/packages/dsh-liangshen/README.zh.md
+++ b/packages/dsh-liangshen/README.zh.md
@@ -63,6 +63,15 @@ dsh plugin --profile web remove @linxin666/dsh-liangshen
 node tools/analyze-session.mjs <导出的 session.jsonl>
 ```
 
+## 配置
+
+| 键 | 默认值 | 行为 |
+| --- | --- | --- |
+| `enabled` | `true` | 总开关：关闭后预设同步与公告都不执行。 |
+| `announceToAgent` | `false` | 按需开启：开启后向 agent 系统提示注入本插件公告。默认关闭，保持系统提示词干净。 |
+
+两个字段都可在 Web 设置界面（插件配置，即时生效）或 profile patch（`dsh plugin` / `cordis.patch.yml`）中编辑。
+
 ## 行为与限制
 
 - 第一次模型响应如果没有调用工具，在响应后即自动晋升；锚定门控中的会话也会在首轮结束（`turn/end`）时释放。释放判定发生在 prompt assemble 阶段，所以新用户轮次一开始就拿到晋升后的 PTC 目录，其消息也不会再被剥离；

--- a/packages/dsh-liangshen/package.json
+++ b/packages/dsh-liangshen/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-settings": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8",
     "@types/node": "^22.20.0",
     "tsdown": "0.22.2",

--- a/packages/dsh-liangshen/src/announce.test.ts
+++ b/packages/dsh-liangshen/src/announce.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Announcement behavior (issue #839): the system-prompt announcement ships
+ * OFF by default and only registers when announceToAgent is on. The apply
+ * path is exercised against a minimal fake context; each test re-imports the
+ * module so the mount-once guard cannot swallow a second apply call.
+ */
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { describe, expect, it, vi } from 'vitest'
+
+interface FakePrompt {
+  section: (spec: { name: string; order: number; text: string }) => () => void
+}
+
+function makeCtx(sections: ReturnType<typeof vi.fn>[] = []) {
+  const registered: Array<{ name: string; order: number; text: string }> = []
+  const systemPrompt: FakePrompt = {
+    section(spec) {
+      registered.push(spec)
+      return () => {}
+    },
+  }
+  return {
+    ctx: {
+      systemPrompt,
+      effect: (fn: () => () => void) => fn(),
+      inject: vi.fn(),
+      logger: { warn: vi.fn(), info: vi.fn() },
+    } as never,
+    registered,
+  }
+}
+
+describe('dsh-liangshen announcement (issue #839)', () => {
+  it('resolves announceToAgent to false by default in the schema', async () => {
+    vi.resetModules()
+    const mod = await import('../src/index.ts')
+    const value = mod.Config({})
+    expect(value.announceToAgent).toBe(false)
+    expect(value.enabled).toBe(true)
+  })
+
+  it('registers the announcement section when announceToAgent is on', async () => {
+    vi.resetModules()
+    const home = mkdtempSync(join(tmpdir(), 'liangshen-announce-'))
+    const previous = process.env.DSH_HOME
+    process.env.DSH_HOME = home
+    try {
+      const mod = await import('../src/index.ts')
+      const { ctx, registered } = makeCtx()
+      mod.apply(ctx, { announceToAgent: true })
+      expect(registered.length).toBe(1)
+      expect(registered[0]?.name).toBe('plugin:dsh-liangshen')
+      expect(registered[0]?.text).toBe(mod.LIANGSHEN_GUIDANCE)
+    } finally {
+      process.env.DSH_HOME = previous
+    }
+  })
+
+  it('keeps silent with the default config (announceToAgent off)', async () => {
+    vi.resetModules()
+    const home = mkdtempSync(join(tmpdir(), 'liangshen-announce-'))
+    const previous = process.env.DSH_HOME
+    process.env.DSH_HOME = home
+    try {
+      const mod = await import('../src/index.ts')
+      const { ctx, registered } = makeCtx()
+      mod.apply(ctx, undefined)
+      expect(registered.length).toBe(0)
+    } finally {
+      process.env.DSH_HOME = previous
+    }
+  })
+})

--- a/packages/dsh-liangshen/src/index.ts
+++ b/packages/dsh-liangshen/src/index.ts
@@ -3,9 +3,11 @@
  *
  * Host half only: on startup it syncs the bundled `presets/` tree into the
  * harness-home agent-presets root (`~/.dsh/.agent-presets`), making the
- * LiangShen preset selectable for new sessions without copying files by hand,
- * and announces the capability through a system-prompt section. No browser
- * half, no routes, no agent tools — the preset itself provides the tools.
+ * LiangShen preset selectable for new sessions without copying files by hand.
+ * The capability announcement is a system-prompt section that ships OFF by
+ * default (`announceToAgent: false`) and can be enabled in the web settings
+ * surface (plugin config) or the profile patch. No browser half, no routes,
+ * no agent tools — the preset itself provides the tools.
  *
  * The preset is the "anchored-standard" idea shipped as a named mode: the
  * first model request sees only the builtin Minimal preset's exact two tools
@@ -18,6 +20,7 @@ import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Context } from '@deepseek-ai/cordis'
+import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
 import type {} from '@deepseek-ai/dsh-system-prompt'
 import z from 'schemastery'
 import { dshHome } from './dsh-home.ts'
@@ -27,6 +30,9 @@ import { mountOnce } from './mount-once.ts'
 /** Stable cordis plugin name. */
 export const name = 'liangshen'
 
+/** Settings namespace of the plugin (the web settings surface edits it). */
+export const LIANGSHEN_SETTINGS_NAMESPACE = settingsNamespace('dsh-liangshen')
+
 /** Prompt assembly must exist before the announcement section can register. */
 export const inject = ['systemPrompt']
 
@@ -34,17 +40,17 @@ export const inject = ['systemPrompt']
 export interface Config {
   /** Master switch: when false, neither sync nor announcement runs. */
   enabled?: boolean
-  /** When true (default), a system-prompt section announces the plugin. */
+  /** When true, a system-prompt section announces the plugin (default false — keep prompts clean unless the user opts in). */
   announceToAgent?: boolean
 }
 
 export const Config: z<Config> = z.object({
   enabled: z.boolean().default(true),
-  announceToAgent: z.boolean().default(true),
+  announceToAgent: z.boolean().default(false),
 })
 
 /** Schema default, re-read for hand-built test contexts. */
-const DEFAULT_ANNOUNCE = true
+const DEFAULT_ANNOUNCE = false
 
 /** Order of the announcement section within the tool-guidance band. */
 const SECTION_ORDER = 150
@@ -65,16 +71,22 @@ export function bundledPresetsRoot(): string {
 
 /**
  * Mount the plugin: sync bundled presets into the harness-home agent-presets
- * root, then announce through a system-prompt section.
+ * root, register the settings namespace (enabled / announceToAgent, live),
+ * and announce through a system-prompt section when announceToAgent is on
+ * (off by default).
  * @param ctx - host plugin context carrying systemPrompt.
  * @param config - resolved plugin config (schema defaults applied by the loader).
  */
 export const apply = mountOnce('@linxin666/dsh-liangshen', applyImpl)
 
 function applyImpl(ctx: Context, config?: Config): void {
+  // The live source the announcement reads: the settings section once the web
+  // settings surface is served, the composition entry otherwise
+  // (installSettingsSection swaps it when the namespace registers).
+  let current: () => Config = () => config ?? {}
   const resolve = (): Config => ({
-    announceToAgent: config?.announceToAgent ?? DEFAULT_ANNOUNCE,
-    enabled: config?.enabled ?? true,
+    announceToAgent: current().announceToAgent ?? DEFAULT_ANNOUNCE,
+    enabled: current().enabled ?? true,
   })
 
   const sync = (): void => {
@@ -110,6 +122,17 @@ function applyImpl(ctx: Context, config?: Config): void {
       })
     }
   }
+
+  // The web settings surface gets the plugin's enabled / announceToAgent
+  // fields from this namespace; a settings edit re-runs refresh live, and
+  // deployments without a settings service keep the composition entry.
+  installSettingsSection(ctx, LIANGSHEN_SETTINGS_NAMESPACE, Config, config ?? {}, {
+    setSource: (source) => {
+      current = source
+      refresh()
+    },
+    onChange: refresh,
+  })
 
   refresh()
   ctx.effect(() => () => { disposeSection?.(); disposeSection = undefined }, 'dsh-liangshen: announcement')

--- a/packages/dsh-ssh/README.i18n.yaml
+++ b/packages/dsh-ssh/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: b1afe899f25da4852267428fffb38f523db77bea
-README.zh.md: 59dc5ccd746defa339cc2d89d79b4b243f782ad0
+README.md: 5c57247b1446cf415240d49ca113b64e9a6f4f29
+README.zh.md: 15a4a15a5fd8b575e1393a7ba2648bb6538cfd00

--- a/packages/dsh-ssh/README.md
+++ b/packages/dsh-ssh/README.md
@@ -49,7 +49,7 @@ After installing, **restart `dsh web`**: a "SSH" entry appears in the sidebar; t
 
 ## Configuration
 
-The settings panel (plugin config) toggles `announceToAgent` (whether to announce the plugin to the Agent) and `enabled` (master switch), and sets `terminalFontFamily` (the web terminal font; empty defers to the CSS chain: `--dsh-ssh-terminal-font` → the official `--ds-font-family-code` token → the built-in monospace stack). The terminal font is fixed in the xterm constructor, so a plain stylesheet cannot override it; to render powerline / Nerd Font glyphs, enter a Nerd Font stack here (e.g. `"SauceCodePro Nerd Font", monospace`). Changes re-apply to open terminals live, no reconnect needed.
+The settings panel (plugin config) toggles `announceToAgent` (whether to announce the plugin to the Agent; off by default so system prompts stay clean) and `enabled` (master switch), and sets `terminalFontFamily` (the web terminal font; empty defers to the CSS chain: `--dsh-ssh-terminal-font` → the official `--ds-font-family-code` token → the built-in monospace stack). The terminal font is fixed in the xterm constructor, so a plain stylesheet cannot override it; to render powerline / Nerd Font glyphs, enter a Nerd Font stack here (e.g. `"SauceCodePro Nerd Font", monospace`). Changes re-apply to open terminals live, no reconnect needed.
 
 ## Data
 

--- a/packages/dsh-ssh/README.zh.md
+++ b/packages/dsh-ssh/README.zh.md
@@ -49,7 +49,7 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-ssh
 
 ## 配置
 
-设置面板（插件配置）可开关 `announceToAgent`（是否向 Agent 宣告插件）与 `enabled`（总开关），并可设置 `terminalFontFamily`（Web 终端字体，留空则按 CSS 链解析：`--dsh-ssh-terminal-font` → 官方 `--ds-font-family-code` token → 内置 monospace 栈）。终端字体写死在 xterm 构造参数里，CSS 无法直接覆盖；要渲染 powerline / Nerd Font 图标，请在此填入对应 Nerd Font 栈（如 `"SauceCodePro Nerd Font", monospace`），修改对已打开的终端即时生效，无需重连。
+设置面板（插件配置）可开关 `announceToAgent`（是否向 Agent 宣告插件；默认关闭，保持系统提示词干净）与 `enabled`（总开关），并可设置 `terminalFontFamily`（Web 终端字体，留空则按 CSS 链解析：`--dsh-ssh-terminal-font` → 官方 `--ds-font-family-code` token → 内置 monospace 栈）。终端字体写死在 xterm 构造参数里，CSS 无法直接覆盖；要渲染 powerline / Nerd Font 图标，请在此填入对应 Nerd Font 栈（如 `"SauceCodePro Nerd Font", monospace`），修改对已打开的终端即时生效，无需重连。
 
 ## 数据
 

--- a/packages/dsh-ssh/src/index.ts
+++ b/packages/dsh-ssh/src/index.ts
@@ -52,13 +52,13 @@ export interface Config {
 }
 
 export const Config: z<Config> = z.object({
-  announceToAgent: z.boolean().default(true),
+  announceToAgent: z.boolean().default(false),
   enabled: z.boolean().default(true),
   terminalFontFamily: z.string().default(''),
 })
 
 /** Schema default, re-read for hand-built test contexts (the loader applies them normally). */
-const DEFAULT_ANNOUNCE = true
+const DEFAULT_ANNOUNCE = false
 
 /** Order of the announcement section within the tool-guidance band. */
 const SECTION_ORDER = 150

--- a/packages/dsh-ssh/tests/announce-default.spec.ts
+++ b/packages/dsh-ssh/tests/announce-default.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * Announcement default (issue #839): announceToAgent resolves to false so
+ * agent system prompts stay clean unless the user opts in.
+ */
+import { describe, expect, it } from 'vitest'
+import { Config } from '../src/index.ts'
+
+describe('announcement default (issue #839)', () => {
+  it('resolves announceToAgent to false by default', () => {
+    const value = Config({}) as { announceToAgent: boolean; enabled: boolean }
+    expect(value.announceToAgent).toBe(false)
+    expect(value.enabled).toBe(true)
+  })
+
+  it('keeps an explicit true override', () => {
+    const value = Config({ announceToAgent: true }) as { announceToAgent: boolean }
+    expect(value.announceToAgent).toBe(true)
+  })
+})

--- a/packages/dsh-task-board/README.i18n.yaml
+++ b/packages/dsh-task-board/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 359b35160b1cf7a8c697152b4e3fc60193ed3599
-README.zh.md: 535ac2b5c8b4c6fdbff61c08b9cadae3b5679cc7
+README.md: d65b9b3213fd504715bffb3a00be17074703e8c6
+README.zh.md: 09705ff5ff6cfdc3df7896cd0af6489c35fbe174

--- a/packages/dsh-task-board/README.md
+++ b/packages/dsh-task-board/README.md
@@ -52,7 +52,7 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-task-board
 | Key | Default | Behavior |
 | --- | --- | --- |
 | `enabled` | `true` | Enables the Host service and browser board. |
-| `announceToAgent` | `true` | Adds the task-board guidance section to agent system prompts. |
+| `announceToAgent` | `false` | Opt-in: when true, adds the task-board guidance section to agent system prompts. |
 | `preventIdleSleep` | `false` | Holds one system idle-sleep assertion while any DSH session runs, any schedule is enabled, or session state is unknown. |
 | `trustedProxyHosts` | `[]` | Canonical `host[:port]` authorities accepted only through the authenticated loopback reverse-proxy path. |
 | `proxyTokenEnv` | `DSH_TASK_BOARD_PROXY_TOKEN` | Environment variable containing the reverse-proxy token; the token itself is never stored in plugin config. |

--- a/packages/dsh-task-board/README.zh.md
+++ b/packages/dsh-task-board/README.zh.md
@@ -52,7 +52,7 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-task-board
 | 键 | 默认值 | 行为 |
 | --- | --- | --- |
 | `enabled` | `true` | 启用 Host 服务与浏览器看板。 |
-| `announceToAgent` | `true` | 向 agent 系统提示加入任务看板说明。 |
+| `announceToAgent` | `false` | 按需开启：开启后向 agent 系统提示加入任务看板说明。 |
 | `preventIdleSleep` | `false` | 存在运行中的 DSH 会话、已启用计划或未知会话状态时，持有一个系统空闲睡眠断言。 |
 | `trustedProxyHosts` | `[]` | 仅通过已认证 loopback 反向代理路径接受的规范 `host[:port]` authority 白名单。 |
 | `proxyTokenEnv` | `DSH_TASK_BOARD_PROXY_TOKEN` | 保存反向代理 token 的环境变量名；token 本身不会写入插件配置。 |

--- a/packages/dsh-task-board/src/index.ts
+++ b/packages/dsh-task-board/src/index.ts
@@ -55,7 +55,7 @@ export interface Config {
 }
 
 export const Config: z<Config> = z.object({
-  announceToAgent: z.boolean().default(true),
+  announceToAgent: z.boolean().default(false),
   enabled: z.boolean().default(true),
   preventIdleSleep: z.boolean().default(false),
   trustedProxyHosts: z.array(z.string()).default([]),
@@ -76,7 +76,7 @@ export function resolveProxyAccess(config: Config | undefined, env: NodeJS.Proce
 }
 
 /** Schema default, re-read for hand-built test contexts (the loader applies them normally). */
-const DEFAULT_ANNOUNCE = true
+const DEFAULT_ANNOUNCE = false
 
 /**
  * Register the board's announcement section, gated on the composition entry's

--- a/packages/dsh-task-board/tests/announce-default.spec.ts
+++ b/packages/dsh-task-board/tests/announce-default.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * Announcement default (issue #839): announceToAgent resolves to false so
+ * agent system prompts stay clean unless the user opts in.
+ */
+import { describe, expect, it } from 'vitest'
+import { Config } from '../src/index.ts'
+
+describe('announcement default (issue #839)', () => {
+  it('resolves announceToAgent to false by default', () => {
+    const value = Config({}) as { announceToAgent: boolean; enabled: boolean }
+    expect(value.announceToAgent).toBe(false)
+    expect(value.enabled).toBe(true)
+  })
+
+  it('keeps an explicit true override', () => {
+    const value = Config({ announceToAgent: true }) as { announceToAgent: boolean }
+    expect(value.announceToAgent).toBe(true)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       '@deepseek-ai/cordis':
         specifier: ^4.0.1
         version: 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-settings':
+        specifier: ^0.1.0-rc.8
+        version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/dsh-system-prompt':
         specifier: ^0.1.0-rc.8
         version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))


### PR DESCRIPTION
## 摘要（Summary）

按 #839 把四个插件的 agent 公告默认关闭，并给 dsh-liangshen 补上设置界面开关：

- `announceToAgent` schema 默认 `true` → `false`（dsh-ssh、dsh-liangshen、dsh-task-board、dsh-desktop-launcher），系统提示词默认保持干净，用户在设置界面 / profile patch 按需开启；
- dsh-liangshen 此前只有 patch 级开关：新增 `installSettingsSection('dsh-liangshen')` 注册（enabled / announceToAgent 字段进入 Web 设置界面，即时生效；无 settings 服务的部署保持组合条目作为来源）；公告注册改为读取 live 源；
- 约定固化进 packages/AGENTS.md（「Agent 公告约定」节：能注入公告的插件必须提供默认 false 的 announceToAgent 开关并暴露到设置界面）；
- 四个包 README（中英 + i18n.yaml）默认值表格同步为 `false`，liangshen 新增 Configuration 节。

聚合总开关（issue 中「可考虑」的第 3 点）未实现，保留为后续可选项。

## 涉及包（Affected Packages）

- [x] 任务看板 packages/dsh-task-board
- [ ] Git 图谱 packages/dsh-git-graph
- [ ] 右侧面板 packages/dsh-aionui-panel
- [ ] 远程 Web UI packages/dsh-remote-web-ui
- [x] SSH 远程运维 packages/dsh-ssh
- [ ] 宠物 packages/dsh-pet
- [ ] 皮肤 / 皮肤中心 packages/dsh-skins / packages/skins
- [ ] 聚合包 / 设置 packages/dsh-web-ui-all / packages/dsh-web-ui-settings
- [x] 其他（请说明）：packages/dsh-liangshen、packages/dsh-desktop-launcher、packages/AGENTS.md、pnpm-lock.yaml

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：git worktree add -b fix/839-announce-default-off origin/dev（基于 d47347082，即 dev 最新提交）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据。

证据：四个包各新增默认值回归测试（liangshen src/announce.test.ts 覆盖 schema 默认 false、开启时注册公告、默认静默三种路径，含 fake ctx 上的 apply 与 installSettingsSection 接线；ssh/task-board/desktop-launcher 各新增 announce-default.spec.ts）；包级测试全部通过（liangshen 99、ssh 123、task-board 240、desktop-launcher 35）；全仓门禁 pnpm typecheck && pnpm test && pnpm test:scripts && pnpm docs:check && pnpm runtime-deps:check && git diff --check 全部通过（ALL_GATES_PASS）。

## 视觉修复要求（Visual Fix Requirements）

未勾选「视觉修复」，跳过本节。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek（deepseek-v4-pro，经 DeepSeek Harness）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 本 PR 未新增包目录。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（README.md / README.zh.md / README.i18n.yaml）并运行 pnpm docs:check。

## 贡献者版权声明（Contributor Copyright）

维持现有版权归属。

## 本地验证（Local Validation）

执行的命令：

```bash
cd /tmp/dsh-web-ui-839
pnpm --filter @linxin666/dsh-liangshen test
pnpm --filter @linxin666/dsh-ssh test
pnpm --filter @linxin666/dsh-client-ui-task-board test
pnpm --filter @linxin666/dsh-desktop-launcher test
pnpm --filter @linxin666/dsh-liangshen typecheck && pnpm --filter @linxin666/dsh-liangshen build
pnpm docs:write-pair packages/dsh-liangshen packages/dsh-ssh packages/dsh-task-board packages/dsh-desktop-launcher
pnpm typecheck && pnpm test && pnpm test:scripts && pnpm docs:check && pnpm runtime-deps:check
git diff --check
```

结果摘要：全部通过。四个包测试 99 / 123 / 240 / 35 全绿；liangshen typecheck + build 绿色；全仓门禁 ALL_GATES_PASS；diff --check 无空白错误。

## 用户可见变更证据（Local Feature Evidence）

证据：本改动让「插件配置」设置界面与系统提示词行为变化——默认不再注入公告（用户可见的 prompt 行为变更，无截图可拍）。liangshen 的设置字段经 installSettingsSection 注册，与 dsh-ssh 同一机制（ssh 的 README 已证实该机制在设置面板渲染开关）；插件挂载正确性由 CI plugin-mount 检查把关（本 PR CI 通过后可见）。