### PR TITLE
feat(dsh-web-ui-all): bundle community archive manager as external plugin

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -355,6 +355,7 @@ This repository is licensed under [Apache-2.0](LICENSE). Third-party code merged
 | dsh-task-board / dsh-git-graph / dsh-aionui-panel / dsh-pet / dsh-remote-web-ui / dsh-web-ui-settings / dsh-liangshen / dsh-skins / dsh-web-ui-all / skins | Authored by zhu1090093659 | Apache-2.0 (zhu1090093659) |
 | dsh-tool-describe-image | Ported from [whitelonng/dsh-plugin-describe-image](https://github.com/whitelonng/dsh-plugin-describe-image) (deepseek-harness `packages/vision/tool-describe-image`) | Apache-2.0 (zhu1090093659) |
 | dsh-better-sidebar | External integrated plugin [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) (right panel, npm dependency reference) | MIT (omdsh-dev) |
+| dsh-archive-manager | External integrated plugin [z953218350/dsh-archive-manager](https://github.com/z953218350/dsh-archive-manager) (settings-page archive manager, npm dependency reference) | MIT (z953218350) |
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ A: 可以。聚合包的行 id 统一带 `web-ui-` 前缀（如 `web-ui-describe
 | dsh-client-ui-skin-matrix | 贡献者原创（Matrix 深夜护眼暗色皮肤） | Apache-2.0（贡献者 seanchen 声明） |
 | dsh-tool-describe-image | 移植自 [whitelonng/dsh-plugin-describe-image](https://github.com/whitelonng/dsh-plugin-describe-image)（deepseek-harness `packages/vision/tool-describe-image`） | Apache-2.0（zhu1090093659） |
 | dsh-better-sidebar | 外部集成插件 [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（右侧面板，npm 依赖引用） | MIT（omdsh-dev） |
+| dsh-archive-manager | 外部集成插件 [z953218350/dsh-archive-manager](https://github.com/z953218350/dsh-archive-manager)（设置页归档管理，npm 依赖引用） | MIT（z953218350） |
 
 ## 贡献者
 

--- a/docs/publish-prep.md
+++ b/docs/publish-prep.md
@@ -89,8 +89,8 @@ npm 侧已发布 @deepseek-ai 核心 SDK 包至 `0.1.0-rc.6`，插件包仍按�
 3. 按依赖顺序发布（用 **`pnpm publish`**，自动改写 workspace:*）：
    各功能包 > skin-center > dsh-skins > web-ui-all；
 4. **外部依赖先行**：web-ui-all 的 dependencies 含 `dsh-better-sidebar`（0.14.0，
-   非本仓库出品，已发布并适配 rc.8 官方 SDK cohort），其版本必须已在 npm 上可解析，
-   再更新 lockfile；
+   非本仓库出品，已发布并适配 rc.8 官方 SDK cohort）与 `@mlgbnb/dsh-archive-manager`
+   （1.0.7，社区插件，已发布），其版本必须已在 npm 上可解析，再更新 lockfile；
 5. 逐包 `pnpm pack --dry-run` 复核 tarball 内容（注意：dry-run 仍会执行
    prepack/prepare 脚本）；
 6. 发布动作前**必须**经维护者确认。

--- a/packages/dsh-web-ui-all/README.i18n.yaml
+++ b/packages/dsh-web-ui-all/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 19ce3abe79fca287b405580bb304763bdb00a119
-README.zh.md: 984aacf0add3d4fc06b6fb81d680c0e12745de33
+README.md: 029f8ee389a4a06fbfd9cd70509735b1409b9b0f
+README.zh.md: 0fe23da57e59d17bd36287aa7c0e4ebc4850894c

--- a/packages/dsh-web-ui-all/README.md
+++ b/packages/dsh-web-ui-all/README.md
@@ -2,12 +2,12 @@
 
 English | [中文](README.zh.md)
 
-The one-click aggregate package for the whole dsh web UI family: installing it brings every functional plugin (task-board / git-graph / pet / remote-web-ui / web-ui-settings / skin-center / community-plugins / aionui-panel) plus the external right-sidebar plugin `dsh-better-sidebar` and the skin family (`dsh-skins`, skin assets bundled inside). The compat bridge layer is folded into this package (`src/client`), so no separate compat npm package is needed.
+The one-click aggregate package for the whole dsh web UI family: installing it brings every functional plugin (task-board / git-graph / pet / remote-web-ui / web-ui-settings / skin-center / community-plugins / aionui-panel) plus the external plugins `dsh-better-sidebar` (right panel) and `@mlgbnb/dsh-archive-manager` (settings-page archive manager) and the skin family (`dsh-skins`, skin assets bundled inside). The compat bridge layer is folded into this package (`src/client`), so no separate compat npm package is needed.
 
 ## What it is
 
-- **One install, everything on**: its dependencies pull in all sub-plugin packages (dsh-client-ui-aionui-panel / dsh-client-ui-task-board / dsh-client-ui-git-graph / dsh-pet / dsh-remote-web-ui / dsh-ssh / dsh-client-ui-web-ui-settings / dsh-client-ui-skin-center / dsh-client-ui-community-plugins / dsh-skins) plus the external npm plugin `dsh-better-sidebar` (the default right sidebar: explorer / editor / terminal / git / browser).
-- **Aggregation carrier**: `cordis.patch.yml` aggregates the `insert` lines of each sub-plugin plus the external `dsh-better-sidebar` row, mounted through the dsh plugin profile mechanism.
+- **One install, everything on**: its dependencies pull in all sub-plugin packages (dsh-client-ui-aionui-panel / dsh-client-ui-task-board / dsh-client-ui-git-graph / dsh-pet / dsh-remote-web-ui / dsh-ssh / dsh-client-ui-web-ui-settings / dsh-client-ui-skin-center / dsh-client-ui-community-plugins / dsh-skins) plus the external npm plugins `dsh-better-sidebar` (the default right sidebar: explorer / editor / terminal / git / browser) and `@mlgbnb/dsh-archive-manager` (the default settings-page archive manager: group by project, search and filter, preview conversations, restore and delete).
+- **Aggregation carrier**: `cordis.patch.yml` aggregates the `insert` lines of each sub-plugin plus the external `dsh-better-sidebar` and `@mlgbnb/dsh-archive-manager` rows, mounted through the dsh plugin profile mechanism.
 - **Right panel**: the right panel is always `dsh-better-sidebar` (the aionui panel can no longer be enabled). Settings → Web UI Plugins → Side Card declares the right panel comes from [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) and edits its everyday settings inline; the provider choice was removed.
 
 ## Install
@@ -52,5 +52,5 @@ See [issue #513](https://github.com/zhu1090093659/dsh-web-ui/issues/513).
 
 - Every sub-plugin activates together. For only a subset, install that sub-plugin package directly.
 - Aggregate rows are namespaced `web-ui-*`, so the bundle can coexist with a standalone install of the same plugin: the loader no longer rejects the duplicate id, the host half runs once (the second source is a no-op), and the browser half is deduped by package name. Keeping both sources has no benefit; prefer one. When the bundle is the source, profile patch config rows must use the `web-ui-*` id (e.g. `web-ui-remote-web-ui` for the remote-web-ui `autoTunnel` row); standalone installs keep the plugin's own id.
-- `dsh-better-sidebar` is an external npm dependency (not authored in this repo); it must be published before this package's release (see `docs/publish-prep.md` for the release order).
+- `dsh-better-sidebar` and `@mlgbnb/dsh-archive-manager` are external npm dependencies (not authored in this repo); they must be published before this package's release (see `docs/publish-prep.md` for the release order).
 - Dependencies on the `@deepseek-ai/*` SDK are pinned; compatibility follows the repository's release cadence.

--- a/packages/dsh-web-ui-all/README.zh.md
+++ b/packages/dsh-web-ui-all/README.zh.md
@@ -2,12 +2,12 @@
 
 [English](README.md) | 中文
 
-DSH Web UI 全家桶聚合插件：一键安装全部功能插件（task-board / git-graph / pet / remote-web-ui / web-ui-settings / skin-center / community-plugins / aionui-panel），外加外部右侧栏插件 `dsh-better-sidebar` 与皮肤全家桶（`dsh-skins`，皮肤资产内置）。compat 桥接层已并入本包（`src/client`），因此无需独立的 compat npm 包。
+DSH Web UI 全家桶聚合插件：一键安装全部功能插件（task-board / git-graph / pet / remote-web-ui / web-ui-settings / skin-center / community-plugins / aionui-panel），外加外部插件 `dsh-better-sidebar`（右侧面板）与 `@mlgbnb/dsh-archive-manager`（设置页归档管理）以及皮肤全家桶（`dsh-skins`，皮肤资产内置）。compat 桥接层已并入本包（`src/client`），因此无需独立的 compat npm 包。
 
 ## 是什么
 
-- **一次安装、全部到位**：其 dependencies 引入全部子插件包（dsh-client-ui-aionui-panel / dsh-client-ui-task-board / dsh-client-ui-git-graph / dsh-pet / dsh-remote-web-ui / dsh-ssh / dsh-client-ui-web-ui-settings / dsh-client-ui-skin-center / dsh-client-ui-community-plugins / dsh-skins），外加外部 npm 插件 `dsh-better-sidebar`（默认右侧面板：文件资源管理器 / 编辑器 / 终端 / Git / 浏览器）。
-- **聚合载具**：`cordis.patch.yml` 汇总各子插件的 `insert` 行与外部 `dsh-better-sidebar` 行，经 dsh 插件 profile 机制挂载。
+- **一次安装、全部到位**：其 dependencies 引入全部子插件包（dsh-client-ui-aionui-panel / dsh-client-ui-task-board / dsh-client-ui-git-graph / dsh-pet / dsh-remote-web-ui / dsh-ssh / dsh-client-ui-web-ui-settings / dsh-client-ui-skin-center / dsh-client-ui-community-plugins / dsh-skins），外加外部 npm 插件 `dsh-better-sidebar`（默认右侧面板：文件资源管理器 / 编辑器 / 终端 / Git / 浏览器）与 `@mlgbnb/dsh-archive-manager`（默认设置页归档管理：按项目分组、搜索筛选、预览对话、一键恢复与删除）。
+- **聚合载具**：`cordis.patch.yml` 汇总各子插件的 `insert` 行与外部 `dsh-better-sidebar`、`@mlgbnb/dsh-archive-manager` 行，经 dsh 插件 profile 机制挂载。
 - **右侧面板**：右侧面板固定为 `dsh-better-sidebar`（aionui-panel 已不可启用）。设置 → Web UI 插件 → 侧边卡片 声明右侧面板来自 [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) 并内嵌其常用设置。
 
 ## 安装
@@ -52,5 +52,5 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-web-ui-all
 
 - 各子插件随本包一起激活；若只需要其中一部分，请直接安装对应子插件包。
 - 聚合行 id 统一带 `web-ui-` 命名空间，本包可与同名独立插件包共存：loader 不再拒绝重复 id，host 半区只注册一次（第二个来源为空操作），浏览器半区按包名去重。两个来源并存没有额外收益，建议只保留一个。插件来自本包时，profile 里按 id 写的配置行要改用 `web-ui-` 前缀（如 remote-web-ui 的 `autoTunnel` 配置行写成 `web-ui-remote-web-ui`）；独立安装时仍用插件原 id。
-- `dsh-better-sidebar` 是外部 npm 依赖（非本仓库出品），本包发版前必须先发布它（发布顺序见 `docs/publish-prep.md`）。
+- `dsh-better-sidebar` 与 `@mlgbnb/dsh-archive-manager` 是外部 npm 依赖（均非本仓库出品），本包发版前必须先发布它们（发布顺序见 `docs/publish-prep.md`）。
 - 依赖的 `@deepseek-ai/*` SDK 版本已锁定，兼容性跟随本仓库的发版节奏。

--- a/packages/dsh-web-ui-all/aggregate.yml
+++ b/packages/dsh-web-ui-all/aggregate.yml
@@ -59,3 +59,8 @@ deps:
 # （即将弃用）/ 使用 DSH-better-sidebar」，默认后者），无需行级 config patch。
 rows:
   - {"id": "better-sidebar", "name": "dsh-better-sidebar"}
+  # 外部 npm 插件：dsh-archive-manager（社区版「归档管理」）在设置页提供
+  # Codex 风格会话归档管理（按项目分组、搜索筛选、预览、恢复、物理删除）。
+  # 依赖引用 @mlgbnb/dsh-archive-manager@1.0.7（见 package.json，生成器保留
+  # 非 workspace 依赖），行排在 better-sidebar 之后统一应用。
+  - {"id": "archive-manager", "name": "@mlgbnb/dsh-archive-manager"}

--- a/packages/dsh-web-ui-all/cordis.patch.yml
+++ b/packages/dsh-web-ui-all/cordis.patch.yml
@@ -92,3 +92,8 @@
 - insert:
     - id: web-ui-better-sidebar
       name: 'dsh-better-sidebar'
+
+# external: @mlgbnb/dsh-archive-manager
+- insert:
+    - id: web-ui-archive-manager
+      name: '@mlgbnb/dsh-archive-manager'

--- a/packages/dsh-web-ui-all/package.json
+++ b/packages/dsh-web-ui-all/package.json
@@ -53,6 +53,7 @@
     "@linxin666/dsh-client-ui-web-ui-settings": "workspace:*",
     "@linxin666/dsh-skins": "workspace:*",
     "@linxin666/dsh-client-ui-skin-center": "workspace:*",
+    "@mlgbnb/dsh-archive-manager": "1.0.7",
     "dsh-better-sidebar": "0.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1038,6 +1038,9 @@ importers:
       '@linxin666/dsh-tool-describe-image':
         specifier: workspace:*
         version: link:../dsh-tool-describe-image
+      '@mlgbnb/dsh-archive-manager':
+        specifier: 1.0.7
+        version: 1.0.7(react@18.3.1)
       dsh-better-sidebar:
         specifier: 0.14.0
         version: 0.14.0(bc87b4acea0ead060a176b8af9a1b6b3)
@@ -2131,6 +2134,11 @@ packages:
 
   '@mermaid-js/parser@1.2.1':
     resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
+
+  '@mlgbnb/dsh-archive-manager@1.0.7':
+    resolution: {integrity: sha512-OvdrCOJN+gm9VAHvm1B0LNdf1xaRP8uOQ98qSQsstXMVqSa2jXw899P8S8hb153GgEFT9gkd6W4ZT0byjonzjg==}
+    peerDependencies:
+      react: ^18.2.0
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
@@ -5327,6 +5335,10 @@ snapshots:
   '@mermaid-js/parser@1.2.1':
     dependencies:
       '@chevrotain/types': 11.1.2
+
+  '@mlgbnb/dsh-archive-manager@1.0.7(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,3 +69,7 @@ minimumReleaseAgeExclude:
   # minimum-release-age guard must not reject the fresh version. Scoped to
   # that exact version so later upstream publishes get no cooldown bypass.
   - 'dsh-better-sidebar@0.14.0'
+  # The aggregate bundle mounts @mlgbnb/dsh-archive-manager at exactly 1.0.7;
+  # pnpm 11's minimum-release-age guard must not reject the fresh version.
+  # Scoped to that exact version so later upstream publishes get no cooldown bypass.
+  - '@mlgbnb/dsh-archive-manager@1.0.7'

--- a/scripts/aggregate.test.mjs
+++ b/scripts/aggregate.test.mjs
@@ -70,3 +70,12 @@ test('web-ui-all mounts dsh-better-sidebar as an external row', () => {
   // The paired name line resolves the row from the profile root (npm package).
   assert.match(lines[idx + 1] ?? '', /^ {6}name: 'dsh-better-sidebar'$/)
 })
+
+test('web-ui-all mounts @mlgbnb/dsh-archive-manager as an external row', () => {
+  const patch = readFileSync(join(ROOT, 'packages/dsh-web-ui-all/cordis.patch.yml'), 'utf8')
+  const lines = patch.split(/\r?\n/)
+  const idx = lines.findIndex((line) => /^ {4}- id: web-ui-archive-manager$/.test(line))
+  assert.ok(idx >= 0, 'web-ui-archive-manager row is missing from the aggregate patch')
+  // The paired name line resolves the scoped npm package from the profile root.
+  assert.match(lines[idx + 1] ?? '', /^ {6}name: '@mlgbnb\/dsh-archive-manager'$/)
+})

--- a/tests/e2e/mount.e2e.ts
+++ b/tests/e2e/mount.e2e.ts
@@ -23,16 +23,16 @@ if (!BASE_URL) {
 }
 
 /** Plugin crash-marker prefixes (the client renders a strip instead of crashing). */
-const CRASH_STRIP_PATTERNS = [/^dsh-better-sidebar:/, /^\[dsh-better-sidebar\]/]
+const CRASH_STRIP_PATTERNS = [/^dsh-better-sidebar:/, /^\[dsh-better-sidebar\]/, /^dsh-archive-manager:/, /^\[dsh-archive-manager\]/]
 
-test('family bundle mounts dsh-better-sidebar without crash markers', async ({ page }) => {
+test('family bundle mounts the external plugins without crash markers', async ({ page }) => {
   const pageErrors: string[] = []
   const pluginConsoleErrors: string[] = []
   page.on('pageerror', (error) => { pageErrors.push(error.message) })
   page.on('console', (message) => {
     if (message.type() !== 'error') return
     const text = message.text()
-    if (/dsh-better-sidebar/.test(text)) pluginConsoleErrors.push(text)
+    if (/dsh-better-sidebar|archive-manager/.test(text)) pluginConsoleErrors.push(text)
   })
 
   await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' })
@@ -43,7 +43,7 @@ test('family bundle mounts dsh-better-sidebar without crash markers', async ({ p
   await page.waitForSelector('[data-dsh-better-sidebar]', { state: 'attached', timeout: 30_000 })
   await expect(page.locator('[data-dsh-better-sidebar]')).toHaveCount(1)
 
-  // No better-sidebar crash strips anywhere on the page.
+  // No better-sidebar / archive-manager crash strips anywhere on the page.
   for (const pattern of CRASH_STRIP_PATTERNS) {
     await expect(page.getByText(pattern)).toHaveCount(0)
   }


### PR DESCRIPTION
## 摘要（Summary）

将社区插件「归档管理」（`@mlgbnb/dsh-archive-manager@1.0.7`，作者 z953218350，MIT）按 Better Sidebar 的外部插件模式内置进全家桶聚合包 `@linxin666/dsh-web-ui-all`：用户在设置页获得独立的 Archive Manager 会话归档管理（按项目分组、搜索筛选、预览、一键恢复与物理删除），默认随聚合包挂载，无需单独安装。

## 涉及包（Affected Packages）

- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`

## PR 类别（PR Category）

- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin && git rebase origin/dev`（分支基于 57c794ce7，最终确认 ahead 1 / behind 0）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

实现方式与 Better Sidebar 完全一致（外部 npm 依赖引用 + 聚合外部行，不搬源码）：

1. `packages/dsh-web-ui-all/package.json` 增加 `"@mlgbnb/dsh-archive-manager": "1.0.7"`（精确版本）；
2. `packages/dsh-web-ui-all/aggregate.yml` `rows` 增加 `{"id": "archive-manager", "name": "@mlgbnb/dsh-archive-manager"}`，`node scripts/aggregate.mjs` 生成 `cordis.patch.yml` 外部行 `web-ui-archive-manager`；
3. `pnpm-workspace.yaml` `minimumReleaseAgeExclude` 增加 `@mlgbnb/dsh-archive-manager@1.0.7`；
4. 同步更新聚合包 README 中英三件套、根 README 版权表、`docs/publish-prep.md` 外部依赖清单、`scripts/aggregate.test.mjs` 外部行断言、`tests/e2e/mount.e2e.ts` 冒烟断言。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/aggregate.mjs && node scripts/aggregate.mjs --check
pnpm docs:write-pair packages/dsh-web-ui-all && pnpm docs:check
pnpm typecheck && pnpm test && pnpm test:scripts
node scripts/runtime-deps-check.mjs
bash scripts/e2e-mount.sh   # 真实 DSH 挂载冒烟
```

结果摘要：全部通过。`test:scripts` 153/153（含新增 `web-ui-archive-manager` 外部行断言）；`runtime-deps-check` 13 包全部 OK；`aggregate:check` 17 rows / 17 deps OK；`docs:check` 通过。

## 用户可见变更证据（Local Feature Evidence）

真实 DSH 环境（scratch profile，`dsh plugin --profile web add file:<聚合包 tarball>` + `dsh web --port 0`）验证：

- `dsh` 安装聚合包时从 npm 解析并安装 `@mlgbnb/dsh-archive-manager@1.0.7`，`dsh.profile.bundles` 注册成功，`dsh web` 正常启动；
- Playwright 冒烟 lane 通过（`tests/e2e/mount.e2e.ts`：外部插件挂载、无崩溃标记、无 archive-manager 控制台错误 / pageerror）；
- 设置对话框出现「Archive Manager」一级分区（语言为英文时），点击后渲染完整归档管理界面（搜索、全部聊天 / 全部项目筛选、Delete all、空态「No archived conversations.」），无控制台错误；
- 本地截图：`/tmp/am-evidence/section.png`（设置页 Archive Manager 分区）、`/tmp/am-evidence/settings-open.png`（设置对话框分区导航）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek V4 Flash Vision（deepseek-v4-flash-vision-exp）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。