### PR TITLE
fix(remote-web-ui): honor host pairing policy (#905)

### DIFF
--- a/packages/dsh-remote-web-ui/README.i18n.yaml
+++ b/packages/dsh-remote-web-ui/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: dac3fd0ab51d68ce43474d04407c10ff67596b64
-README.zh.md: 035d14c5d69ff95c86fc5f5540df9cf5ec547b4f
+README.md: dc31fab1b49b32fe325ead616d52846435fa1180
+README.zh.md: e5ccaf0f52d01e9b8f92e265947c22dff68e2a97

--- a/packages/dsh-remote-web-ui/README.md
+++ b/packages/dsh-remote-web-ui/README.md
@@ -476,6 +476,10 @@ opens at `http://127.0.0.1`.
   unpair one at a time. Credential-bearing device ids and raw User-Agent
   values are not rendered. `/api/pair/status` never returns the device id
   list, even to a paired phone.
+- **The desktop gate policy is public**: `/api/pair/status` exposes only the
+  boolean `requirePairingForLan` policy so a remote desktop can choose the
+  correct transport before its settings scope is available. This field is
+  not a credential and does not expose tokens, devices, counts, or tunnel URLs.
 - **Quick-tunnel hostnames change per run**: a `trycloudflare.com` URL is
   random on every `cloudflared` start, so `publicBaseUrl` must be updated
   whenever the tunnel restarts. A named tunnel (fixed hostname) avoids the

--- a/packages/dsh-remote-web-ui/README.zh.md
+++ b/packages/dsh-remote-web-ui/README.zh.md
@@ -173,6 +173,7 @@ pnpm run build
 - **撤销是逐请求的**：已配对手机请求已在 停止 落地时在途，完成该请求；下一个 403。
 - **已配对设备会话默认落盘**：设备会话（不含一次性二维码 token）写入 `$DSH_HOME/remote-web-ui-devices.json`（0600，临时文件加原子 rename）。已配对 cookie 在重启 `dsh web` 后仍然有效。刷新二维码仍会签发新 token；重启不会恢复当前二维码。点「停止」或单台「取消配对」会立即撤销并同步落盘。超过 `idleExpireMs`（默认 7 天，无心跳或门控请求）的会话会被删除，必须重新扫码。设备 id 即会话凭证（网关凭 cookie 中的设备 id 放行请求）。需要时可用 `devicesFile` 覆盖为其他绝对路径。变更 `cookieName` 会使旧设备失效（预期行为）。
 - **设备名单仅本机可见**：配对面板根据 User-Agent 显示精简设备名称（例如 `Windows · Chrome`）、在线/离线状态与最近活动时间，并可单台取消配对。界面不渲染作为会话凭据的设备 id 或原始 User-Agent。`/api/pair/status` 即使对已配对手机也不返回设备 id 名单。
+- **桌面门控策略是公开字段**：`/api/pair/status` 只公开布尔值 `requirePairingForLan`，让远程桌面在设置作用域不可用前选择正确传输通道。该字段不是凭据，也不暴露令牌、设备、计数或隧道 URL。
 - **Quick-tunnel hostname 每次运行变化**：`trycloudflare.com` URL 每次 `cloudflared` 启动随机，所以隧道重启时 `publicBaseUrl` 必须随之更新。named tunnel（固定 hostname）避免这种抖动，也是持久安装 PWA 地址所必需的。
 - **PWA 为在线优先**：只缓存静态壳和离线页。全部移动端远程控制能力仍要求运行中的 DSH host；离线时不提供会话、API 响应或命令。
 - **开发 HMR**：`dsh web --dev` 按路径轮询每个 roster bundle，因此重建本包（其自己的 `tsdown --watch`）会热重载 client bundle；无 harness 侧 watcher。

--- a/packages/dsh-remote-web-ui/src/client/index.ts
+++ b/packages/dsh-remote-web-ui/src/client/index.ts
@@ -23,8 +23,8 @@ import { PairFailedNotice } from './PairFailedNotice.tsx'
 import { RemoteSettingsCard, RemoteSettingsCardController, type RemoteSettings } from './RemoteSettingsCard.tsx'
 import { en, zh, type RemoteKey } from './locales.ts'
 import { PAIR_FAILED_MARKER, runPairBootFlow } from './deep-link.ts'
-import { sendHeartbeat } from './pair-api.ts'
-import { channelTransition, installRemoteChannel, isLoopbackHostname } from './remote-channel.ts'
+import { readPairGatePolicy, sendHeartbeat } from './pair-api.ts'
+import { channelTransition, installRemoteChannel, isLoopbackHostname, remoteChannelRequired } from './remote-channel.ts'
 import { FenceNotice } from './FenceNotice.tsx'
 
 export type { RemoteEntryProps } from './RemoteEntry.tsx'
@@ -201,6 +201,8 @@ export function apply(ctx: ClientContext): void {
   // rewritten onto this plugin's gated /remote/api prefix (remote-channel.ts)
   // while the fence setting demands it. Loopback origins are untouched.
   let disposeChannel: (() => void) | undefined
+  let hostPairingPolicy: boolean | undefined
+  let unpairedWhilePolicyPending = false
   let fenceNotice: { unmount: () => void; node: HTMLElement } | undefined
   const showFenceNotice = (): void => {
     if (fenceNotice !== undefined) return
@@ -214,22 +216,23 @@ export function apply(ctx: ClientContext): void {
     fenceNotice?.unmount()
     fenceNotice = undefined
   }
-  const channelActive = (): boolean => {
-    if (isLoopbackHostname(window.location.hostname)) return false
-    // A not-yet-loaded (or unavailable) settings snapshot falls back to the
-    // schema defaults — enabled and requirePairingForLan are both true, and
-    // on a remote origin the snapshot may never load (its own transport is
-    // what the channel gates), so waiting for 'ready' here would deadlock
-    // the channel off exactly where it is needed most.
-    const snapshot = settingsScope.getSnapshot()
-    const value = snapshot.status === 'ready' ? snapshot.value : undefined
-    return (value?.enabled ?? true) && (value?.requirePairingForLan ?? true)
+  const handleUnpaired = (): void => {
+    if (settingsScope.getSnapshot().status !== 'ready' && hostPairingPolicy === undefined) {
+      unpairedWhilePolicyPending = true
+      return
+    }
+    showFenceNotice()
   }
+  const channelActive = (): boolean => remoteChannelRequired(
+    window.location.hostname,
+    settingsScope.getSnapshot(),
+    hostPairingPolicy,
+  )
   const syncChannel = (): void => {
     const transition = channelTransition(channelActive(), disposeChannel !== undefined)
     if (transition === 'install') {
       disposeChannel = ctx.effect(() => {
-        const restore = installRemoteChannel(window, { onUnpaired: showFenceNotice, onPaired: hideFenceNotice })
+        const restore = installRemoteChannel(window, { onUnpaired: handleUnpaired, onPaired: hideFenceNotice })
         return restore
       }, 'remote-web-ui: remote desktop channel')
     } else if (transition === 'retire' && disposeChannel !== undefined) {
@@ -246,6 +249,20 @@ export function apply(ctx: ClientContext): void {
   }
   settingsScope.subscribe(syncChannel)
   syncChannel()
+  if (!isLoopbackHostname(window.location.hostname) && settingsScope.getSnapshot().status !== 'ready') {
+    void readPairGatePolicy().then((policy) => {
+      hostPairingPolicy = policy.requirePairingForLan
+      syncChannel()
+      if (hostPairingPolicy && unpairedWhilePolicyPending) showFenceNotice()
+      unpairedWhilePolicyPending = false
+    }).catch(() => {
+      // Fail closed when the policy endpoint is unavailable or malformed.
+      hostPairingPolicy = true
+      syncChannel()
+      if (unpairedWhilePolicyPending) showFenceNotice()
+      unpairedWhilePolicyPending = false
+    })
+  }
 
   // One-time failed-pair toast. The accept result lands asynchronously, so
   // the marker check is deferred past the accept round trip.

--- a/packages/dsh-remote-web-ui/src/client/pair-api.ts
+++ b/packages/dsh-remote-web-ui/src/client/pair-api.ts
@@ -36,6 +36,22 @@ export interface IssueLoopbackRequired {
 
 export type IssueResponse = IssueResult | IssueLanRequired | IssueUnknownAddress | IssueLoopbackRequired
 
+/** Public policy fields returned by the pairing status endpoint. */
+export interface PairGatePolicy {
+  requirePairingForLan: boolean
+}
+
+/** Read the host-authoritative desktop pairing policy. */
+export async function readPairGatePolicy(): Promise<PairGatePolicy> {
+  const response = await fetch('/api/pair/status')
+  if (!response.ok) throw new Error(`remote-web-ui: status failed with ${String(response.status)}`)
+  const value = await response.json() as { requirePairingForLan?: unknown }
+  if (typeof value.requirePairingForLan !== 'boolean') {
+    throw new Error('remote-web-ui: status omitted requirePairingForLan')
+  }
+  return { requirePairingForLan: value.requirePairingForLan }
+}
+
 /** accept() refusal codes. */
 export type AcceptFailure = { ok: false; code: 'invalid' | 'used' | 'forbidden' }
 

--- a/packages/dsh-remote-web-ui/src/client/remote-channel.ts
+++ b/packages/dsh-remote-web-ui/src/client/remote-channel.ts
@@ -46,6 +46,27 @@ const WS_PATHS = new Set([
   '/api/dsh-ssh/terminal',
 ])
 
+/** Minimal settings snapshot used by the remote channel decision. */
+export interface RemoteChannelSettingsSnapshot {
+  status: 'ready' | 'loading' | 'unavailable' | string
+  value?: { enabled?: boolean; requirePairingForLan?: boolean }
+}
+
+/** Decide whether a remote desktop channel is required from local or host policy. */
+export function remoteChannelRequired(
+  hostname: string,
+  snapshot: RemoteChannelSettingsSnapshot,
+  hostPairingPolicy: boolean | undefined,
+): boolean {
+  if (isLoopbackHostname(hostname)) return false
+  if (snapshot.status === 'ready') {
+    return (snapshot.value?.enabled ?? true) && (snapshot.value?.requirePairingForLan ?? true)
+  }
+  // Install provisionally while the host probe is pending so early SDK calls
+  // cannot escape onto the plain remote origin. A confirmed false retires it.
+  return hostPairingPolicy !== false
+}
+
 /**
  * Browser-safe loopback classification for the page origin (the SDK client
  * exports its own; this copy keeps the module dependency-free).

--- a/packages/dsh-remote-web-ui/src/index.ts
+++ b/packages/dsh-remote-web-ui/src/index.ts
@@ -353,7 +353,7 @@ function applyImpl(ctx: Context, config?: Config): void {
     },
   })
   const routes = [
-    ...makeRoutes({ service, lanAddresses }),
+    ...makeRoutes({ service, lanAddresses, requirePairingForLan: () => resolve().requirePairingForLan }),
     ...makeMobileRoutes(),
     ...(apiProxy !== undefined
       ? makeMobileApiRoutes({ service, apiProxy, mobileEnterToSend: () => resolve().mobileEnterToSend })

--- a/packages/dsh-remote-web-ui/src/routes.ts
+++ b/packages/dsh-remote-web-ui/src/routes.ts
@@ -195,6 +195,8 @@ export interface PairRoutesDeps {
   service: PairingService
   /** The LAN IP literals the fence accepts (derived from the bind host). */
   lanAddresses: readonly string[]
+  /** Current desktop gate policy, re-read for every status response. */
+  requirePairingForLan?: boolean | (() => boolean)
 }
 
 /**
@@ -203,7 +205,10 @@ export interface PairRoutesDeps {
  * @returns the exact routes to register on webServer.
  */
 export function makeRoutes(deps: PairRoutesDeps): WebRoute[] {
-  const { service, lanAddresses } = deps
+  const { service, lanAddresses, requirePairingForLan = true } = deps
+  const pairingRequired = (): boolean => typeof requirePairingForLan === 'function'
+    ? requirePairingForLan()
+    : requirePairingForLan
   const events = new PairingEventsStream(service)
 
   /** Loopback-only fence: the desktop panel's control endpoints. */
@@ -404,7 +409,7 @@ export function makeRoutes(deps: PairRoutesDeps): WebRoute[] {
     const visible = paired
       ? rest
       : { phase: snapshot.phase, lanAvailable: snapshot.lanAvailable, lanAddresses: snapshot.lanAddresses }
-    writeJson(res, 200, { ok: true, paired, ...visible })
+    writeJson(res, 200, { ok: true, paired, requirePairingForLan: pairingRequired(), ...visible })
   }
 
   const handleEvents = (req: IncomingMessage, res: ServerResponse): void => {

--- a/packages/dsh-remote-web-ui/tests/remote-channel.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/remote-channel.spec.ts
@@ -7,6 +7,7 @@ import {
   channelTransition,
   installRemoteChannel,
   isLoopbackHostname,
+  remoteChannelRequired,
   isUnpairedDenied,
   REMOTE_API_PREFIX,
   rewriteRawUrl,
@@ -58,6 +59,18 @@ describe('rewrite rules', () => {
       .toBe('/remote/pet/a.png?v=1#sprite')
     expect(rewriteRawUrl('https://elsewhere.example.com/pet/a.png', 'https://tunnel.example.com/page', 'https://tunnel.example.com'))
       .toBe('https://elsewhere.example.com/pet/a.png')
+  })
+
+  it('uses the host policy while remote settings are unavailable (issue #905)', () => {
+    const unavailable = { status: 'unavailable' as const }
+    expect(remoteChannelRequired('192.168.1.5', unavailable, undefined)).toBe(true)
+    expect(remoteChannelRequired('192.168.1.5', unavailable, false)).toBe(false)
+    expect(remoteChannelRequired('192.168.1.5', unavailable, true)).toBe(true)
+    expect(remoteChannelRequired('127.0.0.1', unavailable, true)).toBe(false)
+    expect(remoteChannelRequired('192.168.1.5', {
+      status: 'ready',
+      value: { enabled: true, requirePairingForLan: false },
+    }, true)).toBe(false)
   })
 
   it('decides the channel lifecycle transitions (issue #808)', () => {

--- a/packages/dsh-remote-web-ui/tests/routes.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/routes.spec.ts
@@ -266,6 +266,26 @@ describe('/api/pair routes', () => {
     }
   })
 
+  it('publishes the live desktop gate policy without exposing sensitive state', async () => {
+    const service = makeService()
+    let requirePairingForLan = false
+    const { port, close } = await serve(makeRoutes({
+      service,
+      lanAddresses: ['192.168.1.5'],
+      requirePairingForLan: () => requirePairingForLan,
+    }))
+    try {
+      const disabled = await call(port, 'GET', '/api/pair/status', { host: '192.168.1.5:3080' })
+      expect(disabled.body).toMatchObject({ ok: true, paired: false, requirePairingForLan: false })
+      requirePairingForLan = true
+      const enabled = await call(port, 'GET', '/api/pair/status', { host: '192.168.1.5:3080' })
+      expect(enabled.body).toMatchObject({ ok: true, paired: false, requirePairingForLan: true })
+      expect(enabled.body).not.toHaveProperty('deviceCount')
+    } finally {
+      await close()
+    }
+  })
+
   it('redacts the pairing oracle fields from unpaired status callers', async () => {
     const service = makeService()
     service.setPublicBaseUrl('https://phone.example.com')
@@ -276,7 +296,7 @@ describe('/api/pair routes', () => {
       // No cookie: only pairing-relevant fields, no token/device/tunnel oracle.
       const unpaired = await call(port, 'GET', '/api/pair/status', { host: '192.168.1.5:3080' })
       expect(unpaired.status).toBe(200)
-      expect(unpaired.body).toMatchObject({ ok: true, paired: false, phase: 'waiting', lanAvailable: true })
+      expect(unpaired.body).toMatchObject({ ok: true, paired: false, requirePairingForLan: true, phase: 'waiting', lanAvailable: true })
       expect(unpaired.body).not.toHaveProperty('tokenId')
       expect(unpaired.body).not.toHaveProperty('tokenExpiresAt')
       expect(unpaired.body).not.toHaveProperty('deviceCount')


### PR DESCRIPTION
﻿## 摘要（Summary）

Closes #905

修复非 loopback 桌面在 settingsScope 不可用时错误回退到 `requirePairingForLan: true`，导致 profile patch 已关闭配对仍显示阻断弹窗的问题。Host 通过 `/api/pair/status` 提供实时策略；客户端确认 false 后退出临时门控通道且不显示阻断页，策略异常时继续 fail-closed。

## 涉及包（Affected Packages）

- [x] 远程 Web UI `packages/dsh-remote-web-ui`

## PR 类别（PR Category）

- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin && git rebase origin/dev`## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

不适用。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：GPT-5.6-sol

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

不适用。

## 新皮肤收录（New Skin）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。
## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
pnpm --filter @linxin666/dsh-remote-web-ui build
pnpm docs:check
pnpm runtime-deps:check
git diff --check
```

结果摘要：

33 个测试文件、319 项测试通过；typecheck、build、docs、runtime dependency 与 diff 检查通过。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（行为修复由 host 策略端点、transport 决策与回归测试覆盖；未改视觉）。
