### PR TITLE
fix(doctor): recover interrupted promotion layouts

### DIFF
--- a/packages/dsh-doctor/src/cli.ts
+++ b/packages/dsh-doctor/src/cli.ts
@@ -8,7 +8,7 @@ import { servicePlan, ensureServiceInstalled, removeService, runCommand } from '
 import { currentPackageVersion } from './agent/version.ts'
 import { provisionCapsule } from './agent/capsule.ts'
 import { resolveDshHome } from './core/profile.ts'
-import { diagnoseAndPlan, repairProfile, rollbackTransaction, snapshotProfile } from './core/recover.ts'
+import { diagnoseAndPlan, discoverRollbackProfile, repairProfile, rollbackTransaction, snapshotProfile } from './core/recover.ts'
 import type { RecoveryRequest } from './core/recover.ts'
 
 export async function main(argv = process.argv.slice(2)): Promise<number> {
@@ -18,18 +18,38 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (command === 'status') { const token = (await readFile(paths.token, 'utf8')).trim(); console.log(JSON.stringify(await callSupervisor(paths.socket, token, { protocol: DOCTOR_PROTOCOL_VERSION, type: 'status' }), null, 2)); return 0 }
   if (command === 'provision') { const dsh = process.env.DSH_DOCTOR_REAL_DSH || 'dsh'; const version = currentPackageVersion(); const profileName = argv[1] ?? 'web'; const mirrorCredentials = !argv.includes('--no-credentials') && process.env.DSH_DOCTOR_CREDENTIALS !== 'off'; const manifest = await provisionCapsule({ paths, dshExecutable: dsh, doctorSpec: process.env.DSH_DOCTOR_PACKAGE || '@linxin666/dsh-doctor@' + version, doctorPackageDir: process.env.DSH_DOCTOR_PACKAGE_DIR, doctorVersion: version, sourceHome: resolveDshHome(), sourceProfile: profileName, mirrorCredentials }); console.log(JSON.stringify(manifest, null, 2)); return 0 }
   if (command === 'diagnose' || command === 'repair' || command === 'snapshot' || command === 'rollback') {
-    const profile = argv[1] ?? 'web'
-    const base: RecoveryRequest = {
-      home: resolveDshHome(),
-      profile,
-      dshPath: process.env.DSH_DOCTOR_REAL_DSH || findRealDsh(),
-      allowLive: command !== 'repair' || argv.includes('--allow-live'),
-    }
+    const home = resolveDshHome()
     if (command === 'rollback') {
       const txnId = argv[1]
       if (txnId === undefined) { console.error('usage: dsh-doctor rollback <txnId>'); return 2 }
-      console.log(JSON.stringify(await rollbackTransaction(base, txnId), null, 2))
-      return 0
+      let profile: string
+      try {
+        profile = await discoverRollbackProfile(home, txnId)
+      } catch (error) {
+        console.log(JSON.stringify({
+          ok: false,
+          phase: 'failed',
+          diagnostics: [],
+          actions: [],
+          manualActions: [],
+          txnId,
+          message: error instanceof Error ? error.message : String(error),
+        }, null, 2))
+        return 2
+      }
+      // Rollback only restores an existing transaction and never launches
+      // DSH, so recovery must still work when the executable itself is broken.
+      const outcome = await rollbackTransaction({ home, profile }, txnId)
+      console.log(JSON.stringify(outcome, null, 2))
+      return outcome.ok ? 0 : 2
+    }
+    const dshPath = process.env.DSH_DOCTOR_REAL_DSH || findRealDsh()
+    const profile = argv[1] ?? 'web'
+    const base: RecoveryRequest = {
+      home,
+      profile,
+      dshPath,
+      allowLive: command !== 'repair' || argv.includes('--allow-live'),
     }
     const outcome = command === 'snapshot' ? await snapshotProfile(base) : command === 'diagnose' ? await diagnoseAndPlan(base) : await repairProfile(base)
     console.log(JSON.stringify(outcome, null, 2))

--- a/packages/dsh-doctor/src/core/lock.ts
+++ b/packages/dsh-doctor/src/core/lock.ts
@@ -84,27 +84,18 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
     const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
     const deadline = now() + timeoutMs
     for (;;) {
-      const exists = await fs.exists(path)
+      let exists: boolean
+      try {
+        exists = await fs.exists(path)
+      } catch (error) {
+        throw new LockError('LOCK_ERROR', scope, key, String(error))
+      }
       if (!exists) {
         try {
-          await fs.mkdir(root, { recursive: true })
-          await fs.mkdir(path)
-          const token: LockToken = {
-            pid,
-            host,
-            intent: options.intent,
-            startedAt: iso(),
-            heartbeatAt: now(),
-            nonce: Math.random().toString(36).slice(2, 10),
-          }
-          await fs.writeText(join(path, 'token.json'), JSON.stringify(token, undefined, 2) + String.fromCharCode(10))
-          return makeHandle(scope, key, path)
+          const claimed = await claim(scope, key, path, options.intent)
+          if (claimed !== undefined) return claimed
         } catch (error) {
-          if (isExistsError(error)) {
-            // Lost the race; treat as held and continue polling.
-          } else {
-            throw new LockError('LOCK_ERROR', scope, key, String(error))
-          }
+          throw new LockError('LOCK_ERROR', scope, key, String(error))
         }
       } else {
         const stale = await isStale(path, staleMs)
@@ -112,15 +103,20 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
           const stealTo = path + '.stale-' + String(now())
           try {
             await fs.rename(path, stealTo)
-            await fs.mkdir(path)
-            await fs.writeText(join(path, 'token.json'), JSON.stringify(buildToken(), undefined, 2) + String.fromCharCode(10))
-            return makeHandle(scope, key, path, true)
           } catch (error) {
-            if (isExistsError(error)) {
-              // Another acquirer stole or created; continue polling.
+            const released = isMissingError(error) || await fs.exists(path).then((exists) => !exists, () => false)
+            if (isExistsError(error) || released) {
+              // Another acquirer stole, created, or released; continue polling.
+              continue
             } else {
               throw new LockError('LOCK_STALE', scope, key, 'stale lock could not be displaced: ' + String(error))
             }
+          }
+          try {
+            const claimed = await claim(scope, key, path, options.intent)
+            if (claimed !== undefined) return claimed
+          } catch (error) {
+            throw new LockError('LOCK_STALE', scope, key, 'stale lock was displaced but replacement failed: ' + String(error))
           }
         }
       }
@@ -133,14 +129,34 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
     }
   }
 
-  const buildToken = (): LockToken => ({
+  const buildToken = (intent: string): LockToken => ({
     pid,
     host,
-    intent: 'unknown',
+    intent,
     startedAt: iso(),
     heartbeatAt: now(),
     nonce: Math.random().toString(36).slice(2, 10),
   })
+
+  const claim = async (scope: LockScope, key: string, path: string, intent: string): Promise<LockHandle | undefined> => {
+    const token = buildToken(intent)
+    const temporary = path + '.claim-' + String(pid) + '-' + token.nonce
+    let temporaryCreated = false
+    try {
+      await fs.mkdir(root, { recursive: true })
+      await fs.mkdir(temporary)
+      temporaryCreated = true
+      await fs.writeText(join(temporary, 'token.json'), JSON.stringify(token, undefined, 2) + String.fromCharCode(10))
+      await fs.rename(temporary, path)
+      temporaryCreated = false
+      return makeHandle(scope, key, path)
+    } catch (error) {
+      if (temporaryCreated) await fs.remove(temporary, { recursive: true }).catch(() => undefined)
+      const targetExists = await fs.exists(path).catch(() => false)
+      if (isExistsError(error) || targetExists) return undefined
+      throw error
+    }
+  }
 
   const isStale = async (path: string, staleMs: number): Promise<boolean> => {
     const token = await readTokenOrNull(path)
@@ -149,7 +165,7 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
     return now() - token.heartbeatAt > staleMs
   }
 
-  const makeHandle = (scope: LockScope, key: string, path: string, stolen = false): LockHandle => {
+  const makeHandle = (scope: LockScope, key: string, path: string): LockHandle => {
     return {
       scope,
       key,

--- a/packages/dsh-doctor/src/core/lock.ts
+++ b/packages/dsh-doctor/src/core/lock.ts
@@ -12,10 +12,10 @@ import { locksDir } from './paths.ts'
 import type { LockScope, LockState, LockToken } from './types.ts'
 
 export class LockError extends Error {
-  readonly code: 'LOCK_HELD' | 'LOCK_STALE' | 'LOCK_ERROR'
+  readonly code: 'LOCK_HELD' | 'LOCK_STALE' | 'LOCK_LOST' | 'LOCK_ERROR'
   readonly scope: LockScope
   readonly key: string
-  constructor(code: 'LOCK_HELD' | 'LOCK_STALE' | 'LOCK_ERROR', scope: LockScope, key: string, detail: string) {
+  constructor(code: 'LOCK_HELD' | 'LOCK_STALE' | 'LOCK_LOST' | 'LOCK_ERROR', scope: LockScope, key: string, detail: string) {
     super('lock ' + scope + ':' + key + ': ' + detail)
     this.name = 'LockError'
     this.code = code
@@ -37,7 +37,7 @@ export interface LockManagerDeps {
   iso(): string
   /** Alive probe for stale detection; defaults to 'always dead'. */
   pidAlive?(pid: number): boolean
-  /** Sleep injection for polling loops; defaults to immediate. */
+  /** Sleep injection for polling loops; defaults to a real timer. */
   sleep?(ms: number): Promise<void>
 }
 
@@ -75,7 +75,9 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
   const now = deps.clock
   const iso = deps.iso
   const pidAlive = deps.pidAlive ?? (() => false)
-  const sleep = deps.sleep ?? (async () => {})
+  const sleep = deps.sleep ?? (async (ms: number) => {
+    await new Promise<void>((resolve) => setTimeout(resolve, ms))
+  })
 
   const acquire = async (scope: LockScope, profile: string | undefined, options: AcquireOptions): Promise<LockHandle> => {
     const key = lockKey(scope, profile)
@@ -98,8 +100,19 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
           throw new LockError('LOCK_ERROR', scope, key, String(error))
         }
       } else {
-        const stale = await isStale(path, staleMs)
-        if (stale) {
+        const observed = await readTokenOrNull(path)
+        if (isTokenStale(observed, staleMs)) {
+          // The owner may refresh or be replaced after the first observation.
+          // Revalidate the same lease immediately before moving the directory.
+          const confirmed = await readTokenOrNull(path)
+          if (!isSameStaleLease(observed, confirmed, staleMs)) {
+            if (now() >= deadline) {
+              if (confirmed !== undefined) throw new LockError('LOCK_HELD', scope, key, 'held by pid ' + confirmed.pid + ' (intent ' + confirmed.intent + ')')
+              throw new LockError('LOCK_STALE', scope, key, 'lock ownership changed while checking staleness')
+            }
+            await sleep(100)
+            continue
+          }
           const stealTo = path + '.stale-' + String(now())
           try {
             await fs.rename(path, stealTo)
@@ -112,6 +125,22 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
               throw new LockError('LOCK_STALE', scope, key, 'stale lock could not be displaced: ' + String(error))
             }
           }
+          const displaced = await readTokenOrNull(stealTo)
+          if (!isSameStaleLease(confirmed, displaced, staleMs)) {
+            const occupied = await fs.exists(path).catch(() => true)
+            if (!occupied) {
+              try {
+                await fs.rename(stealTo, path)
+              } catch (error) {
+                throw new LockError('LOCK_STALE', scope, key, 'lock refreshed during takeover and could not be restored: ' + String(error))
+              }
+            } else {
+              throw new LockError('LOCK_STALE', scope, key, 'lock refreshed during takeover after the canonical path was reclaimed')
+            }
+            await sleep(100)
+            continue
+          }
+          if (displaced?.released === true) await fs.remove(stealTo, { recursive: true }).catch(() => undefined)
           try {
             const claimed = await claim(scope, key, path, options.intent)
             if (claimed !== undefined) return claimed
@@ -149,7 +178,7 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
       await fs.writeText(join(temporary, 'token.json'), JSON.stringify(token, undefined, 2) + String.fromCharCode(10))
       await fs.rename(temporary, path)
       temporaryCreated = false
-      return makeHandle(scope, key, path)
+      return makeHandle(scope, key, path, token.nonce)
     } catch (error) {
       if (temporaryCreated) await fs.remove(temporary, { recursive: true }).catch(() => undefined)
       const targetExists = await fs.exists(path).catch(() => false)
@@ -158,29 +187,84 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
     }
   }
 
-  const isStale = async (path: string, staleMs: number): Promise<boolean> => {
-    const token = await readTokenOrNull(path)
+  const isTokenStale = (token: LockToken | undefined, staleMs: number): boolean => {
     if (token === undefined) return true
+    if (token.released === true) return true
     if (!pidAlive(token.pid)) return true
     return now() - token.heartbeatAt > staleMs
   }
 
-  const makeHandle = (scope: LockScope, key: string, path: string): LockHandle => {
+  const isSameStaleLease = (observed: LockToken | undefined, confirmed: LockToken | undefined, staleMs: number): boolean => {
+    if (observed === undefined) return confirmed === undefined
+    return confirmed !== undefined && confirmed.nonce === observed.nonce && isTokenStale(confirmed, staleMs)
+  }
+
+  let touchSequence = 0
+
+  const makeHandle = (scope: LockScope, key: string, path: string, nonce: string): LockHandle => {
+    let released = false
+    let operationQueue = Promise.resolve()
+
+    const ownedToken = async (): Promise<LockToken> => {
+      if (released) throw new LockError('LOCK_LOST', scope, key, 'lock handle has already been released')
+      const token = await readTokenOrNull(path)
+      if (token === undefined) throw new LockError('LOCK_LOST', scope, key, 'lock dir or token vanished')
+      if (token.nonce !== nonce) throw new LockError('LOCK_LOST', scope, key, 'lock ownership moved to a different nonce')
+      if (token.released === true) throw new LockError('LOCK_LOST', scope, key, 'lock lease has already been released')
+      return token
+    }
+
+    const runExclusive = async <T>(operation: () => Promise<T>): Promise<T> => {
+      const previous = operationQueue
+      let unlock!: () => void
+      operationQueue = new Promise<void>((resolve) => { unlock = resolve })
+      await previous
+      try {
+        return await operation()
+      } finally {
+        unlock()
+      }
+    }
+
+    const publishOwnedToken = async (token: LockToken, kind: 'touch' | 'release'): Promise<void> => {
+      const temporary = join(path, 'token.' + nonce + '.' + kind + '-' + String(touchSequence += 1))
+      try {
+        await fs.writeText(temporary, JSON.stringify(token, undefined, 2) + String.fromCharCode(10))
+        // Bind publication to the same directory generation. If takeover
+        // moved it aside, this check fails and the temporary moves with it.
+        await ownedToken()
+        await fs.rename(temporary, join(path, 'token.json'))
+      } catch (error) {
+        const current = await readTokenOrNull(path)
+        if (current === undefined || current.nonce !== nonce || current.released === true) {
+          throw new LockError('LOCK_LOST', scope, key, 'lock ownership changed while publishing ' + kind)
+        }
+        throw error
+      } finally {
+        await fs.remove(temporary).catch(() => undefined)
+      }
+    }
+
     return {
       scope,
       key,
       path,
       async touch(at: number) {
-        const token = await readTokenOrNull(path)
-        if (token === undefined) throw new LockError('LOCK_ERROR', scope, key, 'lock dir vanished')
-        await fs.writeText(join(path, 'token.json'), JSON.stringify({ ...token, heartbeatAt: at }, undefined, 2) + String.fromCharCode(10))
+        await runExclusive(async () => {
+          const token = await ownedToken()
+          await publishOwnedToken({ ...token, heartbeatAt: at }, 'touch')
+        })
       },
       async release() {
-        try {
-          await fs.remove(path, { recursive: true })
-        } catch (error) {
-          if (!isMissingError(error)) throw error
-        }
+        await runExclusive(async () => {
+          if (released) return
+          const token = await ownedToken()
+          // Never recursively delete the canonical path: a stale takeover can
+          // replace it between any check and deletion. Publishing a released
+          // lease uses the same generation-bound atomic update as touch().
+          await publishOwnedToken({ ...token, heartbeatAt: now(), released: true }, 'release')
+          released = true
+        })
       },
     }
   }
@@ -189,7 +273,7 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
     const key = lockKey(scope, profile)
     const path = join(root, key.replace(/\//g, '__'))
     const token = await readTokenOrNull(path)
-    if (token === undefined) return { scope, key, path, held: false }
+    if (token === undefined || token.released === true) return { scope, key, path, held: false }
     return { scope, key, path, held: true, token }
   }
 

--- a/packages/dsh-doctor/src/core/lock.ts
+++ b/packages/dsh-doctor/src/core/lock.ts
@@ -83,6 +83,7 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
     const key = lockKey(scope, profile)
     const path = join(root, key.replace(/\//g, '__'))
     const staleMs = options.staleMs ?? DEFAULT_STALE_MS
+    const heartbeatMs = options.heartbeatMs ?? Math.max(1, Math.floor(staleMs / 3))
     const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
     const deadline = now() + timeoutMs
     for (;;) {
@@ -94,17 +95,17 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
       }
       if (!exists) {
         try {
-          const claimed = await claim(scope, key, path, options.intent)
+          const claimed = await claim(scope, key, path, options.intent, heartbeatMs)
           if (claimed !== undefined) return claimed
         } catch (error) {
           throw new LockError('LOCK_ERROR', scope, key, String(error))
         }
       } else {
-        const observed = await readTokenOrNull(path)
+        const observed = await readTokenForLock(scope, key, path, 'reading owner token')
         if (isTokenStale(observed, staleMs)) {
           // The owner may refresh or be replaced after the first observation.
           // Revalidate the same lease immediately before moving the directory.
-          const confirmed = await readTokenOrNull(path)
+          const confirmed = await readTokenForLock(scope, key, path, 'revalidating stale owner')
           if (!isSameStaleLease(observed, confirmed, staleMs)) {
             if (now() >= deadline) {
               if (confirmed !== undefined) throw new LockError('LOCK_HELD', scope, key, 'held by pid ' + confirmed.pid + ' (intent ' + confirmed.intent + ')')
@@ -125,7 +126,21 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
               throw new LockError('LOCK_STALE', scope, key, 'stale lock could not be displaced: ' + String(error))
             }
           }
-          const displaced = await readTokenOrNull(stealTo)
+          let displaced: LockToken | undefined
+          try {
+            displaced = await readTokenForLock(scope, key, stealTo, 'verifying displaced owner')
+          } catch (error) {
+            const occupied = await fs.exists(path).catch(() => true)
+            if (!occupied) {
+              try {
+                await fs.rename(stealTo, path)
+              } catch (restoreError) {
+                throw new LockError('LOCK_STALE', scope, key, 'displaced owner could not be verified or restored: ' + String(error) + ' / ' + String(restoreError))
+              }
+              throw new LockError('LOCK_STALE', scope, key, 'displaced owner could not be verified; original lock restored: ' + String(error))
+            }
+            throw new LockError('LOCK_STALE', scope, key, 'displaced owner could not be verified after the canonical path was reclaimed: ' + String(error))
+          }
           if (!isSameStaleLease(confirmed, displaced, staleMs)) {
             const occupied = await fs.exists(path).catch(() => true)
             if (!occupied) {
@@ -142,15 +157,18 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
           }
           if (displaced?.released === true) await fs.remove(stealTo, { recursive: true }).catch(() => undefined)
           try {
-            const claimed = await claim(scope, key, path, options.intent)
-            if (claimed !== undefined) return claimed
+            const claimed = await claim(scope, key, path, options.intent, heartbeatMs)
+            if (claimed !== undefined) {
+              await fs.remove(stealTo, { recursive: true }).catch(() => undefined)
+              return claimed
+            }
           } catch (error) {
             throw new LockError('LOCK_STALE', scope, key, 'stale lock was displaced but replacement failed: ' + String(error))
           }
         }
       }
       if (now() >= deadline) {
-        const state = await readTokenOrNull(path)
+        const state = await readTokenForLock(scope, key, path, 'reading owner at timeout')
         if (state !== undefined) throw new LockError('LOCK_HELD', scope, key, 'held by pid ' + state.pid + ' (intent ' + state.intent + ')')
         throw new LockError('LOCK_STALE', scope, key, 'lock present without a readable token')
       }
@@ -167,7 +185,7 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
     nonce: Math.random().toString(36).slice(2, 10),
   })
 
-  const claim = async (scope: LockScope, key: string, path: string, intent: string): Promise<LockHandle | undefined> => {
+  const claim = async (scope: LockScope, key: string, path: string, intent: string, heartbeatMs: number): Promise<LockHandle | undefined> => {
     const token = buildToken(intent)
     const temporary = path + '.claim-' + String(pid) + '-' + token.nonce
     let temporaryCreated = false
@@ -178,7 +196,7 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
       await fs.writeText(join(temporary, 'token.json'), JSON.stringify(token, undefined, 2) + String.fromCharCode(10))
       await fs.rename(temporary, path)
       temporaryCreated = false
-      return makeHandle(scope, key, path, token.nonce)
+      return makeHandle(scope, key, path, token.nonce, heartbeatMs)
     } catch (error) {
       if (temporaryCreated) await fs.remove(temporary, { recursive: true }).catch(() => undefined)
       const targetExists = await fs.exists(path).catch(() => false)
@@ -201,13 +219,22 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
 
   let touchSequence = 0
 
-  const makeHandle = (scope: LockScope, key: string, path: string, nonce: string): LockHandle => {
+  const makeHandle = (scope: LockScope, key: string, path: string, nonce: string, heartbeatMs: number): LockHandle => {
     let released = false
     let operationQueue = Promise.resolve()
+    let heartbeatStopped = heartbeatMs <= 0
+    let heartbeatTimer: ReturnType<typeof setTimeout> | undefined
+    let leaseFailure: LockError | undefined
 
     const ownedToken = async (): Promise<LockToken> => {
       if (released) throw new LockError('LOCK_LOST', scope, key, 'lock handle has already been released')
-      const token = await readTokenOrNull(path)
+      if (leaseFailure !== undefined) throw leaseFailure
+      let token: LockToken | undefined
+      try {
+        token = await readTokenOrNull(path)
+      } catch (error) {
+        throw new LockError('LOCK_ERROR', scope, key, 'lock ownership could not be verified: ' + String(error))
+      }
       if (token === undefined) throw new LockError('LOCK_LOST', scope, key, 'lock dir or token vanished')
       if (token.nonce !== nonce) throw new LockError('LOCK_LOST', scope, key, 'lock ownership moved to a different nonce')
       if (token.released === true) throw new LockError('LOCK_LOST', scope, key, 'lock lease has already been released')
@@ -235,7 +262,12 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
         await ownedToken()
         await fs.rename(temporary, join(path, 'token.json'))
       } catch (error) {
-        const current = await readTokenOrNull(path)
+        let current: LockToken | undefined
+        try {
+          current = await readTokenOrNull(path)
+        } catch (readError) {
+          throw new LockError('LOCK_ERROR', scope, key, 'lock ownership could not be verified after publishing ' + kind + ': ' + String(readError))
+        }
         if (current === undefined || current.nonce !== nonce || current.released === true) {
           throw new LockError('LOCK_LOST', scope, key, 'lock ownership changed while publishing ' + kind)
         }
@@ -245,17 +277,56 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
       }
     }
 
-    return {
+    const touchOwnedLease = async (at: number): Promise<void> => {
+      try {
+        const token = await ownedToken()
+        await publishOwnedToken({ ...token, heartbeatAt: at }, 'touch')
+      } catch (error) {
+        if (error instanceof LockError) throw error
+        throw new LockError('LOCK_ERROR', scope, key, 'heartbeat failed: ' + String(error))
+      }
+    }
+
+    const stopHeartbeat = (): void => {
+      heartbeatStopped = true
+      if (heartbeatTimer !== undefined) {
+        clearTimeout(heartbeatTimer)
+        heartbeatTimer = undefined
+      }
+    }
+
+    const scheduleHeartbeat = (): void => {
+      if (heartbeatStopped || released) return
+      heartbeatTimer = setTimeout(async () => {
+        heartbeatTimer = undefined
+        try {
+          await runExclusive(async () => {
+            if (heartbeatStopped || released) return
+            await touchOwnedLease(now())
+          })
+        } catch (error) {
+          leaseFailure = error instanceof LockError
+            ? error
+            : new LockError('LOCK_ERROR', scope, key, 'heartbeat failed: ' + String(error))
+          heartbeatStopped = true
+        } finally {
+          scheduleHeartbeat()
+        }
+      }, heartbeatMs)
+      ;(heartbeatTimer as unknown as { unref?: () => void }).unref?.()
+    }
+
+    const handle: LockHandle = {
       scope,
       key,
       path,
       async touch(at: number) {
         await runExclusive(async () => {
-          const token = await ownedToken()
-          await publishOwnedToken({ ...token, heartbeatAt: at }, 'touch')
+          await touchOwnedLease(at)
         })
       },
       async release() {
+        stopHeartbeat()
         await runExclusive(async () => {
           if (released) return
           const token = await ownedToken()
@@ -267,12 +338,14 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
         })
       },
     }
+    scheduleHeartbeat()
+    return handle
   }
 
   const status = async (scope: LockScope, profile: string | undefined): Promise<LockState> => {
     const key = lockKey(scope, profile)
     const path = join(root, key.replace(/\//g, '__'))
-    const token = await readTokenOrNull(path)
+    const token = await readTokenForLock(scope, key, path, 'reading lock status')
     if (token === undefined || token.released === true) return { scope, key, path, held: false }
     return { scope, key, path, held: true, token }
   }
@@ -287,7 +360,15 @@ export function createLockManager(deps: LockManagerDeps): LockManager {
       return JSON.parse(text) as LockToken
     } catch (error) {
       if (isMissingError(error)) return undefined
-      return undefined
+      throw error
+    }
+  }
+
+  async function readTokenForLock(scope: LockScope, key: string, path: string, action: string): Promise<LockToken | undefined> {
+    try {
+      return await readTokenOrNull(path)
+    } catch (error) {
+      throw new LockError('LOCK_ERROR', scope, key, action + ' failed: ' + String(error))
     }
   }
 

--- a/packages/dsh-doctor/src/core/recover.ts
+++ b/packages/dsh-doctor/src/core/recover.ts
@@ -14,11 +14,11 @@ import { createRequire } from 'node:module'
 import { join, resolve } from 'node:path'
 import { createYamlEngine, type YamlEngine } from './yaml.ts'
 import { createLockManager } from './lock.ts'
-import { createJournal } from './journal.ts'
+import { createJournal, type Journal } from './journal.ts'
 import { captureSnapshot, listProfileFiles } from './snapshot.ts'
 import { diagnoseProfile, diagnoseFallback } from './diagnose.ts'
 import { planRepair } from './plan.ts'
-import { createCandidateTransaction, type CandidateTransactionDeps } from './transaction.ts'
+import { createCandidateTransaction, type CandidateTransaction, type CandidateTransactionDeps } from './transaction.ts'
 import { redactText } from './redact.ts'
 import { readProfileManifest } from './manifest.ts'
 import { parsePatchList } from './patch.ts'
@@ -299,20 +299,32 @@ export async function repairProfile(request: RecoveryRequest, gateOptions: RealG
       await journal.append({ op: 'repair:gates-failed', ok: false, detail: { txn: txn.txnId, report: gateReports } })
       return { ok: false, phase: 'aborted', diagnostics: diagnosis.diagnostics, actions: diagnosis.actions, manualActions: diagnosis.manualActions, snapshotId: snapshotResult.snapshotId, gates: gateReports, txnId: txn.txnId, message: 'candidate failed the isolated health gates' }
     }
-    await txn.promote()
-    await journal.append({ op: 'repair:promote', ok: true, detail: { txn: txn.txnId } })
-    await writeTransactionRecord(fs, home, txn.record)
-    const liveEnv = gateEnvironmentOf(request, gateOptions, home)
-    const liveDump = await runDumpDefaultGateSafe(gates, request.dshPath, home, request.profile, liveEnv, gateOptions.timeoutMs)
-    if (!liveDump.ok) {
-      await txn.rollback()
+    try {
+      await txn.promote()
+      await journal.append({ op: 'repair:promote', ok: true, detail: { txn: txn.txnId } })
       await writeTransactionRecord(fs, home, txn.record)
-      await journal.append({ op: 'repair:live-verify-failed', ok: false, detail: { txn: txn.txnId } })
-      return { ok: false, phase: 'rolled-back', diagnostics: diagnosis.diagnostics, actions: diagnosis.actions, manualActions: diagnosis.manualActions, snapshotId: snapshotResult.snapshotId, gates: gateReports, txnId: txn.txnId, message: 'live verification failed after promote; rolled back' }
+      const liveEnv = gateEnvironmentOf(request, gateOptions, home)
+      const liveDump = await runDumpDefaultGateSafe(gates, request.dshPath, home, request.profile, liveEnv, gateOptions.timeoutMs)
+      if (!liveDump.ok) {
+        await rollbackPromotedFailure(fs, home, journal, txn, 'live verification failed')
+        await journal.append({ op: 'repair:live-verify-failed', ok: false, detail: { txn: txn.txnId } })
+        return { ok: false, phase: 'rolled-back', diagnostics: diagnosis.diagnostics, actions: diagnosis.actions, manualActions: diagnosis.manualActions, snapshotId: snapshotResult.snapshotId, gates: gateReports, txnId: txn.txnId, message: 'live verification failed after promote; rolled back' }
+      }
+      // Keep the transaction rollback-capable until every fallible recovery
+      // side effect has completed. commit() is deliberately the final await.
+      await journal.append({ op: 'repair:commit', ok: true, detail: { txn: txn.txnId } })
+      await txn.commit()
+      return { ok: true, phase: 'promoted', diagnostics: diagnosis.diagnostics, actions: diagnosis.actions, manualActions: diagnosis.manualActions, snapshotId: snapshotResult.snapshotId, gates: gateReports, txnId: txn.txnId }
+    } catch (error) {
+      if (txn.phase() === 'promoted') {
+        try {
+          await rollbackPromotedFailure(fs, home, journal, txn, error instanceof Error ? error.message : String(error))
+        } catch (rollbackError) {
+          throw new Error('post-promote failure: ' + String(error) + '; automatic rollback failed: ' + String(rollbackError))
+        }
+      }
+      throw error
     }
-    await txn.commit()
-    await journal.append({ op: 'repair:commit', ok: true, detail: { txn: txn.txnId } })
-    return { ok: true, phase: 'promoted', diagnostics: diagnosis.diagnostics, actions: diagnosis.actions, manualActions: diagnosis.manualActions, snapshotId: snapshotResult.snapshotId, gates: gateReports, txnId: txn.txnId }
   } catch (error) {
     await journal.append({ op: 'repair:error', ok: false, detail: { error: error instanceof Error ? error.message : String(error) } }).catch(() => undefined)
     return { ok: false, phase: 'failed', diagnostics: [], actions: [], manualActions: [], message: error instanceof Error ? error.message : String(error) }
@@ -320,6 +332,24 @@ export async function repairProfile(request: RecoveryRequest, gateOptions: RealG
     await profileLock?.release().catch(() => undefined)
     await globalLock.release().catch(() => undefined)
   }
+}
+
+async function rollbackPromotedFailure(fs: FsLike, home: string, journal: Journal, txn: CandidateTransaction, cause: string): Promise<void> {
+  let rollbackWarning: string | undefined
+  try {
+    await txn.rollback()
+  } catch (error) {
+    rollbackWarning = error instanceof Error ? error.message : String(error)
+  }
+  if (txn.phase() !== 'rolled-back') {
+    throw new Error(rollbackWarning ?? 'transaction remained in phase ' + txn.phase())
+  }
+  await writeTransactionRecord(fs, home, txn.record)
+  await journal.append({
+    op: 'repair:post-promote-rollback',
+    ok: false,
+    detail: { txn: txn.txnId, cause, ...(rollbackWarning === undefined ? {} : { rollbackWarning }) },
+  }).catch(() => undefined)
 }
 
 /** Restore a promoted transaction by moving the quarantine back. */

--- a/packages/dsh-doctor/src/core/recover.ts
+++ b/packages/dsh-doctor/src/core/recover.ts
@@ -13,7 +13,7 @@
 import { createRequire } from 'node:module'
 import { join, resolve } from 'node:path'
 import { createYamlEngine, type YamlEngine } from './yaml.ts'
-import { createLockManager } from './lock.ts'
+import { createLockManager, LockError } from './lock.ts'
 import { createJournal, type Journal } from './journal.ts'
 import { captureSnapshot, listProfileFiles } from './snapshot.ts'
 import { diagnoseProfile, diagnoseFallback } from './diagnose.ts'
@@ -78,6 +78,9 @@ export interface RecoveryOutcome {
   txnId?: string
   message?: string
 }
+
+/** Inputs needed to restore an existing transaction; no DSH process is run. */
+export type RollbackRequest = Pick<RecoveryRequest, 'home' | 'profile' | 'fs' | 'now' | 'clock' | 'pid' | 'pidAlive'>
 
 export interface RealGateOptions {
   /** Extra env for the gate runs (default process.env). */
@@ -258,7 +261,18 @@ export async function repairProfile(request: RecoveryRequest, gateOptions: RealG
     profileLock = await locks.acquire('profile', request.profile, { intent: 'repair' })
     const diagnosis = await diagnoseAndPlan(request)
     const snapshotResult = await snapshotProfile(request)
-    const txnDeps: CandidateTransactionDeps = { fs, home, profile: request.profile, now, journal }
+    const txnDeps: CandidateTransactionDeps = {
+      fs,
+      home,
+      profile: request.profile,
+      now,
+      journal,
+      beforeCompensation: async () => {
+        await globalLock.touch(clock())
+        if (profileLock === undefined) throw new LockError('LOCK_LOST', 'profile', 'profile/' + request.profile, 'profile lock is no longer held')
+        await profileLock.touch(clock())
+      },
+    }
     const txn = createCandidateTransaction(txnDeps)
     if (diagnosis.actions.length === 0 && diagnosis.manualActions.length > 0) {
       await journal.append({ op: 'repair:manual-required', ok: false, detail: { profile: request.profile, manual: diagnosis.manualActions } })
@@ -299,12 +313,24 @@ export async function repairProfile(request: RecoveryRequest, gateOptions: RealG
       await journal.append({ op: 'repair:gates-failed', ok: false, detail: { txn: txn.txnId, report: gateReports } })
       return { ok: false, phase: 'aborted', diagnostics: diagnosis.diagnostics, actions: diagnosis.actions, manualActions: diagnosis.manualActions, snapshotId: snapshotResult.snapshotId, gates: gateReports, txnId: txn.txnId, message: 'candidate failed the isolated health gates' }
     }
+    // Surface a lost background lease before the first live-profile mutation.
+    await globalLock.touch(clock())
+    await profileLock.touch(clock())
     try {
       await txn.promote()
-      await journal.append({ op: 'repair:promote', ok: true, detail: { txn: txn.txnId } })
+      // Persist the promoted layout before any auxiliary journal write. If
+      // lease verification then fails, a new owner can recover from this
+      // record without relying on the in-memory transaction object.
       await writeTransactionRecord(fs, home, txn.record)
+      await globalLock.touch(clock())
+      await profileLock.touch(clock())
+      await journal.append({ op: 'repair:promote', ok: true, detail: { txn: txn.txnId } })
       const liveEnv = gateEnvironmentOf(request, gateOptions, home)
       const liveDump = await runDumpDefaultGateSafe(gates, request.dshPath, home, request.profile, liveEnv, gateOptions.timeoutMs)
+      // A live verification can outlast the lease interval. Revalidate both
+      // generations before rollback or commit mutates the promoted layout.
+      await globalLock.touch(clock())
+      await profileLock.touch(clock())
       if (!liveDump.ok) {
         await rollbackPromotedFailure(fs, home, journal, txn, 'live verification failed')
         await journal.append({ op: 'repair:live-verify-failed', ok: false, detail: { txn: txn.txnId } })
@@ -316,7 +342,16 @@ export async function repairProfile(request: RecoveryRequest, gateOptions: RealG
       await txn.commit()
       return { ok: true, phase: 'promoted', diagnostics: diagnosis.diagnostics, actions: diagnosis.actions, manualActions: diagnosis.manualActions, snapshotId: snapshotResult.snapshotId, gates: gateReports, txnId: txn.txnId }
     } catch (error) {
+      // If ownership cannot be proved, do not perform compensating live-path
+      // mutations either. The durable promoted record is safe to recover on
+      // the next invocation that successfully acquires both locks.
+      if (error instanceof LockError) throw error
       if (txn.phase() === 'promoted') {
+        // The triggering error may be unrelated to the lock while a
+        // background heartbeat has already failed. Prove both generations
+        // again before any compensating live-profile move.
+        await globalLock.touch(clock())
+        await profileLock.touch(clock())
         try {
           await rollbackPromotedFailure(fs, home, journal, txn, error instanceof Error ? error.message : String(error))
         } catch (rollbackError) {
@@ -353,7 +388,7 @@ async function rollbackPromotedFailure(fs: FsLike, home: string, journal: Journa
 }
 
 /** Restore a promoted transaction by moving the quarantine back. */
-export async function rollbackTransaction(request: RecoveryRequest, txnId: string): Promise<RecoveryOutcome> {
+export async function rollbackTransaction(request: RollbackRequest, txnId: string): Promise<RecoveryOutcome> {
   const fs: FsLike = request.fs ?? nodeFs
   const home = request.home
   const now = request.now ?? (() => new Date().toISOString())
@@ -383,22 +418,48 @@ export async function rollbackTransaction(request: RecoveryRequest, txnId: strin
       throw new Error('no readable transaction record for ' + txnId + ': ' + String(error))
     }
     const { record, livePath, quarantinePath } = validateRollbackRecord(parsed, home, profile, txnId)
+    // The heartbeat runs in the background, but an explicit refresh turns a
+    // prior ownership loss into a fail-closed result before filesystem moves.
+    await globalLock.touch(clock())
+    await profileLock.touch(clock())
+    const discardedPath = livePath + '.doctor-discarded-' + txnId
     if (record.phase === 'rolled-back') {
+      await fs.remove(discardedPath, { recursive: true }).catch(() => undefined)
       return { ok: true, phase: 'rolled-back', diagnostics: [], actions: [], manualActions: [], txnId, message: 'transaction ' + txnId + ' is already rolled back' }
     }
     if (record.phase !== 'promoted' && record.phase !== 'committed') {
       throw new Error('transaction ' + txnId + ' is ' + record.phase + '; only promoted or committed transactions roll back')
     }
-    if (!(await fs.exists(quarantinePath))) {
+    const quarantineExists = await fs.exists(quarantinePath)
+    const liveExists = await fs.exists(livePath)
+    const discardedExists = await fs.exists(discardedPath)
+    if (!quarantineExists && liveExists && discardedExists) {
+      // A previous rollback restored the quarantined original, then stopped
+      // before its phase update became durable. This exact layout is
+      // unambiguous: the canonical live path is already restored and the
+      // displaced promoted candidate remains at this transaction's path.
+      const rolledBackRecord = makeRolledBackRecord(record, quarantinePath, livePath)
+      await writeTransactionRecord(fs, home, rolledBackRecord)
+      await globalLock.touch(clock())
+      await profileLock.touch(clock())
+      await fs.remove(discardedPath, { recursive: true }).catch(() => undefined)
+      await journal.append({ op: 'repair:rollback-finalize', ok: true, detail: { txn: txnId } }).catch(() => undefined)
+      return { ok: true, phase: 'rolled-back', diagnostics: [], actions: [], manualActions: [], txnId, message: 'finalized interrupted rollback at ' + livePath }
+    }
+    if (!quarantineExists) {
       throw new Error('quarantine path missing at ' + quarantinePath + '; live profile left untouched')
     }
     let discarded: string | undefined
-    if (await fs.exists(livePath)) {
-      discarded = livePath + '.doctor-discarded-' + txnId
-      if (await fs.exists(discarded)) {
-        throw new Error('discarded path already exists at ' + discarded + '; live profile left untouched')
+    if (liveExists) {
+      discarded = discardedPath
+      if (discardedExists) {
+        throw new Error('discarded path already exists at ' + discardedPath + '; live profile left untouched')
       }
       await movePath(fs, livePath, discarded)
+    } else if (discardedExists) {
+      // Resume an earlier rollback that stopped after displacing the
+      // promoted candidate but before restoring the quarantine.
+      discarded = discardedPath
     }
     try {
       await movePath(fs, quarantinePath, livePath)
@@ -413,15 +474,18 @@ export async function rollbackTransaction(request: RecoveryRequest, txnId: strin
       throw error
     }
 
-    const rolledBackRecord: CandidateRecord = {
-      ...record,
-      phase: 'rolled-back',
-      steps: [...record.steps, { step: 'rollback-restore', from: quarantinePath, to: livePath }],
-    }
-    delete rolledBackRecord.error
+    await globalLock.touch(clock())
+    await profileLock.touch(clock())
+
+    const rolledBackRecord = makeRolledBackRecord(record, quarantinePath, livePath)
     try {
       await writeTransactionRecord(fs, home, rolledBackRecord)
     } catch (error) {
+      // Atomic record replacement can itself block long enough for a lease
+      // failure. Never reverse the file moves unless both locks are still
+      // owned by this rollback generation.
+      await globalLock.touch(clock())
+      await profileLock.touch(clock())
       try {
         await movePath(fs, livePath, quarantinePath)
         if (discarded !== undefined) await movePath(fs, discarded, livePath)
@@ -430,6 +494,8 @@ export async function rollbackTransaction(request: RecoveryRequest, txnId: strin
       }
       throw new Error('transaction record persistence failed; rollback file moves were reverted: ' + String(error))
     }
+    await globalLock.touch(clock())
+    await profileLock.touch(clock())
     if (discarded !== undefined) await fs.remove(discarded, { recursive: true }).catch(() => undefined)
     await journal.append({ op: 'repair:rollback', ok: true, detail: { txn: txnId } })
     return { ok: true, phase: 'rolled-back', diagnostics: [], actions: [], manualActions: [], txnId, message: 'restored quarantine to ' + livePath }
@@ -442,6 +508,16 @@ export async function rollbackTransaction(request: RecoveryRequest, txnId: strin
   }
 }
 
+function makeRolledBackRecord(record: CandidateRecord, quarantinePath: string, livePath: string): CandidateRecord {
+  const rolledBackRecord: CandidateRecord = {
+    ...record,
+    phase: 'rolled-back',
+    steps: [...record.steps, { step: 'rollback-restore', from: quarantinePath, to: livePath }],
+  }
+  delete rolledBackRecord.error
+  return rolledBackRecord
+}
+
 async function writeTransactionRecord(fs: FsLike, home: string, record: CandidateRecord): Promise<void> {
   validateSegment(record.txnId, 'transaction id')
   await writeJsonAtomicFs(fs, transactionRecordPath(home, record.txnId), record)
@@ -449,6 +525,30 @@ async function writeTransactionRecord(fs: FsLike, home: string, record: Candidat
 
 function transactionRecordPath(home: string, txnId: string): string {
   return join(doctorRoot(home), 'transactions', txnId + '.json')
+}
+
+/** Read and validate the profile identity needed by `rollback <txnId>`. */
+export async function discoverRollbackProfile(home: string, txnId: string, fs: FsLike = nodeFs): Promise<string> {
+  validateSegment(txnId, 'transaction id')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(await fs.readText(transactionRecordPath(home, txnId))) as unknown
+  } catch (error) {
+    throw new Error('no readable transaction record for ' + txnId + ': ' + String(error))
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('transaction ' + txnId + ' has a malformed record')
+  }
+  const record = parsed as { txnId?: unknown; profile?: unknown }
+  if (record.txnId !== txnId) {
+    throw new Error('transaction record id mismatch: expected ' + txnId + ', got ' + String(record.txnId))
+  }
+  if (typeof record.profile !== 'string') {
+    throw new Error('transaction ' + txnId + ' has no valid profile')
+  }
+  const profile = validateSegment(record.profile, 'transaction profile')
+  resolveProfileDir(home, profile)
+  return profile
 }
 
 function validateRollbackRecord(value: unknown, home: string, profile: string, txnId: string): { record: CandidateRecord; livePath: string; quarantinePath: string } {

--- a/packages/dsh-doctor/src/core/recover.ts
+++ b/packages/dsh-doctor/src/core/recover.ts
@@ -11,6 +11,7 @@
  * is injected so the flow is hermetic in tests.
  */
 import { createRequire } from 'node:module'
+import { join, resolve } from 'node:path'
 import { createYamlEngine, type YamlEngine } from './yaml.ts'
 import { createLockManager } from './lock.ts'
 import { createJournal } from './journal.ts'
@@ -21,18 +22,21 @@ import { createCandidateTransaction, type CandidateTransactionDeps } from './tra
 import { redactText } from './redact.ts'
 import { readProfileManifest } from './manifest.ts'
 import { parsePatchList } from './patch.ts'
-import { nodeFs, type FsLike } from './fs.ts'
+import { movePath, nodeFs, type FsLike } from './fs.ts'
+import { writeJsonAtomicFs } from './store.ts'
 import type { GateDeps as GateDepsAlias } from './gates.ts'
 import { runDumpDefaultGate, runStartGate } from './gates.ts'
 import {
   doctorRoot,
   journalPath,
+  quarantineDir,
   resolveProfileDir,
   profilesDir,
   snapshotsDir,
+  validateSegment,
   workDir,
 } from './paths.ts'
-import type { Diagnostic, GateReport, PlanAction } from './types.ts'
+import type { CandidateRecord, Diagnostic, GateReport, PlanAction } from './types.ts'
 
 const nodeRequire = createRequire(import.meta.url)
 
@@ -297,12 +301,12 @@ export async function repairProfile(request: RecoveryRequest, gateOptions: RealG
     }
     await txn.promote()
     await journal.append({ op: 'repair:promote', ok: true, detail: { txn: txn.txnId } })
-    await fs.mkdir(doctorRoot(home) + '/transactions', { recursive: true })
-    await fs.writeText(doctorRoot(home) + '/transactions/' + txn.txnId + '.json', JSON.stringify(txn.record, null, 2) + '\n')
+    await writeTransactionRecord(fs, home, txn.record)
     const liveEnv = gateEnvironmentOf(request, gateOptions, home)
     const liveDump = await runDumpDefaultGateSafe(gates, request.dshPath, home, request.profile, liveEnv, gateOptions.timeoutMs)
     if (!liveDump.ok) {
       await txn.rollback()
+      await writeTransactionRecord(fs, home, txn.record)
       await journal.append({ op: 'repair:live-verify-failed', ok: false, detail: { txn: txn.txnId } })
       return { ok: false, phase: 'rolled-back', diagnostics: diagnosis.diagnostics, actions: diagnosis.actions, manualActions: diagnosis.manualActions, snapshotId: snapshotResult.snapshotId, gates: gateReports, txnId: txn.txnId, message: 'live verification failed after promote; rolled back' }
     }
@@ -322,30 +326,138 @@ export async function repairProfile(request: RecoveryRequest, gateOptions: RealG
 export async function rollbackTransaction(request: RecoveryRequest, txnId: string): Promise<RecoveryOutcome> {
   const fs: FsLike = request.fs ?? nodeFs
   const home = request.home
-  const recordPath = doctorRoot(home) + '/transactions/' + txnId + '.json'
-  let record: { livePath: string; quarantinePath: string; phase: string }
+  const now = request.now ?? (() => new Date().toISOString())
+  const clock = request.clock ?? Date.now
+  let profile: string
   try {
-    record = JSON.parse(await fs.readText(recordPath)) as { livePath: string; quarantinePath: string; phase: string }
+    validateSegment(txnId, 'transaction id')
+    profile = validateSegment(request.profile, 'profile')
+    resolveProfileDir(home, profile)
   } catch (error) {
-    return { ok: false, phase: 'failed', diagnostics: [], actions: [], manualActions: [], message: 'no transaction record for ' + txnId + ': ' + String(error) }
+    return rollbackFailure(txnId, 'invalid rollback request: ' + String(error))
   }
-  if (record.phase !== 'promoted' && record.phase !== 'committed') {
-    return { ok: false, phase: 'failed', diagnostics: [], actions: [], manualActions: [], message: 'transaction ' + txnId + ' is ' + record.phase + '; only promoted transactions roll back' }
-  }
-  const journal = createJournal({ fs, file: journalPath(home), now: request.now ?? (() => new Date().toISOString()) })
+
+  const recordPath = transactionRecordPath(home, txnId)
+  const journal = createJournal({ fs, file: journalPath(home), now })
+  const locks = createLockManager({ fs, home, pid: request.pid ?? process.pid, host: 'local', clock, iso: now, pidAlive: request.pidAlive ?? ((pid) => pid !== 0) })
+  let globalLock: Awaited<ReturnType<typeof locks.acquire>> | undefined
+  let profileLock: Awaited<ReturnType<typeof locks.acquire>> | undefined
   try {
-    if (await fs.exists(record.livePath)) {
-      const discarded = record.livePath + '.doctor-discarded-' + txnId
-      await fs.rename(record.livePath, discarded)
-      await fs.remove(discarded, { recursive: true }).catch(() => undefined)
+    globalLock = await locks.acquire('global', undefined, { intent: 'rollback ' + profile + '/' + txnId })
+    profileLock = await locks.acquire('profile', profile, { intent: 'rollback ' + txnId })
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(await fs.readText(recordPath)) as unknown
+    } catch (error) {
+      throw new Error('no readable transaction record for ' + txnId + ': ' + String(error))
     }
-    await fs.rename(record.quarantinePath, record.livePath)
+    const { record, livePath, quarantinePath } = validateRollbackRecord(parsed, home, profile, txnId)
+    if (record.phase === 'rolled-back') {
+      return { ok: true, phase: 'rolled-back', diagnostics: [], actions: [], manualActions: [], txnId, message: 'transaction ' + txnId + ' is already rolled back' }
+    }
+    if (record.phase !== 'promoted' && record.phase !== 'committed') {
+      throw new Error('transaction ' + txnId + ' is ' + record.phase + '; only promoted or committed transactions roll back')
+    }
+    if (!(await fs.exists(quarantinePath))) {
+      throw new Error('quarantine path missing at ' + quarantinePath + '; live profile left untouched')
+    }
+    let discarded: string | undefined
+    if (await fs.exists(livePath)) {
+      discarded = livePath + '.doctor-discarded-' + txnId
+      if (await fs.exists(discarded)) {
+        throw new Error('discarded path already exists at ' + discarded + '; live profile left untouched')
+      }
+      await movePath(fs, livePath, discarded)
+    }
+    try {
+      await movePath(fs, quarantinePath, livePath)
+    } catch (error) {
+      if (discarded !== undefined) {
+        try {
+          await movePath(fs, discarded, livePath)
+        } catch (restoreError) {
+          throw new Error('quarantine restore failed: ' + String(error) + '; restoring the live profile also failed: ' + String(restoreError))
+        }
+      }
+      throw error
+    }
+
+    const rolledBackRecord: CandidateRecord = {
+      ...record,
+      phase: 'rolled-back',
+      steps: [...record.steps, { step: 'rollback-restore', from: quarantinePath, to: livePath }],
+    }
+    delete rolledBackRecord.error
+    try {
+      await writeTransactionRecord(fs, home, rolledBackRecord)
+    } catch (error) {
+      try {
+        await movePath(fs, livePath, quarantinePath)
+        if (discarded !== undefined) await movePath(fs, discarded, livePath)
+      } catch (restoreError) {
+        throw new Error('transaction record persistence failed: ' + String(error) + '; restoring the promoted layout also failed: ' + String(restoreError))
+      }
+      throw new Error('transaction record persistence failed; rollback file moves were reverted: ' + String(error))
+    }
+    if (discarded !== undefined) await fs.remove(discarded, { recursive: true }).catch(() => undefined)
     await journal.append({ op: 'repair:rollback', ok: true, detail: { txn: txnId } })
-    return { ok: true, phase: 'rolled-back', diagnostics: [], actions: [], manualActions: [], txnId, message: 'restored quarantine to ' + record.livePath }
+    return { ok: true, phase: 'rolled-back', diagnostics: [], actions: [], manualActions: [], txnId, message: 'restored quarantine to ' + livePath }
   } catch (error) {
     await journal.append({ op: 'repair:rollback-error', ok: false, detail: { error: String(error) } }).catch(() => undefined)
-    return { ok: false, phase: 'failed', diagnostics: [], actions: [], manualActions: [], txnId, message: error instanceof Error ? error.message : String(error) }
+    return rollbackFailure(txnId, error instanceof Error ? error.message : String(error))
+  } finally {
+    await profileLock?.release().catch(() => undefined)
+    await globalLock?.release().catch(() => undefined)
   }
+}
+
+async function writeTransactionRecord(fs: FsLike, home: string, record: CandidateRecord): Promise<void> {
+  validateSegment(record.txnId, 'transaction id')
+  await writeJsonAtomicFs(fs, transactionRecordPath(home, record.txnId), record)
+}
+
+function transactionRecordPath(home: string, txnId: string): string {
+  return join(doctorRoot(home), 'transactions', txnId + '.json')
+}
+
+function validateRollbackRecord(value: unknown, home: string, profile: string, txnId: string): { record: CandidateRecord; livePath: string; quarantinePath: string } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('transaction ' + txnId + ' has a malformed record; live profile left untouched')
+  }
+  const record = value as Partial<CandidateRecord>
+  if (record.txnId !== txnId) {
+    throw new Error('transaction record id mismatch: expected ' + txnId + ', got ' + String(record.txnId))
+  }
+  if (typeof record.profile !== 'string') {
+    throw new Error('transaction ' + txnId + ' has no valid profile; live profile left untouched')
+  }
+  validateSegment(record.profile, 'transaction profile')
+  resolveProfileDir(home, record.profile)
+  if (record.profile !== profile) {
+    throw new Error('transaction ' + txnId + ' belongs to profile ' + record.profile + ', not ' + profile)
+  }
+  if (typeof record.phase !== 'string' || typeof record.livePath !== 'string' || typeof record.quarantinePath !== 'string' || typeof record.stagingPath !== 'string' || !Array.isArray(record.steps)) {
+    throw new Error('transaction ' + txnId + ' has a malformed record; live profile left untouched')
+  }
+
+  const livePath = resolveProfileDir(home, profile)
+  const quarantinePath = join(quarantineDir(home), profile, txnId, 'original')
+  if (!samePath(record.livePath, livePath)) {
+    throw new Error('transaction ' + txnId + ' live path does not match profile ' + profile + '; live profile left untouched')
+  }
+  if (!samePath(record.quarantinePath, quarantinePath)) {
+    throw new Error('transaction ' + txnId + ' quarantine path does not match profile ' + profile + '; live profile left untouched')
+  }
+  return { record: record as CandidateRecord, livePath, quarantinePath }
+}
+
+function samePath(left: string, right: string): boolean {
+  return resolve(left) === resolve(right)
+}
+
+function rollbackFailure(txnId: string, message: string): RecoveryOutcome {
+  return { ok: false, phase: 'failed', diagnostics: [], actions: [], manualActions: [], txnId, message }
 }
 
 async function copyProfileFiles(fs: FsLike, fromDir: string, toDir: string): Promise<void> {

--- a/packages/dsh-doctor/src/core/recover.ts
+++ b/packages/dsh-doctor/src/core/recover.ts
@@ -267,6 +267,14 @@ export async function repairProfile(request: RecoveryRequest, gateOptions: RealG
       profile: request.profile,
       now,
       journal,
+      beforePromote: async (record) => {
+        // The staged record is a durable promotion intent. Persist it while
+        // both leases are owned and before the first live-profile rename.
+        await globalLock.touch(clock())
+        if (profileLock === undefined) throw new LockError('LOCK_LOST', 'profile', 'profile/' + request.profile, 'profile lock is no longer held')
+        await profileLock.touch(clock())
+        await writeTransactionRecord(fs, home, record)
+      },
       beforeCompensation: async () => {
         await globalLock.touch(clock())
         if (profileLock === undefined) throw new LockError('LOCK_LOST', 'profile', 'profile/' + request.profile, 'profile lock is no longer held')
@@ -417,7 +425,7 @@ export async function rollbackTransaction(request: RollbackRequest, txnId: strin
     } catch (error) {
       throw new Error('no readable transaction record for ' + txnId + ': ' + String(error))
     }
-    const { record, livePath, quarantinePath } = validateRollbackRecord(parsed, home, profile, txnId)
+    const { record, livePath, quarantinePath, stagingPath } = validateRollbackRecord(parsed, home, profile, txnId)
     // The heartbeat runs in the background, but an explicit refresh turns a
     // prior ownership loss into a fail-closed result before filesystem moves.
     await globalLock.touch(clock())
@@ -425,14 +433,53 @@ export async function rollbackTransaction(request: RollbackRequest, txnId: strin
     const discardedPath = livePath + '.doctor-discarded-' + txnId
     if (record.phase === 'rolled-back') {
       await fs.remove(discardedPath, { recursive: true }).catch(() => undefined)
+      await fs.remove(stagingPath, { recursive: true }).catch(() => undefined)
       return { ok: true, phase: 'rolled-back', diagnostics: [], actions: [], manualActions: [], txnId, message: 'transaction ' + txnId + ' is already rolled back' }
     }
-    if (record.phase !== 'promoted' && record.phase !== 'committed') {
-      throw new Error('transaction ' + txnId + ' is ' + record.phase + '; only promoted or committed transactions roll back')
+    if (record.phase !== 'staged' && record.phase !== 'promoted' && record.phase !== 'committed') {
+      throw new Error('transaction ' + txnId + ' is ' + record.phase + '; only staged, promoted or committed transactions roll back')
     }
-    const quarantineExists = await fs.exists(quarantinePath)
-    const liveExists = await fs.exists(livePath)
+    let quarantineExists = await fs.exists(quarantinePath)
+    let liveExists = await fs.exists(livePath)
+    const stagingExists = await fs.exists(stagingPath)
     const discardedExists = await fs.exists(discardedPath)
+
+    if (record.phase === 'staged' && !quarantineExists) {
+      if (!liveExists || !stagingExists || discardedExists) {
+        throw new Error('staged transaction ' + txnId + ' has an ambiguous pre-promote layout; live profile left untouched')
+      }
+      const rolledBackRecord = makeRolledBackRecord(record, quarantinePath, livePath)
+      await writeTransactionRecord(fs, home, rolledBackRecord)
+      await globalLock.touch(clock())
+      await profileLock.touch(clock())
+      await fs.remove(stagingPath, { recursive: true }).catch(() => undefined)
+      return { ok: true, phase: 'rolled-back', diagnostics: [], actions: [], manualActions: [], txnId, message: record.steps.some(step => step.step === 'rollback-restore') ? 'finalized restored interrupted promotion' : 'cancelled durable promotion intent before live mutation' }
+    }
+    if (record.phase === 'staged' && quarantineExists && !liveExists) {
+      if (!stagingExists || discardedExists) {
+        throw new Error('staged transaction ' + txnId + ' has an ambiguous interrupted-promote layout; live profile left untouched')
+      }
+      // Promotion stopped after live -> quarantine but before the candidate
+      // became live. Restoring the original is the only data-preserving move.
+      await movePath(fs, quarantinePath, livePath)
+      const rolledBackRecord = makeRolledBackRecord(record, quarantinePath, livePath)
+      try {
+        await globalLock.touch(clock())
+        await profileLock.touch(clock())
+        await writeTransactionRecord(fs, home, rolledBackRecord)
+      } catch (error) {
+        // Keep the durable staged record retryable. The original is already
+        // restored, so a retry sees the safe pre-promote layout and finalizes.
+        throw new Error('restored interrupted promotion but could not persist rolled-back state: ' + String(error))
+      }
+      await fs.remove(stagingPath, { recursive: true }).catch(() => undefined)
+      return { ok: true, phase: 'rolled-back', diagnostics: [], actions: [], manualActions: [], txnId, message: 'restored promotion interrupted before candidate activation' }
+    }
+    if (record.phase === 'staged' && quarantineExists && liveExists && stagingExists) {
+      throw new Error('staged transaction ' + txnId + ' has both live and staged candidates after quarantine; live profile left untouched')
+    }
+    quarantineExists = await fs.exists(quarantinePath)
+    liveExists = await fs.exists(livePath)
     if (!quarantineExists && liveExists && discardedExists) {
       // A previous rollback restored the quarantined original, then stopped
       // before its phase update became durable. This exact layout is
@@ -551,7 +598,7 @@ export async function discoverRollbackProfile(home: string, txnId: string, fs: F
   return profile
 }
 
-function validateRollbackRecord(value: unknown, home: string, profile: string, txnId: string): { record: CandidateRecord; livePath: string; quarantinePath: string } {
+function validateRollbackRecord(value: unknown, home: string, profile: string, txnId: string): { record: CandidateRecord; livePath: string; quarantinePath: string; stagingPath: string } {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new Error('transaction ' + txnId + ' has a malformed record; live profile left untouched')
   }
@@ -572,6 +619,7 @@ function validateRollbackRecord(value: unknown, home: string, profile: string, t
   }
 
   const livePath = resolveProfileDir(home, profile)
+  const stagingPath = join(profilesDir(home), '.doctor-staging', profile, txnId)
   const quarantinePath = join(quarantineDir(home), profile, txnId, 'original')
   if (!samePath(record.livePath, livePath)) {
     throw new Error('transaction ' + txnId + ' live path does not match profile ' + profile + '; live profile left untouched')
@@ -579,7 +627,10 @@ function validateRollbackRecord(value: unknown, home: string, profile: string, t
   if (!samePath(record.quarantinePath, quarantinePath)) {
     throw new Error('transaction ' + txnId + ' quarantine path does not match profile ' + profile + '; live profile left untouched')
   }
-  return { record: record as CandidateRecord, livePath, quarantinePath }
+  if (!samePath(record.stagingPath, stagingPath)) {
+    throw new Error('transaction ' + txnId + ' staging path does not match profile ' + profile + '; live profile left untouched')
+  }
+  return { record: record as CandidateRecord, livePath, quarantinePath, stagingPath }
 }
 
 function samePath(left: string, right: string): boolean {

--- a/packages/dsh-doctor/src/core/store.ts
+++ b/packages/dsh-doctor/src/core/store.ts
@@ -1,5 +1,8 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import type { FsLike } from './fs.ts'
+
+let atomicWriteSequence = 0
 
 export async function readJson<T>(path: string, fallback: T): Promise<T> {
   try { return JSON.parse(await readFile(path, 'utf8')) as T } catch (error) {
@@ -13,6 +16,19 @@ export async function writeJsonAtomic(path: string, value: unknown, mode = 0o600
   const temporary = `${path}.tmp-${process.pid}-${Date.now()}`
   await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode })
   await rename(temporary, path)
+}
+
+/** Atomically replace a JSON document through an injected filesystem. */
+export async function writeJsonAtomicFs(fs: FsLike, path: string, value: unknown): Promise<void> {
+  await fs.mkdir(dirname(path), { recursive: true })
+  const temporary = `${path}.tmp-${process.pid}-${Date.now()}-${atomicWriteSequence += 1}`
+  try {
+    await fs.writeText(temporary, `${JSON.stringify(value, null, 2)}\n`)
+    await fs.rename(temporary, path)
+  } catch (error) {
+    await fs.remove(temporary).catch(() => undefined)
+    throw error
+  }
 }
 
 export async function appendJsonLine(path: string, value: unknown): Promise<void> {

--- a/packages/dsh-doctor/src/core/transaction.ts
+++ b/packages/dsh-doctor/src/core/transaction.ts
@@ -23,6 +23,8 @@ export interface CandidateTransactionDeps {
   journal?: { append(entry: { op: string; ok: boolean; detail?: Record<string, unknown> }): Promise<unknown> }
   /** Optional same-device assertion; when provided and false, promote refuses. */
   sameDevice?(a: string, b: string): Promise<boolean>
+  /** Revalidate the caller's ownership before any compensating live move. */
+  beforeCompensation?(): Promise<void>
 }
 
 export interface CandidateTransaction {
@@ -80,6 +82,7 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
   }
 
   const rollbackPromoted = async (): Promise<void> => {
+    await deps.beforeCompensation?.()
     const discarded = stagingBase + '/' + profile + '/' + txnId + '.discarded'
     if (!(await fs.exists(quarantinePath))) {
       throw txnError(txnId, phase, 'quarantine path missing at ' + quarantinePath + '; live profile left untouched')
@@ -92,6 +95,7 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
       await movePath(fs, quarantinePath, livePath)
     } catch (error) {
       try {
+        await deps.beforeCompensation?.()
         await movePath(fs, discarded, livePath)
       } catch (restoreError) {
         setPhase('failed')
@@ -153,6 +157,7 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
           if (candidateActivated) {
             await rollbackPromoted()
           } else if (originalQuarantined) {
+            await deps.beforeCompensation?.()
             await movePath(fs, quarantinePath, livePath)
             steps.push({ step: 'promote-rollback', from: quarantinePath, to: livePath })
             await fs.remove(stagingPath, { recursive: true })

--- a/packages/dsh-doctor/src/core/transaction.ts
+++ b/packages/dsh-doctor/src/core/transaction.ts
@@ -79,6 +79,36 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
     }
   }
 
+  const rollbackPromoted = async (): Promise<void> => {
+    const discarded = stagingBase + '/' + profile + '/' + txnId + '.discarded'
+    if (!(await fs.exists(quarantinePath))) {
+      throw txnError(txnId, phase, 'quarantine path missing at ' + quarantinePath + '; live profile left untouched')
+    }
+    if (await fs.exists(discarded)) {
+      throw txnError(txnId, phase, 'discarded path already exists at ' + discarded + '; live profile left untouched')
+    }
+    await movePath(fs, livePath, discarded)
+    try {
+      await movePath(fs, quarantinePath, livePath)
+    } catch (error) {
+      try {
+        await movePath(fs, discarded, livePath)
+      } catch (restoreError) {
+        setPhase('failed')
+        record.error = 'rollback failed and restoring the live profile failed: ' + String(error) + ' / ' + String(restoreError)
+        throw txnError(txnId, phase, record.error)
+      }
+      record.error = String(error)
+      await journal('rollback-failed', { error: String(error) }).catch(() => undefined)
+      throw txnError(txnId, phase, 'rollback failed: ' + String(error))
+    }
+    setPhase('rolled-back')
+    delete record.error
+    steps.push({ step: 'rollback-restore', from: quarantinePath, to: livePath })
+    await fs.remove(discarded, { recursive: true }).catch(() => undefined)
+    await journal('rollback-restore')
+  }
+
   return {
     txnId,
     record,
@@ -100,27 +130,46 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
         throw txnError(txnId, phase, 'quarantine path already exists: ' + quarantinePath)
       }
       await fs.mkdir(quarantineBase + '/' + profile + '/' + txnId, { recursive: true })
-      const first = await movePath(fs, livePath, quarantinePath)
-      steps.push({ step: 'promote-quarantine', from: livePath, to: quarantinePath, copied: first.copied })
-      await journal('promote-quarantine', { from: livePath, to: quarantinePath, copied: first.copied })
+      let originalQuarantined = false
+      let candidateActivated = false
       try {
+        const first = await movePath(fs, livePath, quarantinePath)
+        originalQuarantined = true
+        steps.push({ step: 'promote-quarantine', from: livePath, to: quarantinePath, copied: first.copied })
+        await journal('promote-quarantine', { from: livePath, to: quarantinePath, copied: first.copied })
         const second = await movePath(fs, stagingPath, livePath)
+        candidateActivated = true
         steps.push({ step: 'promote-activate', from: stagingPath, to: livePath, copied: second.copied })
-        await journal('promote-activate', { from: stagingPath, to: livePath, copied: second.copied })
         setPhase('promoted')
+        await journal('promote-activate', { from: stagingPath, to: livePath, copied: second.copied })
       } catch (error) {
-        try {
-          await movePath(fs, quarantinePath, livePath)
-          steps.push({ step: 'promote-rollback', from: quarantinePath, to: livePath })
-        } catch (rollbackError) {
-          setPhase('failed')
-          record.error = 'promote failed and rollback failed: ' + String(error) + ' / ' + String(rollbackError)
-          throw txnError(txnId, 'failed', record.error)
+        if (!originalQuarantined) {
+          record.error = String(error)
+          await journal('promote-failed', { error: record.error }).catch(() => undefined)
+          throw txnError(txnId, phase, 'promote failed before quarantining live: ' + record.error)
         }
-        setPhase('rolled-back')
-        record.error = String(error)
-        await journal('promote-failed', { error: String(error) })
-        throw txnError(txnId, 'rolled-back', 'promote failed: ' + String(error))
+        let rollbackError: unknown
+        try {
+          if (candidateActivated) {
+            await rollbackPromoted()
+          } else if (originalQuarantined) {
+            await movePath(fs, quarantinePath, livePath)
+            steps.push({ step: 'promote-rollback', from: quarantinePath, to: livePath })
+            await fs.remove(stagingPath, { recursive: true })
+            setPhase('rolled-back')
+          }
+        } catch (caught) {
+          rollbackError = caught
+        }
+        const phaseAfterRollback = record.phase
+        if (phaseAfterRollback !== 'rolled-back') {
+          if (phaseAfterRollback !== 'promoted' && phaseAfterRollback !== 'failed') setPhase('failed')
+          record.error = 'promote failed and rollback failed: ' + String(error) + ' / ' + String(rollbackError)
+          throw txnError(txnId, phase, record.error)
+        }
+        record.error = String(error) + (rollbackError === undefined ? '' : '; rollback warning: ' + String(rollbackError))
+        await journal('promote-failed', { error: record.error }).catch(() => undefined)
+        throw txnError(txnId, phase, 'promote failed: ' + record.error)
       }
     },
     async rollback() {
@@ -131,38 +180,12 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
         return
       }
       if (phase !== 'promoted') throw txnError(txnId, phase, 'rollback requires state staged or promoted')
-      const discarded = stagingBase + '/' + profile + '/' + txnId + '.discarded'
-      if (!(await fs.exists(quarantinePath))) {
-        throw txnError(txnId, phase, 'quarantine path missing at ' + quarantinePath + '; live profile left untouched')
-      }
-      if (await fs.exists(discarded)) {
-        throw txnError(txnId, phase, 'discarded path already exists at ' + discarded + '; live profile left untouched')
-      }
-      await movePath(fs, livePath, discarded)
-      try {
-        await movePath(fs, quarantinePath, livePath)
-      } catch (error) {
-        try {
-          await movePath(fs, discarded, livePath)
-        } catch (restoreError) {
-          setPhase('failed')
-          record.error = 'rollback failed and restoring the live profile failed: ' + String(error) + ' / ' + String(restoreError)
-          throw txnError(txnId, phase, record.error)
-        }
-        record.error = String(error)
-        await journal('rollback-failed', { error: String(error) })
-        throw txnError(txnId, phase, 'rollback failed: ' + String(error))
-      }
-      setPhase('rolled-back')
-      delete record.error
-      steps.push({ step: 'rollback-restore', from: quarantinePath, to: livePath })
-      await journal('rollback-restore')
-      await fs.remove(discarded, { recursive: true }).catch(() => undefined)
+      await rollbackPromoted()
     },
     async abort() {
       if (phase === 'created') return
       if (phase === 'promoted') {
-        await this.rollback()
+        await rollbackPromoted()
         return
       }
       if (phase === 'rolled-back' || phase === 'aborted') return
@@ -172,8 +195,8 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
     },
     async commit() {
       if (phase !== 'promoted') throw txnError(txnId, phase, 'commit requires state promoted')
-      setPhase('committed')
       await journal('commit', { quarantinePath })
+      setPhase('committed')
     },
   }
 }

--- a/packages/dsh-doctor/src/core/transaction.ts
+++ b/packages/dsh-doctor/src/core/transaction.ts
@@ -132,12 +132,32 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
       }
       if (phase !== 'promoted') throw txnError(txnId, phase, 'rollback requires state staged or promoted')
       const discarded = stagingBase + '/' + profile + '/' + txnId + '.discarded'
+      if (!(await fs.exists(quarantinePath))) {
+        throw txnError(txnId, phase, 'quarantine path missing at ' + quarantinePath + '; live profile left untouched')
+      }
+      if (await fs.exists(discarded)) {
+        throw txnError(txnId, phase, 'discarded path already exists at ' + discarded + '; live profile left untouched')
+      }
       await movePath(fs, livePath, discarded)
-      await movePath(fs, quarantinePath, livePath)
-      await fs.remove(discarded, { recursive: true })
+      try {
+        await movePath(fs, quarantinePath, livePath)
+      } catch (error) {
+        try {
+          await movePath(fs, discarded, livePath)
+        } catch (restoreError) {
+          setPhase('failed')
+          record.error = 'rollback failed and restoring the live profile failed: ' + String(error) + ' / ' + String(restoreError)
+          throw txnError(txnId, phase, record.error)
+        }
+        record.error = String(error)
+        await journal('rollback-failed', { error: String(error) })
+        throw txnError(txnId, phase, 'rollback failed: ' + String(error))
+      }
       setPhase('rolled-back')
+      delete record.error
       steps.push({ step: 'rollback-restore', from: quarantinePath, to: livePath })
       await journal('rollback-restore')
+      await fs.remove(discarded, { recursive: true }).catch(() => undefined)
     },
     async abort() {
       if (phase === 'created') return
@@ -169,4 +189,3 @@ function txnError(txnId: string, phase: CandidatePhase, detail: string): Error {
   error.phase = phase
   return error
 }
-

--- a/packages/dsh-doctor/src/core/transaction.ts
+++ b/packages/dsh-doctor/src/core/transaction.ts
@@ -23,6 +23,8 @@ export interface CandidateTransactionDeps {
   journal?: { append(entry: { op: string; ok: boolean; detail?: Record<string, unknown> }): Promise<unknown> }
   /** Optional same-device assertion; when provided and false, promote refuses. */
   sameDevice?(a: string, b: string): Promise<boolean>
+  /** Persist recovery intent while the candidate is still staged. */
+  beforePromote?(record: CandidateRecord): Promise<void>
   /** Revalidate the caller's ownership before any compensating live move. */
   beforeCompensation?(): Promise<void>
 }
@@ -83,7 +85,9 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
 
   const rollbackPromoted = async (): Promise<void> => {
     await deps.beforeCompensation?.()
-    const discarded = stagingBase + '/' + profile + '/' + txnId + '.discarded'
+    // Keep one transaction-owned discard convention across in-process and
+    // CLI rollback so a later invocation can finalize an interrupted restore.
+    const discarded = livePath + '.doctor-discarded-' + txnId
     if (!(await fs.exists(quarantinePath))) {
       throw txnError(txnId, phase, 'quarantine path missing at ' + quarantinePath + '; live profile left untouched')
     }
@@ -134,6 +138,13 @@ export function createCandidateTransaction(deps: CandidateTransactionDeps): Cand
         throw txnError(txnId, phase, 'quarantine path already exists: ' + quarantinePath)
       }
       await fs.mkdir(quarantineBase + '/' + profile + '/' + txnId, { recursive: true })
+      if (deps.beforePromote === undefined) {
+        throw txnError(txnId, phase, 'promote requires a durable recovery-intent writer')
+      }
+      // This atomic record write is the crash-recovery boundary. It must land
+      // before live is renamed so every partially promoted layout has durable
+      // profile, staging and quarantine identities.
+      await deps.beforePromote(record)
       let originalQuarantined = false
       let candidateActivated = false
       try {

--- a/packages/dsh-doctor/src/core/types.ts
+++ b/packages/dsh-doctor/src/core/types.ts
@@ -191,6 +191,8 @@ export interface LockToken {
   startedAt: string
   heartbeatAt: number
   nonce: string
+  /** A released lease is immediately reclaimable but remains atomic on disk. */
+  released?: boolean
 }
 
 export interface LockState {
@@ -292,4 +294,3 @@ export interface HttpResult {
   status: number
   body: string
 }
-

--- a/packages/dsh-doctor/tests/cli-rollback.spec.ts
+++ b/packages/dsh-doctor/tests/cli-rollback.spec.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { main } from '../src/cli.ts'
+
+describe('doctor rollback CLI', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('discovers the profile from the transaction record', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-cli-rollback-'))
+    const txnId = 'txn-20260101000000'
+    const livePath = join(home, 'profiles', 'web')
+    const quarantinePath = join(home, '.dsh-doctor', 'quarantine', 'web', txnId, 'original')
+    const recordPath = join(home, '.dsh-doctor', 'transactions', txnId + '.json')
+    try {
+      await mkdir(livePath, { recursive: true })
+      await writeFile(join(livePath, 'package.json'), '{"name":"web","version":2}')
+      await mkdir(quarantinePath, { recursive: true })
+      await writeFile(join(quarantinePath, 'package.json'), '{"name":"web","version":1}')
+      await mkdir(join(home, '.dsh-doctor', 'transactions'), { recursive: true })
+      await writeFile(recordPath, JSON.stringify({
+        txnId,
+        profile: 'web',
+        phase: 'promoted',
+        livePath,
+        stagingPath: join(home, 'staging', txnId),
+        quarantinePath,
+        steps: [],
+      }) + '\n')
+      vi.stubEnv('DSH_HOME', home)
+      vi.stubEnv('DSH_DOCTOR_REAL_DSH', '')
+      vi.stubEnv('PATH', '')
+      const output: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((value) => { output.push(String(value)) })
+
+      const code = await main(['rollback', txnId])
+
+      expect(code).toBe(0)
+      expect(JSON.parse(output.at(-1) ?? '{}')).toMatchObject({ ok: true, phase: 'rolled-back', txnId })
+      expect(await readFile(join(livePath, 'package.json'), 'utf8')).toBe('{"name":"web","version":1}')
+      expect(JSON.parse(await readFile(recordPath, 'utf8'))).toMatchObject({ profile: 'web', phase: 'rolled-back' })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('returns a failure exit code when the transaction record is missing', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-cli-rollback-missing-'))
+    try {
+      vi.stubEnv('DSH_HOME', home)
+      vi.stubEnv('DSH_DOCTOR_REAL_DSH', '')
+      vi.stubEnv('PATH', '')
+      const output: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((value) => { output.push(String(value)) })
+
+      const code = await main(['rollback', 'txn-20260101000000'])
+
+      expect(code).toBe(2)
+      expect(JSON.parse(output.at(-1) ?? '{}')).toMatchObject({
+        ok: false,
+        phase: 'failed',
+        txnId: 'txn-20260101000000',
+      })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('returns a failure exit code when the discovered rollback cannot complete', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-cli-rollback-failed-'))
+    const txnId = 'txn-20260101000000'
+    const livePath = join(home, 'profiles', 'web')
+    const quarantinePath = join(home, '.dsh-doctor', 'quarantine', 'web', txnId, 'original')
+    const recordPath = join(home, '.dsh-doctor', 'transactions', txnId + '.json')
+    try {
+      await mkdir(livePath, { recursive: true })
+      await writeFile(join(livePath, 'package.json'), '{"name":"web","version":2}')
+      await mkdir(join(home, '.dsh-doctor', 'transactions'), { recursive: true })
+      await writeFile(recordPath, JSON.stringify({
+        txnId,
+        profile: 'web',
+        phase: 'promoted',
+        livePath,
+        stagingPath: join(home, 'staging', txnId),
+        quarantinePath,
+        steps: [],
+      }) + '\n')
+      vi.stubEnv('DSH_HOME', home)
+      vi.stubEnv('DSH_DOCTOR_REAL_DSH', '')
+      vi.stubEnv('PATH', '')
+      const output: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((value) => { output.push(String(value)) })
+
+      const code = await main(['rollback', txnId])
+
+      expect(code).toBe(2)
+      expect(JSON.parse(output.at(-1) ?? '{}')).toMatchObject({ ok: false, phase: 'failed', txnId })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/dsh-doctor/tests/cli-rollback.spec.ts
+++ b/packages/dsh-doctor/tests/cli-rollback.spec.ts
@@ -27,7 +27,7 @@ describe('doctor rollback CLI', () => {
         profile: 'web',
         phase: 'promoted',
         livePath,
-        stagingPath: join(home, 'staging', txnId),
+        stagingPath: join(home, 'profiles', '.doctor-staging', 'web', txnId),
         quarantinePath,
         steps: [],
       }) + '\n')
@@ -85,7 +85,7 @@ describe('doctor rollback CLI', () => {
         profile: 'web',
         phase: 'promoted',
         livePath,
-        stagingPath: join(home, 'staging', txnId),
+        stagingPath: join(home, 'profiles', '.doctor-staging', 'web', txnId),
         quarantinePath,
         steps: [],
       }) + '\n')

--- a/packages/dsh-doctor/tests/core-journal-lock.spec.ts
+++ b/packages/dsh-doctor/tests/core-journal-lock.spec.ts
@@ -55,6 +55,9 @@ describe('lock manager', () => {
     const state = await manager.status('profile', 'web')
     expect(state.held).toBe(true)
     expect(state.token?.pid).toBe(10)
+    await handle.touch(2000)
+    expect((await manager.status('profile', 'web')).token?.heartbeatAt).toBe(2000)
+    await handle.release()
     await handle.release()
     expect((await manager.status('profile', 'web')).held).toBe(false)
   })
@@ -151,6 +154,142 @@ describe('lock manager', () => {
     const state = await manager.status('profile', 'web')
     expect(state.token?.pid).toBe(3)
     await gained.release()
+  })
+
+  it('prevents a stale owner from touching or releasing a replacement lock', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-owner-'))
+    try {
+      let clock = 1000
+      const firstManager = createLockManager({ fs: nodeFs, home, pid: 11, clock: () => clock, iso: () => 'first', pidAlive: () => true })
+      const first = await firstManager.acquire('profile', 'web', { intent: 'first' })
+      clock = 20_000
+      const secondManager = createLockManager({ fs: nodeFs, home, pid: 12, clock: () => clock, iso: () => 'second', pidAlive: (pid) => pid === 12 })
+      const second = await secondManager.acquire('profile', 'web', { intent: 'second' })
+      const replacement = (await secondManager.status('profile', 'web')).token
+      expect(replacement).toMatchObject({ pid: 12, intent: 'second' })
+
+      await expect(first.touch(clock + 1)).rejects.toMatchObject({ code: 'LOCK_LOST' })
+      expect((await secondManager.status('profile', 'web')).token).toEqual(replacement)
+      await expect(first.release()).rejects.toMatchObject({ code: 'LOCK_LOST' })
+      expect((await secondManager.status('profile', 'web')).token).toEqual(replacement)
+
+      await second.release()
+      expect((await secondManager.status('profile', 'web')).held).toBe(false)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('does not delete a replacement that takes over during release', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-release-race-'))
+    const releasePublishReady = deferred()
+    const continueRelease = deferred()
+    try {
+      const lockPath = join(home, '.dsh-doctor', 'locks', 'profile__web')
+      const tokenPath = join(lockPath, 'token.json')
+      const originalRename = nodeFs.rename.bind(nodeFs)
+      const releasingFs: FsLike = {
+        ...nodeFs,
+        async rename(from, to) {
+          if (to === tokenPath && from.includes('.release-')) {
+            releasePublishReady.resolve()
+            await continueRelease.promise
+          }
+          await originalRename(from, to)
+        },
+      }
+      let clock = 1000
+      const firstManager = createLockManager({ fs: releasingFs, home, pid: 31, clock: () => clock, iso: () => 'first', pidAlive: () => true })
+      const first = await firstManager.acquire('profile', 'web', { intent: 'first' })
+      const releasing = first.release()
+      await releasePublishReady.promise
+
+      clock = 20_000
+      const secondManager = createLockManager({ fs: nodeFs, home, pid: 32, clock: () => clock, iso: () => 'second', pidAlive: (pid) => pid === 32 })
+      const second = await secondManager.acquire('profile', 'web', { intent: 'second' })
+      const replacement = (await secondManager.status('profile', 'web')).token
+      expect(replacement).toMatchObject({ pid: 32, intent: 'second' })
+
+      continueRelease.resolve()
+      await expect(releasing).rejects.toMatchObject({ code: 'LOCK_LOST' })
+      expect((await secondManager.status('profile', 'web')).token).toEqual(replacement)
+      await second.release()
+    } finally {
+      continueRelease.resolve()
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('does not steal when the observed owner refreshes before takeover', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-refresh-'))
+    try {
+      const lockPath = join(home, '.dsh-doctor', 'locks', 'profile__web')
+      const tokenPath = join(lockPath, 'token.json')
+      const staleToken = { pid: 21, host: 'local', intent: 'first', startedAt: 'first', heartbeatAt: 1000, nonce: 'same-owner' }
+      await nodeFs.mkdir(lockPath, { recursive: true })
+      await nodeFs.writeText(tokenPath, JSON.stringify(staleToken) + '\n')
+
+      const originalReadText = nodeFs.readText.bind(nodeFs)
+      const originalRename = nodeFs.rename.bind(nodeFs)
+      let tokenReads = 0
+      let takeoverRenames = 0
+      const refreshedHeartbeat = 20_000
+      const refreshingFs: FsLike = {
+        ...nodeFs,
+        async readText(path) {
+          if (path === tokenPath) {
+            tokenReads += 1
+            if (tokenReads === 2) {
+              await nodeFs.writeText(tokenPath, JSON.stringify({ ...staleToken, heartbeatAt: refreshedHeartbeat }) + '\n')
+            }
+          }
+          return await originalReadText(path)
+        },
+        async rename(from, to) {
+          if (from === lockPath && to.startsWith(lockPath + '.stale-')) takeoverRenames += 1
+          await originalRename(from, to)
+        },
+      }
+      const manager = createLockManager({ fs: refreshingFs, home, pid: 22, clock: () => refreshedHeartbeat, iso: () => 'second', pidAlive: () => true })
+
+      await expect(manager.acquire('profile', 'web', { intent: 'second', staleMs: 1000, timeoutMs: 0 })).rejects.toMatchObject({ code: 'LOCK_HELD' })
+      expect(takeoverRenames).toBe(0)
+      expect((await manager.status('profile', 'web')).token).toEqual({ ...staleToken, heartbeatAt: refreshedHeartbeat })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('restores an owner that refreshes after the final stale check', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-refresh-race-'))
+    try {
+      const lockPath = join(home, '.dsh-doctor', 'locks', 'profile__web')
+      const tokenPath = join(lockPath, 'token.json')
+      const staleToken = { pid: 41, host: 'local', intent: 'first', startedAt: 'first', heartbeatAt: 1000, nonce: 'same-owner' }
+      const refreshedHeartbeat = 20_000
+      await nodeFs.mkdir(lockPath, { recursive: true })
+      await nodeFs.writeText(tokenPath, JSON.stringify(staleToken) + '\n')
+
+      const originalRename = nodeFs.rename.bind(nodeFs)
+      let refreshedDuringRename = false
+      const refreshingFs: FsLike = {
+        ...nodeFs,
+        async rename(from, to) {
+          if (!refreshedDuringRename && from === lockPath && to.startsWith(lockPath + '.stale-')) {
+            refreshedDuringRename = true
+            await nodeFs.writeText(tokenPath, JSON.stringify({ ...staleToken, heartbeatAt: refreshedHeartbeat }) + '\n')
+          }
+          await originalRename(from, to)
+        },
+      }
+      const manager = createLockManager({ fs: refreshingFs, home, pid: 42, clock: () => refreshedHeartbeat, iso: () => 'second', pidAlive: () => true })
+
+      await expect(manager.acquire('profile', 'web', { intent: 'second', staleMs: 1000, timeoutMs: 0 })).rejects.toMatchObject({ code: 'LOCK_HELD' })
+      expect(refreshedDuringRename).toBe(true)
+      expect((await manager.status('profile', 'web')).token).toEqual({ ...staleToken, heartbeatAt: refreshedHeartbeat })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
   })
 
   it('reports a clean status for absent locks', async () => {

--- a/packages/dsh-doctor/tests/core-journal-lock.spec.ts
+++ b/packages/dsh-doctor/tests/core-journal-lock.spec.ts
@@ -143,6 +143,75 @@ describe('lock manager', () => {
     await held.release()
   })
 
+  it('heartbeats a lock held longer than its stale lease', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-heartbeat-'))
+    try {
+      let clock = 1_000
+      const firstManager = createLockManager({ fs: nodeFs, home, pid: 51, clock: () => clock, iso: () => 'first', pidAlive: () => true })
+      const first = await firstManager.acquire('global', undefined, { intent: 'long repair', staleMs: 150 })
+      const initialHeartbeat = (await firstManager.status('global', undefined)).token?.heartbeatAt
+
+      clock = 20_000
+      let refreshedHeartbeat = initialHeartbeat
+      for (let attempt = 0; attempt < 100 && refreshedHeartbeat !== clock; attempt += 1) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 10))
+        refreshedHeartbeat = (await firstManager.status('global', undefined)).token?.heartbeatAt
+      }
+      expect(refreshedHeartbeat).toBe(clock)
+
+      const secondManager = createLockManager({ fs: nodeFs, home, pid: 52, clock: () => clock, iso: () => 'second', pidAlive: () => true })
+      await expect(secondManager.acquire('global', undefined, {
+        intent: 'second repair',
+        staleMs: 150,
+        timeoutMs: 0,
+      })).rejects.toMatchObject({ code: 'LOCK_HELD' })
+
+      await first.release()
+      const releasedTokenPath = join(home, '.dsh-doctor', 'locks', 'global', 'token.json')
+      const releasedToken = await nodeFs.readText(releasedTokenPath)
+      await new Promise<void>((resolve) => setTimeout(resolve, 80))
+      expect(await nodeFs.readText(releasedTokenPath)).toBe(releasedToken)
+      const second = await secondManager.acquire('global', undefined, { intent: 'second repair', staleMs: 150 })
+      expect((await secondManager.status('global', undefined)).token).toMatchObject({ pid: 52 })
+      await second.release()
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed after an automatic heartbeat cannot be persisted', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-heartbeat-failure-'))
+    const heartbeatAttempted = deferred()
+    try {
+      const originalWriteText = nodeFs.writeText.bind(nodeFs)
+      const failingFs: FsLike = {
+        ...nodeFs,
+        async writeText(path, text) {
+          if (path.includes('.touch-')) {
+            heartbeatAttempted.resolve()
+            const error = new Error('injected heartbeat write failure') as Error & { code: string }
+            error.code = 'EACCES'
+            throw error
+          }
+          await originalWriteText(path, text)
+        },
+      }
+      const manager = createLockManager({ fs: failingFs, home, pid: 61, clock: Date.now, iso: () => 'owner', pidAlive: () => true })
+      const handle = await manager.acquire('global', undefined, { intent: 'repair', staleMs: 150 })
+
+      await Promise.race([
+        heartbeatAttempted.promise,
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('heartbeat did not run')), 1_000)),
+      ])
+      await new Promise<void>((resolve) => setTimeout(resolve, 10))
+
+      await expect(handle.touch(Date.now())).rejects.toMatchObject({ code: 'LOCK_ERROR' })
+      await expect(handle.release()).rejects.toMatchObject({ code: 'LOCK_ERROR' })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   it('steals a stale lock left by a dead pid', async () => {
     const fs = createMemoryFs()
     await fs.mkdir('/h/.dsh-doctor/locks', { recursive: true })
@@ -167,6 +236,7 @@ describe('lock manager', () => {
       const second = await secondManager.acquire('profile', 'web', { intent: 'second' })
       const replacement = (await secondManager.status('profile', 'web')).token
       expect(replacement).toMatchObject({ pid: 12, intent: 'second' })
+      expect((await nodeFs.readdir(join(home, '.dsh-doctor', 'locks'))).some((entry) => entry.name.includes('.stale-'))).toBe(false)
 
       await expect(first.touch(clock + 1)).rejects.toMatchObject({ code: 'LOCK_LOST' })
       expect((await secondManager.status('profile', 'web')).token).toEqual(replacement)
@@ -175,6 +245,24 @@ describe('lock manager', () => {
 
       await second.release()
       expect((await secondManager.status('profile', 'web')).held).toBe(false)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('does not treat a malformed owner token as a missing stale lease', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-malformed-'))
+    try {
+      const lockPath = join(home, '.dsh-doctor', 'locks', 'profile__web')
+      const tokenPath = join(lockPath, 'token.json')
+      await nodeFs.mkdir(lockPath, { recursive: true })
+      await nodeFs.writeText(tokenPath, '{broken')
+      const manager = createLockManager({ fs: nodeFs, home, pid: 62, clock: () => 20_000, iso: () => 'second', pidAlive: () => false })
+
+      await expect(manager.acquire('profile', 'web', { intent: 'second', timeoutMs: 0 })).rejects.toMatchObject({ code: 'LOCK_ERROR' })
+
+      expect(await nodeFs.readText(tokenPath)).toBe('{broken')
+      expect((await nodeFs.readdir(join(home, '.dsh-doctor', 'locks'))).some((entry) => entry.name.includes('.stale-'))).toBe(false)
     } finally {
       await rm(home, { recursive: true, force: true })
     }
@@ -292,12 +380,53 @@ describe('lock manager', () => {
     }
   })
 
+  it('restores a displaced owner when its token cannot be revalidated', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-displaced-read-'))
+    try {
+      const lockPath = join(home, '.dsh-doctor', 'locks', 'profile__web')
+      const tokenPath = join(lockPath, 'token.json')
+      const staleToken = { pid: 71, host: 'local', intent: 'first', startedAt: 'first', heartbeatAt: 1_000, nonce: 'first-owner' }
+      await nodeFs.mkdir(lockPath, { recursive: true })
+      await nodeFs.writeText(tokenPath, JSON.stringify(staleToken) + '\n')
+      const originalReadText = nodeFs.readText.bind(nodeFs)
+      const originalRename = nodeFs.rename.bind(nodeFs)
+      let replacementClaims = 0
+      const unreadableFs: FsLike = {
+        ...nodeFs,
+        async readText(path) {
+          if (path.startsWith(lockPath + '.stale-') && path.endsWith('token.json')) {
+            const error = new Error('injected displaced token read failure') as Error & { code: string }
+            error.code = 'EIO'
+            throw error
+          }
+          return await originalReadText(path)
+        },
+        async rename(from, to) {
+          if (to === lockPath && from.startsWith(lockPath + '.claim-')) replacementClaims += 1
+          await originalRename(from, to)
+        },
+      }
+      const manager = createLockManager({ fs: unreadableFs, home, pid: 72, clock: () => 20_000, iso: () => 'second', pidAlive: () => false })
+
+      await expect(manager.acquire('profile', 'web', { intent: 'second', staleMs: 1_000, timeoutMs: 0 })).rejects.toMatchObject({ code: 'LOCK_STALE' })
+
+      expect(replacementClaims).toBe(0)
+      expect(JSON.parse(await nodeFs.readText(tokenPath))).toEqual(staleToken)
+      expect((await nodeFs.readdir(join(home, '.dsh-doctor', 'locks'))).some((entry) => entry.name.includes('.stale-'))).toBe(false)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   it('reports a clean status for absent locks', async () => {
-    const fs = createMemoryFs()
-    await fs.mkdir('/h', { recursive: true })
-    const manager = createLockManager({ fs, home: '/h', pid: 1, clock: () => 1, iso: () => 'x' })
-    const state = await manager.status('profile', 'web')
-    expect(state.held).toBe(false)
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-status-'))
+    try {
+      const manager = createLockManager({ fs: nodeFs, home, pid: 1, clock: () => 1, iso: () => 'x' })
+      const state = await manager.status('profile', 'web')
+      expect(state.held).toBe(false)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
   })
 
   it('wraps unrecoverable acquire failures in LOCK_ERROR', async () => {

--- a/packages/dsh-doctor/tests/core-journal-lock.spec.ts
+++ b/packages/dsh-doctor/tests/core-journal-lock.spec.ts
@@ -1,10 +1,19 @@
 /**
  * Journal append/replay and lock manager behavior.
  */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { createMemoryFs } from '../src/core/fs.ts'
+import { createMemoryFs, nodeFs, type FsLike } from '../src/core/fs.ts'
 import { createJournal } from '../src/core/journal.ts'
 import { createLockManager, LockError } from '../src/core/lock.ts'
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => { resolve = done })
+  return { promise, resolve }
+}
 
 async function makeJournal() {
   const fs = createMemoryFs()
@@ -61,6 +70,58 @@ describe('lock manager', () => {
     await b.release()
   })
 
+  it('publishes a fully initialized lock atomically when two acquirers race', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-lock-'))
+    try {
+      const lockPath = join(home, '.dsh-doctor', 'locks', 'global')
+      const firstClaimReady = deferred()
+      const releaseFirstClaim = deferred()
+      const firstObservedWinner = deferred()
+      const originalExists = nodeFs.exists.bind(nodeFs)
+      const originalRename = nodeFs.rename.bind(nodeFs)
+      let firstRenameBlocked = false
+      let firstRenameReleased = false
+      const racingFs: FsLike = {
+        ...nodeFs,
+        async exists(path) {
+          const exists = await originalExists(path)
+          if (firstRenameReleased && path === lockPath && exists) firstObservedWinner.resolve()
+          return exists
+        },
+        async rename(from, to) {
+          if (!firstRenameBlocked && to === lockPath && from.startsWith(lockPath + '.claim-')) {
+            firstRenameBlocked = true
+            firstClaimReady.resolve()
+            await releaseFirstClaim.promise
+            firstRenameReleased = true
+          }
+          await originalRename(from, to)
+        },
+      }
+      const firstManager = createLockManager({ fs: racingFs, home, pid: 11, clock: Date.now, iso: () => 'first', pidAlive: () => true })
+      const secondManager = createLockManager({ fs: racingFs, home, pid: 12, clock: Date.now, iso: () => 'second', pidAlive: () => true })
+      let firstSettled = false
+      const first = firstManager.acquire('global', undefined, { intent: 'first' }).then((handle) => {
+        firstSettled = true
+        return handle
+      })
+      await firstClaimReady.promise
+
+      const second = await secondManager.acquire('global', undefined, { intent: 'second' })
+      expect((await secondManager.status('global', undefined)).token).toMatchObject({ pid: 12, intent: 'second' })
+      releaseFirstClaim.resolve()
+      await firstObservedWinner.promise
+      expect(firstSettled).toBe(false)
+
+      await second.release()
+      const firstHandle = await first
+      expect((await firstManager.status('global', undefined)).token).toMatchObject({ pid: 11, intent: 'first' })
+      await firstHandle.release()
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   it('times out with LOCK_HELD when a live pid holds the lock', async () => {
     const fs = createMemoryFs()
     await fs.mkdir('/h', { recursive: true })
@@ -112,4 +173,3 @@ describe('lock manager', () => {
     expect(() => { throw new LockError('LOCK_HELD', 'profile', 'web', 'held') }).toThrowError(/held/)
   })
 })
-

--- a/packages/dsh-doctor/tests/core-recover.spec.ts
+++ b/packages/dsh-doctor/tests/core-recover.spec.ts
@@ -2,25 +2,26 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { createMemoryFs, type FsLike } from '../src/core/fs.ts'
+import { createMemoryFs, nodeFs, type FsLike } from '../src/core/fs.ts'
 import { createYamlEngine } from '../src/core/yaml.ts'
 import { createJournal } from '../src/core/journal.ts'
 import { redactText } from '../src/core/redact.ts'
 import { repairProfile, diagnoseAndPlan, rollbackTransaction, type RecoveryRequest } from '../src/core/recover.ts'
 import type { GateDeps, ProcessClient, HttpClient, SpawnHandle } from '../src/core/gates.ts'
 
-function fakeGates(script: { dumpStdout?: string; startStdout?: string; httpBody?: string; exit?: number }): { gates: GateDeps; spawned: string[][] } {
+function fakeGates(script: { dumpStdout?: string; startStdout?: string; httpBody?: string; exit?: number; exits?: number[] }): { gates: GateDeps; spawned: string[][] } {
   const spawned: string[][] = []
   let pid = 1000
   const client: ProcessClient = {
     spawn(command: string[], opts: { cwd?: string; env?: Record<string, string | undefined> }): SpawnHandle {
+      const call = spawned.length
       spawned.push([command.join(' '), (opts.env as any)?.DSH_HOME ?? '', (opts.env as any)?.DSH_TELEMETRY_DISABLED ?? ''])
       const isDump = command.includes('--dump-default-config')
       const stdout = isDump ? (script.dumpStdout ?? '[]\n') : (script.startStdout ?? 'dsh web: http://127.0.0.1:4567\n')
       const handle: SpawnHandle = {
         onStdout(cb) { queueMicrotask(() => cb(stdout)) },
         onStderr(cb) { queueMicrotask(() => cb('')) },
-        onExit(cb) { queueMicrotask(() => cb(script.exit ?? 0, null)) },
+        onExit(cb) { queueMicrotask(() => cb(script.exits?.[call] ?? script.exit ?? 0, null)) },
         kill() {},
       }
       pid += 1
@@ -35,6 +36,50 @@ function fakeGates(script: { dumpStdout?: string; startStdout?: string; httpBody
 
 function request(fs: FsLike, home: string, extra: Partial<RecoveryRequest> = {}): RecoveryRequest {
   return { home, profile: 'web', dshPath: '/fake/dsh', fs, allowLive: true, now: () => '2026-01-01T00:00:00Z', clock: () => 1_700_000_000_000, pidAlive: () => true, ...extra }
+}
+
+async function withRealHome(run: (fs: FsLike, home: string) => Promise<void>): Promise<void> {
+  const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-rollback-'))
+  try {
+    await run(nodeFs, home)
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+}
+
+async function seedPromotedTransaction(fs: FsLike, home: string, txnId = 'web-20260101000000'): Promise<{ livePath: string; quarantinePath: string; recordPath: string }> {
+  const livePath = join(home, 'profiles', 'web')
+  const quarantinePath = join(home, '.dsh-doctor', 'quarantine', 'web', txnId, 'original')
+  const recordPath = join(home, '.dsh-doctor', 'transactions', txnId + '.json')
+  await fs.mkdir(livePath, { recursive: true })
+  await fs.writeText(join(livePath, 'package.json'), JSON.stringify({ name: 'web', dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } } }))
+  await fs.writeText(join(livePath, 'cordis.patch.yml'), '# repaired candidate\n')
+  await fs.mkdir(quarantinePath, { recursive: true })
+  await fs.writeText(join(quarantinePath, 'package.json'), JSON.stringify({ name: 'web', dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } } }))
+  await fs.writeText(join(quarantinePath, 'cordis.patch.yml'), 'bad: [unclosed\n')
+  await fs.mkdir(join(home, '.dsh-doctor', 'transactions'), { recursive: true })
+  await fs.writeText(recordPath, JSON.stringify({ txnId, profile: 'web', phase: 'promoted', livePath, stagingPath: join(home, 'staging', txnId), quarantinePath, steps: [] }, null, 2) + '\n')
+  return { livePath, quarantinePath, recordPath }
+}
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => { resolve = done })
+  return { promise, resolve }
+}
+
+async function waitForSignal(signal: Promise<void>, label: string): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      signal,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error('timed out waiting for ' + label)), 1_000)
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
 }
 
 describe('recovery orchestration', () => {
@@ -109,16 +154,294 @@ describe('recovery orchestration', () => {
     expect(outcome.ok).toBe(true)
   })
 
-  it('rolls back a committed transaction from its record', async () => {
+  it('persists a rollback and treats a repeated request as a no-op', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, recordPath } = await seedPromotedTransaction(fs, home, txnId)
+      const rolled = await rollbackTransaction({ ...request(fs, home) }, txnId)
+      expect(rolled.ok).toBe(true)
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+      expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
+
+      const repeated = await rollbackTransaction({ ...request(fs, home) }, txnId)
+      expect(repeated).toMatchObject({ ok: true, phase: 'rolled-back' })
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+    })
+  })
+
+  it('serializes concurrent rollbacks and rereads the record after locking', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath } = await seedPromotedTransaction(fs, home, txnId)
+      const discardedPath = livePath + '.doctor-discarded-' + txnId
+      const globalLockPath = join(home, '.dsh-doctor', 'locks', 'global')
+      const firstMoveStarted = deferred()
+      const releaseFirstMove = deferred()
+      const secondSawLock = deferred()
+      const originalExists = fs.exists.bind(fs)
+      const originalRename = fs.rename.bind(fs)
+      let firstMoveBlocked = false
+      let liveMoveCalls = 0
+      const racingFs: FsLike = {
+        ...fs,
+        async exists(path) {
+          const exists = await originalExists(path)
+          if (firstMoveBlocked && path === globalLockPath && exists) secondSawLock.resolve()
+          return exists
+        },
+        async rename(from, to) {
+          if (from === livePath && to === discardedPath) {
+            liveMoveCalls += 1
+            if (liveMoveCalls === 1) {
+              firstMoveBlocked = true
+              firstMoveStarted.resolve()
+              await releaseFirstMove.promise
+            }
+          }
+          await originalRename(from, to)
+        },
+      }
+
+      const first = rollbackTransaction({ ...request(racingFs, home), pid: 301, clock: Date.now }, txnId)
+      await waitForSignal(firstMoveStarted.promise, 'the first rollback move')
+      let secondSettled = false
+      const second = rollbackTransaction({ ...request(racingFs, home), pid: 302, clock: Date.now }, txnId).then((outcome) => {
+        secondSettled = true
+        return outcome
+      })
+
+      let observationError: unknown
+      let observed: { liveMoveCalls: number; secondSettled: boolean } | undefined
+      try {
+        await waitForSignal(secondSawLock.promise, 'the second rollback lock check')
+        observed = { liveMoveCalls, secondSettled }
+      } catch (error) {
+        observationError = error
+      } finally {
+        releaseFirstMove.resolve()
+      }
+      const outcomes = await Promise.all([first, second])
+      if (observationError !== undefined) throw observationError
+
+      expect(observed).toEqual({ liveMoveCalls: 1, secondSettled: false })
+      expect(outcomes).toEqual([
+        expect.objectContaining({ ok: true, phase: 'rolled-back' }),
+        expect.objectContaining({ ok: true, phase: 'rolled-back' }),
+      ])
+      expect(liveMoveCalls).toBe(1)
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+    })
+  })
+
+  it('serializes rollback against repair for the same profile', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath } = await seedPromotedTransaction(fs, home, txnId)
+      await fs.writeText(join(quarantinePath, 'cordis.patch.yml'), '[]\n')
+      const discardedPath = livePath + '.doctor-discarded-' + txnId
+      const livePatchPath = join(livePath, 'cordis.patch.yml')
+      const globalLockPath = join(home, '.dsh-doctor', 'locks', 'global')
+      const firstMoveStarted = deferred()
+      const releaseFirstMove = deferred()
+      const repairSawLock = deferred()
+      const originalExists = fs.exists.bind(fs)
+      const originalReadText = fs.readText.bind(fs)
+      const originalRename = fs.rename.bind(fs)
+      let firstMoveBlocked = false
+      let observeRepair = false
+      let liveReads = 0
+      const racingFs: FsLike = {
+        ...fs,
+        async exists(path) {
+          const exists = await originalExists(path)
+          if (firstMoveBlocked && path === globalLockPath && exists) repairSawLock.resolve()
+          return exists
+        },
+        async readText(path) {
+          if (observeRepair && path === livePatchPath) liveReads += 1
+          return await originalReadText(path)
+        },
+        async rename(from, to) {
+          if (!firstMoveBlocked && from === livePath && to === discardedPath) {
+            firstMoveBlocked = true
+            firstMoveStarted.resolve()
+            await releaseFirstMove.promise
+          }
+          await originalRename(from, to)
+        },
+      }
+
+      const rollback = rollbackTransaction({ ...request(racingFs, home), pid: 401, clock: Date.now }, txnId)
+      await waitForSignal(firstMoveStarted.promise, 'the rollback move')
+      observeRepair = true
+      let repairSettled = false
+      const repair = repairProfile({
+        ...request(racingFs, home),
+        pid: 402,
+        clock: Date.now,
+        now: () => '2026-01-02T00:00:00Z',
+        gate: fakeGates({}).gates,
+      }).then((outcome) => {
+        repairSettled = true
+        return outcome
+      })
+
+      let observationError: unknown
+      let observed: { liveReads: number; repairSettled: boolean } | undefined
+      try {
+        await waitForSignal(repairSawLock.promise, 'the repair lock check')
+        observed = { liveReads, repairSettled }
+      } catch (error) {
+        observationError = error
+      } finally {
+        releaseFirstMove.resolve()
+      }
+      const [rollbackOutcome, repairOutcome] = await Promise.all([rollback, repair])
+      if (observationError !== undefined) throw observationError
+
+      expect(observed).toEqual({ liveReads: 0, repairSettled: false })
+      expect(rollbackOutcome).toMatchObject({ ok: true, phase: 'rolled-back' })
+      expect(repairSettled).toBe(true)
+      if (process.platform === 'win32') {
+        expect(repairOutcome).toMatchObject({ ok: false, phase: 'failed' })
+        expect(repairOutcome.message).toContain('mkdir')
+      } else {
+        expect(repairOutcome, repairOutcome.message).toMatchObject({ ok: true, phase: 'noop' })
+      }
+    })
+  })
+
+  it('reverts file moves when atomic transaction replacement is interrupted', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath, recordPath } = await seedPromotedTransaction(fs, home, txnId)
+      const originalRename = fs.rename.bind(fs)
+      let interrupted = false
+      const interruptedFs: FsLike = {
+        ...fs,
+        async rename(from, to) {
+          if (!interrupted && to === recordPath && from.startsWith(recordPath + '.tmp-')) {
+            interrupted = true
+            throw new Error('injected atomic replacement interruption')
+          }
+          await originalRename(from, to)
+        },
+      }
+
+      const failed = await rollbackTransaction({ ...request(interruptedFs, home) }, txnId)
+      expect(failed).toMatchObject({ ok: false, phase: 'failed' })
+      expect(failed.message).toContain('rollback file moves were reverted')
+      expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'promoted' })
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('# repaired candidate\n')
+      expect(await fs.readText(join(quarantinePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+      expect(await fs.exists(livePath + '.doctor-discarded-' + txnId)).toBe(false)
+      expect((await fs.readdir(join(home, '.dsh-doctor', 'transactions'))).some((entry) => entry.name.includes('.tmp-'))).toBe(false)
+
+      const retried = await rollbackTransaction({ ...request(fs, home) }, txnId)
+      expect(retried).toMatchObject({ ok: true, phase: 'rolled-back' })
+      expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
+    })
+  })
+
+  it('rejects unsafe transaction ids before resolving a record path', async () => {
+    await withRealHome(async (fs, home) => {
+      const marker = join(home, 'outside.json')
+      await fs.writeText(marker, 'keep')
+
+      const outcome = await rollbackTransaction({ ...request(fs, home) }, '../outside')
+
+      expect(outcome).toMatchObject({ ok: false, phase: 'failed' })
+      expect(outcome.message).toContain('safe segment')
+      expect(await fs.readText(marker)).toBe('keep')
+      expect(await fs.exists(join(home, '.dsh-doctor', 'locks'))).toBe(false)
+    })
+  })
+
+  it('rejects a transaction record belonging to another profile', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath, recordPath } = await seedPromotedTransaction(fs, home, txnId)
+      const record = JSON.parse(await fs.readText(recordPath)) as Record<string, unknown>
+      record.profile = 'other'
+      await fs.writeText(recordPath, JSON.stringify(record) + '\n')
+
+      const outcome = await rollbackTransaction({ ...request(fs, home) }, txnId)
+
+      expect(outcome).toMatchObject({ ok: false, phase: 'failed' })
+      expect(outcome.message).toContain('belongs to profile other')
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('# repaired candidate\n')
+      expect(await fs.readText(join(quarantinePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+    })
+  })
+
+  it.each([
+    ['livePath', 'profiles/other', 'live path does not match profile'],
+    ['quarantinePath', 'outside/original', 'quarantine path does not match profile'],
+  ] as const)('rejects an unexpected %s in the transaction record', async (field, replacement, expectedMessage) => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath, recordPath } = await seedPromotedTransaction(fs, home, txnId)
+      const record = JSON.parse(await fs.readText(recordPath)) as Record<string, unknown>
+      record[field] = join(home, ...replacement.split('/'))
+      await fs.writeText(recordPath, JSON.stringify(record) + '\n')
+
+      const outcome = await rollbackTransaction({ ...request(fs, home) }, txnId)
+
+      expect(outcome).toMatchObject({ ok: false, phase: 'failed' })
+      expect(outcome.message).toContain(expectedMessage)
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('# repaired candidate\n')
+      expect(await fs.readText(join(quarantinePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+    })
+  })
+
+  it('leaves the live profile untouched when the quarantine is missing', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath } = await seedPromotedTransaction(fs, home, txnId)
+      const liveBefore = await fs.readText(join(livePath, 'cordis.patch.yml'))
+      await fs.remove(quarantinePath, { recursive: true })
+
+      const rolled = await rollbackTransaction({ ...request(fs, home) }, txnId)
+      expect(rolled).toMatchObject({ ok: false, phase: 'failed' })
+      expect(rolled.message).toContain('quarantine path missing')
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe(liveBefore)
+      expect(await fs.exists(livePath + '.doctor-discarded-' + txnId)).toBe(false)
+    })
+  })
+
+  it('restores the live profile when moving the quarantine back fails', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath } = await seedPromotedTransaction(fs, home, txnId)
+      const liveBefore = await fs.readText(join(livePath, 'cordis.patch.yml'))
+      const originalRename = fs.rename.bind(fs)
+      const failingFs: FsLike = {
+        ...fs,
+        async rename(from, to) {
+          if (from === quarantinePath && to === livePath) throw new Error('injected quarantine restore failure')
+          await originalRename(from, to)
+        },
+      }
+
+      const rolled = await rollbackTransaction({ ...request(failingFs, home) }, txnId)
+      expect(rolled).toMatchObject({ ok: false, phase: 'failed' })
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe(liveBefore)
+      expect(await fs.exists(quarantinePath)).toBe(true)
+      expect(await fs.exists(livePath + '.doctor-discarded-' + txnId)).toBe(false)
+    })
+  })
+
+  it('persists the rolled-back phase after live verification fails', async () => {
     const fs = createMemoryFs()
     const home = '/h'
     await fs.mkdir(home + '/profiles/web', { recursive: true })
     await fs.writeText(home + '/profiles/web/package.json', JSON.stringify({ dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } }, name: 'web' }))
     await fs.writeText(home + '/profiles/web/cordis.patch.yml', 'bad: [unclosed\n')
-    const outcome = await repairProfile({ ...request(fs, home), gate: fakeGates({}).gates })
-    expect(outcome.phase).toBe('promoted')
-    const rolled = await rollbackTransaction({ ...request(fs, home) }, outcome.txnId!)
-    expect(rolled.ok).toBe(true)
+
+    const outcome = await repairProfile({ ...request(fs, home), gate: fakeGates({ exits: [0, 0, 1] }).gates })
+    expect(outcome).toMatchObject({ ok: false, phase: 'rolled-back' })
+    const recordPath = home + '/.dsh-doctor/transactions/' + outcome.txnId + '.json'
+    expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
     expect(await fs.readText(home + '/profiles/web/cordis.patch.yml')).toBe('bad: [unclosed\n')
   })
 })
@@ -127,7 +450,7 @@ describe('recovery filesystem isolation', () => {
   it('uses real nodeFs against a temp directory', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'dsh-doctor-recover-'))
     try {
-      const fs = (await import('../src/core/fs.ts')).nodeFs as FsLike
+      const fs = nodeFs as FsLike
       await fs.mkdir(dir + '/profiles/web', { recursive: true })
       await fs.writeText(dir + '/profiles/web/package.json', JSON.stringify({ dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } }, name: 'web' }))
       await fs.writeText(dir + '/profiles/web/cordis.patch.yml', '[]\n')

--- a/packages/dsh-doctor/tests/core-recover.spec.ts
+++ b/packages/dsh-doctor/tests/core-recover.spec.ts
@@ -38,6 +38,26 @@ function request(fs: FsLike, home: string, extra: Partial<RecoveryRequest> = {})
   return { home, profile: 'web', dshPath: '/fake/dsh', fs, allowLive: true, now: () => '2026-01-01T00:00:00Z', clock: () => 1_700_000_000_000, pidAlive: () => true, ...extra }
 }
 
+function withPortablePaths(fs: FsLike): FsLike {
+  const path = (value: string): string => value.replaceAll('\\', '/')
+  return {
+    readText: async (value) => await fs.readText(path(value)),
+    readBytes: async (value) => await fs.readBytes(path(value)),
+    writeText: async (value, text) => await fs.writeText(path(value), text),
+    writeBytes: async (value, data) => await fs.writeBytes(path(value), data),
+    exists: async (value) => await fs.exists(path(value)),
+    stat: async (value) => await fs.stat(path(value)),
+    lstat: async (value) => await fs.lstat(path(value)),
+    readlink: async (value) => await fs.readlink(path(value)),
+    symlink: async (target, value) => await fs.symlink(target, path(value)),
+    mkdir: async (value, opts) => await fs.mkdir(path(value), opts),
+    readdir: async (value) => await fs.readdir(path(value)),
+    rename: async (from, to) => await fs.rename(path(from), path(to)),
+    unlink: async (value) => await fs.unlink(path(value)),
+    remove: async (value, opts) => await fs.remove(path(value), opts),
+  }
+}
+
 async function withRealHome(run: (fs: FsLike, home: string) => Promise<void>): Promise<void> {
   const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-rollback-'))
   try {
@@ -443,6 +463,44 @@ describe('recovery orchestration', () => {
     const recordPath = home + '/.dsh-doctor/transactions/' + outcome.txnId + '.json'
     expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
     expect(await fs.readText(home + '/profiles/web/cordis.patch.yml')).toBe('bad: [unclosed\n')
+  })
+
+  it('rolls back when the first transaction record write fails after promote', async () => {
+    const fs = withPortablePaths(createMemoryFs())
+    const home = '/h'
+    const txnId = 'web-20260101000000'
+    const livePath = join(home, 'profiles', 'web')
+    const recordPath = join(home, '.dsh-doctor', 'transactions', txnId + '.json')
+    const quarantinePath = join(home, '.dsh-doctor', 'quarantine', 'web', txnId, 'original')
+    const discardedPath = join(home, 'profiles', '.doctor-staging', 'web', txnId + '.discarded')
+    await fs.mkdir(livePath, { recursive: true })
+    await fs.writeText(join(livePath, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } }, name: 'web' }))
+    await fs.writeText(join(livePath, 'cordis.patch.yml'), 'bad: [unclosed\n')
+
+    const originalRename = fs.rename.bind(fs)
+    let interrupted = false
+    const interruptedFs: FsLike = {
+      ...fs,
+      async rename(from, to) {
+        if (!interrupted && to === recordPath && from.startsWith(recordPath + '.tmp-')) {
+          interrupted = true
+          throw new Error('injected post-promote transaction write failure')
+        }
+        await originalRename(from, to)
+      },
+    }
+
+    const outcome = await repairProfile({ ...request(interruptedFs, home), gate: fakeGates({}).gates })
+
+    expect(interrupted, outcome.message).toBe(true)
+    expect(outcome).toMatchObject({ ok: false, phase: 'failed' })
+    expect(outcome.message).toContain('injected post-promote transaction write failure')
+    expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+    expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
+    expect(await fs.exists(quarantinePath)).toBe(false)
+    expect(await fs.exists(discardedPath)).toBe(false)
+    const journal = createJournal({ fs, file: join(home, '.dsh-doctor', 'journal.jsonl'), now: () => '2026-01-01T00:00:00Z' })
+    expect((await journal.replay()).entries.some((entry) => entry.op === 'repair:post-promote-rollback')).toBe(true)
   })
 })
 

--- a/packages/dsh-doctor/tests/core-recover.spec.ts
+++ b/packages/dsh-doctor/tests/core-recover.spec.ts
@@ -189,6 +189,75 @@ describe('recovery orchestration', () => {
     })
   })
 
+  it('finalizes a rollback interrupted after restoring quarantine to live', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath, recordPath } = await seedPromotedTransaction(fs, home, txnId)
+      const discardedPath = livePath + '.doctor-discarded-' + txnId
+      await fs.rename(livePath, discardedPath)
+      await fs.rename(quarantinePath, livePath)
+
+      const outcome = await rollbackTransaction({ ...request(fs, home) }, txnId)
+
+      expect(outcome).toMatchObject({ ok: true, phase: 'rolled-back' })
+      expect(outcome.message).toContain('interrupted rollback')
+      expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+      expect(await fs.exists(quarantinePath)).toBe(false)
+      expect(await fs.exists(discardedPath)).toBe(false)
+    })
+  })
+
+  it('retries finalization when the interrupted rollback record write fails', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath, recordPath } = await seedPromotedTransaction(fs, home, txnId)
+      const discardedPath = livePath + '.doctor-discarded-' + txnId
+      await fs.rename(livePath, discardedPath)
+      await fs.rename(quarantinePath, livePath)
+      const originalRename = fs.rename.bind(fs)
+      let interrupted = false
+      const interruptedFs: FsLike = {
+        ...fs,
+        async rename(from, to) {
+          if (!interrupted && to === recordPath && from.startsWith(recordPath + '.tmp-')) {
+            interrupted = true
+            throw new Error('injected interrupted-finalize record failure')
+          }
+          await originalRename(from, to)
+        },
+      }
+
+      const failed = await rollbackTransaction({ ...request(interruptedFs, home) }, txnId)
+      expect(failed).toMatchObject({ ok: false, phase: 'failed' })
+      expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'promoted' })
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+      expect(await fs.exists(discardedPath)).toBe(true)
+
+      const retried = await rollbackTransaction({ ...request(fs, home) }, txnId)
+      expect(retried).toMatchObject({ ok: true, phase: 'rolled-back' })
+      expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
+      expect(await fs.exists(discardedPath)).toBe(false)
+    })
+  })
+
+  it('resumes a rollback interrupted after displacing the promoted profile', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath, recordPath } = await seedPromotedTransaction(fs, home, txnId)
+      const discardedPath = livePath + '.doctor-discarded-' + txnId
+      await fs.rename(livePath, discardedPath)
+
+      const outcome = await rollbackTransaction({ ...request(fs, home) }, txnId)
+
+      expect(outcome).toMatchObject({ ok: true, phase: 'rolled-back' })
+      expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+      expect(await fs.exists(quarantinePath)).toBe(false)
+      expect(await fs.exists(discardedPath)).toBe(false)
+    })
+  })
+
   it('serializes concurrent rollbacks and rereads the record after locking', async () => {
     await withRealHome(async (fs, home) => {
       const txnId = 'web-20260101000000'
@@ -463,6 +532,53 @@ describe('recovery orchestration', () => {
     const recordPath = home + '/.dsh-doctor/transactions/' + outcome.txnId + '.json'
     expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
     expect(await fs.readText(home + '/profiles/web/cordis.patch.yml')).toBe('bad: [unclosed\n')
+  })
+
+  it('does not compensate a promoted profile after both lock generations are replaced', async () => {
+    const fs = withPortablePaths(createMemoryFs())
+    const home = '/h'
+    const livePath = join(home, 'profiles', 'web')
+    const txnId = 'web-20260101000000'
+    const recordPath = join(home, '.dsh-doctor', 'transactions', txnId + '.json')
+    const quarantinePath = join(home, '.dsh-doctor', 'quarantine', 'web', txnId, 'original')
+    await fs.mkdir(livePath, { recursive: true })
+    await fs.writeText(join(livePath, 'package.json'), JSON.stringify({ name: 'web', dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } } }))
+    await fs.writeText(join(livePath, 'cordis.patch.yml'), 'bad: [unclosed\n')
+    const { gates: baseGates } = fakeGates({})
+    const originalSpawn = baseGates.client.spawn.bind(baseGates.client)
+    let spawnCalls = 0
+    const gates: GateDeps = {
+      ...baseGates,
+      client: {
+        spawn(command, options) {
+          spawnCalls += 1
+          if (spawnCalls === 3) {
+            const replacement = JSON.stringify({
+              pid: 999,
+              host: 'replacement',
+              intent: 'replacement repair',
+              startedAt: 'replacement',
+              heartbeatAt: 1_700_000_000_000,
+              nonce: 'replacement',
+            }) + '\n'
+            // MemoryFs applies the write synchronously before its resolved
+            // promise is observed, matching a competing owner publication.
+            void fs.writeText(join(home, '.dsh-doctor', 'locks', 'global', 'token.json'), replacement)
+            void fs.writeText(join(home, '.dsh-doctor', 'locks', 'profile__web', 'token.json'), replacement)
+            throw new Error('injected live gate failure after lock replacement')
+          }
+          return originalSpawn(command, options)
+        },
+      },
+    }
+
+    const outcome = await repairProfile({ ...request(fs, home), gate: gates })
+
+    expect(outcome).toMatchObject({ ok: false, phase: 'failed' })
+    expect(outcome.message).toContain('ownership moved to a different nonce')
+    expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'promoted' })
+    expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toContain('quarantined a broken patch')
+    expect(await fs.readText(join(quarantinePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
   })
 
   it('rolls back when the first transaction record write fails after promote', async () => {

--- a/packages/dsh-doctor/tests/core-recover.spec.ts
+++ b/packages/dsh-doctor/tests/core-recover.spec.ts
@@ -78,7 +78,7 @@ async function seedPromotedTransaction(fs: FsLike, home: string, txnId = 'web-20
   await fs.writeText(join(quarantinePath, 'package.json'), JSON.stringify({ name: 'web', dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } } }))
   await fs.writeText(join(quarantinePath, 'cordis.patch.yml'), 'bad: [unclosed\n')
   await fs.mkdir(join(home, '.dsh-doctor', 'transactions'), { recursive: true })
-  await fs.writeText(recordPath, JSON.stringify({ txnId, profile: 'web', phase: 'promoted', livePath, stagingPath: join(home, 'staging', txnId), quarantinePath, steps: [] }, null, 2) + '\n')
+  await fs.writeText(recordPath, JSON.stringify({ txnId, profile: 'web', phase: 'promoted', livePath, stagingPath: join(home, 'profiles', '.doctor-staging', 'web', txnId), quarantinePath, steps: [] }, null, 2) + '\n')
   return { livePath, quarantinePath, recordPath }
 }
 
@@ -172,6 +172,49 @@ describe('recovery orchestration', () => {
     const outcome = await diagnoseAndPlan(request(fs, home))
     expect(outcome.phase).toBe('noop')
     expect(outcome.ok).toBe(true)
+  })
+
+
+  it('restores a durable promotion interrupted between the two live renames', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const livePath = join(home, 'profiles', 'web')
+      const stagingPath = join(home, 'profiles', '.doctor-staging', 'web', txnId)
+      const quarantinePath = join(home, '.dsh-doctor', 'quarantine', 'web', txnId, 'original')
+      const recordPath = join(home, '.dsh-doctor', 'transactions', txnId + '.json')
+      await fs.mkdir(stagingPath, { recursive: true })
+      await fs.writeText(join(stagingPath, 'package.json'), '{"name":"web","version":2}')
+      await fs.mkdir(quarantinePath, { recursive: true })
+      await fs.writeText(join(quarantinePath, 'package.json'), '{"name":"web","version":1}')
+      await fs.mkdir(join(home, '.dsh-doctor', 'transactions'), { recursive: true })
+      await fs.writeText(recordPath, JSON.stringify({ txnId, profile: 'web', phase: 'staged', livePath, stagingPath, quarantinePath, steps: [] }) + '\n')
+
+      const outcome = await rollbackTransaction({ ...request(fs, home) }, txnId)
+
+      expect(outcome).toMatchObject({ ok: true, phase: 'rolled-back' })
+      expect(outcome.message).toContain('interrupted before candidate activation')
+      expect(await fs.readText(join(livePath, 'package.json'))).toBe('{"name":"web","version":1}')
+      expect(await fs.exists(stagingPath)).toBe(false)
+      expect(await fs.exists(quarantinePath)).toBe(false)
+      expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
+    })
+  })
+
+  it('finalizes an interrupted in-process rollback using the shared discard path', async () => {
+    await withRealHome(async (fs, home) => {
+      const txnId = 'web-20260101000000'
+      const { livePath, quarantinePath, recordPath } = await seedPromotedTransaction(fs, home, txnId)
+      const discardedPath = livePath + '.doctor-discarded-' + txnId
+      await fs.rename(livePath, discardedPath)
+      await fs.rename(quarantinePath, livePath)
+
+      const outcome = await rollbackTransaction({ ...request(fs, home) }, txnId)
+
+      expect(outcome).toMatchObject({ ok: true, phase: 'rolled-back' })
+      expect(await fs.exists(discardedPath)).toBe(false)
+      expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
+      expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
+    })
   })
 
   it('persists a rollback and treats a repeated request as a no-op', async () => {
@@ -581,14 +624,14 @@ describe('recovery orchestration', () => {
     expect(await fs.readText(join(quarantinePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
   })
 
-  it('rolls back when the first transaction record write fails after promote', async () => {
+  it('does not mutate live when the durable promotion-intent write fails', async () => {
     const fs = withPortablePaths(createMemoryFs())
     const home = '/h'
     const txnId = 'web-20260101000000'
     const livePath = join(home, 'profiles', 'web')
     const recordPath = join(home, '.dsh-doctor', 'transactions', txnId + '.json')
     const quarantinePath = join(home, '.dsh-doctor', 'quarantine', 'web', txnId, 'original')
-    const discardedPath = join(home, 'profiles', '.doctor-staging', 'web', txnId + '.discarded')
+    const discardedPath = livePath + '.doctor-discarded-' + txnId
     await fs.mkdir(livePath, { recursive: true })
     await fs.writeText(join(livePath, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } }, name: 'web' }))
     await fs.writeText(join(livePath, 'cordis.patch.yml'), 'bad: [unclosed\n')
@@ -612,11 +655,10 @@ describe('recovery orchestration', () => {
     expect(outcome).toMatchObject({ ok: false, phase: 'failed' })
     expect(outcome.message).toContain('injected post-promote transaction write failure')
     expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
-    expect(JSON.parse(await fs.readText(recordPath))).toMatchObject({ phase: 'rolled-back' })
+    expect(await fs.exists(recordPath)).toBe(false)
     expect(await fs.exists(quarantinePath)).toBe(false)
     expect(await fs.exists(discardedPath)).toBe(false)
-    const journal = createJournal({ fs, file: join(home, '.dsh-doctor', 'journal.jsonl'), now: () => '2026-01-01T00:00:00Z' })
-    expect((await journal.replay()).entries.some((entry) => entry.op === 'repair:post-promote-rollback')).toBe(true)
+    expect(await fs.readText(join(livePath, 'cordis.patch.yml'))).toBe('bad: [unclosed\n')
   })
 })
 

--- a/packages/dsh-doctor/tests/core-transaction.spec.ts
+++ b/packages/dsh-doctor/tests/core-transaction.spec.ts
@@ -1,8 +1,11 @@
 /**
  * Candidate transaction: stage, promote, rollback, abort.
  */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { createMemoryFs, FsError } from '../src/core/fs.ts'
+import { createMemoryFs, FsError, nodeFs, type FsLike } from '../src/core/fs.ts'
 import { createCandidateTransaction } from '../src/core/transaction.ts'
 
 const HOME = '/h'
@@ -70,6 +73,41 @@ describe('candidate transaction', () => {
     expect(await fs.exists('/h/.dsh-doctor/quarantine/web/web-20260821230000/original')).toBe(false)
   })
 
+  it('puts the promoted profile back when restoring quarantine fails', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-transaction-'))
+    try {
+      const live = join(home, 'profiles', 'web')
+      await nodeFs.mkdir(live, { recursive: true })
+      await nodeFs.writeText(join(live, 'package.json'), '{"name":"web"}')
+      const originalRename = nodeFs.rename.bind(nodeFs)
+      let failRestore = false
+      let quarantine = ''
+      let livePath = ''
+      const failingFs: FsLike = {
+        ...nodeFs,
+        async rename(from, to) {
+          if (failRestore && from === quarantine && to === livePath) throw new FsError('EBUSY', to, 'injected')
+          await originalRename(from, to)
+        },
+      }
+      const txn = createCandidateTransaction({ fs: failingFs, home, profile: 'web', now: () => '2026-08-21T23:00:00.000Z', txnId: () => 'web-20260821230000' })
+      quarantine = txn.record.quarantinePath
+      livePath = txn.record.livePath
+      await txn.stage()
+      await nodeFs.writeText(join(txn.record.stagingPath, 'package.json'), '{"name":"web","version":2}')
+      await txn.promote()
+      failRestore = true
+
+      await expect(txn.rollback()).rejects.toThrow('injected')
+      expect(txn.phase()).toBe('promoted')
+      expect(await nodeFs.readText(join(live, 'package.json'))).toBe('{"name":"web","version":2}')
+      expect(await nodeFs.exists(join(quarantine, 'package.json'))).toBe(true)
+      expect(await nodeFs.exists(txn.record.stagingPath + '.discarded')).toBe(false)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   it('abort before promote discards staging and touches nothing else', async () => {
     const fs = createMemoryFs()
     await seedLive(fs)
@@ -130,4 +168,3 @@ describe('candidate transaction', () => {
     await expect(txn.commit()).rejects.toMatchObject({ code: 'TXN_STATE' })
   })
 })
-

--- a/packages/dsh-doctor/tests/core-transaction.spec.ts
+++ b/packages/dsh-doctor/tests/core-transaction.spec.ts
@@ -61,6 +61,39 @@ describe('candidate transaction', () => {
 `)
   })
 
+  it.each(['promote-quarantine', 'promote-activate'] as const)('restores the original when %s journaling fails', async (failedStep) => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-promote-journal-'))
+    try {
+      const live = join(home, 'profiles', 'web')
+      await nodeFs.mkdir(live, { recursive: true })
+      await nodeFs.writeText(join(live, 'package.json'), '{"name":"web"}')
+      const txn = createCandidateTransaction({
+        fs: nodeFs,
+        home,
+        profile: 'web',
+        now: () => '2026-08-21T23:00:00.000Z',
+        txnId: () => 'web-20260821230000',
+        journal: {
+          async append(entry) {
+            if (entry.op.endsWith(':' + failedStep)) throw new Error('injected ' + failedStep + ' journal failure')
+            return undefined
+          },
+        },
+      })
+      await txn.stage()
+      await nodeFs.writeText(join(txn.record.stagingPath, 'package.json'), '{"name":"web","version":2}')
+
+      await expect(txn.promote()).rejects.toThrow('injected ' + failedStep + ' journal failure')
+      expect(txn.phase()).toBe('rolled-back')
+      expect(await nodeFs.readText(join(live, 'package.json'))).toBe('{"name":"web"}')
+      expect(await nodeFs.exists(txn.record.quarantinePath)).toBe(false)
+      expect(await nodeFs.exists(txn.record.stagingPath)).toBe(false)
+      expect(await nodeFs.exists(txn.record.stagingPath + '.discarded')).toBe(false)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   it('rollback restores the quarantined original', async () => {
     const fs = createMemoryFs()
     await seedLive(fs)
@@ -166,5 +199,37 @@ describe('candidate transaction', () => {
     await seedLive(fs)
     const { txn } = makeTxn(fs)
     await expect(txn.commit()).rejects.toMatchObject({ code: 'TXN_STATE' })
+  })
+
+  it('remains rollback-capable when commit journaling fails', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-commit-'))
+    try {
+      const live = join(home, 'profiles', 'web')
+      await nodeFs.mkdir(live, { recursive: true })
+      await nodeFs.writeText(join(live, 'package.json'), '{"name":"web"}')
+      const txn = createCandidateTransaction({
+        fs: nodeFs,
+        home,
+        profile: 'web',
+        now: () => '2026-08-21T23:00:00.000Z',
+        txnId: () => 'web-20260821230000',
+        journal: {
+          async append(entry) {
+            if (entry.op.endsWith(':commit')) throw new Error('injected commit journal failure')
+            return undefined
+          },
+        },
+      })
+      await txn.stage()
+      await txn.promote()
+
+      await expect(txn.commit()).rejects.toThrow('injected commit journal failure')
+      expect(txn.phase()).toBe('promoted')
+      await txn.rollback()
+      expect(txn.phase()).toBe('rolled-back')
+      expect(await nodeFs.readText(join(live, 'package.json'))).toBe('{"name":"web"}')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/dsh-doctor/tests/core-transaction.spec.ts
+++ b/packages/dsh-doctor/tests/core-transaction.spec.ts
@@ -94,6 +94,52 @@ describe('candidate transaction', () => {
     }
   })
 
+  it.each(['promote-quarantine', 'promote-activate'] as const)('does not compensate %s failure after ownership is lost', async (failedStep) => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-doctor-promote-owner-'))
+    try {
+      const live = join(home, 'profiles', 'web')
+      await nodeFs.mkdir(live, { recursive: true })
+      await nodeFs.writeText(join(live, 'package.json'), '{"name":"web"}')
+      let compensationChecks = 0
+      const txn = createCandidateTransaction({
+        fs: nodeFs,
+        home,
+        profile: 'web',
+        now: () => '2026-08-21T23:00:00.000Z',
+        txnId: () => 'web-20260821230000',
+        beforeCompensation: async () => {
+          compensationChecks += 1
+          throw new Error('injected lost ownership')
+        },
+        journal: {
+          async append(entry) {
+            if (entry.op.endsWith(':' + failedStep)) throw new Error('injected ' + failedStep + ' journal failure')
+            return undefined
+          },
+        },
+      })
+      await txn.stage()
+      await nodeFs.writeText(join(txn.record.stagingPath, 'package.json'), '{"name":"web","version":2}')
+
+      await expect(txn.promote()).rejects.toThrow('injected lost ownership')
+
+      expect(compensationChecks).toBe(1)
+      expect(await nodeFs.readText(join(txn.record.quarantinePath, 'package.json'))).toBe('{"name":"web"}')
+      expect(await nodeFs.exists(txn.record.stagingPath + '.discarded')).toBe(false)
+      if (failedStep === 'promote-quarantine') {
+        expect(txn.phase()).toBe('failed')
+        expect(await nodeFs.exists(live)).toBe(false)
+        expect(await nodeFs.readText(join(txn.record.stagingPath, 'package.json'))).toBe('{"name":"web","version":2}')
+      } else {
+        expect(txn.phase()).toBe('promoted')
+        expect(await nodeFs.readText(join(live, 'package.json'))).toBe('{"name":"web","version":2}')
+        expect(await nodeFs.exists(txn.record.stagingPath)).toBe(false)
+      }
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   it('rollback restores the quarantined original', async () => {
     const fs = createMemoryFs()
     await seedLive(fs)

--- a/packages/dsh-doctor/tests/core-transaction.spec.ts
+++ b/packages/dsh-doctor/tests/core-transaction.spec.ts
@@ -29,6 +29,7 @@ function makeTxn(fs: ReturnType<typeof createMemoryFs>, txnId = 'web-20260821230
       profile: 'web',
       now: () => '2026-08-21T23:00:00.000Z',
       txnId: () => txnId,
+      beforePromote: async () => undefined,
       journal: { append: async (entry) => { journalEntries.push(entry) } },
     }),
     journalEntries,
@@ -73,6 +74,7 @@ describe('candidate transaction', () => {
         profile: 'web',
         now: () => '2026-08-21T23:00:00.000Z',
         txnId: () => 'web-20260821230000',
+        beforePromote: async () => undefined,
         journal: {
           async append(entry) {
             if (entry.op.endsWith(':' + failedStep)) throw new Error('injected ' + failedStep + ' journal failure')
@@ -107,6 +109,7 @@ describe('candidate transaction', () => {
         profile: 'web',
         now: () => '2026-08-21T23:00:00.000Z',
         txnId: () => 'web-20260821230000',
+        beforePromote: async () => undefined,
         beforeCompensation: async () => {
           compensationChecks += 1
           throw new Error('injected lost ownership')
@@ -169,7 +172,7 @@ describe('candidate transaction', () => {
           await originalRename(from, to)
         },
       }
-      const txn = createCandidateTransaction({ fs: failingFs, home, profile: 'web', now: () => '2026-08-21T23:00:00.000Z', txnId: () => 'web-20260821230000' })
+      const txn = createCandidateTransaction({ fs: failingFs, home, profile: 'web', now: () => '2026-08-21T23:00:00.000Z', txnId: () => 'web-20260821230000', beforePromote: async () => undefined })
       quarantine = txn.record.quarantinePath
       livePath = txn.record.livePath
       await txn.stage()
@@ -220,7 +223,7 @@ describe('candidate transaction', () => {
         return originalRename(from, to)
       },
     }
-    const failed = createCandidateTransaction({ fs: fsSabotaged, home: HOME, profile: 'web', now: () => '2026-08-21T23:00:00.000Z', txnId: () => 'web-20260821230000' })
+    const failed = createCandidateTransaction({ fs: fsSabotaged, home: HOME, profile: 'web', now: () => '2026-08-21T23:00:00.000Z', txnId: () => 'web-20260821230000', beforePromote: async () => undefined })
     await failed.stage()
     await expect(failed.promote()).rejects.toMatchObject({ code: 'TXN_STATE' })
     expect(await fs.exists(LIVE + '/package.json')).toBe(true)
@@ -259,6 +262,7 @@ describe('candidate transaction', () => {
         profile: 'web',
         now: () => '2026-08-21T23:00:00.000Z',
         txnId: () => 'web-20260821230000',
+        beforePromote: async () => undefined,
         journal: {
           async append(entry) {
             if (entry.op.endsWith(':commit')) throw new Error('injected commit journal failure')


### PR DESCRIPTION
## 摘要（Summary）

整合并保留 PR #939 的全部 contributor commits，在此基础上修复 #958 的两个 hard-kill recovery 窗口：promotion 第一处 live rename 前原子持久化 recovery intent；in-process 与 CLI rollback 共用唯一 discard 路径。staged transaction 的安全布局现在可以由下一次 rollback 自动取消、恢复或 finalize，歧义布局继续 fail closed。

Fixes #960

Refs #958 (auto-closed by form image gate)
Supersedes #939 while preserving Vikky / @Nath-Vikky as the author of its three original commits.

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-doctor`

## PR 类别（PR Category）

- [x] 维护 / 其他

## PR 类型（PR Type）

- [x] Bug 修复
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin && git rebase origin/dev`（同步到 `8eb884efe` 后重新执行全部门禁）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支，并附上同步后重新测试通过的证据。

## 视觉修复要求（Visual Fix Requirements）

不适用：host recovery core，无视觉改动。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：GPT-5.6

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（本 PR 未改 README；`pnpm docs:check` 通过）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-doctor typecheck
pnpm --filter @linxin666/dsh-doctor test
pnpm --filter @linxin666/dsh-doctor build
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
pnpm runtime-deps:check
codegraph sync /tmp/dsh-web-ui-issue-958
codegraph status /tmp/dsh-web-ui-issue-958
```

结果摘要：

- dsh-doctor：26 files / 260 tests 通过；typecheck、build 通过。
- 新增/聚焦 recovery suite：3 files / 41 tests 通过，包含 interrupted promote 和 shared discard finalize。
- 全仓 typecheck / tests / 153 script tests / docs / runtime-deps 全部通过。
- CodeGraph：887 files，index up to date。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A。改动仅影响进程被硬终止后的 host recovery 数据安全；fault-injection tests 是可执行证据。

