### PR TITLE
fix(pet): 避免重开后显示已结束的旧任务

### DIFF
--- a/packages/dsh-pet/src/service.ts
+++ b/packages/dsh-pet/src/service.ts
@@ -234,6 +234,12 @@ export class PetService extends Service {
    * disposed sessions are removed by the 'session/disposed' listener.
    */
   private readonly sessionActivity = new Map<Session, SessionActivity>()
+  /**
+   * Sessions whose reward source is the official event stream. This metadata
+   * outlives transient visual resets so a derived legacy `done` cannot reward
+   * the same turn again after the pet is disabled and re-enabled.
+   */
+  private readonly officialEventSessions = new WeakSet<Session>()
 
   constructor(ctx: Context, config: PetConfig = {}) {
     super(ctx, 'pet')
@@ -356,6 +362,7 @@ export class PetService extends Service {
   setEnabled(enabled: boolean): void {
     this.enabled = enabled
     this.syncActivity()
+    if (!enabled) this.resetActivity()
   }
 
   private syncActivity(): void {
@@ -391,6 +398,7 @@ export class PetService extends Service {
           const transition = projectOfficialEvent(event, runtime)
           if (transition === undefined) return
           runtime.officialEventsSeen = true
+          this.officialEventSessions.add(session)
           this.applyActivity(session, transition.input, transition.whisper)
           if (transition.completedTurn !== undefined) {
             this.rewardTurn(String(session.id), transition.completedTurn)
@@ -398,6 +406,7 @@ export class PetService extends Service {
         }),
         this.ctx.on('session/disposed', (session: Session) => {
           this.ledger.forgetSession(String(session.id))
+          this.officialEventSessions.delete(session)
           this.sessionActivity.delete(session)
           if (session !== this.displaySession) return
           // The display session is gone: fall back to the most recent
@@ -418,12 +427,21 @@ export class PetService extends Service {
     })()
   }
 
+  /** Drop transient activity because terminal events missed while disabled cannot be replayed safely. */
+  private resetActivity(): void {
+    this.displaySession = undefined
+    this.sessionActivity.clear()
+    this.machine.onSessionDisposed()
+  }
+
   /** Return the per-session activity record, creating it on first sight. */
   private activityOf(session: Session): SessionActivity {
     let activity = this.sessionActivity.get(session)
     if (activity === undefined) {
+      const runtime = emptyProjectionRuntime(this.voicePools())
+      runtime.officialEventsSeen = this.officialEventSessions.has(session)
       activity = {
-        runtime: emptyProjectionRuntime(this.voicePools()),
+        runtime,
         machine: new PetStateMachine(this.stateConfig),
       }
       this.sessionActivity.set(session, activity)

--- a/packages/dsh-pet/tests/service-enabled.spec.ts
+++ b/packages/dsh-pet/tests/service-enabled.spec.ts
@@ -204,8 +204,34 @@ describe('PetService (rc.6 session events)', () => {
 
       service.setEnabled(false)
       ctx.emit('session/event', session, turnEnd(2, { kind: 'completed' }, 3))
-      expect((await service.state()).animation).toBe('jumping')
+      expect(await service.state()).toMatchObject({ animation: 'idle', phase: 'idle', sessionActive: false })
       expect((await service.state()).affinity.turns).toBe(1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not restore in-flight activity whose terminal event was missed while disabled', async () => {
+    const ctx = new Context()
+    const dir = tempDir()
+    const session = makeSession('stale')
+    try {
+      const service = new PetService(ctx, { persistDir: dir })
+      ctx.emit('session/event', session, toolCall(1, 1, 'call-stale', 'shell', 1))
+      expect(await service.state()).toMatchObject({
+        animation: 'running-right',
+        bubble: '正在使用 shell',
+        sessionActive: true,
+      })
+
+      service.setEnabled(false)
+      ctx.emit('session/event', session, turnEnd(1, { kind: 'completed' }, 2))
+      service.setEnabled(true)
+
+      const reopened = await service.state()
+      expect(reopened).toMatchObject({ animation: 'idle', phase: 'idle', sessionActive: false })
+      expect(reopened.bubble).toBeUndefined()
+      expect(reopened.sessions).toEqual([])
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -719,6 +745,25 @@ describe('PetService (rc.6 session events)', () => {
       ctx.emit('session/event', officialSession, turnEnd(1, { kind: 'completed' }, 2))
       ctx.emit('session/event', officialSession, activity('done', 3, '完成啦'))
       expect((await service.state()).affinity.turns).toBe(2)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps official reward deduplication across an enable toggle', async () => {
+    const ctx = new Context()
+    const dir = tempDir()
+    const session = makeSession('toggle-dedup')
+    try {
+      const service = new PetService(ctx, { persistDir: dir })
+      ctx.emit('session/event', session, turnEnd(1, { kind: 'completed' }, 1))
+      expect((await service.state()).affinity.turns).toBe(1)
+
+      service.setEnabled(false)
+      service.setEnabled(true)
+      ctx.emit('session/event', session, activity('done', 2, '完成啦'))
+
+      expect((await service.state()).affinity.turns).toBe(1)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## 摘要（Summary）

修复宠物关闭后重新开启时，可能继续显示已经结束的旧任务状态的问题。

宠物关闭时现在会在卸载会话事件监听后清理视觉临时状态，包括当前显示会话、会话气泡和全局状态机。用于区分官方事件与 legacy 兼容事件奖励来源的元数据独立保留，因此重开后同一会话的派生 `activity/status(done)` 不会重复奖励；好感度、小鱼干、互动冷却、名称和位置等持久数据也不受影响。

## 问题证据

原实现的关闭流程只卸载 `session/event` 和 `session/disposed` 监听，仍保留内存中的 `sessionActivity`、`displaySession` 与全局状态机。

稳定复现路径：

1. 任务进入工具执行状态，宠物显示“正在使用 shell”；
2. 关闭宠物，Host 停止监听会话事件；
3. 任务在关闭期间结束，终态事件不会被宠物接收；
4. 重新开启宠物；
5. 旧的工具执行状态被重新显示，直到同一会话产生新的有效事件。

修复前回归测试的实际结果：

```text
Expected:
  animation: idle
  phase: idle
  sessionActive: false

Received:
  animation: running-right
  phase: tool
  sessionActive: true
```

维护者复查同时确认了另一条确定性路径：同一 session 先收到官方 `turn/end(completed)`，关闭并重开宠物后再收到派生的 legacy `activity/status(done)`，若清理时一并丢失 `officialEventsSeen`，轮次会从 1 错误增加到 2。

本 PR 将视觉活动快照与官方事件奖励来源元数据分离：关闭时仍完整清除无法安全续接的视觉状态，重新开启后从空闲状态开始；同一 live Session 的官方来源标记会保留到 session disposed，从而维持混合事件流的奖励去重。若仍有任务继续运行，后续新事件会正常重新建立会话状态。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [x] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [ ] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream dev --prune
git rebase upstream/dev
```

同步结果：分支基于 `upstream/dev@23527f41`，对比为 ahead 1 / behind 0。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

不适用。本 PR 不修改 UI 布局、样式或视觉资源。

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GPT-5

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未修改 README），并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

不适用。

## 新皮肤收录（New Skin）

不适用。

## 社区插件索引登记（Community Plugin Index）

不适用。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-pet exec vitest run tests/service-enabled.spec.ts -t "does not restore in-flight activity|keeps legacy activity rewards|keeps official reward deduplication"
pnpm --filter @linxin666/dsh-pet test
pnpm --filter @linxin666/dsh-pet typecheck
pnpm --filter @linxin666/dsh-pet build
pnpm typecheck
pnpm docs:check
pnpm aggregate:check
pnpm sync-shared:check
git diff --check
```

结果摘要：

- 维护者复现序列在修复前稳定得到 `Expected 1 / Received 2`；修复后轮次保持为 1。
- 旧任务清理、原有官方/legacy 去重、enable toggle 后去重：3 passed。
- `service-enabled.spec.ts`：40 passed。
- `dsh-pet` 全量测试：32 个测试文件、359 项测试全部通过。
- `dsh-pet` 源码及测试类型检查通过，Host、Client 与 Live2D vendor 构建通过。
- 全仓 typecheck：19 个参与项目全部通过。
- 文档、聚合、共享文件与差异格式门禁通过。
- 已在最新 `upstream/dev@23527f41` 上重新执行上述验证，分支 ahead 1 / behind 0；GitHub CI、plugin-mount 与贡献证据门禁全部通过。

## 用户可见变更证据（Local Feature Evidence）

N/A。本 PR 不修改视觉呈现；通过真实会话事件序列的回归测试验证“运行中 → 关闭 → 关闭期间结束 → 重新开启”的完整生命周期。
