### PR TITLE
fix(remote-web-ui): recover complete mobile delivery (#851)

### DIFF
--- a/packages/dsh-remote-web-ui/src/mobile/messages.test.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/messages.test.ts
@@ -183,6 +183,29 @@ describe('foldEvents', () => {
     expect(assistant?.pending).toBeFalsy()
   })
 
+  it('keeps same-turn steps in final-event order after turn/end', () => {
+    const result = foldEvents([
+      makeEvent('user/message', userMessageData('u-1', 'multi-step'), 0),
+      makeEvent('assistant/message', assistantMessageData('step-z', 0, 0, 'first'), 2),
+      makeEvent('assistant/message', assistantMessageData('step-a', 0, 1, 'second'), 4),
+      makeEvent('assistant/message', assistantMessageData('step-m', 0, 2, 'third'), 6),
+      makeEvent('turn/end', { turn: 0, reason: { kind: 'completed' } }, 7),
+    ])
+
+    const assistants = result.filter(message => message.kind === 'assistant')
+    expect(assistants.map(message => message.id)).toEqual(['step-z', 'step-a', 'step-m'])
+    expect(assistants.map(message => message.seq)).toEqual([2, 4, 6])
+    expect(assistants.every(message => message.pending !== true)).toBe(true)
+  })
+
+  it('keeps stable insertion order when legacy rows share a seq', () => {
+    const folder = new EventFolder([
+      { id: 'z-last-lexically', kind: 'assistant', text: 'first', seq: 5, time: 5_000 },
+      { id: 'a-first-lexically', kind: 'assistant', text: 'second', seq: 5, time: 5_000 },
+    ])
+    expect(folder.snapshot().map(message => message.id)).toEqual(['z-last-lexically', 'a-first-lexically'])
+  })
+
   it('is idempotent: applying the same batch twice yields an identical list', () => {
     const events: WireEvent[] = [
       makeEvent('user/message', userMessageData('u-1', 'hi'), 0),

--- a/packages/dsh-remote-web-ui/src/mobile/messages.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/messages.ts
@@ -589,7 +589,8 @@ function applyTurnEnd(state: FoldState, event: WireEvent): void {
       ...message,
       ...(wasPending ? { pending: false } : {}),
       ...(failed ? { failed: true } : {}),
-      seq: Math.max(message.seq, event.seq),
+      // Preserve each step's own final-event seq. Collapsing every message
+      // onto turn/end makes same-turn ordering depend on arbitrary ids.
       time: event.time,
     })
   }
@@ -666,10 +667,11 @@ function snapshotOf(state: FoldState): RenderMessage[] {
   for (let index = 1; index < out.length; index += 1) {
     const prev = out[index - 1]!
     const current = out[index]!
-    if (prev.seq > current.seq || (prev.seq === current.seq && prev.id >= current.id)) {
+    if (prev.seq > current.seq) {
       ordered = false
       break
     }
   }
-  return ordered ? out : out.sort((a, b) => a.seq - b.seq || (a.id < b.id ? -1 : 1))
+  // Array.sort is stable: equal-seq rows keep their event insertion order.
+  return ordered ? out : out.sort((a, b) => a.seq - b.seq)
 }

--- a/packages/dsh-remote-web-ui/src/mobile/mux.test.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/mux.test.ts
@@ -95,6 +95,22 @@ describe('MuxClient polling fallback', () => {
     client.stop()
   })
 
+  it('sorts an out-of-order history page before advancing the watermark', async () => {
+    const { factory } = makeSources()
+    const pollLatest = vi.fn(async (_sessionId: string) => pageOf([2, 1, 3]))
+    const client = new MuxClient('/m/api/events.mux', baseOptions(pollLatest, factory))
+    const seqs: number[] = []
+    client.onFrame((frame) => {
+      if (frame.type === 'session/event' && typeof frame.event.seq === 'number') seqs.push(frame.event.seq)
+    })
+    client.start()
+    client.observe('s1')
+
+    await vi.advanceTimersByTimeAsync(1200)
+    expect(seqs).toEqual([1, 2, 3])
+    client.stop()
+  })
+
   it('keeps the watermark so a repeated page never re-emits old events', async () => {
     const { factory } = makeSources()
     // Two calls return the same page: the second must emit nothing.
@@ -168,6 +184,54 @@ describe('MuxClient polling fallback', () => {
     const live = frames.filter(frame => (frame as { type?: string })?.type === 'session/subscribed')
     expect(live).toHaveLength(1)
     expect(live[0]).toMatchObject({ type: 'session/subscribed', sessionId: 's1' })
+    client.stop()
+  })
+
+  it('recovers when a previously-live SSE stream becomes silently stalled', async () => {
+    const { factory, sources } = makeSources()
+    const pollLatest = vi.fn(async (_sessionId: string) => pageOf([5]))
+    const client = new MuxClient('/m/api/events.mux', baseOptions(pollLatest, factory))
+    const frames: Array<{ type: string; event?: { seq: number } }> = []
+    client.onFrame(frame => { frames.push(frame as never) })
+    client.start()
+    client.observe('s1')
+
+    sources[0]?.onmessage?.({ data: envelopeWith({ type: 'session/subscribed', sessionId: 's1', lastSeq: 4 }) })
+    await vi.advanceTimersByTimeAsync(2400)
+    expect(pollLatest).not.toHaveBeenCalled()
+
+    // A once-live stream gets three stall windows; the next scheduler tick
+    // crosses that boundary and starts the ordinary-HTTP recovery path.
+    await vi.advanceTimersByTimeAsync(400)
+    expect(pollLatest).toHaveBeenCalledTimes(1)
+    expect(frames.at(-1)?.event).toMatchObject({ seq: 5 })
+    client.stop()
+  })
+
+  it('backs empty polls off and resets to the base cadence after progress', async () => {
+    const { factory } = makeSources()
+    const pages = [pageOf([]), pageOf([1]), pageOf([1, 2])]
+    const pollLatest = vi.fn(async (_sessionId: string) => pages.shift() ?? pageOf([]))
+    const client = new MuxClient('/m/api/events.mux', baseOptions(pollLatest, factory))
+    client.start()
+    client.observe('s1')
+
+    await vi.advanceTimersByTimeAsync(1200)
+    expect(pollLatest).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(pollLatest).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(pollLatest).toHaveBeenCalledTimes(2)
+
+    // The productive second poll resets the next delay from 800 ms to 400 ms.
+    await vi.advanceTimersByTimeAsync(400)
+    expect(pollLatest).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(pollLatest).toHaveBeenCalledTimes(4)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(pollLatest).toHaveBeenCalledTimes(4)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(pollLatest).toHaveBeenCalledTimes(5)
     client.stop()
   })
 

--- a/packages/dsh-remote-web-ui/src/mobile/mux.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/mux.ts
@@ -39,9 +39,9 @@ export interface MuxClientOptions {
    * the ordinary HTTP channel (unaffected by SSE-impairing tunnels).
    */
   pollLatest?: (sessionId: string) => Promise<HistoryPage>
-  /** Poll cadence while SSE is stalled (default 3000 ms). */
+  /** Initial poll cadence while SSE is stalled (default 3000 ms). Empty polls back off to 60000 ms. */
   pollIntervalMs?: number
-  /** How long SSE must go without a frame before fallback kicks in (default 12000 ms). */
+  /** Initial SSE stall window (default 12000 ms); a previously-live stream gets three windows before fallback. */
   stallThresholdMs?: number
   /** Clock seam for tests (defaults to Date.now). */
   now?: () => number
@@ -66,6 +66,8 @@ type SessionEventFrame = Extract<MuxFrame, { type: 'session/event' }>
 
 const DEFAULT_POLL_INTERVAL_MS = 3000
 const DEFAULT_STALL_THRESHOLD_MS = 12000
+const LIVE_SSE_STALL_MULTIPLIER = 3
+const MAX_POLL_BACKOFF_MS = 60000
 /**
  * Stall-check granularity: the single scheduler tick runs at least this
  * often so fallback arms within a second of the stall threshold passing,
@@ -98,8 +100,8 @@ export class MuxClient {
   private lastDataAt = 0
   /**
    * Whether the SSE channel has ever delivered a frame in this stream (a
-   * delivered frame proves the tunnel forwards SSE; silence alone then means
-   * the agent idle, not a dead channel — only an onerror re-arms fallback).
+   * delivered frame proves the tunnel can forward SSE; sustained silence may
+   * still mean a suspended mobile tunnel, so polling re-arms after 3 windows).
    */
   private sseAlive = false
   /** Per-session highest event seq already emitted, for poll dedup. */
@@ -109,6 +111,8 @@ export class MuxClient {
   private polling = false
   /** Epoch ms of the next due poll while polling (kept on the same tick timer). */
   private nextPollAt = 0
+  /** Adaptive delay: productive polls reset it; empty/error polls add one base interval up to one minute. */
+  private pollDelayMs: number
 
   /**
    * @param url - the mobile events endpoint (browser-relative).
@@ -119,6 +123,7 @@ export class MuxClient {
     this.sourceFactory = options.sourceFactory ?? browserSource
     this.pollLatest = options.pollLatest ?? ((sessionId) => fetchHistory(sessionId, undefined, DEFAULT_POLL_PAGE_SIZE))
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+    this.pollDelayMs = this.pollIntervalMs
     this.stallThresholdMs = options.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS
     this.now = options.now ?? (() => Date.now())
   }
@@ -159,9 +164,7 @@ export class MuxClient {
       return
     }
     // If SSE is already stalled for this session, start patching right away.
-    if (!this.polling && !this.stopped && !this.sseAlive && (this.now() - this.lastDataAt) > this.stallThresholdMs) {
-      this.startPolling()
-    }
+    if (!this.polling && !this.stopped && this.isSseStalled()) this.startPolling()
   }
 
   private connect(): void {
@@ -208,29 +211,37 @@ export class MuxClient {
     if (this.stopped) return
     if (this.observeSessionId === undefined) return
     if (this.polling) {
-      // The stall phase has ended; the same tick now paces the polls.
+      // The stall phase has ended; the same tick now paces the adaptive polls.
       if (this.now() >= this.nextPollAt) {
-        this.nextPollAt = this.now() + this.pollIntervalMs
+        // pollTick schedules the next run after it settles, so slow requests
+        // cannot overlap with another scheduler tick.
+        this.nextPollAt = Number.POSITIVE_INFINITY
         void this.pollTick()
       }
       return
     }
-    // A live SSE channel only goes silent while the agent idles; never poll
-    // against it. Fallback arms again only via onerror or a stream that has
-    // never delivered.
-    if (this.sseAlive) return
-    if ((this.now() - this.lastDataAt) > this.stallThresholdMs) this.startPolling()
+    if (this.isSseStalled()) this.startPolling()
+  }
+
+  private isSseStalled(): boolean {
+    const windowMs = this.sseAlive
+      ? this.stallThresholdMs * LIVE_SSE_STALL_MULTIPLIER
+      : this.stallThresholdMs
+    return (this.now() - this.lastDataAt) > windowMs
   }
 
   private startPolling(): void {
     if (this.polling || this.stopped) return
     this.polling = true
-    this.nextPollAt = this.now() + this.pollIntervalMs
+    this.pollDelayMs = this.pollIntervalMs
+    this.nextPollAt = Number.POSITIVE_INFINITY
     void this.pollTick()
   }
 
   private stopPolling(): void {
     this.polling = false
+    this.pollDelayMs = this.pollIntervalMs
+    this.nextPollAt = 0
   }
 
   /**
@@ -244,19 +255,35 @@ export class MuxClient {
       this.stopPolling()
       return
     }
+    let emitted = 0
     try {
       const page = await this.pollLatest(sessionId)
       let maxSeq = this.pollWatermark.get(sessionId) ?? -1
-      for (const entry of page.events) {
+      const ordered = [...page.events].sort((left, right) => {
+        const leftSeq = typeof left.event?.seq === 'number' ? left.event.seq : -1
+        const rightSeq = typeof right.event?.seq === 'number' ? right.event.seq : -1
+        return leftSeq - rightSeq
+      })
+      for (const entry of ordered) {
         const event = entry.event
         const seq = typeof event?.seq === 'number' ? event.seq : -1
         if (seq <= maxSeq) continue
         maxSeq = seq
+        emitted += 1
         this.emit({ type: 'session/event', sessionId: sessionId as SessionEventFrame['sessionId'], event } as SessionEventFrame)
       }
       this.pollWatermark.set(sessionId, maxSeq)
     } catch {
-      // Transient (network, pairing, history paging); the next tick retries.
+      // Transient (network, pairing, history paging); retry with backoff.
+    } finally {
+      if (emitted > 0) {
+        this.pollDelayMs = this.pollIntervalMs
+      } else {
+        this.pollDelayMs = Math.min(MAX_POLL_BACKOFF_MS, this.pollDelayMs + this.pollIntervalMs)
+      }
+      if (this.polling && this.observeSessionId === sessionId) {
+        this.nextPollAt = this.now() + this.pollDelayMs
+      }
     }
   }
 


### PR DESCRIPTION
## 摘要（Summary）

修复 #851 已复现的移动端消息投递缺陷族：轮询页按 seq 排序、已连通过的 SSE 静默挂起后自动恢复、空轮询退避，以及同轮多 step 的稳定排序。

## 涉及包（Affected Packages）

- [x] 远程 Web UI `packages/dsh-remote-web-ui`

## PR 类别（PR Category）

- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch origin && git rebase origin/dev
```

结果：分支以 `bd8bce860f925314a64345a101aa20ed163e9486` 为基线，rebase 报告已是最新。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：gpt-5.6-sol

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui exec vitest run src/mobile/mux.test.ts src/mobile/messages.test.ts
pnpm --filter @linxin666/dsh-remote-web-ui test
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
pnpm --filter @linxin666/dsh-remote-web-ui build
pnpm typecheck && pnpm test && pnpm test:scripts && pnpm docs:check
git diff origin/dev...HEAD --check
```

结果摘要：聚焦回归 2 个文件 37 项通过；包全量 33 个文件 324 项通过；包 typecheck/build 通过；仓库 typecheck/test/test:scripts/docs:check 全部通过；diff check 通过。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A。修复的是移动端投递与折叠逻辑，无视觉样式变化；自动化测试覆盖实际 MuxClient 轮询路径和 EventFolder 折叠路径。

Fixes #851
