### PR TITLE
fix(plugin-manager): resolve boot profile from desktopProfiles service

### DIFF
--- a/packages/dsh-plugin-manager/src/host/profile.ts
+++ b/packages/dsh-plugin-manager/src/host/profile.ts
@@ -25,15 +25,24 @@ export interface ProfileFacts {
 }
 
 /**
- * Resolve the boot profile name from the host argv: an explicit `--profile`
- * flag wins, then the DSH_PROFILE environment override, then the `web`
- * subcommand alias. The launcher hands the app its own args verbatim, so the
- * web app's argv is the reliable source on every CLI-launched host.
+ * Resolve the boot profile name: an explicit `--profile` flag wins, then the
+ * DSH_PROFILE environment override, then the `web` subcommand alias, then the
+ * desktop app's active profile. The launcher hands the app its own args
+ * verbatim, so the web app's argv is the reliable source on every
+ * CLI-launched host; the packaged Desktop shell (deepseek-harness-desktop)
+ * boots the harness in-process with none of those facts, so its
+ * `desktopProfiles` service name is the final fallback.
  * @param argv - process argv (test seam).
  * @param env - process environment (test seam).
+ * @param desktopProfileName - active profile reported by the desktop shell's
+ * `desktopProfiles` service, when this runtime provides one.
  * @returns the resolved profile facts.
  */
-export function resolveProfile(argv: readonly string[] = process.argv, env: NodeJS.ProcessEnv = process.env): ProfileFacts {
+export function resolveProfile(
+  argv: readonly string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env,
+  desktopProfileName?: string,
+): ProfileFacts {
   const flagIndex = argv.indexOf('--profile')
   let name: string | undefined
   if (flagIndex !== -1 && argv[flagIndex + 1] !== undefined && argv[flagIndex + 1] !== '') {
@@ -42,6 +51,9 @@ export function resolveProfile(argv: readonly string[] = process.argv, env: Node
     name = env.DSH_PROFILE.trim()
   } else if (argv.includes('web')) {
     name = 'web'
+  }
+  if (name === undefined && desktopProfileName !== undefined && desktopProfileName.trim() !== '') {
+    name = desktopProfileName.trim()
   }
   if (name === undefined) {
     throw new Error('plugin-manager: cannot determine the boot profile; pass --profile <name> or set DSH_PROFILE')

--- a/packages/dsh-plugin-manager/src/index.ts
+++ b/packages/dsh-plugin-manager/src/index.ts
@@ -29,12 +29,15 @@ export const inject = ['webServer']
 export const apply = mountOnce('@linxin666/dsh-client-ui-plugin-manager', applyImpl)
 
 function applyImpl(ctx: Context): void {
-  // Gateway mode needs the boot profile; on hosts without one (desktop
-  // launches that do not pass --profile) the official channels serve the
-  // browser half, so this half stays dormant.
+  // Gateway mode needs the boot profile. CLI-launched hosts carry
+  // --profile / DSH_PROFILE / the web subcommand in argv; the packaged
+  // Desktop shell (deepseek-harness-desktop) boots the harness in-process
+  // with none of those, so its desktopProfiles service reports the active
+  // profile and this half must serve the browser tab there as well.
   let facts
   try {
-    facts = resolveProfile()
+    const desktop = ctx.get('desktopProfiles') as { current?: { name?: string } } | undefined
+    facts = resolveProfile(undefined, undefined, desktop?.current?.name)
   } catch (error) {
     console.error('[plugin-manager]', error instanceof Error ? error.message : String(error))
     return

--- a/packages/dsh-plugin-manager/tests/profile.spec.ts
+++ b/packages/dsh-plugin-manager/tests/profile.spec.ts
@@ -22,6 +22,25 @@ describe('resolveProfile', () => {
     expect(facts.profileName).toBe('web')
   })
 
+  it('falls back to the desktop profile name when no launcher fact names one', () => {
+    const facts = resolveProfile(['node', 'bin.js'], env, 'web')
+    expect(facts.profileName).toBe('web')
+    expect(facts.profileDir).toBe(join('/tmp/dsh-home', 'profiles', 'web'))
+  })
+
+  it('prefers launcher facts over the desktop profile name', () => {
+    const facts = resolveProfile(['node', 'bin.js', '--profile', 'headless'], env, 'web')
+    expect(facts.profileName).toBe('headless')
+  })
+
+  it('ignores a blank desktop profile name', () => {
+    expect(() => resolveProfile(['node', 'bin.js'], env, '   ')).toThrow(/cannot determine the boot profile/)
+  })
+
+  it('rejects traversal in the desktop profile name', () => {
+    expect(() => resolveProfile(['node', 'bin.js'], env, '../etc')).toThrow(/invalid profile name/)
+  })
+
   it('throws when nothing names a profile', () => {
     expect(() => resolveProfile(['node', 'bin.js'], env)).toThrow(/cannot determine the boot profile/)
   })


### PR DESCRIPTION
## 摘要（Summary）

修复 dsh-plugin-manager 在打包版桌面端（兼容 https://github.com/anywhere-labs/deepseek-harness-desktop）中无法解析 boot profile 的问题。

原因：桌面 Electron shell 在进程内启动 harness，argv 里没有 `--profile` / `web`，也没有 `DSH_PROFILE` 环境变量，host 端 `resolveProfile()` 抛错后静默放弃注册 `/api/plugin-manager/*` 路由，设置页「插件管理」Tab 显示「操作失败：load」且列表空白。

修复：解析失败时回退到桌面端 `desktopProfiles` 服务上报的激活 profile（CLI 启动的 dsh web 行为不变，argv / 环境变量优先级保持不变）。

## 涉及包（Affected Packages）

- [x] 其他：`packages/dsh-plugin-manager`

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 已基于最新 `dev` 分支开发，并在提交前 rebase 最新 upstream `dev`（`git fetch upstream && git rebase upstream/dev`）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 本地测试证据：`packages/dsh-plugin-manager` 下 `pnpm typecheck` 通过；`pnpm test` 15 个测试文件、116 个用例全部通过（含新增 4 个 resolveProfile 桌面回退用例）。
- [x] 已同步上游最新 `dev` 分支并 rebase，同步后未产生冲突。

运行时验证（deepseek-harness-desktop 实机）：同一份回退逻辑先以临时补丁形式打到已安装的 0.2.6 包上验证——桌面端重启后 `/api/plugin-manager/list` 由 404 变为正常返回插件列表，「插件管理」页恢复加载；CLI 启动的 `dsh web` 行为不变。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek
使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增 / 修改文件不含任何 emoji 字符。
- [x] 未改动 README / 文档，无需运行 docs 相关检查。

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-plugin-manager
pnpm typecheck   # passed
pnpm test        # 15 files, 116 tests passed
```

结果摘要：全部通过。

## 用户可见变更证据（Local Feature Evidence）

证据：deepseek-harness-desktop 实机验证——未修复时桌面端 `/api/plugin-manager/list` 返回 404、「插件管理」页显示「操作失败：load」且列表空白；应用本修复（等价逻辑）后桌面重启，「插件管理」页正常加载插件列表。CLI 启动的 web 实例不受影响。
