### PR TITLE
feat(community-plugins): register miku-pet in the community plugin index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -407,6 +407,17 @@
       "repo": "https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-session-id",
       "npm": "@linxin666/dsh-client-ui-session-id",
       "category": "ui"
+    },
+    {
+      "id": "miku-pet",
+      "name": "Miku 桌宠",
+      "rank": 36,
+      "nameEn": "Miku Pet",
+      "author": "stushansusu",
+      "description": "只属于 Miku 的浮动桌宠：手绘风帧动画，5s 随机待机（连漏 2 次必演）、连续工作赚金币、商店恢复饥饿、属性彩条与两级悬停菜单；路由 /miku-pet 与内置 dsh-pet 共存。",
+      "descriptionEn": "A floating pet exclusively for Miku: hand-drawn frame animations, 5s random idle with a pity timer, a continuous work loop earning coins, a shop restoring hunger, stat bars and a two-level hover menu; coexists with the built-in dsh-pet under the /miku-pet namespace.",
+      "repo": "https://github.com/stushansusu/miku-pet",
+      "category": "ui"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -367,5 +367,15 @@
     "repo": "https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-session-id",
     "npm": "@linxin666/dsh-client-ui-session-id",
     "category": "ui"
+  },
+  {
+    "id": "miku-pet",
+    "name": "Miku 桌宠",
+    "nameEn": "Miku Pet",
+    "author": "stushansusu",
+    "description": "只属于 Miku 的浮动桌宠：手绘风帧动画，5s 随机待机（连漏 2 次必演）、连续工作赚金币、商店恢复饥饿、属性彩条与两级悬停菜单；路由 /miku-pet 与内置 dsh-pet 共存。",
+    "descriptionEn": "A floating pet exclusively for Miku: hand-drawn frame animations, 5s random idle with a pity timer, a continuous work loop earning coins, a shop restoring hunger, stat bars and a two-level hover menu; coexists with the built-in dsh-pet under the /miku-pet namespace.",
+    "repo": "https://github.com/stushansusu/miku-pet",
+    "category": "ui"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

将 `miku-pet`（Miku 桌宠插件，独立开源在 https://github.com/stushansusu/miku-pet）登记进社区插件索引：在 `packages/dsh-community-plugins/community.json` 追加条目，并按当前 `docs/plugins.md` 的登记流程重生成 `market/dist/manifest/plugins.json`。仅新增索引链接、不搬代码（本仓库惯例），条目指向作者独立仓库。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-community-plugins`（`community.json` 追加条目）+ `market/dist/manifest/plugins.json`（生成物）

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```
git fetch origin && git rebase origin/dev
```

本 PR 基于 `origin/dev`（01d18fb7）新建分支 `feat/miku-pet`，无落后。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

本地已执行：

```bash
node scripts/community-index           # community-index: OK (36 entries)
node scripts/community-index --check   # OK (36 entries)，CI 门禁同款校验通过
```

- `market/dist/manifest/plugins.json` 已按 `scripts/market-build` 的 `scanPlugins` + `mk` 生成逻辑重写（36 条，`rank: 36`，字段顺序与缩进格式与生成器一致）；本机未安装仓库依赖（`@deepseek-ai/dsh-settings` 等缺失）导致 `node scripts/market-build --check` 无法直接运行，且 `market:check` 不在 CI 门禁内，故以生成器逻辑复算代替
- 插件本体（独立仓库 `stushansusu/miku-pet`）已在本机 dsh web 实机挂载并 e2e 验证：拖拽循环、松手摔倒→站起、连续工作金币（+3/-1、下限 0）、商店购买与 0-100 夹取、饥饿衰减、两级悬停菜单、改名持久（localStorage）、双主题菜单白底黑字、台词气泡，全部通过

## 视觉修复要求（Visual Fix Requirements）

不适用（非视觉修复类 PR）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：

DeepSeek V4

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本 PR 未新增包目录）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改任何包 README）

## 贡献者版权声明（Contributor Copyright）

本 PR 仅登记第三方插件的索引链接，不贡献插件代码；插件源码与版权归作者仓库 https://github.com/stushansusu/miku-pet 所有（MIT，改编自 PC2005-cloud/dsh-pet）。

## 社区插件索引登记（Community Plugin Index）

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 校验通过（OK, 36 entries）。当前 dev 的登记流程（docs/plugins.md）：`community-index` 负责数据校验，`scripts/market-build` 将 community.json 派生为 `market/dist/manifest/plugins.json`（`community.ts` 生成物已随重构移除），本 PR 已按生成器逻辑重写并提交 `market/dist/manifest/plugins.json`。
- [x] 已确认插件与 dsh-web-ui 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本机 dsh web 挂载并正常运行（`/miku-pet/*` 路由 + client bundle，与内置 dsh-pet 共存无冲突）。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web-ui 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index
node scripts/community-index --check
# 插件本体（独立仓库 stushansusu/miku-pet，与本地开发目录同源）：
npm run bundle                  # esbuild 双入口构建通过
node _tmp/verify-menu.cjs       # 两级菜单 PASS
node _tmp/verify-rename.cjs     # 改名+持久 PASS
node _tmp/verify-work.cjs       # 连续工作+钱包(下限0) PASS
node _tmp/verify-shop.cjs       # 商店购买+0-100夹取 PASS
node _tmp/verify-theme-both.cjs # 双主题白底黑字 PASS
```

结果摘要：

- `node scripts/community-index`：`OK (36 entries)`（含新增 miku-pet 条目）
- `node scripts/community-index --check`：`OK (36 entries)`，通过
- `market/dist/manifest/plugins.json`：重写后 36 条，miku-pet 为 `rank: 36`，与生成器输出一致
- 插件 e2e 全部通过（含失败场景：金币不足拒绝、属性越界夹取）；本机 dsh web 实机挂载 `/miku-pet/*` 路由与客户端均正常

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A —— 本 PR 仅为社区插件索引登记（元数据 + 生成物），不涉及面向用户的功能或行为变更；插件使用说明与界面见作者仓库 README：https://github.com/stushansusu/miku-pet
