### PR TITLE
chore(skin-center): rebuild lib after the shiki background re-bind (#826)

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -1206,6 +1206,7 @@ function transformSkinCss(css, options) {
 	}
 	out += css.slice(cursor);
 	out += `\n${scope} [id="root"] { background: transparent; }\n`;
+	out += `\n${scope} body { --shiki-background: var(--dsw-alias-markdown-code-block); }\n`;
 	if (options.deriveFallbacks === true) {
 		const fallbacks = deriveFallbackTokens(defined);
 		if (fallbacks.length > 0) out += `\n${scope} body {\n  ${fallbacks.join("\n  ")}\n}\n`;


### PR DESCRIPTION
## 摘要（Summary）

补齐 #826 的构建产物：skin-center 的 src 修复（shiki 背景 re-bind）已随 PR #864 合并，但当时遗漏了重建并提交生成产物 `packages/skins/skin-center/lib/index.js`（本仓库约定 skin-center 的 src 变更须同提交 lib 产物，参考 #646 / #838 的提交）。本 PR 仅重建该文件（+1 行），无源码变更。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 packages/dsh-skins / packages/skins
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：git worktree add -b chore/skin-center-lib-rebuild origin/dev（基于 ec099e466，即 dev 最新提交）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。

证据：pnpm --filter @linxin666/dsh-client-ui-skin-center build 后 git diff 仅包含 lib/index.js 的 +1 行（与 #826 src 变更一一对应）；该文件在 CI 中随 plugin-mount / CI checks 验证。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek（deepseek-v4-pro，经 DeepSeek Harness）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-skin-center build
git diff --check
```

结果摘要：build 绿色；diff 仅 lib/index.js +1 行；diff --check 无空白错误。