### PR TITLE
fix(plugin-manager): locate local dsh CLI (#900)

### DIFF
--- a/packages/dsh-plugin-manager/README.i18n.yaml
+++ b/packages/dsh-plugin-manager/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: f9ee4a3413a4726d2dfe4660823563340101ecb0
-README.zh.md: 3bc50a231e29f73f67841804a3a80caa8121581b
+README.md: 9ac748bbee33fe6d4e3b73b72b149c912e02a25d
+README.zh.md: 5b49a88cd58ca7fd3196a0cb938a46927b927e31

--- a/packages/dsh-plugin-manager/README.md
+++ b/packages/dsh-plugin-manager/README.md
@@ -55,7 +55,7 @@ The contract source of truth is `src/core/service.ts` (`PluginManagerService`). 
 ## Known limitations
 
 - Loopback-only: on a LAN or remote browser the tab renders a local-only notice (the same boundary the official installer tab enforces; the gateway refuses non-loopback requests with 403).
-- On the npm-published web runtime, gateway writes go through the official CLI, so the `dsh` binary must be on the host process PATH; installs of git sources can take minutes and run as background jobs. Gateway updates apply only to npm registry sources, resolve the latest version on the host, and succeed only after the same installed package reports that exact version.
+- On the npm-published web runtime, gateway writes go through the official CLI. The gateway resolves `dsh` from the host process PATH first and then from `node_modules/.bin` project roots above the running host entry, which covers local-wrapper and npx launches. If neither source contains the CLI, writes remain unavailable. Installs of git sources can take minutes and run as background jobs. Gateway updates apply only to npm registry sources, resolve the latest version on the host, and succeed only after the same installed package reports that exact version.
 - On the npm-published web runtime there is no boot-failure ring and no safe mode: those surfaces degrade to empty, and only install errors offer the repair handoff.
 - Enablement on the npm runtime writes bare `disabled` override rows into the profile's cordis.patch.yml; the runtime's loader honors them at the next start, but this path is less exercised than the official desktop writer's.
 - The web build has no in-place restart: changes apply at the next manual restart.

--- a/packages/dsh-plugin-manager/README.zh.md
+++ b/packages/dsh-plugin-manager/README.zh.md
@@ -55,7 +55,7 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-plugin-manager
 ## 已知限制
 
 - 仅限本机：LAN 或远程浏览器只显示「仅限本机操作」提示（与官方安装器 Tab 同一边界；网关对非 loopback 请求返回 403）。
-- npm 发布的官方 web 上，网关写入经官方 CLI 执行，因此 host 进程 PATH 里必须有 `dsh`；git 源安装可能耗时数分钟，以后台任务运行。网关更新只适用于 npm registry 源，由 host 解析最新版本，且仅当同一已装包报告该精确版本时才算成功。
+- npm 发布的官方 web 上，网关写入经官方 CLI 执行。网关先从 host 进程 PATH 解析 `dsh`，再从运行中 host 入口上层各项目根的 `node_modules/.bin` 回退查找，覆盖本地包装器与 npx 启动；两处都没有 CLI 时才不可写。git 源安装可能耗时数分钟，以后台任务运行。网关更新只适用于 npm registry 源，由 host 解析最新版本，且仅当同一已装包报告该精确版本时才算成功。
 - npm 发布的官方 web 没有启动失败环与安全模式：这两处界面降级为空，只有安装错误提供修复转交。
 - npm 运行时上的启停会在 profile 的 cordis.patch.yml 写入裸 `disabled` 覆盖行；该运行时 loader 在下次启动时认读这些行，但这条路径不如官方桌面写入器经过充分锻炼。
 - web 端无壳内重启：变更在下次手动重启后生效。

--- a/packages/dsh-plugin-manager/src/host/gateway.ts
+++ b/packages/dsh-plugin-manager/src/host/gateway.ts
@@ -12,7 +12,7 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { join, win32 } from 'node:path'
+import { join, posix, win32 } from 'node:path'
 import type { InstalledPluginItem } from '../core/protocol.ts'
 import type { ControlChange } from '../core/conflict.ts'
 import { diffLayer, overlappingIds, significantChanges, type LayerChange, type LayerSnapshot } from '../core/patch-diff.ts'
@@ -78,15 +78,31 @@ export function findDshBinary(
   env: NodeJS.ProcessEnv = process.env,
   platform: string = process.platform,
   exists: (path: string) => boolean = existsSync,
+  hostEntryPath: string | undefined = process.argv[1],
 ): string | null {
   const candidates: string[] = []
   const separator = platform === 'win32' ? ';' : ':'
+  const pathApi = platform === 'win32' ? win32 : posix
   for (const dir of (env.PATH ?? '').split(separator)) {
     if (dir === '') continue
     if (platform === 'win32') {
       candidates.push(`${dir}\\dsh.cmd`, `${dir}\\dsh.exe`)
     } else {
       candidates.push(`${dir}/dsh`)
+    }
+  }
+  // A local wrapper or npx launch may omit its node_modules/.bin directory
+  // from PATH. Walk up from the actual host entry script and probe each npm
+  // project root without guessing from the DSH_HOME profile location.
+  if (hostEntryPath !== undefined && hostEntryPath !== '') {
+    let current = pathApi.dirname(hostEntryPath)
+    for (let depth = 0; depth < 10; depth += 1) {
+      const binDir = pathApi.join(current, 'node_modules', '.bin')
+      if (platform === 'win32') candidates.push(pathApi.join(binDir, 'dsh.cmd'), pathApi.join(binDir, 'dsh.exe'))
+      else candidates.push(pathApi.join(binDir, 'dsh'))
+      const parent = pathApi.dirname(current)
+      if (parent === current) break
+      current = parent
     }
   }
   if (platform === 'darwin') {

--- a/packages/dsh-plugin-manager/tests/gateway.spec.ts
+++ b/packages/dsh-plugin-manager/tests/gateway.spec.ts
@@ -13,6 +13,36 @@ describe('findDshBinary', () => {
     expect(findDshBinary({ PATH: 'C:\\tools' }, 'win32', exists(['C:\\tools\\dsh.cmd']))).toBe('C:\\tools\\dsh.cmd')
   })
 
+  it('falls back to a local wrapper installation outside PATH on Windows', () => {
+    const binary = 'D:\\APP\\DSH\\node_modules\\.bin\\dsh.cmd'
+    expect(findDshBinary(
+      { PATH: 'C:\\Windows\\System32' },
+      'win32',
+      exists([binary]),
+      'D:\\APP\\DSH\\node_modules\\@deepseek-ai\\dsh\\lib\\bin.js',
+    )).toBe(binary)
+  })
+
+  it('keeps PATH precedence over the host installation fallback', () => {
+    const pathBinary = 'C:\\tools\\dsh.cmd'
+    const localBinary = 'D:\\APP\\DSH\\node_modules\\.bin\\dsh.cmd'
+    expect(findDshBinary(
+      { PATH: 'C:\\tools' },
+      'win32',
+      exists([pathBinary, localBinary]),
+      'D:\\APP\\DSH\\node_modules\\@deepseek-ai\\dsh\\lib\\bin.js',
+    )).toBe(pathBinary)
+  })
+
+  it('finds the nearest POSIX project shim from the host entry', () => {
+    expect(findDshBinary(
+      { PATH: '/nothing' },
+      'linux',
+      exists(['/opt/dsh/node_modules/.bin/dsh']),
+      '/opt/dsh/node_modules/@deepseek-ai/dsh/lib/bin.js',
+    )).toBe('/opt/dsh/node_modules/.bin/dsh')
+  })
+
   it('falls back to the darwin homebrew location', () => {
     expect(findDshBinary({ PATH: '/nothing' }, 'darwin', exists(['/opt/homebrew/bin/dsh']))).toBe('/opt/homebrew/bin/dsh')
   })


### PR DESCRIPTION
﻿## 摘要（Summary）

Closes #900

插件管理器在 PATH 查找失败后，从实际运行的 host 入口向上遍历 npm 项目根并查找 `node_modules/.bin/dsh`，覆盖本地包装器与 npx 启动，同时保留 PATH 优先级。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-plugin-manager`

## PR 类别（PR Category）

- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin && git rebase origin/dev`## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

不适用。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：GPT-5.6-sol

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

不适用。

## 新皮肤收录（New Skin）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。
## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-plugin-manager test
pnpm --filter @linxin666/dsh-client-ui-plugin-manager typecheck
pnpm --filter @linxin666/dsh-client-ui-plugin-manager build
pnpm docs:check
git diff --check
```

结果摘要：

15 个测试文件、123 项测试通过；typecheck、build、docs 与 diff 检查通过；新增 Windows 本地 wrapper、PATH 优先级与 POSIX 本地 shim 测试。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（host CLI 定位修复，无视觉变化；由路径解析和 gateway 回归测试覆盖）。
