### PR TITLE
fix(skin-center): detect Wallpaper Engine libraries by appmanifest and honor DSH_SKINS_DIR

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -1903,7 +1903,15 @@ function steamPathFromRegistry(run = () => execFileSync(join(process.env.SystemR
 		return null;
 	}
 }
-/** Parse libraryfolders.vdf for library roots that own app 431960. */
+/**
+* Parse libraryfolders.vdf for library roots that own app 431960.
+*
+* The vdf's per-library `apps` block is a Steam-maintained cache and can lag
+* reality (a library that owns app 431960 — its `steamapps/appmanifest_431960.acf`
+* exists — is not always listed there, e.g. when Steam has not rewritten the
+* file since the install). So this parser alone is not the authority; the
+* app-manifest probe (libraryOwnsAppFromManifest) is the fallback.
+*/
 function librariesFromVdf(vdfText) {
 	const libraries = [];
 	let current = null;
@@ -1918,10 +1926,35 @@ function librariesFromVdf(vdfText) {
 	return libraries;
 }
 /**
+* Parse every library root listed in libraryfolders.vdf, regardless of
+* whether its `apps` block names app 431960. The vdf is the authoritative
+* list of Steam library locations; the per-app cache is not.
+*/
+function allLibrariesFromVdf(vdfText) {
+	const libraries = [];
+	for (const line of vdfText.split(/\r?\n/)) {
+		const match = /^\s*"path"\s+"([^"]+)"\s*$/.exec(line);
+		if (match) {
+			const root = match[1].replace(/\\\\/g, "\\");
+			if (!libraries.includes(root)) libraries.push(root);
+		}
+	}
+	return libraries;
+}
+/**
+* Whether a Steam library root owns app `appid`, decided by the durable
+* install manifest (`steamapps/appmanifest_<appid>.acf`) rather than the
+* vdf's apps cache. Injectable for tests.
+*/
+function libraryOwnsAppFromManifest(library, appid, exists = existsSync) {
+	return exists(join(library, "steamapps", `appmanifest_${appid}.acf`));
+}
+/**
 * Locate the Wallpaper Engine install directory (holds wallpaper32.exe).
-* Probes: registry Steam root, well-known paths, then every library that
-* owns the app. Non-Windows platforms return null (WE ships Windows-only;
-* manual library folders are the fallback there).
+* Probes: registry Steam root, well-known paths, then every library listed
+* in any libraryfolders.vdf (whether or not its apps cache names 431960 —
+* the exe itself is the authority). Non-Windows platforms return null (WE
+* ships Windows-only; manual library folders are the fallback there).
 * @param opts.env - environment (tests inject).
 * @param opts.exists - existence probe (tests inject).
 */
@@ -1934,7 +1967,7 @@ function locateWallpaperEngine(opts = {}) {
 		for (const probe of probes) {
 			const vdf = join(probe, "steamapps", "libraryfolders.vdf");
 			if (exists(vdf)) try {
-				libraries.push(...librariesFromVdf(readFileSync(vdf, "utf8")));
+				libraries.push(...allLibrariesFromVdf(readFileSync(vdf, "utf8")));
 			} catch {}
 		}
 		const candidates = [];
@@ -1947,20 +1980,31 @@ function locateWallpaperEngine(opts = {}) {
 /**
 * Steam library roots that own app 431960 (for the workshop content dir).
 * Empty on non-Windows or when nothing is found.
+*
+* Two sources are merged and deduped:
+*   - libraries whose vdf `apps` block names 431960 (fast cache hit), and
+*   - every library whose `steamapps/appmanifest_431960.acf` exists (the
+*     durable fact, covering stale vdf caches that omit the app).
 */
 function owningLibraries(opts = {}) {
 	const exists = opts.exists ?? existsSync;
 	if (process.platform !== "win32" && !opts.exists) return [];
 	const registry = opts.registry ?? (() => steamPathFromRegistry());
 	const probes = [...new Set([registry(), ...STEAM_PROBE_DIRS].filter((d) => !!d))];
-	const libraries = [];
+	const owning = /* @__PURE__ */ new Set();
 	for (const probe of probes) {
 		const vdf = join(probe, "steamapps", "libraryfolders.vdf");
-		if (exists(vdf)) try {
-			libraries.push(...librariesFromVdf(readFileSync(vdf, "utf8")));
-		} catch {}
+		if (!exists(vdf)) continue;
+		let vdfText;
+		try {
+			vdfText = readFileSync(vdf, "utf8");
+		} catch {
+			continue;
+		}
+		for (const root of librariesFromVdf(vdfText)) owning.add(root);
+		for (const root of allLibrariesFromVdf(vdfText)) if (libraryOwnsAppFromManifest(root, "431960", exists)) owning.add(root);
 	}
-	return [...new Set(libraries)];
+	return [...owning];
 }
 /** Infer the wallpaper type from the main file extension (project.json fallback). */
 function inferType(file) {

--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -401,10 +401,18 @@ function resolveHarnessPaths(home, profile, fromUrl = import.meta.url) {
 function builtinSkinsDir(fromUrl = import.meta.url) {
 	return join(dirname(fileURLToPath(fromUrl)), "..", "skins");
 }
-/** User skins live in $DSH_HOME/skins/. DSH_SKINS_HOME overrides (tests). */
+/**
+* User skins live in $DSH_HOME/skins/. DSH_SKINS_HOME overrides (tests).
+*
+* DSH_SKINS_DIR is also honored (after DSH_SKINS_HOME) for deployments that
+* set the legacy variable: earlier skin tooling used DSH_SKINS_DIR, and
+* existing launcher scripts still export it.
+*/
 function userSkinsDir(env = process.env) {
-	const override = env.DSH_SKINS_HOME;
-	if (override && override.trim() !== "") return resolve(override);
+	const home = env.DSH_SKINS_HOME;
+	if (home && home.trim() !== "") return resolve(home);
+	const dir = env.DSH_SKINS_DIR;
+	if (dir && dir.trim() !== "") return resolve(dir);
 	return join(resolveHarnessHome(), "skins");
 }
 function readManifest(dir) {

--- a/packages/skins/skin-center/src/skin-repo.ts
+++ b/packages/skins/skin-center/src/skin-repo.ts
@@ -60,10 +60,18 @@ export function builtinSkinsDir(fromUrl: string = import.meta.url): string {
   return join(dirname(fileURLToPath(fromUrl)), '..', 'skins')
 }
 
-/** User skins live in $DSH_HOME/skins/. DSH_SKINS_HOME overrides (tests). */
+/**
+ * User skins live in $DSH_HOME/skins/. DSH_SKINS_HOME overrides (tests).
+ *
+ * DSH_SKINS_DIR is also honored (after DSH_SKINS_HOME) for deployments that
+ * set the legacy variable: earlier skin tooling used DSH_SKINS_DIR, and
+ * existing launcher scripts still export it.
+ */
 export function userSkinsDir(env: NodeJS.ProcessEnv = process.env): string {
-  const override = env.DSH_SKINS_HOME
-  if (override && override.trim() !== '') return resolvePath(override)
+  const home = env.DSH_SKINS_HOME
+  if (home && home.trim() !== '') return resolvePath(home)
+  const dir = env.DSH_SKINS_DIR
+  if (dir && dir.trim() !== '') return resolvePath(dir)
   return join(resolveHarnessHome(), 'skins')
 }
 

--- a/packages/skins/skin-center/src/we-library.ts
+++ b/packages/skins/skin-center/src/we-library.ts
@@ -151,7 +151,15 @@ export function steamPathFromRegistry(
   }
 }
 
-/** Parse libraryfolders.vdf for library roots that own app 431960. */
+/**
+ * Parse libraryfolders.vdf for library roots that own app 431960.
+ *
+ * The vdf's per-library `apps` block is a Steam-maintained cache and can lag
+ * reality (a library that owns app 431960 — its `steamapps/appmanifest_431960.acf`
+ * exists — is not always listed there, e.g. when Steam has not rewritten the
+ * file since the install). So this parser alone is not the authority; the
+ * app-manifest probe (libraryOwnsAppFromManifest) is the fallback.
+ */
 export function librariesFromVdf(vdfText: string): string[] {
   const libraries: string[] = []
   let current: string | null = null
@@ -169,10 +177,41 @@ export function librariesFromVdf(vdfText: string): string[] {
 }
 
 /**
+ * Parse every library root listed in libraryfolders.vdf, regardless of
+ * whether its `apps` block names app 431960. The vdf is the authoritative
+ * list of Steam library locations; the per-app cache is not.
+ */
+export function allLibrariesFromVdf(vdfText: string): string[] {
+  const libraries: string[] = []
+  for (const line of vdfText.split(/\r?\n/)) {
+    const match = /^\s*"path"\s+"([^"]+)"\s*$/.exec(line)
+    if (match) {
+      const root = match[1].replace(/\\\\/g, '\\')
+      if (!libraries.includes(root)) libraries.push(root)
+    }
+  }
+  return libraries
+}
+
+/**
+ * Whether a Steam library root owns app `appid`, decided by the durable
+ * install manifest (`steamapps/appmanifest_<appid>.acf`) rather than the
+ * vdf's apps cache. Injectable for tests.
+ */
+export function libraryOwnsAppFromManifest(
+  library: string,
+  appid: string,
+  exists: (path: string) => boolean = existsSync,
+): boolean {
+  return exists(joinPath(library, 'steamapps', `appmanifest_${appid}.acf`))
+}
+
+/**
  * Locate the Wallpaper Engine install directory (holds wallpaper32.exe).
- * Probes: registry Steam root, well-known paths, then every library that
- * owns the app. Non-Windows platforms return null (WE ships Windows-only;
- * manual library folders are the fallback there).
+ * Probes: registry Steam root, well-known paths, then every library listed
+ * in any libraryfolders.vdf (whether or not its apps cache names 431960 —
+ * the exe itself is the authority). Non-Windows platforms return null (WE
+ * ships Windows-only; manual library folders are the fallback there).
  * @param opts.env - environment (tests inject).
  * @param opts.exists - existence probe (tests inject).
  */
@@ -191,7 +230,7 @@ export function locateWallpaperEngine(opts: {
       const vdf = joinPath(probe, 'steamapps', 'libraryfolders.vdf')
       if (exists(vdf)) {
         try {
-          libraries.push(...librariesFromVdf(readFileSync(vdf, 'utf8')))
+          libraries.push(...allLibrariesFromVdf(readFileSync(vdf, 'utf8')))
         } catch {
           // Unreadable vdf: skip this probe.
         }
@@ -212,6 +251,11 @@ export function locateWallpaperEngine(opts: {
 /**
  * Steam library roots that own app 431960 (for the workshop content dir).
  * Empty on non-Windows or when nothing is found.
+ *
+ * Two sources are merged and deduped:
+ *   - libraries whose vdf `apps` block names 431960 (fast cache hit), and
+ *   - every library whose `steamapps/appmanifest_431960.acf` exists (the
+ *     durable fact, covering stale vdf caches that omit the app).
  */
 export function owningLibraries(opts: {
   exists?: (path: string) => boolean
@@ -221,18 +265,23 @@ export function owningLibraries(opts: {
   if (process.platform !== 'win32' && !opts.exists) return []
   const registry = opts.registry ?? (() => steamPathFromRegistry())
   const probes = [...new Set([registry(), ...STEAM_PROBE_DIRS].filter((d): d is string => !!d))]
-  const libraries: string[] = []
+  const owning = new Set<string>()
   for (const probe of probes) {
     const vdf = joinPath(probe, 'steamapps', 'libraryfolders.vdf')
-    if (exists(vdf)) {
-      try {
-        libraries.push(...librariesFromVdf(readFileSync(vdf, 'utf8')))
-      } catch {
-        // Skip.
-      }
+    if (!exists(vdf)) continue
+    let vdfText: string
+    try {
+      vdfText = readFileSync(vdf, 'utf8')
+    } catch {
+      // Skip unreadable vdf.
+      continue
+    }
+    for (const root of librariesFromVdf(vdfText)) owning.add(root)
+    for (const root of allLibrariesFromVdf(vdfText)) {
+      if (libraryOwnsAppFromManifest(root, WE_APPID, exists)) owning.add(root)
     }
   }
-  return [...new Set(libraries)]
+  return [...owning]
 }
 
 /** Infer the wallpaper type from the main file extension (project.json fallback). */

--- a/packages/skins/skin-center/tests/skin-repo.spec.ts
+++ b/packages/skins/skin-center/tests/skin-repo.spec.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { findSkin, loadSkinCatalog, resolveInsideSkin } from '../src/skin-repo.ts'
+import { findSkin, loadSkinCatalog, resolveInsideSkin, userSkinsDir } from '../src/skin-repo.ts'
 import type { SkinCatalogEntry } from '../src/skin-repo.ts'
 
 let root: string
@@ -93,6 +93,14 @@ describe('loadSkinCatalog', () => {
     const catalog = loadSkinCatalog({ builtinDir: join(root, 'nope'), userDir: join(root, 'nada') })
     expect(catalog.skins).toEqual([])
     expect(catalog.diagnostics).toEqual([])
+  })
+})
+
+describe('userSkinsDir', () => {
+  it('prefers DSH_SKINS_HOME, then DSH_SKINS_DIR, then $DSH_HOME/skins', () => {
+    expect(userSkinsDir({ DSH_SKINS_HOME: 'C:\\a', DSH_SKINS_DIR: 'C:\\b' })).toBe('C:\\a')
+    expect(userSkinsDir({ DSH_SKINS_DIR: 'C:\\b' })).toBe('C:\\b')
+    expect(userSkinsDir({ DSH_SKINS_DIR: '  ' })).toBe(join(process.env.DSH_HOME ?? join(process.cwd(), '..'), 'skins'))
   })
 })
 

--- a/packages/skins/skin-center/tests/we-library.spec.ts
+++ b/packages/skins/skin-center/tests/we-library.spec.ts
@@ -4,15 +4,19 @@
  * synthesis), the import store, and inventory update detection — all against
  * synthetic fixture trees in a temp dir; nothing real is ever touched.
  */
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
+  allLibrariesFromVdf,
   buildInventory,
   expandUser,
   inferType,
   librariesFromVdf,
+  libraryOwnsAppFromManifest,
+  locateWallpaperEngine,
+  owningLibraries,
   readImportedManifest,
   readProjectJson,
   scanImportStore,
@@ -62,6 +66,124 @@ describe('librariesFromVdf', () => {
       '}',
     ].join('\n')
     expect(librariesFromVdf(vdf)).toEqual(['C:\\Steam'])
+  })
+})
+
+describe('allLibrariesFromVdf', () => {
+  it('collects every library root, ignoring the per-app apps cache', () => {
+    const vdf = [
+      '"libraryfolders"',
+      '{',
+      '  "0"',
+      '  {',
+      '    "path"    "C:\\\\Steam"',
+      '    "apps"',
+      '    {',
+      '      "431960"    "123"',
+      '    }',
+      '  }',
+      '  "1"',
+      '  {',
+      '    "path"    "D:\\\\SteamLibrary"',
+      '    "apps"',
+      '    {',
+      '      "570"    "456"',
+      '    }',
+      '  }',
+      '}',
+    ].join('\n')
+    expect(allLibrariesFromVdf(vdf)).toEqual(['C:\\Steam', 'D:\\SteamLibrary'])
+  })
+
+  it('dedupes repeated roots', () => {
+    const vdf = '"path" "C:\\\\Steam"\n"path" "C:\\\\Steam"\n'.replace(/\\\\/g, '\\')
+    expect(allLibrariesFromVdf(vdf)).toEqual(['C:\\Steam'])
+  })
+})
+
+describe('libraryOwnsAppFromManifest', () => {
+  it('decides ownership from the durable appmanifest instead of the vdf cache', () => {
+    const library = join(root, 'lib')
+    mkdirSync(join(library, 'steamapps'), { recursive: true })
+    writeFileSync(join(library, 'steamapps', 'appmanifest_431960.acf'), '"appid" "431960"', 'utf8')
+    expect(libraryOwnsAppFromManifest(library, '431960')).toBe(true)
+    expect(libraryOwnsAppFromManifest(join(root, 'other'), '431960')).toBe(false)
+  })
+})
+
+describe('owningLibraries', () => {
+  it('adds a library whose appmanifest exists even when the vdf apps cache omits 431960', () => {
+    const steam = join(root, 'steam')
+    const library = join(root, 'G', 'SteamLibrary')
+    mkdirSync(join(steam, 'steamapps'), { recursive: true })
+    mkdirSync(join(library, 'steamapps'), { recursive: true })
+    writeFileSync(join(steam, 'steamapps', 'libraryfolders.vdf'), [
+      '"libraryfolders"',
+      '{',
+      '  "0"',
+      '  {',
+      '    "path"    "' + library.replace(/\\/g, '\\\\') + '"',
+      '    "apps"',
+      '    {',
+      '    }',
+      '  }',
+      '}',
+    ].join('\n'), 'utf8')
+    // The durable manifest exists, but the vdf apps block does not name it.
+    writeFileSync(join(library, 'steamapps', 'appmanifest_431960.acf'), '"appid" "431960"', 'utf8')
+    expect(owningLibraries({ exists: existsSync, registry: () => steam })).toEqual([library])
+  })
+
+  it('keeps the vdf cache match without an appmanifest', () => {
+    const steam = join(root, 'steam2')
+    const library = join(root, 'lib2')
+    mkdirSync(join(steam, 'steamapps'), { recursive: true })
+    mkdirSync(join(library, 'steamapps'), { recursive: true })
+    writeFileSync(join(steam, 'steamapps', 'libraryfolders.vdf'), [
+      '"libraryfolders"',
+      '{',
+      '  "0"',
+      '  {',
+      '    "path"    "' + library.replace(/\\/g, '\\\\') + '"',
+      '    "apps"',
+      '    {',
+      '      "431960"    "123"',
+      '    }',
+      '  }',
+      '}',
+    ].join('\n'), 'utf8')
+    expect(owningLibraries({ exists: existsSync, registry: () => steam })).toEqual([library])
+  })
+})
+
+describe('locateWallpaperEngine', () => {
+  it('finds the install in a library whose vdf apps cache omits 431960', () => {
+    const steam = join(root, 'steam3')
+    const library = join(root, 'lib3')
+    const install = join(library, 'steamapps', 'common', 'wallpaper_engine')
+    mkdirSync(join(steam, 'steamapps'), { recursive: true })
+    mkdirSync(install, { recursive: true })
+    writeFileSync(join(install, 'wallpaper32.exe'), 'x', 'utf8')
+    writeFileSync(join(steam, 'steamapps', 'libraryfolders.vdf'), [
+      '"libraryfolders"',
+      '{',
+      '  "0"',
+      '  {',
+      '    "path"    "' + library.replace(/\\/g, '\\\\') + '"',
+      '    "apps"',
+      '    {',
+      '    }',
+      '  }',
+      '}',
+    ].join('\n'), 'utf8')
+    expect(locateWallpaperEngine({ env: { OS: 'Windows_NT' }, exists: existsSync, registry: () => steam })).toBe(install)
+  })
+
+  it('returns null when nothing is found', () => {
+    const steam = join(root, 'steam4')
+    mkdirSync(join(steam, 'steamapps'), { recursive: true })
+    writeFileSync(join(steam, 'steamapps', 'libraryfolders.vdf'), '"libraryfolders"\n{\n}\n', 'utf8')
+    expect(locateWallpaperEngine({ env: { OS: 'Windows_NT' }, exists: existsSync, registry: () => steam })).toBeNull()
   })
 })
 


### PR DESCRIPTION
## 摘要（Summary）

修复皮肤中心 Wallpaper Engine 库发现的两个问题：

1. **壁纸扫描不到**：`libraryfolders.vdf` 的 per-library `apps` 块是 Steam 维护的缓存，会滞后于磁盘事实——一个库即使已安装 Wallpaper Engine（`steamapps/appmanifest_431960.acf` 存在），vdf 里也可能没有 431960。原实现只信任 vdf 文本，导致 `locateWallpaperEngine()` 返回 null、`owningLibraries()` 为空，创意工坊壁纸全部扫不到。
2. **自定义皮肤目录失效**：`userSkinsDir()` 只认 `DSH_SKINS_HOME` 或 `$DSH_HOME/skins`，但既有部署（启动脚本）使用 `DSH_SKINS_DIR` 变量，导致 wallpaper-1~9 等用户皮肤进不了 catalog。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/skins/skin-center`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，并在提交前 rebase 了最新 `dev`。

同步记录：`git fetch origin dev && git rebase origin/dev` 后，分支基于 `058d624`（origin/dev 最新），rebase 无冲突。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据。

```bash
pnpm exec vitest run --config packages/skins/skin-center/vitest.config.ts --root packages/skins/skin-center
# Test Files  2 failed | 18 passed (20)
# Tests       2 failed | 344 passed (346)
# 2 个失败均为既有失败（见下），与本次改动无关。
```

```bash
pnpm exec tsc -p packages/skins/skin-center/tsconfig.json --noEmit
# 通过（exit 0）
```

- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据。

同步后（基于 `058d624`）重新执行的测试结果：

```bash
git fetch origin dev && git rebase origin/dev   # 无冲突
pnpm exec vitest run --config packages/skins/skin-center/vitest.config.ts --root packages/skins/skin-center
# Test Files  2 failed | 18 passed (20)
# Tests       2 failed | 344 passed (346)
pnpm exec tsc -p packages/skins/skin-center/tsconfig.json --noEmit   # exit 0
```

关于 2 个既有失败（在未改动的 `dev` 基线上同样失败，已用 `git stash` 对比验证）：

- `pkg-extract.spec.ts > refuses to read project files that are symlinks escaping the directory`：Windows 上创建 symlink 需要开发者模式/管理员权限，属环境问题；
- `we-routes.spec.ts > scene-probe cache (#817) > evicts the oldest probe entries`：偶发失败，多次运行中非稳定出现。

新增测试（全部通过）：

- `we-library.spec.ts`：`allLibrariesFromVdf`、`libraryOwnsAppFromManifest`、`owningLibraries`（vdf 缺 431960 但 .acf 存在时仍识别）、`locateWallpaperEngine`（vdf apps 缓存缺项时仍找到 wallpaper32.exe）
- `skin-repo.spec.ts`：`userSkinsDir` 优先级（DSH_SKINS_HOME > DSH_SKINS_DIR > $DSH_HOME/skins）

## 用户可见变更证据（Local Feature Evidence）

- 修复前：皮肤中心壁纸面板显示「未检测到 Wallpaper Engine 安装」，0 个壁纸。
- 修复后（本机真实环境验证）：自动定位 `G:\SteamLibrary\steamapps\common\wallpaper_engine`，列出 26 个壁纸（7 创意工坊 + 19 本地默认），无需手动填目录。
- 修复后：用户皮肤（wallpaper-1~9，部署于 `DSH_SKINS_DIR` 指定目录）重新进入 catalog。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- 使用的 AI 模型：DeepSeek
- 使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 未改动 README（行为修复，不涉及文档契约变更）。

## 本地验证（Local Validation）

执行的命令：

```bash
git fetch origin dev && git rebase origin/dev
pnpm exec vitest run --config packages/skins/skin-center/vitest.config.ts --root packages/skins/skin-center
pnpm exec tsc -p packages/skins/skin-center/tsconfig.json --noEmit
```

结果摘要：同步最新 dev（058d624）后 344 passed / 2 既有失败（基线同样失败）；typecheck 通过。

## 说明

场景复原（本机真实环境）：Steam 根目录 `e:/steam`，Wallpaper Engine 装在 `G:\SteamLibrary` 库（`appmanifest_431960.acf` 存在），但 `e:/steam/steamapps/libraryfolders.vdf` 的 G 库 `apps` 块没有列出 431960（Steam 未重写缓存）。原代码因此完全扫不到；本 PR 让 `.acf` 成为权威事实，同时保留 vdf 快照路径作为快速通道。
