### PR TITLE
fix(skins/blue-fantasy): background occlusion slider now dims the art in both themes

### DIFF
--- a/packages/skins/skin-center/skins/blue-fantasy/skin.css
+++ b/packages/skins/skin-center/skins/blue-fantasy/skin.css
@@ -9,15 +9,15 @@ body[data-ds-dark-theme] {
 }
 
 :root {
-  --dsw-alias-bg-base: rgba(255, 255, 255, calc(var(--dsw-skin-scrim, 0) * .45));
-  --dsw-alias-bg-layer-1: rgba(243, 245, 251, calc(1 - var(--dsw-skin-scrim, 0) * .5));
-  --dsw-alias-bg-layer-2: rgba(233, 237, 247, calc(1 - var(--dsw-skin-scrim, 0) * .45));
-  --dsw-alias-bg-layer-3: rgba(221, 227, 241, calc(1 - var(--dsw-skin-scrim, 0) * .42));
+  --dsw-alias-bg-base: rgba(255, 255, 255, 0);
+  --dsw-alias-bg-layer-1: rgba(243, 245, 251, 1);
+  --dsw-alias-bg-layer-2: rgba(233, 237, 247, 1);
+  --dsw-alias-bg-layer-3: rgba(221, 227, 241, 1);
   --dsw-alias-bg-mask-1: #1c254666;
   --dsw-alias-bg-mask-2: #1c254633;
   --dsw-alias-bg-mask-3: #1c254680;
   --dsw-alias-bg-mask-photo: #101424e0;
-  --dsw-alias-bg-module-platform: rgba(233, 237, 247, calc(1 - var(--dsw-skin-scrim, 0) * .45));
+  --dsw-alias-bg-module-platform: rgba(233, 237, 247, 1);
   --dsw-alias-bg-multi-select: #dce3f7cc;
   --dsw-alias-bg-overlay: #eef1f9eb;
   --dsw-alias-bg-skeleton: #1c25460f;
@@ -88,11 +88,11 @@ body[data-ds-dark-theme] {
   --dsw-alias-tooltip-fg: #1a2238;
   --dsw-specific-bubble-highlight: #c3cfee;
   --dsw-specific-bubble: #dce3f7;
-  --dsw-specific-input-major: rgba(255, 255, 255, calc(1 - var(--dsw-skin-scrim, 0) * .4));
-  --dsw-specific-login-input: rgba(255, 255, 255, calc(1 - var(--dsw-skin-scrim, 0) * .4));
+  --dsw-specific-input-major: rgba(255, 255, 255, 1);
+  --dsw-specific-login-input: rgba(255, 255, 255, 1);
   --dsw-specific-menu: #f3f5fbf0;
   --dsw-specific-selector: #e4eaf7d9;
-  --dsw-specific-sidebar-fill: rgba(242, 245, 250, calc(1 - var(--dsw-skin-scrim, 0) * .5));
+  --dsw-specific-sidebar-fill: rgba(242, 245, 250, 1);
   --dsw-specific-sidebar-nav-item-active-accent: #a5b7e2;
   --dsw-specific-sidebar-nav-item-active: #dce3f7;
   --dsw-specific-sidebar-nav-item-hover: #e4eaf7;
@@ -100,15 +100,15 @@ body[data-ds-dark-theme] {
 }
 
 body[data-ds-dark-theme] {
-  --dsw-alias-bg-base: rgba(16, 22, 42, calc(var(--dsw-skin-scrim, 0) * .5));
-  --dsw-alias-bg-layer-1: rgba(26, 34, 56, calc(1 - var(--dsw-skin-scrim, 0) * .45));
-  --dsw-alias-bg-layer-2: rgba(32, 42, 68, calc(1 - var(--dsw-skin-scrim, 0) * .4));
-  --dsw-alias-bg-layer-3: rgba(38, 50, 79, calc(1 - var(--dsw-skin-scrim, 0) * .36));
+  --dsw-alias-bg-base: rgba(16, 22, 42, 0);
+  --dsw-alias-bg-layer-1: rgba(26, 34, 56, 1);
+  --dsw-alias-bg-layer-2: rgba(32, 42, 68, 1);
+  --dsw-alias-bg-layer-3: rgba(38, 50, 79, 1);
   --dsw-alias-bg-mask-1: #0000008c;
   --dsw-alias-bg-mask-2: #0000004d;
   --dsw-alias-bg-mask-3: #0009;
   --dsw-alias-bg-mask-photo: #060914e6;
-  --dsw-alias-bg-module-platform: rgba(32, 42, 68, calc(1 - var(--dsw-skin-scrim, 0) * .4));
+  --dsw-alias-bg-module-platform: rgba(32, 42, 68, 1);
   --dsw-alias-bg-multi-select: #2c3765cc;
   --dsw-alias-bg-overlay: #1a2238eb;
   --dsw-alias-bg-skeleton: #ffffff0f;
@@ -179,11 +179,11 @@ body[data-ds-dark-theme] {
   --dsw-alias-tooltip-fg: #1a2238;
   --dsw-specific-bubble-highlight: #33417a;
   --dsw-specific-bubble: #2c3765;
-  --dsw-specific-input-major: rgba(26, 34, 56, calc(1 - var(--dsw-skin-scrim, 0) * .35));
-  --dsw-specific-login-input: rgba(26, 34, 56, calc(1 - var(--dsw-skin-scrim, 0) * .35));
+  --dsw-specific-input-major: rgba(26, 34, 56, 1);
+  --dsw-specific-login-input: rgba(26, 34, 56, 1);
   --dsw-specific-menu: #1a2238f0;
   --dsw-specific-selector: #1e2740d9;
-  --dsw-specific-sidebar-fill: rgba(29, 37, 57, calc(1 - var(--dsw-skin-scrim, 0) * .45));
+  --dsw-specific-sidebar-fill: rgba(29, 37, 57, 1);
   --dsw-specific-sidebar-nav-item-active-accent: #33417a;
   --dsw-specific-sidebar-nav-item-active: #2c3765;
   --dsw-specific-sidebar-nav-item-hover: #202a44;
@@ -312,4 +312,19 @@ body[data-ds-dark-theme] {
 
 body[data-ds-dark-theme] [data-dsh-part="dialog"] {
   border-color: #a0b4e638;
+}
+
+/*
+ * Occlusion fix: the scrim veil must DIM the whale art, not wash it toward
+ * white nor open the panels to reveal it. The skin-center paints the art in
+ * its fixed background decoration layer (z-index -2); dimming that image
+ * directly lowers the backdrop brightness while leaving every panel surface
+ * opaque and readable, in both light and dark themes. The background surface
+ * tokens above are scrim-independent (bg-base stays transparent so the art
+ * shows through the chat column and gaps; layer tokens stay opaque so the art
+ * never bleeds through panels). --dsw-skin-scrim is 0..1 from the skin-center
+ * background slider (0 = no veil, 1 = fully obscured).
+ */
+[data-dsh-skin-layer="background"] img {
+  filter: brightness(calc(1 - var(--dsw-skin-scrim, 0) * .6));
 }

--- a/packages/skins/skin-center/skins/blue-fantasy/skin.json
+++ b/packages/skins/skin-center/skins/blue-fantasy/skin.json
@@ -6,7 +6,7 @@
   "nameEn": "Blue Fantasy",
   "author": "powerdog996（DreamSkin 社区）· dsh-web-ui 适配",
   "tagline": "鲸鱼插画背景 · periwinkle 靛蓝调色板 · 半透明面板",
-  "description": "DreamSkin「DeepSeek-鲸鱼娘」Codex 桌面主题的 dsh 适配：鲸鱼插画背景垫在半透明面板之下，遮罩随亮/暗主题实时切换，periwinkle 靛蓝色调重映射到全部 dsh token。",
+  "description": "DreamSkin「DeepSeek-鲸鱼娘」Codex 桌面主题的 dsh 适配：鲸鱼插画背景垫在半透明面板之下，遮罩随亮/暗主题实时切换，periwinkle 靛蓝色调重映射到全部 dsh token。修复背景遮挡滑杆：亮色下原白色纱帘反而提亮、暗色下面板随遮挡变透明透出插画；现统一为直接压暗插画，面板保持不透明。",
   "tags": [
     "dreamskin",
     "whale",
@@ -16,7 +16,7 @@
   ],
   "accent": "#4a5fa8",
   "order": 1,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "preview": {
     "light": "preview/light.png",
     "dark": "preview/dark.png"


### PR DESCRIPTION
## 摘要（Summary）

修复 Blue Fantasy（蓝色幻想）皮肤在「皮肤中心 → 背景遮挡」滑杆上的两个相反缺陷：**亮色主题**下白纱帘把已经很亮的鲸鱼插画越调越亮（实测画面亮度 172→175，几乎无变化）；**暗色主题**下面板/侧边栏随遮挡升高变得更透明，把插画"透"出来（侧边栏亮度 43→51 反而上升）。现改为：所有表面 token 与 scrim 解耦（面板恒不透明、bg-base 恒透明），并在皮肤中心背景装饰层上直接压暗插画本身（`filter: brightness(calc(1 - var(--dsw-skin-scrim, 0) * .6))`）。两种主题下滑杆现在都单调、可见地压暗背景，面板与文字保持可读。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`

## PR 类别（PR Category）

- [x] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [x] 视觉修复（UI / 视觉类问题的修复）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令： `git fetch origin && git rebase origin/dev`（已 rebase 到最新 `dev` 5b412fd6，无冲突；见下方测试证据）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [x] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [x] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码

使用的 AI 模型： DeepSeek-V4-Flash-Vision-Exp（支持图像输入，用于人工核验前后对比截图）

使用的编码 Agent 工具： DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录，不适用）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未改动 README，不适用）。

## 本地验证（Local Validation）

执行的命令：

```bash
# 1) 本机 DSH Web GUI（localhost:3080）加载了本 PR 的 blue-fantasy 皮肤源码
#    （$DSH_HOME/skins/blue-fantasy 用户皮肤覆盖层与分支 skin.css 逐字节一致，已验证 sha256 相同）
# 2) 用 Chromium（Playwright）打开 设置 → 皮肤中心，实时拖动「背景遮挡」滑杆，
#    读取 document.body.style['--dsw-skin-scrim']、背景装饰层 img 的 computed filter，
#    并对 0% / 50% / 100% 三档截图、统计画面亮度（0..255 平均亮度）。
```

结果摘要：

- **暗色主题**：滑杆 0%→50%→100%，`filter: brightness(1)→(0.7)→(0.4)`；对话区插画亮度 145→61，侧边栏恒定 43（不再透出插画）。
- **亮色主题**：滑杆 0%→100%，`filter: brightness(1)→(0.4)`；整体亮度 172→159（对话视图插画区 145→61，侧边栏 240 恒定）。
- **修复前（旧 CSS）对照**：亮色滑杆 0%→100% 几乎无变化（172→175）；暗色侧边栏 43→51（越遮挡越透出插画）。
- **已 rebase 到最新 dev（5b412fd6）后重新测试**，结果与上一致（见下方截图）。

## 用户可见变更证据（Local Feature Evidence）

证据（修复前后对比，两种主题）：

**亮色（Light）／遮挡 0% vs 100%**

![蓝幻亮色-遮挡0%](https://raw.githubusercontent.com/frecoder007/dsh-web-ui/blue-fantasy-occlusion-assets/blue-fantasy-light-occlusion-0.png)
![蓝幻亮色-遮挡100%](https://raw.githubusercontent.com/frecoder007/dsh-web-ui/blue-fantasy-occlusion-assets/blue-fantasy-light-occlusion-100.png)

**暗色（Dark）／遮挡 0% vs 100%**

![蓝幻暗色-遮挡0%](https://raw.githubusercontent.com/frecoder007/dsh-web-ui/blue-fantasy-occlusion-assets/blue-fantasy-dark-occlusion-0.png)
![蓝幻暗色-遮挡100%](https://raw.githubusercontent.com/frecoder007/dsh-web-ui/blue-fantasy-occlusion-assets/blue-fantasy-dark-occlusion-100.png)
