### PR TITLE
feat(community): add DSH Workbench Suite

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -4,7 +4,6 @@
     {
       "id": "dsh-data-agent",
       "name": "Data Agent",
-      "rank": 1,
       "nameEn": "Data Agent",
       "author": "omdsh-dev",
       "description": "为 DSH 定义专用 Data Agent 预设，让 AI 帮你查询、更新、分析数据。",
@@ -15,7 +14,6 @@
     {
       "id": "dsh-tui",
       "name": "dsh-TUI",
-      "rank": 2,
       "nameEn": "dsh-TUI",
       "author": "ccch1mneyyy",
       "description": "Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时工作状态行、思考流式展开、双击 Esc 回滚、上下文进度条与 TPS 仪表。",
@@ -27,7 +25,6 @@
     {
       "id": "dsh-tianshu-tui",
       "name": "天书 TUI",
-      "rank": 3,
       "nameEn": "Tianshu TUI",
       "author": "huiliyi37",
       "description": "基于官方 DeepSeek Harness 的交互式终端 UI 插件，在官方基础上增加 TDD 与证据门等工作流。",
@@ -38,7 +35,6 @@
     {
       "id": "dsh-builtin-toggles",
       "name": "内置能力检查器",
-      "rank": 4,
       "nameEn": "Built-in Capability Inspector",
       "author": "Starfie1d1272",
       "description": "Evidence-backed 内置 capability Inspector：展示 DSH Web built-in capability 的 provenance、compatibility 与 structural drift；仅对 9 个经过审阅的 UI leaves 提供 fail-closed 开关。",
@@ -50,7 +46,6 @@
     {
       "id": "dsh-pilot",
       "name": "Pilot 浏览器驾驶舱",
-      "rank": 5,
       "nameEn": "Pilot Browser Cockpit",
       "author": "guo6x",
       "description": "给 agent 一双会开车的手：零依赖 CDP 浏览器操控（8 个 pilot_* 工具：导航/点击/输入/按键/JS/截图）+ Web GUI 可拖拽驾驶舱面板，无需 Playwright、无需 API key。",
@@ -61,7 +56,6 @@
     {
       "id": "dsh-housekeeper",
       "name": "环境管家",
-      "rank": 6,
       "nameEn": "Environment Housekeeper",
       "author": "guo6x",
       "description": "管住 agent 的脏手：工具链台账（node/pnpm/git/gh/ffmpeg 等自动探测）、缓存与临时目录扫描 + 白名单安全一键清理、机器规则 AGENTS.md 查看编辑，全在设置面板完成。",
@@ -72,7 +66,6 @@
     {
       "id": "dsh-deepread",
       "name": "DeepRead 精读助手",
-      "rank": 7,
       "nameEn": "DeepRead Assistant",
       "author": "xiehuan123",
       "description": "五种模式精读插件（quick / deep / map / feynman / book），支持公众号链接与文件输入、批量对比、预算预检与后台任务进度透明，导出 md / mm / html，Web UI 提供工具结果卡片与精读面板。",
@@ -84,7 +77,6 @@
     {
       "id": "dsh-mnemon",
       "name": "Mnemon 记忆系统",
-      "rank": 8,
       "nameEn": "Mnemon Memory",
       "author": "omdsh-dev",
       "description": "与 Mnemon CLI 集成的跨 Agent、本地优先持久记忆插件：用户画像 / 工作记忆 / 项目档案与长期 Memory Spaces，支持导入导出。",
@@ -96,7 +88,6 @@
     {
       "id": "dsh-plugin-hub",
       "name": "插件中心（dsh-plugin-hub）",
-      "rank": 9,
       "nameEn": "Plugin Hub",
       "author": "Noob-stupid",
       "description": "插件管理面板：已安装插件一键启用/停用，内置 GitHub dsh-plugin 插件市场（官方/聚合识别、子包浏览、一键安装与本地 AI 兜底修复、删除卸载），版本检测与一键更新、框架一键升级。",
@@ -108,7 +99,6 @@
     {
       "id": "dsh-genui",
       "name": "GenUI 生成式 UI",
-      "rank": 10,
       "nameEn": "GenUI",
       "author": "omdsh-dev",
       "description": "给模型输出配交互式 UI：助手回复内联渲染 dsh-ui 围栏（布局、图表、表格、表单、Mermaid、3D、原生音视频），双通道渲染兼容原版 DSH 与新构建，支持流式渲染、面板停靠与组件交互回传模型。",
@@ -119,7 +109,6 @@
     {
       "id": "dsh-annotation",
       "name": "选中批注",
-      "rank": 11,
       "nameEn": "Selection Annotation",
       "author": "omdsh-dev",
       "description": "选中助手文字即可批注，回车随消息发送；自己的气泡只显示问题与「批注 ×N」标签，模型按 Annotation N 逐条对照回复（悬浮芯片）；UI 与批注块跟随 DSH 语言切换 zh/en，Cmd/Ctrl+Enter 可直发纯批注，斜杠命令原样放行。",
@@ -130,7 +119,6 @@
     {
       "id": "deepseek-harness-auth",
       "name": "DeepSeek Harness Auth",
-      "rank": 12,
       "nameEn": "DeepSeek Harness Auth",
       "author": "taichuy",
       "description": "为 DSH Web 公网部署提供登录认证前置代理，支持账号密码、验证码、失败锁定和 IP/CIDR 白名单。",
@@ -142,7 +130,6 @@
     {
       "id": "dsh-cloud-sync",
       "name": "云同步服务",
-      "rank": 13,
       "nameEn": "Cloud Sync",
       "author": "dickpy",
       "description": "支持 WebDAV、S3、阿里云 OSS、腾讯云 COS 与 MinIO 的 DSH 云同步插件，可同步 profile、插件配置及本地插件源码归档。",
@@ -154,7 +141,6 @@
     {
       "id": "dsh-auto-memory",
       "name": "自动记忆",
-      "rank": 14,
       "nameEn": "Auto Memory",
       "author": "Aik358",
       "description": "三层自动记忆插件：用户级/项目笔记/每日日志自动注入与检索、每轮自动沉淀、AI 时段问候、智能检索、日历与工作区思维导图，支持继承 WorkBuddy/CodeBuddy/Claude Code/Codex 等其他 AI 工具的记忆。",
@@ -166,7 +152,6 @@
     {
       "id": "dsh-memoir",
       "name": "项目记忆 Memoir",
-      "rank": 15,
       "nameEn": "Project Memory Memoir",
       "author": "Qinling-Melon-Farmers",
       "description": "项目持久化记忆与会话经验沉淀：memoir_record / memoir_read 工具（BM25 相关度排序检索）、每轮工作自动蒸馏、记忆诊断面板与跨项目全局检索，纯本地零外部依赖。",
@@ -178,7 +163,6 @@
     {
       "id": "dsh-worktime-board",
       "name": "牛马修仙看板",
-      "rank": 16,
       "nameEn": "Worktime Cultivation Board",
       "author": "spacexun2",
       "description": "DeepSeek Harness 工时统计 × 修仙养成：日/周/月/学年四档汇总 agent 活跃时长、token、输入与工具调用，十二重境界（炼气→宇宙洪荒）量化进度，纯本地存储。",
@@ -190,7 +174,6 @@
     {
       "id": "dsh-skill-explorer",
       "name": "技能中心（Skill Explorer）",
-      "rank": 17,
       "nameEn": "Skill Explorer",
       "author": "wingsky-1",
       "description": "DSH 技能中心：按来源分级浏览已加载 skill（系统内置 / 项目 / 用户 / 自定义 / 运行时），支持启用/禁用、创建与删除（移入 .trash）。",
@@ -202,7 +185,6 @@
     {
       "id": "dsh-friendly-steps",
       "name": "过程精简 Friendly Steps",
-      "rank": 18,
       "nameEn": "Friendly Steps",
       "author": "dongwenxiu83-web",
       "description": "面向文字工作者的过程精简：纯 CSS 折叠 Think / 工具调用等技术过程行，右下角浮条「已完成 N 步」一键展开收起，失败步骤红色计数反馈；不注入 React 列表、无全量扫描，零侵入。",
@@ -213,7 +195,6 @@
     {
       "id": "dsh-full-remote",
       "name": "全功能远程访问",
-      "rank": 19,
       "nameEn": "Full Remote Access",
       "author": "JUANWANG-BUAA",
       "description": "令牌门控反向代理：公网隧道或局域网下，在手机等设备上远程使用 DeepSeek Harness，设置、凭据与文件访问保持可用，支持按设备会话。",
@@ -225,7 +206,6 @@
     {
       "id": "dsh-history-tree",
       "name": "历史树",
-      "rank": 20,
       "nameEn": "History Tree",
       "author": "z953218350",
       "description": "在聊天消息左侧提供 Codex 风格对话轮次时间线点阵与悬浮历史概览卡片，支持鱼眼放大动效与点击直达对应轮次。",
@@ -237,7 +217,6 @@
     {
       "id": "dsh-gzip",
       "name": "dsh-gzip",
-      "rank": 21,
       "nameEn": "dsh-gzip",
       "author": "wingsky-1",
       "description": "/api 响应 gzip 压缩插件：为远程 / 低带宽链路开启 /api 响应压缩，解决会话历史因大响应无压缩而超时加载失败的问题；SSE / zip / 已编码响应自动豁免，无全局副作用。",
@@ -249,7 +228,6 @@
     {
       "id": "dsh-wsl-bridge",
       "name": "WSL Windows 桥",
-      "rank": 22,
       "nameEn": "WSL Windows Bridge",
       "author": "ch1bug",
       "description": "让 WSL 里的 agent 访问 Windows 侧：读写 C:\\ 文件、运行 .exe、Explorer 打开、wslpath 路径互转与盘符枚举（win_ls/read/write/run/open/path/drives）。",
@@ -260,7 +238,6 @@
     {
       "id": "dsh-mimo-agent-tools",
       "name": "MiMo 多模态工具",
-      "rank": 23,
       "nameEn": "MiMo Multimodal Tools",
       "author": "ch1bug",
       "description": "把小米 MiMo API 封装为 agent 工具：联网搜索、图像/音频/视频理解、语音转写、语音合成与音色克隆（mimo_search/vision/audio/video/asr/tts/voiceclone）。",
@@ -271,7 +248,6 @@
     {
       "id": "dsh-skill-fuzzy",
       "name": "技能模糊搜索",
-      "rank": 24,
       "nameEn": "Skill Fuzzy Search",
       "author": "ch1bug",
       "description": "Codex 风格模糊技能搜索：/bug、/diag、/regression 都能在 / 技能菜单里命中 diagnosing-bugs（名称子序列 + 描述连续子串匹配）。",
@@ -282,7 +258,6 @@
     {
       "id": "dsh-approve-for-me",
       "name": "自动审批审核",
-      "rank": 25,
       "nameEn": "Approve for Me",
       "author": "DamonKoy",
       "description": "只读工具自动放行、危险命令自动拒绝，可配置全自动模式。",
@@ -294,7 +269,6 @@
     {
       "id": "dsh-memories",
       "name": "项目记忆",
-      "rank": 26,
       "nameEn": "Project Memories",
       "author": "DamonKoy",
       "description": "按项目作用域持久化的键值记忆，支持增删查列与搜索。",
@@ -306,7 +280,6 @@
     {
       "id": "dsh-notifier",
       "name": "dsh-notifier",
-      "rank": 27,
       "nameEn": "dsh-notifier",
       "author": "wingsky-1",
       "description": "审批/完成/错误事件通知：浏览器 Notification + 系统原生 toast（Windows PowerShell WinRT / Linux·macOS notify-send，零依赖）；提示音可配、错误同类合并、免打扰时段、通知历史与配置面板；非安全上下文自动降级横幅。",
@@ -318,7 +291,6 @@
     {
       "id": "dsh-logicprobe",
       "name": "逻辑探针",
-      "rank": 28,
       "nameEn": "Logic Probe",
       "author": "AmethystLuna",
       "description": "AI 智能体声明核查技能：枚举设计文档与重构计划中的每个可验证声明，对照代码库事实逐条核验；行为类声明升级为逻辑原语验证（7 项结构检查 + 7 项对抗探针），重构前后模型对比做回归检测，输出 file:line 证据。",
@@ -329,7 +301,6 @@
     {
       "id": "dsh-chatgpt-subscription",
       "name": "子代理管理",
-      "rank": 29,
       "nameEn": "Subagent Management",
       "author": "Aa728848",
       "description": "让 DSH 通过 ChatGPT 订阅使用 GPT 系列模型：PKCE OAuth 登录、DPAPI/钥匙串/0600 凭据存储、流式 Responses、图片生成、Codex 搜索、额度展示与子代理管理。",
@@ -341,7 +312,6 @@
     {
       "id": "dsh-imagegen",
       "name": "AI 生图",
-      "rank": 30,
       "nameEn": "AI ImageGen",
       "author": "dickpy",
       "description": "AI 生图插件：通过可配置的 OpenAI 兼容端点（gpt-image-2 / gpt-image-1 / dall-e-3）实现文生图与图生图，提供生成历史、提示词模板库与 API 设置卡片。",
@@ -353,7 +323,6 @@
     {
       "id": "dsh-api-visualizer",
       "name": "接口捕获",
-      "rank": 31,
       "nameEn": "API Capture",
       "author": "lemonmmice",
       "description": "Fiddler 式实时抓包面板：tail 客户端 System.Net 跟踪日志自动解析 HTTP 请求/响应（gzip 自动解包）并实时入库，内置本地 MITM 代理可抓任意进程，支持筛选 / 详情 / 导出 / 重放 / 标记。",
@@ -364,7 +333,6 @@
     {
       "id": "dsh-postman",
       "name": "接口调试",
-      "rank": 32,
       "nameEn": "API Debugger",
       "author": "lemonmmice",
       "description": "类 Postman 接口调试面板：由宿主服务端发起 HTTP 请求（绕过浏览器 CORS），支持 WebSocket / 原始 TCP / gRPC、鉴权助手、环境变量、cURL 导入导出、请求集合与历史。",
@@ -375,7 +343,6 @@
     {
       "id": "dsh-workspace-api",
       "name": "企业信息查询 Agent",
-      "rank": 33,
       "nameEn": "Workspace API",
       "author": "liaoyonghong",
       "description": "把企业文档变成可对话的聊天机器人：员工或应用系统用自然语言提问，AI 代理查阅文档后带出处回答；同时提供 workspace 内容 HTTP API。",
@@ -387,7 +354,6 @@
     {
       "id": "dsh-llm-verifier",
       "name": "LLM 裁判复核",
-      "rank": 34,
       "nameEn": "LLM Verifier",
       "author": "Aa728848",
       "description": "DSH 原生可配置 LLM 裁判复核插件：成对比较、锦标赛择优、进度判定与自动验收门控（verifier_compare/select/track/current_session），A–T 标尺 + 期望评分，自带 Web 设置面板。",
@@ -399,7 +365,6 @@
     {
       "id": "dsh-session-id",
       "name": "会话 ID",
-      "rank": 35,
       "nameEn": "Session ID",
       "author": "yufengnigel",
       "description": "侧边栏底部会话 ID 面板：列出全部会话的完整 ID 并一键复制（纯浏览器、只读，不修改会话状态）。",
@@ -411,12 +376,22 @@
     {
       "id": "miku-pet",
       "name": "Miku 桌宠",
-      "rank": 36,
       "nameEn": "Miku Pet",
       "author": "stushansusu",
       "description": "只属于 Miku 的浮动桌宠：手绘风帧动画，5s 随机待机（连漏 2 次必演）、连续工作赚金币、商店恢复饥饿、属性彩条与两级悬停菜单；路由 /miku-pet 与内置 dsh-pet 共存。",
       "descriptionEn": "A floating pet exclusively for Miku: hand-drawn frame animations, 5s random idle with a pity timer, a continuous work loop earning coins, a shop restoring hunger, stat bars and a two-level hover menu; coexists with the built-in dsh-pet under the /miku-pet namespace.",
       "repo": "https://github.com/stushansusu/miku-pet",
+      "category": "ui"
+    },
+    {
+      "id": "dsh-workbench-suite",
+      "name": "DSH 执行工作台套装",
+      "nameEn": "DSH Workbench Suite",
+      "author": "mtdx2001",
+      "description": "一键安装执行工作台、Provider 驱动余额行、AionUI 右侧面板、任务看板与 SSH 集成；保留各组件的配置、凭据和数据所有权。",
+      "descriptionEn": "One install for the execution workbench, Provider-driven balance rows, AionUI right panel, Task Board and SSH integrations, while preserving each component's configuration, credential and data ownership.",
+      "repo": "https://github.com/mtdx2001/dsh-web-ui",
+      "npm": "@mtdx2001/dsh-workbench-suite",
       "category": "ui"
     }
   ]

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -377,5 +377,16 @@
     "descriptionEn": "A floating pet exclusively for Miku: hand-drawn frame animations, 5s random idle with a pity timer, a continuous work loop earning coins, a shop restoring hunger, stat bars and a two-level hover menu; coexists with the built-in dsh-pet under the /miku-pet namespace.",
     "repo": "https://github.com/stushansusu/miku-pet",
     "category": "ui"
+  },
+  {
+    "id": "dsh-workbench-suite",
+    "name": "DSH 执行工作台套装",
+    "nameEn": "DSH Workbench Suite",
+    "author": "mtdx2001",
+    "description": "一键安装执行工作台、Provider 驱动余额行、AionUI 右侧面板、任务看板与 SSH 集成；保留各组件的配置、凭据和数据所有权。",
+    "descriptionEn": "One install for the execution workbench, Provider-driven balance rows, AionUI right panel, Task Board and SSH integrations, while preserving each component's configuration, credential and data ownership.",
+    "repo": "https://github.com/mtdx2001/dsh-web-ui",
+    "npm": "@mtdx2001/dsh-workbench-suite",
+    "category": "ui"
   }
 ]


### PR DESCRIPTION
Superseded because the first generated manifest accidentally removed existing rank fields. A clean replacement PR follows from the corrected branch.