### PR TITLE
fix(skin-center): recover scene wallpaper after WebGL context loss

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -4618,6 +4618,12 @@ const WE_SCENE_PLAYER_HTML = `<!DOCTYPE html>
              canvas.getContext('experimental-webgl', { alpha: true, depth: true });
   if (!gl) return;
 
+  // A lost WebGL context (driver or compositor churn, e.g. theme switches)
+  // would otherwise leave the canvas blank forever. Allow restoration and
+  // reload to rebuild all shader/geometry state cleanly.
+  canvas.addEventListener('webglcontextlost', (e) => { e.preventDefault() })
+  canvas.addEventListener('webglcontextrestored', () => { window.location.reload() })
+
   let sceneData = null;
   let isPaused = false;
   let fitMode = 'cover';

--- a/packages/skins/skin-center/src/we-player-source.ts
+++ b/packages/skins/skin-center/src/we-player-source.ts
@@ -40,6 +40,12 @@ export const WE_SCENE_PLAYER_HTML = `<!DOCTYPE html>
              canvas.getContext('experimental-webgl', { alpha: true, depth: true });
   if (!gl) return;
 
+  // A lost WebGL context (driver or compositor churn, e.g. theme switches)
+  // would otherwise leave the canvas blank forever. Allow restoration and
+  // reload to rebuild all shader/geometry state cleanly.
+  canvas.addEventListener('webglcontextlost', (e) => { e.preventDefault() })
+  canvas.addEventListener('webglcontextrestored', () => { window.location.reload() })
+
   let sceneData = null;
   let isPaused = false;
   let fitMode = 'cover';


### PR DESCRIPTION
## 摘要（Summary）

碰到 #824 那个场景：壁纸在主题深↔浅往返切换后就再也不动了，非得刷新才回来。查了下代码，场景播放器只在启动时拿了一次 WebGL 上下文，之后没有任何 `webglcontextlost` / `webglcontextrestored` 处理。Chromium 在主题切换这类合成器重构时可能把上下文弄丢，丢了之后 gl 调用每帧都抛错，那个 crash guard 只能保证循环不死，画面就一直是空的。

改动很小：监听 `webglcontextlost` 并 `preventDefault()`（按规范得这么做才允许恢复），`webglcontextrestored` 时直接把播放器页面重载一遍，shader、纹理这些状态就全重建了。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

git fetch origin dev && git rebase origin/dev

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek v4 Pro

使用的编码 Agent 工具：

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
# 真实浏览器复现与验证（headless Edge，SwiftShader GL，
# 用 WEBGL_lose_context 模拟上下文丢失）：
node verify-context-loss.mjs original <we-player-source.ts>
node verify-context-loss.mjs patched  <we-player-source.ts>
# 包内测试：
pnpm --filter @linxin666/dsh-client-ui-skin-center test
```

结果摘要：

先用 headless Edge（SwiftShader GL）把原版源码跑了一遍，用 `WEBGL_lose_context` 模拟上下文丢失：lose 之后 restoreContext 根本救不回来，上下文一直是 lost，画面空白，跟 #824 的症状对上了。

换上这个改动的版本再跑：lose 后进入 lost，restore 后恢复 alive，页面重载后重新出图，正常了。

包内测试：skin-center 330/332 通过。剩的 2 个失败（pkg-extract 的符号链接逃逸、we-routes 的场景缓存驱逐）在没改动的 dev 上一样挂，是本地环境的问题，跟这次改动无关。lib/index.js 用 tsdown 重新生成过，diff 里只有这 6 行。

顺带说明 CI：仓库 CI 的 Tests 阶段现在挂在 `dsh-desktop-launcher` 的 `announceToAgent` 默认值测试上（#839 那摊），这个失败在 dev 分支最新提交 `9270d01` 自己跑 CI 时就有，不是这个 PR 引入的，这次改动只碰了 skin-center 的场景播放器。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A。纯渲染健壮性修复，没有界面样式上的变化；恢复行为见上面的本地验证。
