### PR TITLE
fix(scripts): link external aggregate bundle dependencies into dsh profile

### DIFF
--- a/scripts/link-profile.mjs
+++ b/scripts/link-profile.mjs
@@ -21,14 +21,16 @@
  *   node scripts/link-profile.mjs            # link/refresh the family
  *   node scripts/link-profile.mjs --dry-run  # report without changing
  */
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, rmdirSync, symlinkSync, unlinkSync } from 'node:fs'
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, realpathSync, rmdirSync, symlinkSync, unlinkSync } from 'node:fs'
 import { dirname, join, relative, resolve as resolvePath } from 'node:path'
 import { homedir } from 'node:os'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { walkFamilyPackages } from './lib/family-packages.mjs'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolvePath(SCRIPT_DIR, '..')
+const require = createRequire(import.meta.url)
 
 /**
  * Pure decision logic for one link path: what should the caller do with the
@@ -68,6 +70,25 @@ function familyPackages() {
     }
   }
   return found
+}
+
+/** External non-family dependencies required by aggregate packages (e.g. dsh-better-sidebar, @mlgbnb/dsh-archive-manager). */
+function externalPackages() {
+  const dshWebUiAllDir = join(REPO_ROOT, 'packages', 'dsh-web-ui-all')
+  const pkgJsonPath = join(dshWebUiAllDir, 'package.json')
+  if (!existsSync(pkgJsonPath)) return []
+  const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'))
+  const deps = pkgJson.dependencies || {}
+  const externals = []
+  for (const name of Object.keys(deps)) {
+    if (name.startsWith(FAMILY_SCOPE)) continue
+    try {
+      const entryPkg = resolvePath(dirname(require.resolve(`${name}/package.json`, { paths: [dshWebUiAllDir] })))
+      const realDir = realpathSync(entryPkg)
+      externals.push({ fullName: name, dir: realDir })
+    } catch {}
+  }
+  return externals
 }
 
 function main() {
@@ -158,6 +179,54 @@ function main() {
   }
 
   report(changed === 0 ? 'nothing to do' : `${changed} link(s) ${DRY ? 'would be ' : ''}updated`)
+
+  // Also link external dependencies required by dsh-web-ui-all (e.g. @mlgbnb/dsh-archive-manager, dsh-better-sidebar)
+  const extPkgs = externalPackages()
+  if (extPkgs.length) {
+    report(`found ${extPkgs.length} external package(s) from dsh-web-ui-all`)
+    let extChanged = 0
+    for (const { fullName, dir } of extPkgs) {
+      const linkPath = join(PROFILES_NM, fullName)
+      const parentDir = dirname(linkPath)
+      if (!existsSync(parentDir)) {
+        if (!DRY) mkdirSync(parentDir, { recursive: true })
+      }
+      const WIN32 = process.platform === 'win32'
+      const target = WIN32 ? dir : relative(parentDir, dir)
+      let existing = 'missing'
+      let linkIsJunctionDir = false
+      try {
+        const st = lstatSync(linkPath)
+        existing = st.isSymbolicLink() ? 'symlink' : st.isDirectory() ? 'dir' : 'file'
+        if (existing === 'symlink' && st.isDirectory()) linkIsJunctionDir = true
+      } catch {}
+      let current = null
+      if (existing === 'symlink') {
+        try { current = readlinkSync(linkPath) } catch {}
+      }
+      const action = decideLinkAction(existing, target, current)
+      if (action === 'keep') continue
+      if (action === 'skip-report') {
+        report(`skipped external (not a symlink, untouched): ${linkPath}`)
+        continue
+      }
+      if (action === 'create') {
+        if (DRY) { report(`would link external ${fullName} -> ${target}`); extChanged++; continue }
+        symlinkSync(target, linkPath, WIN32 ? 'junction' : undefined)
+        report(`linked external ${fullName} -> ${target}`)
+      } else {
+        if (DRY) { report(`would replace external ${fullName} -> ${current ?? '(broken)'}`); extChanged++; continue }
+        if (linkIsJunctionDir) rmdirSync(linkPath)
+        else unlinkSync(linkPath)
+        symlinkSync(target, linkPath, WIN32 ? 'junction' : undefined)
+        report(`replaced external ${fullName} -> ${target} (was ${current ?? '(broken)'})`)
+      }
+      extChanged++
+    }
+    if (extChanged > 0) {
+      report(`${extChanged} external link(s) ${DRY ? 'would be ' : ''}updated`)
+    }
+  }
 }
 
 // Run only when invoked as the entry script, so the module can be imported


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；
> 提交信息用 Conventional Commits（`type(scope): subject`），禁止 emoji。
> 本仓库接受修复、增强与优化类 PR（bug 修复、现有功能的增强、性能 / 体验优化、维护）；新皮肤始终欢迎，但无背景图、仅简单改色且样式存在问题的低质皮肤 PR 不予接受。全新特性 / 新功能的 PR 暂不接受，请先提 Issue 讨论。
> 仅文档类 PR（标题以 `docs:` 开头或勾选「仅文档」）不接受，会被自动关闭；文档改动请先提 Issue 讨论。
## 摘要（Summary）

修复 link-profile.mjs 仅链接 @linxin666/* 家族包而未链接聚合包（dsh-web-ui-all）所挂载的外部 npm 插件（如 @mlgbnb/dsh-archive-manager 和 dsh-better-sidebar）的问题。扩展脚本以自动扫描 dsh-web-ui-all 的外部依赖并将其链接到 ~/.dsh/profiles/node_modules，保证本地 DSH 启动加载 bundle 时不会因缺少外部插件而报错。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）：仓库维护脚本 `scripts/link-profile.mjs`

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [ ] 社区插件索引
- [x] 维护 / 其他

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

`git fetch origin && git rebase origin/dev`

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

纯维护脚本改动，不涉及视觉修复。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

Gemini 3.7 Flash

使用的编码 Agent 工具：

Antigravity IDE

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

N/A

## 新皮肤收录（New Skin）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
node --test scripts/link-profile.test.mjs
node scripts/link-profile.mjs --dry-run
node scripts/link-profile.mjs
pnpm docs:check
pnpm aggregate:check
pnpm gallery:check
pnpm skin-center:check
dsh --profile web
```

结果摘要：

1. `node --test scripts/link-profile.test.mjs`：6 项测试全部通过。
2. `node scripts/link-profile.mjs`：成功发现并链接 18 个家族包及 2 个外部插件依赖（`@mlgbnb/dsh-archive-manager` 与 `dsh-better-sidebar`）至 `~/.dsh/profiles/node_modules/`。
3. `pnpm docs:check`、`pnpm aggregate:check`、`pnpm gallery:check`、`pnpm skin-center:check` 全部通过。
4. `dsh --profile web` 启动测试：成功加载 plugin tree 并在 `http://127.0.0.1:3080` 正常对外提供服务。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A（纯本地开发维护脚本与配置链接增强，无前端用户可见 UI 变更）
