### PR TITLE
fix(scripts): sync copy-count assertions with doctor consumer

### DIFF
--- a/scripts/sync-shared.test.mjs
+++ b/scripts/sync-shared.test.mjs
@@ -19,13 +19,13 @@ test('header/strip round-trips every file kind', () => {
   }
 })
 
-test('copies cover the settings trio for seven consumers plus host helpers', () => {
+test('copies cover the settings trio for eight consumers plus host helpers', () => {
   // Normalize separators: node:path join yields backslashes on Windows, and
   // the copy-count buckets below match on forward slashes.
   const entries = copyEntries().map(entry => ({ ...entry, target: entry.target.replaceAll('\\', '/') }))
-  assert.equal(entries.length, 63)
+  assert.equal(entries.length, 66)
   const clientTrio = entries.filter(entry => entry.target.includes('/src/client/'))
-  assert.equal(clientTrio.length, 25)
+  assert.equal(clientTrio.length, 28)
   const hostCopies = entries.filter(entry => entry.target.includes('/src/host/')
     || entry.target.includes('/src/dsh-home.ts')
     || entry.target.includes('/src/mount-once.ts')


### PR DESCRIPTION
## 摘要（Summary）

修复 CI 失败（Script tests）：PR #922 为 dsh-doctor 加入 SETTINGS_CONSUMERS 后，scripts/sync-shared.test.mjs 中硬编码的拷贝计数未同步更新（63/25），实际为 66/28（多出 doctor 的 settings 三件套拷贝），导致 pnpm test:scripts 失败（66 !== 63）。

## 涉及包（Affected Packages）

仅脚本改动（维护类），不涉及包目录。

## PR 类别（PR Category）

- [x] 维护 / 其他

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```sh
git fetch origin && git merge --ff-only origin/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：

DeepSeek（deepseek-v4-flash-vision-exp）

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
git fetch origin && git merge --ff-only origin/dev
node scripts/sync-shared.test.mjs
pnpm test:scripts
```

结果摘要：

node scripts/sync-shared.test.mjs：4/4 通过（copies cover the settings trio for eight consumers plus host helpers）。pnpm test:scripts：152/152 通过，0 失败。

## 用户可见变更证据（Local Feature Evidence）

N/A（纯内部脚本断言修复，无用户可见变更）。
