### PR TITLE
fix(remote-web-ui): preserve out-of-order polled events (#851)

### DIFF
--- a/packages/dsh-remote-web-ui/src/mobile/mux.test.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/mux.test.ts
@@ -95,6 +95,20 @@ describe('MuxClient polling fallback', () => {
     client.stop()
   })
 
+  it('sorts an out-of-order poll page before advancing the watermark', async () => {
+    const { factory } = makeSources()
+    const pollLatest = vi.fn(async (_sessionId: string) => pageOf([2, 1, 3]))
+    const client = new MuxClient('/m/api/events.mux', baseOptions(pollLatest, factory))
+    const frames: Array<{ type: string; event?: { seq: number } }> = []
+    client.onFrame(frame => { frames.push(frame as never) })
+    client.start()
+    client.observe('s1')
+
+    await vi.advanceTimersByTimeAsync(1200)
+    expect(frames.map(frame => frame.event?.seq)).toEqual([1, 2, 3])
+    client.stop()
+  })
+
   it('keeps the watermark so a repeated page never re-emits old events', async () => {
     const { factory } = makeSources()
     // Two calls return the same page: the second must emit nothing.

--- a/packages/dsh-remote-web-ui/src/mobile/mux.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/mux.ts
@@ -246,8 +246,13 @@ export class MuxClient {
     }
     try {
       const page = await this.pollLatest(sessionId)
+      const ordered = [...page.events].sort((a, b) => {
+        const aSeq = typeof a.event?.seq === 'number' ? a.event.seq : -1
+        const bSeq = typeof b.event?.seq === 'number' ? b.event.seq : -1
+        return aSeq - bSeq
+      })
       let maxSeq = this.pollWatermark.get(sessionId) ?? -1
-      for (const entry of page.events) {
+      for (const entry of ordered) {
         const event = entry.event
         const seq = typeof event?.seq === 'number' ? event.seq : -1
         if (seq <= maxSeq) continue


### PR DESCRIPTION
## 摘要（Summary）

处理 #851 的 **A 子问题**：mobile polling fallback 不能假设 `session.history` 页内事件已经按 `seq` 升序排列。当前 `pollTick()` 会边遍历边推进 watermark；如果页面顺序为 `[2, 1, 3]`，`seq=1` 会在 watermark 已推进到 2 后被永久跳过。

本 PR 在推进 watermark 前先按事件 `seq` 升序处理，并增加一个乱序 history page 的回归测试。**仅处理 #851-A；#851 后续补充的 B（SSE 静默 stall 恢复）与 C（同轮 step 顺序）明确不在本 PR 范围内。**

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步证据：

```text
upstream dev: 058d624c56e66dee8b32de4458e7f7000e22a601
branch base:  058d624c56e66dee8b32de4458e7f7000e22a601
branch head:  e8ffaedcb66a67c7063fa885470f7f5c74db66f4
```

本分支直接从上游 `dev` 的上述精确 SHA 创建。提交完成后、创建 PR 前再次查询上游 `dev`，仍为同一 SHA，因此无需额外 rebase。base-to-head 比较为 ahead 2 / behind 0，diff 仅含 `mux.ts` 与 `mux.test.ts`。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支，并附上同步后重新测试通过的证据。

提交完成后再次读取上游 `dev`，仍为 `058d624c56e66dee8b32de4458e7f7000e22a601`；随后重新执行最小复现：

```bash
node <<'NODE'
const input = [2, 1, 3]
function deliver(events) {
  let maxSeq = -1
  const out = []
  for (const seq of events) {
    if (seq <= maxSeq) continue
    maxSeq = seq
    out.push(seq)
  }
  return out
}
const oldResult = deliver(input)
const fixedResult = deliver([...input].sort((a, b) => a - b))
if (JSON.stringify(oldResult) !== JSON.stringify([2, 3])) process.exit(1)
if (JSON.stringify(fixedResult) !== JSON.stringify([1, 2, 3])) process.exit(1)
console.log('old:', JSON.stringify(oldResult))
console.log('fixed:', JSON.stringify(fixedResult))
NODE
```

实际输出：

```text
old: [2,3]
fixed: [1,2,3]
```

回归测试已加入 `packages/dsh-remote-web-ui/src/mobile/mux.test.ts`：以 `pageOf([2, 1, 3])` 驱动真实 `MuxClient` polling 路径，并断言最终投递 seq 为 `[1, 2, 3]`。

另外，在 fork 上对**与本 PR 完全相同的 head `e8ffaedcb66a67c7063fa885470f7f5c74db66f4`**运行了仓库原生 `.github/workflows/ci.yml`：

- CI run #1: https://github.com/teddyli18000/dsh-web-ui/actions/runs/32470929563
- `CI checks`: success
  - Typecheck
  - Gallery / Skin center / Community consistency
  - Build
  - Tests
  - Script tests
  - Runtime dependency check
  - Aggregate package consistency
  - No emoji rule
  - Documentation consistency
- `plugin-mount`: success
  - Build
  - Playwright Chromium install
  - Mount + headless-render smoke

因此，本 PR 的精确 head 已通过仓库完整 CI 与 plugin-mount 验证。

## 视觉修复要求（Visual Fix Requirements）

N/A（非视觉修复）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5.6 Sol

使用的编码 Agent 工具：

Sol

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
node <<'NODE'
const input = [2, 1, 3]
function deliver(events) {
  let maxSeq = -1
  const out = []
  for (const seq of events) {
    if (seq <= maxSeq) continue
    maxSeq = seq
    out.push(seq)
  }
  return out
}
const oldResult = deliver(input)
const fixedResult = deliver([...input].sort((a, b) => a - b))
if (JSON.stringify(oldResult) !== JSON.stringify([2, 3])) process.exit(1)
if (JSON.stringify(fixedResult) !== JSON.stringify([1, 2, 3])) process.exit(1)
console.log('old:', JSON.stringify(oldResult))
console.log('fixed:', JSON.stringify(fixedResult))
NODE
```

结果摘要：

```text
old: [2,3]
fixed: [1,2,3]
```

同步上游最新 `dev` 后重新验证结果一致；同时 fork CI run #1 对同一 head 完整通过 `CI checks` 与 `plugin-mount`。

## 用户可见变更证据（Local Feature Evidence）

N/A（内部事件投递顺序修复，无视觉变更；行为由新增回归测试覆盖）。