### PR TITLE
fix(ssh): scope ssh_* agent tools to remote hosts (refs #760)

### DIFF
--- a/packages/dsh-ssh/README.i18n.yaml
+++ b/packages/dsh-ssh/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 5c57247b1446cf415240d49ca113b64e9a6f4f29
-README.zh.md: 15a4a15a5fd8b575e1393a7ba2648bb6538cfd00
+README.md: 7ea38ed3468b6dcac409216661ed4d33a2c81007
+README.zh.md: 736f82081b9d64729e449da4d1e4316efa9b37e1

--- a/packages/dsh-ssh/README.md
+++ b/packages/dsh-ssh/README.md
@@ -27,6 +27,7 @@ Built on the capability list of [badseal/ssh-skill](https://github.com/badseal/s
 - Deleting a host or changing its connection fields (host / port / user / auth / proxyJump) immediately closes that alias's pooled connection and tunnels; later operations reconnect with the new configuration and never reuse a connection authenticated with the old credentials.
 - Before the Agent uses a tool, the host must first be configured in the GUI (or imported from ~/.ssh/config).
 - `ssh_upload` / `ssh_download` read/write arbitrary local paths on this machine with host-process privileges (not through the bash sandbox) — same host-local-path semantics as ssh-skill, be aware of that permission surface.
+- Agent transfer tools move files only between this machine and a remote SSH host; local-file reads and writes must use the local file tools (read / write / edit / bash), never the `ssh_*` tools.
 - The remote output of exec / cluster is returned verbatim (not sanitized); a command like `env` may bring secrets from the remote environment back into the conversation log.
 
 ## Install

--- a/packages/dsh-ssh/README.zh.md
+++ b/packages/dsh-ssh/README.zh.md
@@ -27,6 +27,7 @@
 - 删除主机或修改其连接字段（host / port / user / auth / proxyJump）会立即断开该别名的池化连接与隧道，后续操作按新配置重新建连，不会复用旧凭据的已认证连接。
 - Agent 使用工具前，主机需先在 GUI 中配置（或从 ~/.ssh/config 导入）。
 - `ssh_upload` / `ssh_download` 以宿主进程权限直接读写本机任意路径（不经 bash 沙箱）——与 ssh-skill 的宿主本地路径语义一致，注意该权限面。
+- Agent 传输工具只在本机与远程 SSH 主机之间移动文件；本机文件的读写一律使用本地文件工具（read / write / edit / bash），不要使用 `ssh_*` 工具。
 - exec / cluster 的远程输出原样返回（不脱敏），命令如 `env` 可能把远端环境中的密钥带回对话记录。
 
 ## 安装

--- a/packages/dsh-ssh/src/index.ts
+++ b/packages/dsh-ssh/src/index.ts
@@ -64,7 +64,7 @@ const DEFAULT_ANNOUNCE = false
 const SECTION_ORDER = 150
 
 /** Model-facing announcement: plugin presence, capabilities, and limits. */
-export const SSH_GUIDANCE = '本机已安装 dsh-ssh 插件（DSH 远程 SSH 运维）：侧边栏「SSH」入口；在 dsh-web-ui 插件全家桶仓库（packages/dsh-ssh）统一维护。能力：主机配置存 $DSH_HOME/dsh-ssh.json（默认 ~/.dsh）（可从 ~/.ssh/config 导入）；持久连接池复用长连接（空闲 30 分钟自动断开）；ssh_list 列出主机、ssh_exec 执行远程命令、ssh_upload/ssh_download 传输文件、ssh_tunnel 本地端口转发（访问远程数据库/内网服务）、ssh_cluster 集群并发执行；支持密钥/密码/ssh-agent 认证、passphrase 密钥与 ProxyJump 跳板机；Web 终端走 WebSocket。限制：主机操作由用户在 GUI 中配置后 agent 方可使用；密码以明文存在用户主目录私有文件（权限 0600）；命令输出原样返回、可能含敏感信息；断线重连可能重放非幂等命令；传输/执行消耗真实远程资源，先确认再操作。用户提到「SSH / 远程服务器 / 服务器操作 / 跳板机 / 隧道 / 部署 / 上传下载」时即指本插件，请据此协作。'
+export const SSH_GUIDANCE = '本机已安装 dsh-ssh 插件（DSH 远程 SSH 运维）：侧边栏「SSH」入口；在 dsh-web-ui 插件全家桶仓库（packages/dsh-ssh）统一维护。能力：主机配置存 $DSH_HOME/dsh-ssh.json（默认 ~/.dsh）（可从 ~/.ssh/config 导入）；持久连接池复用长连接（空闲 30 分钟自动断开）；ssh_list 列出主机、ssh_exec 执行远程命令、ssh_upload/ssh_download 传输文件、ssh_tunnel 本地端口转发（访问远程数据库/内网服务）、ssh_cluster 集群并发执行；支持密钥/密码/ssh-agent 认证、passphrase 密钥与 ProxyJump 跳板机；Web 终端走 WebSocket。限制：主机操作由用户在 GUI 中配置后 agent 方可使用；密码以明文存在用户主目录私有文件（权限 0600）；命令输出原样返回、可能含敏感信息；断线重连可能重放非幂等命令；传输/执行消耗真实远程资源，先确认再操作。路径区分：本机（dsh host）上的文件与命令一律用本地工具（read / write / edit / bash），ssh_* 工具只针对远程主机上的路径。用户提到「SSH / 远程服务器 / 服务器操作 / 跳板机 / 隧道 / 部署 / 上传下载」时即指本插件，请据此协作。'
 
 /**
  * Mount the SSH engine, routes, tools, and announcement.

--- a/packages/dsh-ssh/src/tools.ts
+++ b/packages/dsh-ssh/src/tools.ts
@@ -109,7 +109,7 @@ export function sshListTool(engine: SshEngine) {
 export function sshExecTool(engine: SshEngine) {
   return defineTool({
     name: 'ssh_exec',
-    description: 'Execute a command on a configured SSH host by alias. Prefer combining independent read-only queries into one command. ' +
+    description: 'Execute a shell command on a REMOTE SSH host by alias; the command runs on the remote host, never on this machine. For commands on this machine, use the local bash tool. Prefer combining independent read-only queries into one command. ' +
       'Triggers: run command on server, deploy, check server/status, service control, view logs, any remote operation.',
     parameters: {
       alias: { type: 'string', required: true, description: 'Host alias from ssh_list.' },
@@ -154,12 +154,12 @@ export function sshExecTool(engine: SshEngine) {
 export function sshUploadTool(engine: SshEngine) {
   return defineTool({
     name: 'ssh_upload',
-    description: 'Upload a local file to a configured SSH host. The local path is on THIS machine (the dsh host). ' +
+    description: 'Transfer a file FROM this machine (the dsh host) TO a remote SSH host. Use this only when the file must be copied to the remote host. Files that stay on this machine are handled with the local file tools (read / write / edit), not ssh_upload. ' +
       'Triggers: upload file to server, deploy artifact, copy config to server.',
     parameters: {
       alias: { type: 'string', required: true, description: 'Host alias from ssh_list.' },
-      localPath: { type: 'string', required: true, description: 'Absolute local file path on this machine.' },
-      remotePath: { type: 'string', required: true, description: 'Destination path on the remote host (parent dirs are created).' },
+      localPath: { type: 'string', required: true, description: 'Absolute path of the source file on THIS machine (the dsh host) — not a path on the remote host.' },
+      remotePath: { type: 'string', required: true, description: 'Absolute destination path on the remote SSH host (parent dirs are created).' },
     },
     output: {
       schema: {
@@ -191,12 +191,12 @@ export function sshUploadTool(engine: SshEngine) {
 export function sshDownloadTool(engine: SshEngine) {
   return defineTool({
     name: 'ssh_download',
-    description: 'Download a remote FILE from a configured SSH host to a local path on this machine. Directory download is not supported — download files individually. ' +
+    description: 'Copy a remote FILE from a configured SSH host to this machine (the dsh host). Use this only when the source is on the remote host; files already on this machine are read with the local file tools (read / write / edit), not ssh_download. Directory download is not supported — download files individually. ' +
       'Triggers: download file from server, fetch remote log/artifact.',
     parameters: {
       alias: { type: 'string', required: true, description: 'Host alias from ssh_list.' },
-      remotePath: { type: 'string', required: true, description: 'Remote file path.' },
-      localPath: { type: 'string', required: true, description: 'Absolute destination path on this machine.' },
+      remotePath: { type: 'string', required: true, description: 'Absolute path of the source file on the remote SSH host.' },
+      localPath: { type: 'string', required: true, description: 'Absolute destination path on THIS machine (the dsh host).' },
     },
     output: {
       schema: {

--- a/packages/dsh-ssh/tests/tools.test.ts
+++ b/packages/dsh-ssh/tests/tools.test.ts
@@ -174,3 +174,39 @@ describe('ssh_upload / ssh_download', () => {
     expect(down.bytes).toBe(34)
   })
 })
+
+describe('path-scope guidance for agents (issue #760)', () => {
+  it('ssh_upload draws the local-vs-remote boundary and points local files to local tools', () => {
+    const tool = sshUploadTool(engine(new StubEngine()))
+    const name = tool.description.toLowerCase()
+    expect(name).toContain('from this machine')
+    expect(name).toContain('remote ssh host')
+    expect(name).toContain('local file tools')
+    const lparams = tool.parameters as unknown as { properties: Record<string, { description: string }> }
+    const localPath = lparams.properties.localPath.description.toLowerCase()
+    expect(localPath).toContain('this machine')
+    expect(localPath).toContain('not a path on the remote host')
+    const remotePath = lparams.properties.remotePath.description.toLowerCase()
+    expect(remotePath).toContain('remote ssh host')
+  })
+
+  it('ssh_download draws the same boundary', () => {
+    const tool = sshDownloadTool(engine(new StubEngine()))
+    const name = tool.description.toLowerCase()
+    expect(name).toContain('remote file')
+    expect(name).toContain('local file tools')
+    const dparams = tool.parameters as unknown as { properties: Record<string, { description: string }> }
+    const remotePath = dparams.properties.remotePath.description.toLowerCase()
+    expect(remotePath).toContain('remote ssh host')
+    const localPath = dparams.properties.localPath.description.toLowerCase()
+    expect(localPath).toContain('this machine')
+  })
+
+  it('ssh_exec is scoped to the remote host only', () => {
+    const tool = sshExecTool(engine(new StubEngine()))
+    const name = tool.description.toLowerCase()
+    expect(name).toContain('remote ssh host')
+    expect(name).toContain('never on this machine')
+    expect(name).toContain('local bash tool')
+  })
+})


### PR DESCRIPTION
## 摘要（Summary）

修复 #760：配置 dsh-ssh 后，Agent 会把本机（dsh host）路径误当作远程路径，用 ssh_download / ssh_upload / ssh_exec 去操作本应使用本地文件工具（read / write / edit / bash）的文件。本 PR 在工具描述与 SSH_GUIDANCE 公告中显式声明路径范围：ssh_* 工具只针对远程 SSH 主机上的路径；本机文件与命令一律走本地工具。不改任何工具行为，仅澄清模型可见的契约。

## 涉及包（Affected Packages）

- [x] SSH 远程运维 `packages/dsh-ssh`

## PR 类别（PR Category）

- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin && git rebase origin/dev`（分支基于 origin/dev d4ace6197；合并前将再次 rebase）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

不适用（非视觉修复；仅模型可见的工具描述文本与公告文本变更）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek（deepseek-v4-flash-vision-exp）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-ssh run typecheck   # tsc --noEmit 通过
pnpm --filter @linxin666/dsh-ssh run build        # tsc types + tsdown 双半区产物 通过
pnpm --filter @linxin666/dsh-ssh test             # 17 文件 / 133 用例全通过（含新增 3 条 path-scope 回归用例）
pnpm docs:write-pair packages/dsh-ssh            # README 中英双语三件套一致性已重录
```

结果摘要：typecheck、build、test（133 passed）全部通过；README.i18n.yaml 已按 `docs:write-pair` 重录。

## 用户可见变更证据（Local Feature Evidence）

模型可见的工具描述变更（无 UI 变化，文本证据）：

- `ssh_upload` 描述："Transfer a file FROM this machine (the dsh host) TO a remote SSH host. Use this only when the file must be copied to the remote host. Files that stay on this machine are handled with the local file tools (read / write / edit), not ssh_upload."
- `ssh_upload.localPath`："Absolute path of the source file on THIS machine (the dsh host) — not a path on the remote host."
- `ssh_download` 描述："Copy a remote FILE from a configured SSH host to this machine (the dsh host). Use this only when the source is on the remote host; files already on this machine are read with the local file tools (read / write / edit), not ssh_download."
- `ssh_exec` 描述："Execute a shell command on a REMOTE SSH host by alias; the command runs on the remote host, never on this machine. For commands on this machine, use the local bash tool."
- SSH_GUIDANCE（announceToAgent 开启时）新增路径区分规则：本机（dsh host）上的文件与命令一律用本地工具（read / write / edit / bash），ssh_* 工具只针对远程主机上的路径。

回归用例 `path-scope guidance for agents (issue #760)` 锁定上述措辞（3 条，见 tests/tools.test.ts）。
