### PR TITLE
chore(web-ui-all): upgrade dsh-better-sidebar to 0.15.2

### DIFF
--- a/docs/publish-prep.md
+++ b/docs/publish-prep.md
@@ -87,9 +87,10 @@ npm 侧已发布 @deepseek-ai 核心 SDK 包至 `0.1.0-rc.6`，插件包仍按�
 2. 发布前仍需处理：移除 `private: true`（11 包）；
 3. 按依赖顺序发布（用 **`pnpm publish`**，自动改写 workspace:*）：
    各功能包 > skin-center > web-ui-all；
-4. **外部依赖先行**：web-ui-all 的 dependencies 含 `dsh-better-sidebar`（0.14.0，
-   非本仓库出品，已发布并适配 rc.8 官方 SDK cohort）与 `@mlgbnb/dsh-archive-manager`
-   （1.0.7，社区插件，已发布），其版本必须已在 npm 上可解析，再更新 lockfile；
+4. **外部依赖先行**：web-ui-all 的 dependencies 含 `dsh-better-sidebar`（0.15.2，
+   非本仓库出品，已发布并适配 0.1.0-rc.8 – 0.1.1-rc.2 官方 SDK cohort）与
+   `@mlgbnb/dsh-archive-manager`（1.0.7，社区插件，已发布），其版本必须已在 npm
+   上可解析，再更新 lockfile；
 5. 逐包 `pnpm pack --dry-run` 复核 tarball 内容（注意：dry-run 仍会执行
    prepack/prepare 脚本）；
 6. 发布动作前**必须**经维护者确认。

--- a/packages/dsh-web-ui-all/package.json
+++ b/packages/dsh-web-ui-all/package.json
@@ -54,6 +54,6 @@
     "@linxin666/dsh-client-ui-web-ui-settings": "workspace:*",
     "@linxin666/dsh-client-ui-skin-center": "workspace:*",
     "@mlgbnb/dsh-archive-manager": "1.0.7",
-    "dsh-better-sidebar": "0.14.0"
+    "dsh-better-sidebar": "0.15.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,8 +1090,8 @@ importers:
         specifier: 1.0.7
         version: 1.0.7(react@18.3.1)
       dsh-better-sidebar:
-        specifier: 0.14.0
-        version: 0.14.0(bc87b4acea0ead060a176b8af9a1b6b3)
+        specifier: 0.15.2
+        version: 0.15.2(96d11d43015a66f723a480d8d38ac93f)
 
   packages/dsh-web-ui-settings:
     dependencies:
@@ -3209,8 +3209,8 @@ packages:
   dompurify@3.4.14:
     resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
-  dsh-better-sidebar@0.14.0:
-    resolution: {integrity: sha512-bEjHvHnlNnKXkud+/A/kZ4VJvPt79ggHy/mKqEKfODPqLFpvdz7ZcoMCI3K4naPOw/0Wlqp6J3UDR9h2Wm6w4w==}
+  dsh-better-sidebar@0.15.2:
+    resolution: {integrity: sha512-XHr7cAqxz1k60D3W9q5VAuZ64kGhnZz9M4etBaRDNNCzuJZbJTvQ/Fzgl8mY06B/PpEcgzG6PTn2RMYF3FVnGQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
@@ -3226,6 +3226,7 @@ packages:
       '@deepseek-ai/dsh-llm': ^0.1.0-rc.8
       '@deepseek-ai/dsh-session': ^0.1.0-rc.8
       '@deepseek-ai/dsh-settings': ^0.1.0-rc.8
+      '@deepseek-ai/dsh-subagent': ^0.1.0-rc.8
       '@deepseek-ai/dsh-tools': ^0.1.0-rc.8
       cordis: ^4.0.0-rc.8
       react: ^18.2.0
@@ -3920,6 +3921,11 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-icons@5.7.0:
+    resolution: {integrity: sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==}
+    peerDependencies:
+      react: '*'
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -6381,7 +6387,7 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  dsh-better-sidebar@0.14.0(bc87b4acea0ead060a176b8af9a1b6b3):
+  dsh-better-sidebar@0.15.2(96d11d43015a66f723a480d8d38ac93f):
     dependencies:
       '@codemirror/commands': 6.11.0
       '@codemirror/lang-cpp': 6.0.3
@@ -6416,6 +6422,7 @@ snapshots:
       '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-session': 0.1.1-rc.2(a4e4bb24a1f3580ac25e11cfa3c6b8cc)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-subagent': 0.1.1-rc.2(51b2911aec7da0c04a92805cdc38e745)
       '@deepseek-ai/dsh-tools': 0.1.1-rc.2(13a42363b0c37666f1c8e3895ba4ab6e)
       '@lezer/highlight': 1.2.3
       clsx: 2.1.1
@@ -6423,6 +6430,7 @@ snapshots:
       node-pty: 1.1.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+      react-icons: 5.7.0(react@18.3.1)
       rxjs: 7.8.2
       schemastery: 3.18.0
       ws: 8.21.3
@@ -7324,6 +7332,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-icons@5.7.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@17.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,10 +65,10 @@ minimumReleaseAgeExclude:
   - '@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2'
   - '@deepseek-ai/dsh-user-questions@0.1.1-rc.2'
   - '@deepseek-ai/schemastery@3.18.1'
-  # The aggregate bundle pins dsh-better-sidebar at exactly 0.14.0; pnpm 11's
+  # The aggregate bundle pins dsh-better-sidebar at exactly 0.15.2; pnpm 11's
   # minimum-release-age guard must not reject the fresh version. Scoped to
   # that exact version so later upstream publishes get no cooldown bypass.
-  - 'dsh-better-sidebar@0.14.0'
+  - 'dsh-better-sidebar@0.15.2'
   # The aggregate bundle mounts @mlgbnb/dsh-archive-manager at exactly 1.0.7;
   # pnpm 11's minimum-release-age guard must not reject the fresh version.
   # Scoped to that exact version so later upstream publishes get no cooldown bypass.


### PR DESCRIPTION
## 摘要（Summary）

将聚合包 `@linxin666/dsh-web-ui-all` 锁定的外部插件 `dsh-better-sidebar` 从 `0.14.0` 升级到最新上游 `0.15.2`（文件树「在应用中打开」、Tab 右键菜单、Diff 默认折叠、Windows 隐藏 Git 子进程窗口、未跟踪文件夹内文件差异、开关/拖拽每帧重渲染优化）。0.15.2 仍处在本仓库支持的 DSH 运行时区间（0.1.0-rc.8 – 0.1.1-rc.2），因此无需任何代码或 patch 改动；同步更新 pnpm 11 的 minimum-release-age 豁免、pnpm-lock.yaml 与发布准备文档。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [x] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [x] 其他（请说明）：根 `pnpm-workspace.yaml`（minimum-release-age 豁免）与 `docs/publish-prep.md`（外部依赖版本说明）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [ ] 社区插件索引
- [x] 维护 / 其他（外部依赖版本升级）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构（依赖升级）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：分支直接从 `git fetch origin` 后的最新 `origin/dev`（b6fea32d）创建，提交前已再次 fetch 确认无新增提交；无需 rebase。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

不适用：本 PR 未勾选「视觉修复」，也无用户可见行为变更（纯依赖版本升级）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改 README；已运行 `pnpm docs:check` 等价项 `node scripts/verify-docs.mjs` 通过。）

## 贡献者版权声明（Contributor Copyright）

不适用：非插件 / 皮肤贡献。

## 新皮肤收录（New Skin）

不适用：非皮肤 PR。

## 社区插件索引登记（Community Plugin Index）

不适用：非社区插件接入。

## 本地验证（Local Validation）

执行的命令：

```bash
# 基于 origin/dev b6fea32d + 本次提交 67bb2f06
pnpm install
pnpm typecheck
pnpm test
node --test scripts/*.test.mjs
node scripts/verify-docs.mjs
node scripts/aggregate.mjs --check
node scripts/runtime-deps-check.mjs
pnpm --filter @linxin666/dsh-web-ui-all build
```

结果摘要：

- `pnpm install`：成功；lockfile 更新为 dsh-better-sidebar 0.15.2（含新增 `@deepseek-ai/dsh-subagent` peer 与 `react-icons` 依赖）
- `pnpm typecheck`：通过
- `pnpm test`：通过（全仓 vitest 各包测试全绿）
- `node --test scripts/*.test.mjs`：159/159 通过（注：本机 `pnpm run` 会注入 npm_config_*（electron target 等），使依赖子进程 spawn 的 dsh-pet / community-index 用例假失败；直接用 node 运行全部通过，GitHub Actions 干净环境无此问题）
- `node scripts/verify-docs.mjs`：通过（all documentation gates passed）
- `node scripts/aggregate.mjs --check`：`check OK: packages/dsh-web-ui-all (18 row(s), 17 dep(s))`，外部 better-sidebar 行保持
- `node scripts/runtime-deps-check.mjs`：通过（2 个 lib 包）
- `pnpm --filter @linxin666/dsh-web-ui-all build`：通过

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（纯依赖版本升级，无用户可见行为变更；升级后的实际界面行为由 0.15.2 上游发布与其自身测试覆盖）
