### PR TITLE
fix(ssh): drop late async setState after HostsTab unmount

### DIFF
--- a/packages/dsh-ssh/src/client/panel/HostsTab.tsx
+++ b/packages/dsh-ssh/src/client/panel/HostsTab.tsx
@@ -105,15 +105,21 @@ export function HostsTab({ api, onConnect }: HostsTabProps) {
     return () => { clearTimeout(timer) }
   }, [search, load])
 
+  // Every async setState path guards with mountedRef, not just load(): a
+  // promise settling after unmount would setState against the torn-down
+  // environment (window is not defined, main-CI flake).
   const runTest = async (alias: string): Promise<void> => {
+    if (!mountedRef.current) return
     setTestingAlias(alias)
     try {
       const result = await api.testHost(alias)
+      if (!mountedRef.current) return
       setTestResults(prev => ({ ...prev, [alias]: result }))
     } catch (cause) {
+      if (!mountedRef.current) return
       setTestResults(prev => ({ ...prev, [alias]: { ok: false, error: errorMessage(cause) } }))
     } finally {
-      setTestingAlias(null)
+      if (mountedRef.current) setTestingAlias(null)
     }
   }
 
@@ -121,32 +127,38 @@ export function HostsTab({ api, onConnect }: HostsTabProps) {
     if (!window.confirm(tt('hosts.deleteConfirm', { alias }))) return
     try {
       await api.deleteHost(alias)
+      if (!mountedRef.current) return
       void load()
     } catch (cause) {
+      if (!mountedRef.current) return
       setError(errorMessage(cause))
     }
   }
 
   // Group-header batch action (#379): test every host in the group.
   const testGroup = async (group: HostGroup): Promise<void> => {
+    if (!mountedRef.current) return
     setTestingGroup(group.key)
     try {
       await Promise.all(group.hosts.map(host => runTest(host.alias)))
     } finally {
-      setTestingGroup(null)
+      if (mountedRef.current) setTestingGroup(null)
     }
   }
 
   const importConfig = async (): Promise<void> => {
+    if (!mountedRef.current) return
     setImporting(true)
     try {
       const result = await api.importSshConfig()
+      if (!mountedRef.current) return
       setNotice(tt('hosts.imported', { parsed: result.parsed, added: result.added, skipped: result.skipped }))
       void load()
     } catch (cause) {
+      if (!mountedRef.current) return
       setError(errorMessage(cause))
     } finally {
-      setImporting(false)
+      if (mountedRef.current) setImporting(false)
     }
   }
 

--- a/packages/dsh-ssh/tests/panel-hosts.test.tsx
+++ b/packages/dsh-ssh/tests/panel-hosts.test.tsx
@@ -13,7 +13,7 @@ import { createRoot } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { HostsTab, groupHosts } from '../src/client/panel/HostsTab.tsx'
 import type { SshApi } from '../src/client/api.ts'
-import type { SshHostSummary } from '../src/protocol.ts'
+import type { SshHostSummary, TestResult } from '../src/protocol.ts'
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -33,7 +33,15 @@ function makeHost(alias: string, extra: Partial<SshHostSummary> = {}): SshHostSu
   }
 }
 
+// Every rendered root is unmounted in cleanup: a late-settling promise then
+// hits the mounted guard instead of setState-ing against the torn-down jsdom
+// environment (main-CI flake: window is not defined from HostsTab setError).
+const mountedRoots: { root: ReturnType<typeof createRoot> }[] = []
+
 afterEach(() => {
+  for (const { root } of mountedRoots.splice(0)) {
+    act(() => { root.unmount() })
+  }
   document.body.replaceChildren()
 })
 
@@ -85,6 +93,26 @@ describe('HostsTab unmount race (main-CI flake)', () => {
     expect(api.listHosts).toHaveBeenCalled()
   })
 
+  it('a testHost promise settling after unmount never reaches setState', async () => {
+    // Same race as the listHosts case, on the runTest path (setTestResults /
+    // setTestingAlias were unguarded before the mounted ref was applied).
+    let rejectLate: ((error: Error) => void) | undefined
+    const api = {
+      listHosts: vi.fn(async () => [makeHost('web-1')]),
+      testHost: vi.fn(() => new Promise<TestResult>((_resolve, reject) => { rejectLate = reject })),
+    } as unknown as SshApi
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    await act(async () => { root.render(<HostsTab api={api} onConnect={() => undefined} />) })
+    const testButton = [...container.querySelectorAll('button')].find(button => button.textContent === '测试') as HTMLButtonElement
+    await act(async () => { testButton.click() })
+    await act(async () => { root.unmount() })
+    rejectLate!(new Error('late test failure'))
+    await act(async () => { await Promise.resolve() })
+    expect(api.testHost).toHaveBeenCalled()
+  })
+
   it('guards every load-path setState with the mounted ref', () => {
     const source = readFileSync(join(process.cwd(), 'src', 'client', 'panel', 'HostsTab.tsx'), 'utf8')
     expect(source).toContain('mountedRef')
@@ -109,6 +137,7 @@ describe('HostsTab grouped view', () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
     const root = createRoot(container)
+    mountedRoots.push({ root })
     await act(async () => { root.render(<HostsTab api={api} onConnect={() => {}} />) })
     await act(async () => { await Promise.resolve() })
     return container


### PR DESCRIPTION
## 摘要（Summary）

修复 dsh-ssh HostsTab 的收尾竞态（main-CI flake）：异步 setState 路径（runTest / deleteHost / testGroup / importConfig）在组件卸载后仍会落下 setState，与 jsdom teardown 竞争时出现 `ReferenceError: window is not defined`（HostsTab.tsx:93 setError 路径已在此前加过 mounted 保护，但测试从未真正 unmount，其余路径完全未保护）。本次为所有异步 setState 路径补 mounted 保护，并让测试在 afterEach 里真实 unmount，late settle 由既有 guard 丢弃。

## 涉及包（Affected Packages）

- [x] SSH 远程运维 `packages/dsh-ssh`

## PR 类别（PR Category）

- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```sh
git fetch origin && git merge --ff-only origin/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：

DeepSeek（deepseek-v4-flash-vision-exp）

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-ssh test
pnpm --filter @linxin666/dsh-ssh exec vitest run tests/panel-hosts.test.tsx  # x5
pnpm typecheck
pnpm --filter @linxin666/dsh-ssh build
```

结果摘要：

`pnpm --filter @linxin666/dsh-ssh test`：17 文件 / 130 用例全过（新增 testHost late-settle 竞态用例）。panel-hosts.test.tsx 连续 5 次全过。typecheck 全绿。dsh-ssh build 成功（lib/client.js 798.66 kB）。

## 用户可见变更证据（Local Feature Evidence）

N/A（竞态防御 + 测试收尾修复，无用户可见行为变化）。
