### PR TITLE
feat(community-plugins): register dsh-specify-subagent-suite in community index

### DIFF
--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -377,5 +377,16 @@
     "descriptionEn": "A floating pet exclusively for Miku: hand-drawn frame animations, 5s random idle with a pity timer, a continuous work loop earning coins, a shop restoring hunger, stat bars and a two-level hover menu; coexists with the built-in dsh-pet under the /miku-pet namespace.",
     "repo": "https://github.com/stushansusu/miku-pet",
     "category": "ui"
+  },
+  {
+    "id": "dsh-specify-subagent-suite",
+    "name": "子代理模板工具套件",
+    "nameEn": "Subagent Template Suite",
+    "author": "zach_tao",
+    "repo": "https://github.com/Cho-Geer/dsh-specify-subagent-suite",
+    "npm": "@zach-tao/dsh-specify-subagent-suite",
+    "description": "把 5 个子代理/工具模板合并为一个 Cordis 插件：右侧栏 Agent 列表 + 子代理模板面板 + 一次性 record 徽章 + subagent_pro/subagent_pro_audit。",
+    "descriptionEn": "Five resident DSH plugins merged into one Cordis bundle: right Agent list, subagent template panel, one-shot subagent record badge, and the subagent_pro / subagent_pro_presets / subagent_pro_audit tools.",
+    "category": "tools"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

在 community.json 中注册 @zach-tao/dsh-specify-subagent-suite 社区插件。该插件将 5 个 DSH 子代理相关插件合并为一个 Cordis bundle。

## 涉及包（Affected Packages）

- [ ] 其他（请说明）：packages/dsh-community-plugins（community.json 追加条目）

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：git fetch origin dev && git rebase origin/dev

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 社区插件索引登记（Community Plugin Index）

- [x] 已按 docs/plugins.md 的登记说明在 packages/dsh-community-plugins/community.json 追加条目，并运行 node scripts/community-index 验证通过（37 entries OK）。
- [x] 已确认插件与 dsh-web-ui 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 dsh.bundle.patch 指向 cordis.patch.yml、dsh.client 浏览器半区），类型仅基于官方 @deepseek-ai/* NPM SDK，未修改 DSH 源码；已在本仓库最新代码上验证插件可被 dsh web 挂载并正常运行。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web-ui 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index
pnpm --filter @linxin666/dsh-client-ui-community-plugins build
pnpm --filter @linxin666/dsh-client-ui-community-plugins test
pnpm --filter @linxin666/dsh-client-ui-community-plugins typecheck
```

结果摘要：

- community-index: OK (37 entries)
- Build: PASS
- Tests: 2/2 PASS
- Typecheck: PASS (no errors)

## 用户可见变更证据（Local Feature Evidence）

N/A（纯内部改动——community.json 条目追加，无用户可见 UI 变更。插件已在用户本地 DSH web profile 中安装并验证通过，五面检测 4.2a-e 全部 PASS。）