### PR TITLE
fix(skin-center): fall back to preview for unsupported scene tex formats (#906)

### DIFF
--- a/packages/skins/skin-center/lib/index.js
+++ b/packages/skins/skin-center/lib/index.js
@@ -2368,6 +2368,7 @@ function buildInventory(opts = {}) {
 var pkg_extract_exports = /* @__PURE__ */ __exportAll({
 	PKG_ENTRY_FLAG_LZ4: () => 1,
 	TexFormat: () => TexFormat,
+	TexUnsupportedError: () => TexUnsupportedError,
 	buildSceneManifest: () => buildSceneManifest,
 	buildSceneManifestFromDir: () => buildSceneManifestFromDir,
 	decodePngToRgba: () => decodePngToRgba,
@@ -2429,6 +2430,29 @@ const TEX_FORMAT_NAMES = {
 	13: "RGBA1010102",
 	14: "RGBA16161616F",
 	15: "RGB161616F"
+};
+/**
+* A TEX format that is recognized but has no decode implementation in this
+* build (e.g. BC7, 16-bit float). Callers treat it as 'not supported here'
+* rather than a data-corruption failure, so the scene pipeline never emits a
+* partially decoded frame for it and falls back to the author preview (#906).
+*/
+var TexUnsupportedError = class extends Error {
+	/** Raw TEXI0001 format id. */
+	format;
+	/** Human-readable name of the format id, or 'unknown(N)'. */
+	formatName;
+	/** Declared TEXI0001 texture dimensions. */
+	width;
+	height;
+	constructor(format, formatName, width, height) {
+		super("tex: unsupported format " + format);
+		this.name = "TexUnsupportedError";
+		this.format = format;
+		this.formatName = formatName;
+		this.width = width;
+		this.height = height;
+	}
 };
 /** TEXI0001 flags bit marking an animated (sprite-sheet / gif) texture. */
 const TEX_FLAG_IS_GIF = 4;
@@ -2768,7 +2792,7 @@ function parseTexInternal(data) {
 	const imageWidth = r.i32();
 	const imageHeight = r.i32();
 	r.u32();
-	if (TEX_FORMAT_NAMES[format] === void 0) throw new Error("tex: unsupported format " + format);
+	if (TEX_FORMAT_NAMES[format] === void 0) throw new TexUnsupportedError(format, "unknown(" + format + ")", textureWidth, textureHeight);
 	const containerMagic = r.nstring(16);
 	const containerMatch = /^TEXB000([1-4])$/.exec(containerMagic);
 	if (!containerMatch) throw new Error("tex: bad mipmap container magic '" + containerMagic + "'");
@@ -3128,7 +3152,7 @@ function decodeTex(data) {
 			};
 			break;
 		}
-		default: throw new Error("tex: unsupported format " + parsed.format);
+		default: throw new TexUnsupportedError(parsed.format, TEX_FORMAT_NAMES[parsed.format] ?? "unknown(" + parsed.format + ")", parsed.width, parsed.height);
 	}
 	return cropToImageRect(decoded, parsed.width, parsed.height);
 }
@@ -3398,14 +3422,19 @@ function getTextureScore(path) {
 	if (lower.includes("昼夜变化") || lower.includes("mddn") || lower.includes("transition")) score -= 30;
 	return score;
 }
-/** Composite layered 2D sprite scenes into a single full-resolution frame. */
-function tryCompositeMultiLayerScene(scene, access) {
+/** Composite layered 2D sprite scenes into a single full-resolution frame.
+* Rejects the composite when the scene's top-ranked texture (the intended
+* main art) is not among the decoded layers — e.g. an unsupported BC7 main
+* texture — so the caller falls back to the per-candidate path and the
+* author preview instead of emitting a partial frame (#906). */
+function tryCompositeMultiLayerScene(scene, access, topCandidate) {
 	const objects = Array.isArray(scene.objects) ? scene.objects : [];
 	const imageObjects = objects.filter((obj) => obj && typeof obj === "object" && typeof obj.image === "string" && !String(obj.image).startsWith("models/util/") && !isLikelyMaskOrHelper(String(obj.image)));
 	if (imageObjects.length <= 1) return null;
 	let canvasWidth = 1920;
 	let canvasHeight = 1080;
 	const layers = [];
+	const layerSources = [];
 	let hasLargeBase = false;
 	for (const obj of objects) {
 		if (!obj.image || typeof obj.image !== "string" || obj.image.startsWith("models/util/")) continue;
@@ -3455,9 +3484,11 @@ function tryCompositeMultiLayerScene(scene, access) {
 			height: decoded.height,
 			rgba: decoded.rgba
 		});
+		layerSources.push(texPath);
 	}
 	if (imageObjects.length >= 3 && layers.length <= 1) throw new Error("pkg: multi-layer scene composition requires full preview render");
 	if (layers.length <= 1 || !hasLargeBase) return null;
+	if (topCandidate !== null && !layerSources.some((p) => p.toLowerCase() === topCandidate.toLowerCase())) return null;
 	const canvas = new Uint8Array(canvasWidth * canvasHeight * 4);
 	for (const layer of layers) for (let y = 0; y < layer.height; y++) {
 		const cy = layer.y + y;
@@ -3495,8 +3526,6 @@ function extractSceneMainImageVia(access, label) {
 	if (!scene || !Array.isArray(scene.objects)) throw new Error(label + ": scene.json not found or invalid");
 	const projection = sceneProjectionSize(scene);
 	if (scene.objects.some((obj) => obj && typeof obj === "object" && typeof obj.model === "string" && obj.model.length > 0)) throw new Error(label + ": 3D scene cannot be extracted as 2D frame");
-	const composite = tryCompositeMultiLayerScene(scene, access);
-	if (composite !== null) return composite;
 	const rawCandidates = [];
 	for (const obj of scene.objects) if (obj && typeof obj === "object" && typeof obj.image === "string") rawCandidates.push(...collectImageObjectTextures(obj, access.readJson));
 	const allCandidates = [];
@@ -3527,6 +3556,8 @@ function extractSceneMainImageVia(access, label) {
 	});
 	const candidates = ranked.map((r) => r.path);
 	if (candidates.length === 0) throw new Error(label + ": no texture candidates found");
+	const composite = tryCompositeMultiLayerScene(scene, access, candidates[0] ?? null);
+	if (composite !== null) return composite;
 	let lastError = null;
 	for (const path of candidates) {
 		if (isLikelyMaskOrHelper(path)) continue;
@@ -3577,6 +3608,7 @@ function extractSceneMainImageVia(access, label) {
 				texturePath: file.path
 			};
 		} catch (err) {
+			if (err instanceof TexUnsupportedError && path === candidates[0]) throw err;
 			lastError = err;
 		}
 	}
@@ -7196,6 +7228,16 @@ function makeWeRoutes(deps) {
 				res.setHeader("Cache-Control", "no-store");
 				pipeFile(cachePath, res, openReadStream);
 			})().catch((error) => {
+				if (error instanceof TexUnsupportedError) {
+					json(res, 422, {
+						ok: false,
+						error: "unsupported-tex-format",
+						format: error.format,
+						formatName: error.formatName,
+						message: error.message
+					});
+					return;
+				}
 				json(res, 422, {
 					ok: false,
 					error: error instanceof Error ? error.message : String(error)

--- a/packages/skins/skin-center/src/pkg-extract.ts
+++ b/packages/skins/skin-center/src/pkg-extract.ts
@@ -105,6 +105,31 @@ const TEX_FORMAT_NAMES: Record<number, string> = {
   15: 'RGB161616F',
 }
 
+/**
+ * A TEX format that is recognized but has no decode implementation in this
+ * build (e.g. BC7, 16-bit float). Callers treat it as 'not supported here'
+ * rather than a data-corruption failure, so the scene pipeline never emits a
+ * partially decoded frame for it and falls back to the author preview (#906).
+ */
+export class TexUnsupportedError extends Error {
+  /** Raw TEXI0001 format id. */
+  readonly format: number
+  /** Human-readable name of the format id, or 'unknown(N)'. */
+  readonly formatName: string
+  /** Declared TEXI0001 texture dimensions. */
+  readonly width: number
+  readonly height: number
+
+  constructor(format: number, formatName: string, width: number, height: number) {
+    super('tex: unsupported format ' + format)
+    this.name = 'TexUnsupportedError'
+    this.format = format
+    this.formatName = formatName
+    this.width = width
+    this.height = height
+  }
+}
+
 /** TEXI0001 flags bit marking an animated (sprite-sheet / gif) texture. */
 const TEX_FLAG_IS_GIF = 4
 
@@ -557,7 +582,7 @@ function parseTexInternal(data: Uint8Array): TexParsed {
   const imageHeight = r.i32()
   r.u32() // unknown
   if (TEX_FORMAT_NAMES[format] === undefined) {
-    throw new Error('tex: unsupported format ' + format)
+    throw new TexUnsupportedError(format, 'unknown(' + format + ')', textureWidth, textureHeight)
   }
   const containerMagic = r.nstring(16)
   const containerMatch = /^TEXB000([1-4])$/.exec(containerMagic)
@@ -903,7 +928,12 @@ export function decodeTex(data: Uint8Array): DecodedImage {
       break
     }
     default:
-      throw new Error('tex: unsupported format ' + parsed.format)
+      throw new TexUnsupportedError(
+        parsed.format,
+        TEX_FORMAT_NAMES[parsed.format] ?? 'unknown(' + parsed.format + ')',
+        parsed.width,
+        parsed.height,
+      )
   }
   return cropToImageRect(decoded, parsed.width, parsed.height)
 }
@@ -1297,8 +1327,16 @@ function getTextureScore(path: string): number {
   return score
 }
 
-/** Composite layered 2D sprite scenes into a single full-resolution frame. */
-function tryCompositeMultiLayerScene(scene: Record<string, unknown>, access: SceneAccess): SceneMainImage | null {
+/** Composite layered 2D sprite scenes into a single full-resolution frame.
+ * Rejects the composite when the scene's top-ranked texture (the intended
+ * main art) is not among the decoded layers — e.g. an unsupported BC7 main
+ * texture — so the caller falls back to the per-candidate path and the
+ * author preview instead of emitting a partial frame (#906). */
+function tryCompositeMultiLayerScene(
+  scene: Record<string, unknown>,
+  access: SceneAccess,
+  topCandidate: string | null,
+): SceneMainImage | null {
   const objects = Array.isArray(scene.objects) ? (scene.objects as Array<Record<string, unknown>>) : []
   const imageObjects = objects.filter(
     (obj) =>
@@ -1314,6 +1352,7 @@ function tryCompositeMultiLayerScene(scene: Record<string, unknown>, access: Sce
   let canvasHeight = 1080
 
   const layers: { x: number; y: number; width: number; height: number; rgba: Uint8Array }[] = []
+  const layerSources: string[] = []
   let hasLargeBase = false
 
   for (const obj of objects) {
@@ -1386,12 +1425,18 @@ function tryCompositeMultiLayerScene(scene: Record<string, unknown>, access: Sce
     const startY = Math.round(centerY - decoded.height / 2)
 
     layers.push({ x: startX, y: startY, width: decoded.width, height: decoded.height, rgba: decoded.rgba })
+    layerSources.push(texPath)
   }
 
   if (imageObjects.length >= 3 && layers.length <= 1) {
     throw new Error('pkg: multi-layer scene composition requires full preview render')
   }
   if (layers.length <= 1 || !hasLargeBase) return null
+  if (topCandidate !== null && !layerSources.some((p) => p.toLowerCase() === topCandidate.toLowerCase())) {
+    // The scene's intended main texture never decoded; a composite built
+    // from the leftover layers would be a broken frame (#906).
+    return null
+  }
 
   const canvas = new Uint8Array(canvasWidth * canvasHeight * 4)
   for (const layer of layers) {
@@ -1450,11 +1495,6 @@ function extractSceneMainImageVia(access: SceneAccess, label: string): SceneMain
     throw new Error(label + ': 3D scene cannot be extracted as 2D frame')
   }
 
-  const composite = tryCompositeMultiLayerScene(scene, access)
-  if (composite !== null) {
-    return composite
-  }
-
   const rawCandidates: string[] = []
   for (const obj of scene.objects as unknown[]) {
     if (obj && typeof obj === 'object' && typeof (obj as { image?: unknown }).image === 'string') {
@@ -1491,6 +1531,14 @@ function extractSceneMainImageVia(access: SceneAccess, label: string): SceneMain
   const candidates = ranked.map((r) => r.path)
   if (candidates.length === 0) {
     throw new Error(label + ': no texture candidates found')
+  }
+
+  // The top-ranked candidate is the intended main texture: the composite
+  // layer must include it, and the decode loop must stop on its unsupported
+  // format, or the pipeline would emit a partial frame as the wallpaper.
+  const composite = tryCompositeMultiLayerScene(scene, access, candidates[0] ?? null)
+  if (composite !== null) {
+    return composite
   }
   let lastError: unknown = null
   for (const path of candidates) {
@@ -1538,6 +1586,11 @@ function extractSceneMainImageVia(access: SceneAccess, label: string): SceneMain
       }
       return { width, height, png: encodePng(width, height, rgba), texturePath: file.path }
     } catch (err) {
+      // The top-ranked candidate is the intended main texture: a
+      // known-but-undecodable format must stop here so the frame route
+      // reports it and the client falls back to the author preview instead
+      // of substituting a lower-ranked partial layer as the frame (#906).
+      if (err instanceof TexUnsupportedError && path === candidates[0]) throw err
       lastError = err
     }
   }

--- a/packages/skins/skin-center/src/we-routes.ts
+++ b/packages/skins/skin-center/src/we-routes.ts
@@ -47,6 +47,7 @@ import {
   hasSceneVideo,
   hasSceneVideoFromDir,
   parseTexToRGBA,
+  TexUnsupportedError,
 } from './pkg-extract.ts'
 import { WE_SHIM_JS } from './we-shim-source.ts'
 import { WE_SCENE_PLAYER_HTML } from './we-player-source.ts'
@@ -655,6 +656,20 @@ export function makeWeRoutes(deps: WeRouteDeps): WebRoute[] {
         res.setHeader('Cache-Control', 'no-store')
         pipeFile(cachePath, res, openReadStream)
       })().catch((error: unknown) => {
+        if (error instanceof TexUnsupportedError) {
+          // Machine-readable signal for the client: the scene's textures use
+          // a format this build cannot decode, so the frame route reports it
+          // and the wallpaper controller falls back to the author preview
+          // (#906).
+          json(res, 422, {
+            ok: false,
+            error: 'unsupported-tex-format',
+            format: error.format,
+            formatName: error.formatName,
+            message: error.message,
+          })
+          return
+        }
         json(res, 422, { ok: false, error: error instanceof Error ? error.message : String(error) })
       })
     },

--- a/packages/skins/skin-center/tests/pkg-extract.spec.ts
+++ b/packages/skins/skin-center/tests/pkg-extract.spec.ts
@@ -32,6 +32,7 @@ import {
   parseTexToRGBA,
   readPkgEntry,
   extractSceneResourceFromDir,
+  TexUnsupportedError,
 } from '../src/pkg-extract.ts'
 import { encode as encodeJpeg } from 'jpeg-js'
 
@@ -611,6 +612,28 @@ describe('decodeTex', () => {
     expect(() => decodeTex(tex)).toThrow(/tex: unsupported format 12/)
   })
 
+  it('throws a typed TexUnsupportedError with format metadata for BC7 (#906)', () => {
+    const tex = buildTex({
+      width: 8,
+      height: 6,
+      format: TexFormat.BC7,
+      mipmaps: [{ width: 8, height: 6, data: new Uint8Array(48) }],
+    })
+    let caught: unknown = null
+    try {
+      decodeTex(tex)
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(TexUnsupportedError)
+    const err = caught as TexUnsupportedError
+    expect(err.format).toBe(TexFormat.BC7)
+    expect(err.formatName).toBe('BC7')
+    expect(err.width).toBe(8)
+    expect(err.height).toBe(6)
+  })
+
+
   it('crops power-of-two padding to the TEXI image rect (top-left)', () => {
     // 4x2 real image stored in a padded 4x4 mip (like WE's 1920x1080 in
     // 2048x2048); top rows are the content, bottom rows are filler.
@@ -733,6 +756,74 @@ describe('extractSceneMainImage', () => {
     const result = extractSceneMainImage(pkg)
     expect(result.texturePath).toBe('materials/bg.tex')
     expect(decodePng(result.png).rgba).toEqual(bgPixels)
+  })
+
+  it('fails with a typed unsupported error instead of a frame when the only texture is BC7 (#906)', () => {
+    const bc7Tex = buildTex({
+      width: 4,
+      height: 4,
+      format: TexFormat.BC7,
+      mipmaps: [{ width: 4, height: 4, data: new Uint8Array(16) }],
+    })
+    const pkg = buildPkg([
+      { path: 'scene.json', data: sceneJson('materials/art.tex') },
+      { path: 'materials/art.tex', data: bc7Tex },
+    ])
+    let caught: unknown = null
+    try {
+      extractSceneMainImage(pkg)
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(TexUnsupportedError)
+    expect((caught as TexUnsupportedError).format).toBe(TexFormat.BC7)
+  })
+
+  it('does not emit a partial composite frame when the top-ranked main texture is BC7 (#906)', () => {
+    const mainTex = buildTex({
+      width: 1600,
+      height: 900,
+      format: TexFormat.BC7,
+      mipmaps: [{ width: 1600, height: 900, data: new Uint8Array(64) }],
+    })
+    const baseTex = buildTex({
+      width: 1280,
+      height: 720,
+      mipmaps: [{ width: 1280, height: 720, data: solidPixels(1280, 720, 10, 20, 30) }],
+    })
+    const decoTex = buildTex({
+      width: 64,
+      height: 64,
+      mipmaps: [{ width: 64, height: 64, data: solidPixels(64, 64, 200, 0, 0) }],
+    })
+    const layeredScene = encoder.encode(
+      JSON.stringify({
+        objects: [
+          { id: 1, name: 'zz-main', image: 'models/zz-main.json' },
+          { id: 2, name: 'zz-base', image: 'models/zz-base.json' },
+          { id: 3, name: 'zz-deco', image: 'models/zz-deco.json' },
+        ],
+      }),
+    )
+    const pkg = buildPkg([
+      { path: 'scene.json', data: layeredScene },
+      { path: 'models/zz-main.json', data: encoder.encode(JSON.stringify({ material: 'materials/zz-main.json' })) },
+      { path: 'materials/zz-main.json', data: encoder.encode(JSON.stringify({ passes: [{ textures: ['materials/zz-main.tex'] }] })) },
+      { path: 'models/zz-base.json', data: encoder.encode(JSON.stringify({ material: 'materials/zz-base.json' })) },
+      { path: 'materials/zz-base.json', data: encoder.encode(JSON.stringify({ passes: [{ textures: ['materials/zz-base.tex'] }] })) },
+      { path: 'models/zz-deco.json', data: encoder.encode(JSON.stringify({ material: 'materials/zz-deco.json' })) },
+      { path: 'materials/zz-deco.json', data: encoder.encode(JSON.stringify({ passes: [{ textures: ['materials/zz-deco.tex'] }] })) },
+      { path: 'materials/zz-main.tex', data: mainTex },
+      { path: 'materials/zz-base.tex', data: baseTex },
+      { path: 'materials/zz-deco.tex', data: decoTex },
+    ])
+    let caught: unknown = null
+    try {
+      extractSceneMainImage(pkg)
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(TexUnsupportedError)
   })
 
   it('reports the real decode error instead of a later missing-texture fallback (#752)', () => {

--- a/packages/skins/skin-center/tests/we-routes.spec.ts
+++ b/packages/skins/skin-center/tests/we-routes.spec.ts
@@ -65,6 +65,26 @@ const tex64Red = ((): Buffer => {
   ])
 })()
 
+/** Minimal 4x4 BC7 TEX (recognized format with no decoder here) for
+ *  unsupported-format scene-frame tests (#906). */
+const texBc7 = ((): Buffer => {
+  const enc = new TextEncoder()
+  const nstr = (s: string): number[] => [...enc.encode(s), 0]
+  const i32 = (v: number): number[] => {
+    const b = new DataView(new ArrayBuffer(4))
+    b.setInt32(0, v, true)
+    return [...new Uint8Array(b.buffer)]
+  }
+  return Buffer.from([
+    ...nstr('TEXV0005'), ...nstr('TEXI0001'),
+    ...i32(TexFormat.BC7), ...i32(0),
+    ...i32(4), ...i32(4), ...i32(4), ...i32(4), ...i32(0),
+    ...nstr('TEXB0002'), ...i32(1),
+    ...i32(1), ...i32(4), ...i32(4),
+    ...i32(0), ...i32(16), ...i32(16), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  ])
+})()
+
 let root: string
 let library: string
 let store: string
@@ -415,6 +435,19 @@ describe('scene-frame', () => {
     const res = await call('GET', String(scene?.frameUrl))
     expect(res.status).toBe(422)
     expect(res.body.ok).toBe(false)
+  })
+
+  it('answers a structured unsupported-tex-format 422 for BC7-only scenes (#906)', async () => {
+    makeProject(join(library, '999'), { title: 'BC7Scene', type: 'scene', file: 'scene.json' }, {
+      'scene.json': JSON.stringify({ objects: [{ image: 'materials/art.tex' }] }),
+    })
+    mkdirSync(join(library, '999', 'materials'), { recursive: true })
+    writeFileSync(join(library, '999', 'materials', 'art.tex'), texBc7)
+    const inventory = await call('GET', WE_API_PREFIX + '/inventory')
+    const scene = (inventory.body.wallpapers as Array<Record<string, unknown>>).find(w => w.id === '999')
+    const res = await call('GET', String(scene?.frameUrl))
+    expect(res.status).toBe(422)
+    expect(res.body).toMatchObject({ ok: false, error: 'unsupported-tex-format', format: 12, formatName: 'BC7' })
   })
 })
 


### PR DESCRIPTION
## 摘要（Summary）
Scene 壁纸静态帧提取对不支持格式（BC7 / 16-bit float 等）的失败路径无法与解码失败区分，且残余可解码层会合成部分画面当作壁纸帧写入缓存（#906 的花屏）。本 PR 新增类型化 `TexUnsupportedError`、主候选不支持时中止、拒绝不含主纹理的部分合成、`/scene-frame` 返回结构化 `unsupported-tex-format` 错误，客户端走既有 author preview 回退。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [x] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [ ] 社区插件索引
- [ ] 维护 / 其他
## PR 类型（PR Type）

- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 面向用户的功能或行为变更
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin && git rebase origin/dev`（已执行，重建 lib 产物后重新运行测试与类型检查）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（deepseek-v4-flash-vision-exp，支持图像输入）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。（本 PR 未改 README）

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-client-ui-skin-center test
pnpm --filter @linxin666/dsh-client-ui-skin-center typecheck
pnpm --filter @linxin666/dsh-client-ui-skin-center build
```

结果摘要：

rebase 到最新 origin/dev 后：24 个测试文件 / 386 个测试全部通过（含新增 BC7 类型化错误、BC7-only 场景抛错、部分合成拒绝、路由 422 结构化响应 4 条回归）；`tsc --noEmit` 通过；tsdown 构建通过并提交 lib/index.js。验证边界：本机无 Wallpaper Engine（macOS），以合成 TEX/PKG 夹具 + 路由/客户端既有回归为据，端到端复现待 #906 报告者在 Windows 侧 0.2.7+ 确认。

Fixes #906