### PR TITLE
fix(pet): dispose stale client roots

### DIFF
--- a/packages/dsh-pet/src/client/index.test.tsx
+++ b/packages/dsh-pet/src/client/index.test.tsx
@@ -55,8 +55,14 @@ afterEach(() => {
   document.body.replaceChildren()
 })
 
+interface FakeContextHandle {
+  ctx: ClientContext
+  disposeAll: () => void
+}
+
 /** A minimal client root context: ready settings scope, no-op slot system. */
-function fakeContext(): ClientContext {
+function fakeContext(): FakeContextHandle {
+  const disposers: Array<() => void> = []
   const scope = {
     getSnapshot: () => ({
       status: 'ready',
@@ -69,10 +75,12 @@ function fakeContext(): ClientContext {
     }),
     subscribe: () => () => {},
   }
-  return {
+  const ctx = {
     effect: (fn: () => unknown) => {
       const dispose = fn()
-      return typeof dispose === 'function' ? dispose : () => {}
+      const normalized = typeof dispose === 'function' ? dispose as () => void : () => {}
+      disposers.push(normalized)
+      return normalized
     },
     locale: { register: () => () => {} },
     get: () => undefined,
@@ -83,13 +91,34 @@ function fakeContext(): ClientContext {
     },
     sessions: undefined,
   } as unknown as ClientContext
+  return {
+    ctx,
+    disposeAll: () => {
+      for (const dispose of disposers.toReversed()) dispose()
+    },
+  }
 }
 
 describe('pet client apply L2 semantic attributes (#506)', () => {
   it('mounts the pet root container with data-dsh-plugin="pet"', () => {
-    apply(fakeContext())
+    const { ctx } = fakeContext()
+    apply(ctx)
     const root = document.body.querySelector('[data-dsh-pet-root]')
     expect(root).not.toBeNull()
     expect(root!.getAttribute('data-dsh-plugin')).toBe('pet')
+  })
+
+  it('keeps a single global pet root across repeated client applies', () => {
+    apply(fakeContext().ctx)
+    apply(fakeContext().ctx)
+    expect(document.body.querySelectorAll('[data-dsh-pet-root]')).toHaveLength(1)
+  })
+
+  it('removes the pet root when the client fiber is disposed', () => {
+    const handle = fakeContext()
+    apply(handle.ctx)
+    expect(document.body.querySelectorAll('[data-dsh-pet-root]')).toHaveLength(1)
+    handle.disposeAll()
+    expect(document.body.querySelectorAll('[data-dsh-pet-root]')).toHaveLength(0)
   })
 })

--- a/packages/dsh-pet/src/client/index.ts
+++ b/packages/dsh-pet/src/client/index.ts
@@ -73,6 +73,9 @@ const POLL_MS = 2000
 
 /** Settings namespace the pet settings card edits (the Host plugin registers it). */
 const PET_SETTINGS_NS = 'pet'
+const PET_ROOT_DISPOSE = '__dshPetDispose'
+
+type PetRootContainer = HTMLDivElement & { [PET_ROOT_DISPOSE]?: () => void }
 
 /** Required services (sessions powers bubble-to-session navigation). */
 export const inject = ['slots', 'locale', 'connection', 'settingsScope', 'remote', 'sessions']
@@ -296,7 +299,12 @@ export function apply(ctx: ClientContext): void {
       // The entry therefore mounts straight onto document.body via a single
       // React root for the page lifetime: PetSprite portals itself to body
       // when visible, and the hidden-state summon button is fixed-positioned.
-      const container = document.createElement('div')
+      for (const stale of document.body.querySelectorAll('[data-dsh-pet-root]')) {
+        const dispose = (stale as PetRootContainer)[PET_ROOT_DISPOSE]
+        if (dispose !== undefined) dispose()
+        else stale.remove()
+      }
+      const container = document.createElement('div') as PetRootContainer
       container.dataset.dshPetRoot = ''
       container.dataset.dshPlugin = 'pet'
       document.body.appendChild(container)
@@ -305,15 +313,23 @@ export function apply(ctx: ClientContext): void {
 
       disposeUi = () => {
         petRoot.unmount()
+        delete container[PET_ROOT_DISPOSE]
         container.remove()
         disposePoll()
         disposeUi = undefined
       }
+      container[PET_ROOT_DISPOSE] = disposeUi
     } else if (!enabled() && disposeUi !== undefined) {
       disposeUi()
       disposeUi = undefined
     }
   }
-  settingsScope.subscribe(syncUi)
-  syncUi()
+  ctx.effect(() => {
+    const unsubscribe = settingsScope.subscribe(syncUi)
+    syncUi()
+    return () => {
+      unsubscribe()
+      if (disposeUi !== undefined) disposeUi()
+    }
+  }, 'pet: global ui')
 }


### PR DESCRIPTION
## 摘要（Summary）

Fixes #785. The pet browser client now keeps one global `[data-dsh-pet-root]` across repeated client applies, removes stale legacy roots before mounting, and disposes the React root/container when the client fiber is torn down.

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [x] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

`git fetch origin` 后从 `origin/dev` = `314f9ea7` 创建分支。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

N/A: this fixes duplicate lifecycle mounts and is covered by DOM tests.

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5 Codex

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

N/A.

## 新皮肤收录（New Skin）

N/A.

## 社区插件索引登记（Community Plugin Index）

N/A.

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-pet exec vitest run src/client/index.test.tsx
pnpm --filter @linxin666/dsh-pet test
pnpm --filter @linxin666/dsh-pet typecheck
pnpm --filter @linxin666/dsh-pet build
git diff --check
```

结果摘要：

All commands above passed on Windows. `vitest` prints the existing vite-tsconfig-paths deprecation notice, but tests pass.

## 用户可见变更证据（Local Feature Evidence）

证据：

DOM regression test verifies repeated client applies keep exactly one `[data-dsh-pet-root]`, and fiber disposal removes the root container.