### PR TITLE
feat(remote-web-ui): 手机端会话运行中"停止"按钮（复刻桌面端 Send/Stop 切换）

### DIFF
--- a/packages/dsh-remote-web-ui/src/mobile-api.ts
+++ b/packages/dsh-remote-web-ui/src/mobile-api.ts
@@ -53,6 +53,7 @@ const MOBILE_ALLOWLIST = new Set([
   'session.models',
   'session.selectModel',
   'session.rename',
+  'session.cancel',
 ])
 
 /**
@@ -353,5 +354,6 @@ async function dispatch(apiProxy: ApiProxy, method: string, payload: unknown, rp
   if (method === 'session.models') return wrap(await apiProxy.sessions.models(request as never))
   if (method === 'session.selectModel') return wrap(await apiProxy.sessions.selectModel(request as never))
   if (method === 'session.rename') return wrap(await apiProxy.sessions.rename(request as never))
+  if (method === 'session.cancel') return wrap(await apiProxy.sessions.cancel(request as never))
   throw new Error(`unhandled allowlisted method ${method}`)
 }

--- a/packages/dsh-remote-web-ui/src/mobile/api.ts
+++ b/packages/dsh-remote-web-ui/src/mobile/api.ts
@@ -112,6 +112,11 @@ export async function sendCommand(sessionId: string, line: string): Promise<unkn
   })
 }
 
+/** Stop the session's active turn (the mobile "停止" button). */
+export async function cancelSession(sessionId: string): Promise<{ accepted: true }> {
+  return await callUnary<{ accepted: true }>('session.cancel', { sessionId })
+}
+
 /** Fresh advisory model directory for one session (current + groups + failures). */
 export async function models(sessionId: string): Promise<SessionModels> {
   return await callUnary<SessionModels>('session.models', { sessionId })

--- a/packages/dsh-remote-web-ui/src/mobile/views/ChatView.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/ChatView.tsx
@@ -16,7 +16,7 @@ import type { MuxFrame } from '@deepseek-ai/dsh-host-apiproxy/api/events'
 import type { SessionModels } from '@deepseek-ai/dsh-host-apiproxy/api/sessions'
 import { loadHistory, prompt, type SessionView } from './App.tsx'
 import { errorText, formatTime, staleHostHint } from './App.tsx'
-import { fetchMobilePreferences, models, selectModel, sendCommand, fetchPending, respondApproval, respondQuestion } from '../api.ts'
+import { fetchMobilePreferences, models, selectModel, sendCommand, cancelSession, fetchPending, respondApproval, respondQuestion } from '../api.ts'
 import type { PendingApproval, PendingQuestionItem } from '../api.ts'
 import { EventFolder, foldEvents, type RenderMessage, type ToolCallInfo, type WireEvent } from '../messages.ts'
 import { renderMarkdown } from '../markdown.ts'
@@ -167,6 +167,8 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
   const [mobileEnterToSend, setMobileEnterToSend] = useState(true)
   /** Whether the assistant is currently generating (turn/start..turn/end). */
   const [running, setRunning] = useState(false)
+  /** Whether a stop request is in flight (the "停止" button). */
+  const [stopping, setStopping] = useState(false)
   /** Pending tool approvals awaiting user decision (#1025). */
   const [pendingApprovals, setPendingApprovals] = useState<PendingApproval[]>([])
   /** Pending questions awaiting user answer (#1025). */
@@ -441,6 +443,19 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
     )
   }, [input, sending, session.sessionId])
 
+  /** Stop the session's active turn (the "停止" button next to the output indicator). */
+  const stopTurn = useCallback(() => {
+    if (stopping) return
+    setStopping(true)
+    void cancelSession(session.sessionId).then(
+      () => { setStopping(false) },
+      (reason: unknown) => {
+        setStopping(false)
+        setError(errorText(reason))
+      },
+    )
+  }, [stopping, session.sessionId])
+
   const modelLabel = currentModel?.model ?? '模型'
   const permissionLabel = permissions === undefined
     ? undefined
@@ -547,8 +562,17 @@ export function ChatView({ session, mux, onBack }: ChatViewProps) {
             }
           }}
         />
-        <button type="button" className="chat-send" disabled={sending || input.trim() === ''} onClick={() => { void send() }}>
-          {sending ? '发送中…' : '发送'}
+        <button
+          type="button"
+          className="chat-send"
+          disabled={running ? stopping : sending || input.trim() === ''}
+          onClick={() => { if (running) void stopTurn(); else void send() }}
+        >
+          {running ? (
+            <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden>
+              <rect x="3" y="3" width="10" height="10" rx="3" fill="currentColor" />
+            </svg>
+          ) : sending ? '发送中…' : '发送'}
         </button>
       </div>
       {sheet === 'model' && (


### PR DESCRIPTION
## 摘要（Summary）

手机端 `/m/` 会话运行中缺少"停止"按钮，无法中断正在进行的回合。本 PR 复刻桌面端 **Send/Stop 主按钮切换**：会话运行中时，输入栏主按钮由"发送"切换为"停止"（方形停止图标），点击调 `session.cancel` 停止当前回合。

关联 Issue：#1041（手机端会话运行中"停止"按钮——复刻桌面端 Send/Stop 主按钮切换）

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [ ] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch upstream dev && git rebase upstream/dev`（已基于 `6218eef8`，领先 0 落后 0）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

N/A（非视觉修复）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改动 README。）

## 贡献者版权声明（Contributor Copyright）

N/A（不声明，维持现有版权归属）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui build
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
pnpm --filter @linxin666/dsh-remote-web-ui test
```

结果摘要：

- build：通过
- typecheck：通过（exit 0）
- test：**373/373 通过**

## 用户可见变更证据（Local Feature Evidence）

证据（复刻客户端 + 运行中会话实测，手机视口截图）：

- 会话空闲时：输入栏主按钮为"发送"；
- 会话运行中（`turn/start` 至 `turn/end`）：主按钮切换为**方形停止图标**（蓝色按钮 + 白色方块，与桌面端一致），可点击；
- 点击后调 `session.cancel` 停止当前回合，停止请求进行中按钮禁用。

## 改动记录（Change Log）

| 提交 | 内容 |
|---|---|
| `6c22ff3` | feat(mobile): 运行中发送按钮切换为停止按钮——`src/mobile-api.ts` 白名单+dispatch 加 `session.cancel`；`src/mobile/api.ts` 新增 `cancelSession`；`src/mobile/views/ChatView.tsx` 输入栏主按钮 Send/Stop 切换（`running` 时显示方形停止图标，点击调 `cancelSession`，停止中禁用） |