### PR TITLE
feat(remote-web-ui): add user-owned HTTPS preflight and planning (#731)

### DIFF
--- a/packages/dsh-remote-web-ui/README.i18n.yaml
+++ b/packages/dsh-remote-web-ui/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: edd272ef9b98700efc6ff465c5cb0dcc2e2d9648
-README.zh.md: 53f1f72524ad3072ba2526108f7fc650403a5e0a
+README.md: c04a822b44af23f536f9cbc6052c5240a460a995
+README.zh.md: ddf302999999fda873d39c26c5b21d7e2139f186

--- a/packages/dsh-remote-web-ui/README.md
+++ b/packages/dsh-remote-web-ui/README.md
@@ -329,6 +329,13 @@ enters the connection trust fence — so **no profile or harness
 customization is required for the auto tunnel to work**. `--trusted-host`
 is not part of this path: a paired PC uses `/remote/api`.
 
+### User-owned HTTPS setup planning (read-only)
+
+The opt-in user-owned Cloudflare named-tunnel and Access path currently provides only loopback preflight and plan preview. Its contract reports `executionAvailable: false`, and no apply or rollback operation exists. This path is independent of and does not change the existing `autoTunnel` quick-tunnel path.
+
+- The ingress preview enables `/m` by default, includes `/remote` only after explicit opt-in, and ends with a final 404 rule for every other path. Current compatibility blockers in `/m` pairing acceptance and `/remote` boot keep the plan non-executable.
+- macOS launchd automation and Windows manual setup are preview-only actions. No service is installed or started.
+
 ### Manual tunnels (bring your own)
 
 The QR link is normally a LAN URL, so a phone outside the house cannot use
@@ -495,6 +502,9 @@ opens at `http://127.0.0.1`.
 ## Security model
 
 - Mobile unary routes and the mux event stream require a live paired-device session. A missing or revoked session receives HTTP 403 with a JSON rejection carrying `error.code: "unpaired"`; the browser's `EventSource` API exposes only the stream failure, not that response body.
+- **Local planning fence**: the user-owned HTTPS preflight and plan control plane accepts only loopback, same-origin requests and is not exposed through `/remote`. This phase sends only GET/read requests to Cloudflare; successful reads do not prove mutation permissions.
+- **Credential lifetime**: a request-supplied Cloudflare API token is used only in memory for the current local same-origin request; it is never persisted or reflected in a response. This does not claim that a request-supplied token never enters the browser. When Keychain is selected as the credential source, only the host reads the credential value.
+- **No planning side effects**: preflight and plan do not create, update, or delete Cloudflare resources; write local files; install or manage launchd; or write `publicBaseUrl`.
 
 ## Known Limitations and Deferred Work
 

--- a/packages/dsh-remote-web-ui/README.zh.md
+++ b/packages/dsh-remote-web-ui/README.zh.md
@@ -93,6 +93,13 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-remote-web-ui
 
 二维码在隧道报告其 URL 前保持仅局域网，且隧道重启会铸一枚**新的** hostname——插件清除旧链接并铸一枚新的，用户永远不必触碰配置。注意 quick tunnel 是公网的：任何拿到 URL 的人都能加载静态页；已配对设备 cookie 门才是真正的围栏（手机的 `/m/api` 带方法白名单、远程桌面的 `/remote/api`）。连接插件的 `/api` 围栏则直接拒绝隧道化主机——被隧道化的 Host 永远不进入连接信任围栏——因此 **auto tunnel 工作无需任何 profile 或 harness 定制**。`--trusted-host` 不属于这条路径：已配对 PC 走 `/remote/api`。
 
+### 用户自有 HTTPS 配置规划（只读）
+
+可选的用户自有 Cloudflare 命名隧道与 Access 路径当前只提供 loopback 预检与计划预览。其契约返回 `executionAvailable: false`，不存在 apply 或 rollback 操作。这条路径独立于现有 `autoTunnel` quick tunnel，也不会改变后者。
+
+- 入口预览默认启用 `/m`，只有用户显式选择后才包含 `/remote`，并以最终 404 规则拒绝其他所有路径。当前 `/m` 配对接受流程和 `/remote` 启动流程仍有兼容性阻断，因此计划不可执行。
+- macOS launchd 自动化与 Windows 手工配置目前都只是预览动作，不会安装或启动任何服务。
+
 ### 手动隧道（自带）
 
 二维码链接通常是局域网 URL，所以家外的手机无法使用。把隧道指向 dsh web 端口，并告知插件其公网地址——二维码随后由隧道 URL 构建。涉及一个钮；`--trusted-host` 是独立的 SDK flag，不属于这条配对流：
@@ -172,6 +179,9 @@ pnpm run build
 ## 安全模型
 
 - 移动端普通接口与 mux 事件流都要求有效的已配对设备会话。会话缺失或已撤销时返回 HTTP 403，并使用带 `error.code: "unpaired"` 的 JSON 拒绝信封；浏览器 `EventSource` API 只暴露事件流失败，不暴露该响应体。
+- **本机规划围栏**：用户自有 HTTPS 预检与计划控制面只接受 loopback 本机同源请求，且不经 `/remote` 暴露。这一阶段只向 Cloudflare 发出 GET/只读请求；读取成功不等于写权限已验证。
+- **凭据生命周期**：通过请求提供的 Cloudflare API token 只在当前本机同源请求的内存中使用，既不持久化，也不在响应中回显；这不表示通过请求提供的 token 完全不会进入浏览器。选择 Keychain 凭据来源时，仅由 host 读取凭据值。
+- **规划无副作用**：预检与计划不会创建、更新或删除 Cloudflare 资源，不会写本地文件，不会安装或管理 launchd，也不会写入 `publicBaseUrl`。
 
 ## 已知限制与待办
 

--- a/packages/dsh-remote-web-ui/src/cloudflare-plan.ts
+++ b/packages/dsh-remote-web-ui/src/cloudflare-plan.ts
@@ -1,0 +1,578 @@
+/** Read-only Cloudflare inspection and pure HTTPS setup planning for Issue #731. */
+
+import { constants as fsConstants } from 'node:fs'
+import { access } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { homedir, platform as nodePlatform } from 'node:os'
+import { delimiter, join, resolve } from 'node:path'
+import { isLoopbackHostname } from './loopback.ts'
+import type {
+  SetupErrorCode,
+  SetupErrorField,
+  SetupPlan,
+  SetupPlanAction,
+  SetupPlanRequest,
+  SetupPlanResponse,
+  SetupPreflightResponse,
+  SetupServicePreview,
+} from './setup-contract.ts'
+
+const API_BASE = 'https://api.cloudflare.com/client/v4'
+const API_TIMEOUT_MS = 15_000
+const PROCESS_TIMEOUT_MS = 10_000
+const PROCESS_OUTPUT_LIMIT = 64 * 1024
+const PAGE_SIZE = 100
+const MAX_PAGES = 50
+const OTP_IDP_NAME = 'DSH Remote One-time PIN'
+
+/** Stable planner failures whose messages are safe for a loopback UI. */
+export class SetupPlanError extends Error {
+  constructor(
+    readonly code: SetupErrorCode,
+    message: string,
+    readonly retryable = false,
+    readonly field?: SetupErrorField,
+  ) {
+    super(message)
+    this.name = 'SetupPlanError'
+  }
+}
+
+export interface CloudflareZone { id: string; name: string; accountId: string }
+export interface CloudflareTunnel { id: string; name: string; configSrc?: 'local' | 'cloudflare' }
+export interface CloudflareDnsRecord { id: string; type: string; name: string; content: string; proxied: boolean }
+export interface CloudflareIdentityProvider { id: string; name: string; type: string }
+export interface CloudflareAccessApp {
+  id: string
+  name: string
+  domain: string
+  type: string
+  destinations: Array<{ type?: string; uri?: string }>
+  allowedIdps: string[]
+  autoRedirectToIdentity: boolean
+}
+export interface CloudflareAccessPolicy {
+  id: string
+  name: string
+  decision: string
+  include: unknown[]
+  exclude?: unknown[]
+  require?: unknown[]
+}
+
+/** Cloudflare seam for PR1. It intentionally has no write method. */
+export interface CloudflareReadApi {
+  verifyToken(): Promise<void>
+  listZones(): Promise<CloudflareZone[]>
+  listTunnels(accountId: string, name: string): Promise<CloudflareTunnel[]>
+  listDnsRecords(zoneId: string, hostname: string): Promise<CloudflareDnsRecord[]>
+  listIdentityProviders(accountId: string): Promise<CloudflareIdentityProvider[]>
+  listAccessApps(accountId: string): Promise<CloudflareAccessApp[]>
+  listAccessPolicies(accountId: string, appId: string): Promise<CloudflareAccessPolicy[]>
+}
+
+interface ApiEnvelope<T> {
+  success?: boolean
+  result?: T
+  result_info?: { page?: number; per_page?: number; count?: number; total_count?: number }
+}
+
+type FetchLike = typeof fetch
+
+/** GET-only Cloudflare v4 client. The token is held only by this instance. */
+export class CloudflareHttpReadApi implements CloudflareReadApi {
+  constructor(private readonly token: string, private readonly fetchFn: FetchLike = fetch) {}
+
+  private async get<T>(path: string): Promise<ApiEnvelope<T>> {
+    let response: Response
+    try {
+      response = await this.fetchFn(`${API_BASE}${path}`, {
+        method: 'GET',
+        headers: { authorization: `Bearer ${this.token}`, accept: 'application/json' },
+        redirect: 'manual',
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      })
+    } catch {
+      throw new SetupPlanError('cloudflare-unavailable', 'Cloudflare could not be reached for read-only inspection.', true)
+    }
+    if (response.status === 401) throw new SetupPlanError('cloudflare-auth-failed', 'Cloudflare rejected the API token.', false, 'credential')
+    if (response.status === 403) throw new SetupPlanError('cloudflare-permission-denied', 'The credential cannot read the required Cloudflare resources.', false, 'credential')
+    if (!response.ok) throw new SetupPlanError('cloudflare-unavailable', `Cloudflare read-only inspection returned HTTP ${String(response.status)}.`, response.status >= 500)
+    let envelope: ApiEnvelope<T>
+    try {
+      envelope = await response.json() as ApiEnvelope<T>
+    } catch {
+      throw new SetupPlanError('cloudflare-unavailable', 'Cloudflare returned an invalid read response.', true)
+    }
+    if (envelope.success !== true || envelope.result === undefined) {
+      throw new SetupPlanError('cloudflare-unavailable', 'Cloudflare did not return a usable read result.', true)
+    }
+    return envelope
+  }
+
+  private async listAll<T>(path: string): Promise<T[]> {
+    const values: T[] = []
+    const separator = path.includes('?') ? '&' : '?'
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
+      const envelope = await this.get<T[]>(`${path}${separator}per_page=${String(PAGE_SIZE)}&page=${String(page)}`)
+      const batch = envelope.result ?? []
+      values.push(...batch)
+      const info = envelope.result_info
+      const perPage = info?.per_page ?? PAGE_SIZE
+      const total = info?.total_count
+      if (total !== undefined ? values.length >= total : batch.length < perPage) return values
+    }
+    throw new SetupPlanError('cloudflare-unavailable', 'Cloudflare read-only inspection exceeded its pagination safety limit.', true)
+  }
+
+  async verifyToken(): Promise<void> {
+    const response = await this.get<{ status?: string }>('/user/tokens/verify')
+    if (response.result?.status !== 'active') throw new SetupPlanError('cloudflare-auth-failed', 'The Cloudflare API token is not active.', false, 'credential')
+  }
+
+  async listZones(): Promise<CloudflareZone[]> {
+    const values = await this.listAll<{ id?: string; name?: string; account?: { id?: string } }>('/zones?status=active')
+    return values.flatMap(value => value.id !== undefined && value.name !== undefined && value.account?.id !== undefined
+      ? [{ id: value.id, name: value.name.toLowerCase(), accountId: value.account.id }]
+      : [])
+  }
+
+  async listTunnels(accountId: string, name: string): Promise<CloudflareTunnel[]> {
+    const values = await this.listAll<{ id?: string; name?: string; config_src?: 'local' | 'cloudflare' }>(
+      `/accounts/${encodeURIComponent(accountId)}/cfd_tunnel?is_deleted=false&name=${encodeURIComponent(name)}`,
+    )
+    return values.flatMap(value => value.id !== undefined && value.name !== undefined
+      ? [{ id: value.id, name: value.name, configSrc: value.config_src }]
+      : [])
+  }
+
+  async listDnsRecords(zoneId: string, hostname: string): Promise<CloudflareDnsRecord[]> {
+    const values = await this.listAll<{ id?: string; type?: string; name?: string; content?: string; proxied?: boolean }>(
+      `/zones/${encodeURIComponent(zoneId)}/dns_records?name=${encodeURIComponent(hostname)}`,
+    )
+    return values.flatMap(value => value.id !== undefined && value.type !== undefined && value.name !== undefined && value.content !== undefined
+      ? [{ id: value.id, type: value.type, name: value.name.toLowerCase(), content: value.content.toLowerCase(), proxied: value.proxied === true }]
+      : [])
+  }
+
+  async listIdentityProviders(accountId: string): Promise<CloudflareIdentityProvider[]> {
+    const values = await this.listAll<{ id?: string; name?: string; type?: string }>(`/accounts/${encodeURIComponent(accountId)}/access/identity_providers`)
+    return values.flatMap(value => value.id !== undefined && value.type !== undefined
+      ? [{ id: value.id, name: value.name?.trim() || (value.type === 'onetimepin' ? OTP_IDP_NAME : `Cloudflare ${value.type} identity provider`), type: value.type }]
+      : [])
+  }
+
+  async listAccessApps(accountId: string): Promise<CloudflareAccessApp[]> {
+    const values = await this.listAll<{
+      id?: string; name?: string; domain?: string; type?: string
+      destinations?: Array<{ type?: string; uri?: string }>
+      allowed_idps?: string[]; auto_redirect_to_identity?: boolean
+    }>(`/accounts/${encodeURIComponent(accountId)}/access/apps`)
+    return values.flatMap(value => value.id !== undefined && value.type !== undefined
+      ? [{
+          id: value.id, name: value.name ?? '', domain: (value.domain ?? '').toLowerCase(), type: value.type,
+          destinations: value.destinations ?? [], allowedIdps: value.allowed_idps ?? [],
+          autoRedirectToIdentity: value.auto_redirect_to_identity === true,
+        }]
+      : [])
+  }
+
+  async listAccessPolicies(accountId: string, appId: string): Promise<CloudflareAccessPolicy[]> {
+    const values = await this.listAll<{
+      id?: string; name?: string; decision?: string; include?: unknown[]; exclude?: unknown[]; require?: unknown[]
+    }>(`/accounts/${encodeURIComponent(accountId)}/access/apps/${encodeURIComponent(appId)}/policies`)
+    return values.flatMap(value => value.id !== undefined && value.decision !== undefined
+      ? [{ id: value.id, name: value.name ?? '', decision: value.decision, include: value.include ?? [], exclude: value.exclude, require: value.require }]
+      : [])
+  }
+}
+
+export interface ProcessResult { code: number; stdout: string; stderr: string }
+export type ReadOnlyProcessRunner = (executable: string, args: readonly string[], timeoutMs?: number) => Promise<ProcessResult>
+
+const defaultProcessRunner: ReadOnlyProcessRunner = async (executable, args, timeoutMs = PROCESS_TIMEOUT_MS) => await new Promise((resolvePromise, rejectPromise) => {
+  const child = spawn(executable, [...args], { shell: false, stdio: ['ignore', 'pipe', 'pipe'] })
+  const stdout: Buffer[] = []
+  const stderr: Buffer[] = []
+  let size = 0
+  let settled = false
+  const finish = (value: ProcessResult | Error): void => {
+    if (settled) return
+    settled = true
+    clearTimeout(timer)
+    if (value instanceof Error) rejectPromise(value)
+    else resolvePromise(value)
+  }
+  const collect = (target: Buffer[], chunk: Buffer): void => {
+    if (size >= PROCESS_OUTPUT_LIMIT) return
+    const value = chunk.subarray(0, PROCESS_OUTPUT_LIMIT - size)
+    size += value.length
+    target.push(value)
+  }
+  child.stdout.on('data', chunk => { collect(stdout, chunk as Buffer) })
+  child.stderr.on('data', chunk => { collect(stderr, chunk as Buffer) })
+  child.on('error', finish)
+  child.on('close', code => { finish({ code: code ?? 1, stdout: Buffer.concat(stdout).toString('utf8'), stderr: Buffer.concat(stderr).toString('utf8') }) })
+  const timer = setTimeout(() => { child.kill('SIGTERM'); finish(new Error('process timed out')) }, timeoutMs)
+  timer.unref()
+})
+
+export interface CloudflaredProbeResult { found: boolean; path?: string; version?: string }
+export type CloudflaredProbe = () => Promise<CloudflaredProbeResult>
+export type KeychainReader = (reference: { service: string; account?: string }) => Promise<string>
+
+export interface CloudflareSetupPlannerOptions {
+  host: string
+  port: number
+  config: () => { autoTunnel?: boolean; publicBaseUrl?: string }
+  platform?: NodeJS.Platform
+  homeDir?: string
+  processRunner?: ReadOnlyProcessRunner
+  cloudflaredProbe?: CloudflaredProbe
+  keychainReader?: KeychainReader
+  readApiFactory?: (token: string) => CloudflareReadApi
+  fetch?: FetchLike
+}
+
+export interface CloudflareSetupPlanner {
+  readonly localOrigin: string
+  preflight(): Promise<SetupPreflightResponse>
+  plan(input: SetupPlanRequest): Promise<SetupPlanResponse>
+}
+
+/** Factory consumed by the additive host integration. */
+export function createCloudflareSetupPlanner(options: CloudflareSetupPlannerOptions): CloudflareSetupPlanner {
+  const platform = options.platform ?? nodePlatform()
+  const runner = options.processRunner ?? defaultProcessRunner
+  const probe = options.cloudflaredProbe ?? (() => defaultCloudflaredProbe(platform, options.homeDir ?? homedir(), runner))
+  const readKeychain = options.keychainReader ?? (reference => defaultKeychainReader(platform, reference, runner))
+  const makeApi = options.readApiFactory ?? (token => new CloudflareHttpReadApi(token, options.fetch ?? fetch))
+  const normalizedHost = options.host.toLowerCase()
+  const loopbackHost = normalizedHost === '::1' || normalizedHost === '[::1]'
+    ? '[::1]'
+    : isLoopbackHostname(normalizedHost) ? normalizedHost : '127.0.0.1'
+  const localOrigin = new URL(`http://${loopbackHost}:${String(options.port)}`).origin
+
+  const preflight = async (): Promise<SetupPreflightResponse> => {
+    const cloudflared = await probe().catch((): CloudflaredProbeResult => ({ found: false }))
+    const config = safeConfig(options.config)
+    return {
+      ok: true,
+      readOnly: true,
+      executionAvailable: false,
+      preflight: {
+        platform,
+        dsh: {
+          host: options.host,
+          port: options.port,
+          localOrigin,
+          loopbackOnly: normalizedHost === '::1' || isLoopbackHostname(normalizedHost),
+        },
+        cloudflared: { found: cloudflared.found, version: cloudflared.version },
+        serviceMode: platform === 'darwin' ? 'launchd-preview' : 'manual-preview',
+        autoTunnelEnabled: config.autoTunnel === true,
+        configuredPublicBaseUrl: normalizedHttpsOrigin(config.publicBaseUrl),
+      },
+    }
+  }
+
+  return {
+    localOrigin,
+    preflight,
+    plan: async (input): Promise<SetupPlanResponse> => {
+      const status = await preflight()
+      const token = await resolveCredential(input, platform, readKeychain)
+      const api = makeApi(token)
+      const collected = await collectInspection(api, input)
+      const target = {
+        hostname: input.hostname,
+        tunnelName: input.tunnelName ?? defaultTunnelName(input.hostname),
+        accessAppName: input.accessAppName ?? defaultAccessAppName(input.hostname),
+        includeRemote: input.includeRemote,
+        emailHash: sha256(input.email),
+      }
+      return { ok: true, readOnly: true, executionAvailable: false, plan: buildCloudflareSetupPlan({ preflight: status.preflight, target, inspection: collected }) }
+    },
+  }
+}
+
+function safeConfig(read: CloudflareSetupPlannerOptions['config']): { autoTunnel?: boolean; publicBaseUrl?: string } {
+  try { return read() } catch { return {} }
+}
+
+function normalizedHttpsOrigin(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && url.username === '' && url.password === ''
+      && url.pathname === '/' && url.search === '' && url.hash === '' ? url.origin : undefined
+  } catch { return undefined }
+}
+
+async function defaultCloudflaredProbe(platform: NodeJS.Platform, homeDir: string, runner: ReadOnlyProcessRunner): Promise<CloudflaredProbeResult> {
+  const executable = platform === 'win32' ? 'cloudflared.exe' : 'cloudflared'
+  const candidates = new Set<string>()
+  if (platform === 'darwin') { candidates.add('/opt/homebrew/bin/cloudflared'); candidates.add('/usr/local/bin/cloudflared') }
+  if (platform === 'linux') { candidates.add('/usr/local/bin/cloudflared'); candidates.add('/usr/bin/cloudflared') }
+  if (platform === 'win32') candidates.add(join(homeDir, 'AppData', 'Local', 'cloudflared', executable))
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) if (directory !== '') candidates.add(resolve(directory, executable))
+  for (const candidate of candidates) {
+    try { await access(candidate, fsConstants.X_OK) } catch { continue }
+    const result = await runner(candidate, ['version']).catch(() => undefined)
+    return { found: true, path: candidate, version: result?.code === 0 ? (result.stdout || result.stderr).trim().split(/\r?\n/, 1)[0]?.replace(/^cloudflared version\s+/i, '').slice(0, 256) : undefined }
+  }
+  return { found: false }
+}
+
+async function defaultKeychainReader(platform: NodeJS.Platform, reference: { service: string; account?: string }, runner: ReadOnlyProcessRunner): Promise<string> {
+  if (platform !== 'darwin') throw new SetupPlanError('keychain-unavailable', 'Keychain credential references are supported only on macOS.', false, 'credential')
+  const args = ['find-generic-password', '-s', reference.service, ...(reference.account === undefined ? [] : ['-a', reference.account]), '-w']
+  const result = await runner('/usr/bin/security', args, 5_000).catch(() => undefined)
+  const token = result?.code === 0 ? result.stdout.trim() : ''
+  if (token.length < 20 || token.length > 4096 || /\s/.test(token)) throw new SetupPlanError('keychain-unavailable', 'The referenced Keychain credential could not be read.', false, 'credential')
+  return token
+}
+
+async function resolveCredential(input: SetupPlanRequest, platform: NodeJS.Platform, readKeychain: KeychainReader): Promise<string> {
+  if (input.credential.source === 'request') return input.credential.token
+  if (platform !== 'darwin') throw new SetupPlanError('keychain-unavailable', 'Keychain credential references are supported only on macOS.', false, 'credential')
+  return await readKeychain({ service: input.credential.service, account: input.credential.account })
+}
+
+export interface CloudflarePlanTarget {
+  hostname: string
+  tunnelName: string
+  accessAppName: string
+  includeRemote: boolean
+  emailHash: string
+}
+
+export interface CloudflareInspectionSnapshot {
+  zone: CloudflareZone
+  tunnels: CloudflareTunnel[]
+  dnsRecords: CloudflareDnsRecord[]
+  identityProviders: CloudflareIdentityProvider[]
+  accessApps: CloudflareAccessApp[]
+  policies: Array<{ appId: string; id: string; name: string; fingerprint: string; exactEmailOtpId?: string }>
+}
+
+async function collectInspection(api: CloudflareReadApi, input: SetupPlanRequest): Promise<CloudflareInspectionSnapshot> {
+  await api.verifyToken()
+  const zones = await api.listZones()
+  const zone = zones.filter(candidate => input.hostname === candidate.name || input.hostname.endsWith(`.${candidate.name}`)).sort((a, b) => b.name.length - a.name.length)[0]
+  if (zone === undefined) throw new SetupPlanError('zone-not-found', 'No active Cloudflare zone matching this hostname is visible.', false, 'hostname')
+  const tunnelName = input.tunnelName ?? defaultTunnelName(input.hostname)
+  const [tunnels, dnsRecords, identityProviders, accessApps] = await Promise.all([
+    api.listTunnels(zone.accountId, tunnelName), api.listDnsRecords(zone.id, input.hostname),
+    api.listIdentityProviders(zone.accountId), api.listAccessApps(zone.accountId),
+  ])
+  const targetApps = accessApps.filter(app => app.domain === input.hostname || app.destinations.some(destination => destination.uri?.toLowerCase() === input.hostname))
+  const policyRows = await Promise.all(targetApps.map(async app => {
+    const values = await api.listAccessPolicies(zone.accountId, app.id)
+    return values.map(policy => ({
+      appId: app.id, id: policy.id, name: policy.name,
+      fingerprint: sha256(canonicalJson(policy)),
+      exactEmailOtpId: exactPolicyOtpId(policy, input.email),
+    }))
+  }))
+  return normalizeInspection({ zone, tunnels, dnsRecords, identityProviders, accessApps: targetApps, policies: policyRows.flat() })
+}
+
+function exactPolicyOtpId(policy: CloudflareAccessPolicy, email: string): string | undefined {
+  if (policy.decision !== 'allow' || policy.include.length !== 1 || (policy.exclude?.length ?? 0) !== 0 || policy.require?.length !== 1) return undefined
+  const include = policy.include[0] as { email?: { email?: unknown } } | undefined
+  const require = policy.require[0] as { login_method?: { id?: unknown } } | undefined
+  return typeof include?.email?.email === 'string' && include.email.email.toLowerCase() === email
+    && typeof require?.login_method?.id === 'string' ? require.login_method.id : undefined
+}
+
+function normalizeInspection(value: CloudflareInspectionSnapshot): CloudflareInspectionSnapshot {
+  const byId = <T extends { id: string }>(items: T[]): T[] => [...items].sort((a, b) => a.id.localeCompare(b.id))
+  return { ...value, tunnels: byId(value.tunnels), dnsRecords: byId(value.dnsRecords), identityProviders: byId(value.identityProviders), accessApps: byId(value.accessApps), policies: [...value.policies].sort((a, b) => `${a.appId}:${a.id}`.localeCompare(`${b.appId}:${b.id}`)) }
+}
+
+export interface BuildCloudflareSetupPlanInput {
+  preflight: SetupPreflightResponse['preflight']
+  target: CloudflarePlanTarget
+  inspection: CloudflareInspectionSnapshot
+}
+
+/** Pure, token-free planner. The input contains only normalized inspection facts. */
+export function buildCloudflareSetupPlan(input: BuildCloudflareSetupPlanInput): SetupPlan {
+  const { preflight, target } = input
+  const inspection = normalizeInspection(input.inspection)
+  const blockers: SetupPlan['blockers'] = [
+    { code: 'execution-unavailable', message: 'PR1 provides a read-only preview and has no execution endpoint.' },
+    { code: 'mobile-ingress-not-ready', message: 'The current mobile page posts pairing acceptance to /api/pair/accept, which is outside the planned /m ingress and would fail until a future compatibility change is implemented.' },
+  ]
+  const warnings: string[] = ['Cloudflare read access was verified; write permission remains unverified.']
+  if (!preflight.dsh.loopbackOnly) blockers.push({ code: 'dsh-not-loopback', message: 'DSH must bind to a loopback interface before a public ingress can be executed.' })
+  if (!preflight.cloudflared.found) blockers.push({ code: 'cloudflared-not-found', message: 'No user-installed cloudflared executable was found.' })
+  if (preflight.autoTunnelEnabled) {
+    blockers.push({ code: 'auto-tunnel-active', message: 'The existing autoTunnel remains active and owns the advertised public URL.' })
+    warnings.push('This planner does not stop or reconfigure autoTunnel.')
+  }
+  if (target.includeRemote) {
+    blockers.push({ code: 'remote-transport-only', message: '/remote is only the paired desktop transport; publishing it does not publish the desktop boot page, assets, or pairing acceptance.' })
+    warnings.push('The /remote opt-in is transport-only and is not a complete remote desktop ingress.')
+  }
+  if (target.hostname === inspection.zone.name) blockers.push({ code: 'zone-apex-not-supported', message: 'Use a dedicated subdomain instead of the zone apex.' })
+
+  const actions: SetupPlanAction[] = []
+  const tunnels = inspection.tunnels.filter(tunnel => tunnel.name === target.tunnelName)
+  const tunnel = tunnels.length === 1 ? tunnels[0] : undefined
+  const reusableTunnel = tunnel?.configSrc === 'local' ? tunnel : undefined
+  const tunnelConflict = tunnels.length > 1 || (tunnel !== undefined && reusableTunnel === undefined)
+  if (tunnels.length > 1) blockers.push({ code: 'resource-conflict', message: 'Multiple tunnels use the requested name.' })
+  if (tunnel !== undefined && reusableTunnel === undefined) blockers.push({ code: 'resource-conflict', message: 'The matching tunnel is not proven to be locally managed.' })
+  actions.push({
+    id: 'tunnel',
+    resource: 'tunnel',
+    operation: tunnelConflict ? 'manual' : reusableTunnel === undefined ? 'create' : 'reuse',
+    target: target.tunnelName,
+    detail: tunnelConflict
+      ? 'Would stop for manual resolution because the existing tunnel set is not one proven locally managed resource.'
+      : reusableTunnel === undefined
+        ? 'Would create one locally managed named tunnel.'
+        : 'Would reuse the exact locally managed named tunnel after a future confirmed re-inspection.',
+  })
+  actions.push({
+    id: 'credentials',
+    resource: 'credentials',
+    operation: tunnels.length === 0 ? 'write' : 'manual',
+    target: 'private tunnel credential file',
+    detail: tunnels.length === 0
+      ? 'Would write mode-0400 credentials only in a future execution PR.'
+      : 'A future execution PR must verify an existing private credential file before this tunnel can be reused.',
+  })
+
+  const expectedDns = reusableTunnel === undefined ? undefined : `${reusableTunnel.id}.cfargotunnel.com`
+  const exactDns = expectedDns === undefined ? undefined : inspection.dnsRecords.find(record => record.type === 'CNAME'
+    && record.name === target.hostname && record.content.replace(/\.$/, '') === expectedDns && record.proxied)
+  const dnsConflict = inspection.dnsRecords.length > 1 || (inspection.dnsRecords.length === 1 && exactDns === undefined)
+  if (dnsConflict) blockers.push({ code: 'resource-conflict', message: 'Existing DNS does not match one exact proxied tunnel CNAME.' })
+  const dnsNeedsManualResolution = tunnelConflict || dnsConflict
+  actions.push({
+    id: 'dns',
+    resource: 'dns',
+    operation: dnsNeedsManualResolution ? 'manual' : exactDns === undefined ? 'create' : 'reuse',
+    target: target.hostname,
+    detail: dnsNeedsManualResolution
+      ? 'Would stop for manual resolution until both the named tunnel and existing DNS are unambiguous.'
+      : exactDns === undefined ? 'Would create one proxied CNAME for the named tunnel.' : 'Would reuse the exact proxied tunnel CNAME.',
+  })
+
+  const otpCandidates = inspection.identityProviders.filter(provider => provider.type === 'onetimepin')
+  const otp = otpCandidates.length === 1 ? otpCandidates[0] : undefined
+  const otpConflict = otpCandidates.length > 1
+  if (otpConflict) blockers.push({ code: 'resource-conflict', message: 'Multiple One-time PIN identity providers exist; no unique provider can be selected.' })
+  actions.push({
+    id: 'otp-idp',
+    resource: 'otp-idp',
+    operation: otpConflict ? 'manual' : otp === undefined ? 'create' : 'reuse',
+    target: otp?.name ?? OTP_IDP_NAME,
+    detail: otpConflict
+      ? 'Would stop for manual selection because the One-time PIN provider is ambiguous.'
+      : otp === undefined ? 'Would create an account One-time PIN provider.' : 'Would reuse the unique account One-time PIN provider.',
+  })
+
+  const apps = inspection.accessApps
+  const app = apps.length === 1 ? apps[0] : undefined
+  const multipleApps = apps.length > 1
+  if (multipleApps) blockers.push({ code: 'resource-conflict', message: 'Multiple Access apps target this hostname.' })
+  const exactApp = app !== undefined && otp !== undefined && app.type === 'self_hosted' && app.domain === target.hostname
+    && app.destinations.length === 1 && app.destinations[0]?.type === 'public' && app.destinations[0]?.uri?.toLowerCase() === target.hostname
+    && app.allowedIdps.length === 1 && app.allowedIdps[0] === otp.id && app.autoRedirectToIdentity
+  const appConflict = multipleApps || (app !== undefined && !exactApp)
+  if (app !== undefined && !exactApp) blockers.push({ code: 'resource-conflict', message: 'The existing Access app is not restricted to the exact hostname and One-time PIN provider.' })
+  const appNeedsManualResolution = otpConflict || appConflict
+  actions.push({
+    id: 'access-app',
+    resource: 'access-app',
+    operation: appNeedsManualResolution ? 'manual' : exactApp ? 'reuse' : 'create',
+    target: target.accessAppName,
+    detail: appNeedsManualResolution
+      ? 'Would stop for manual resolution until the One-time PIN provider and existing Access apps are unambiguous.'
+      : exactApp ? 'Would reuse the exact self-hosted Access app.' : 'Would create a self-hosted Access app restricted to One-time PIN.',
+  })
+
+  const policies = app === undefined ? [] : inspection.policies.filter(policy => policy.appId === app.id)
+  const exactPolicy = otp === undefined ? undefined : policies.find(policy => policy.exactEmailOtpId === otp.id)
+  const policyConflict = app !== undefined && (policies.length > 1 || (policies.length === 1 && exactPolicy === undefined))
+  if (policyConflict) blockers.push({ code: 'resource-conflict', message: 'The existing Access policy is not one exact-email One-time PIN allow policy.' })
+  const policyNeedsManualResolution = appNeedsManualResolution || policyConflict
+  actions.push({
+    id: 'access-policy',
+    resource: 'access-policy',
+    operation: policyNeedsManualResolution ? 'manual' : exactPolicy === undefined ? 'create' : 'reuse',
+    target: `${target.accessAppName} OTP`.slice(0, 128),
+    detail: policyNeedsManualResolution
+      ? 'Would stop for manual resolution until the Access app, identity provider, and existing policies are unambiguous.'
+      : exactPolicy === undefined ? 'Would create one exact-email One-time PIN allow policy.' : 'Would reuse the exact email-only allow policy.',
+  })
+
+  actions.push({ id: 'config', resource: 'config', operation: 'write', target: 'dedicated cloudflared ingress config', detail: `Would route ${target.includeRemote ? '/m and /remote' : '/m only'} and finish with an HTTP 404 catch-all without Host rewriting.` })
+  const service = servicePreview(preflight.platform)
+  actions.push({ id: 'service', resource: 'service', operation: service.mode === 'launchd-preview' ? 'install' : 'manual', target: service.mode === 'launchd-preview' ? 'dedicated user launchd service' : `${preflight.platform} manual service`, detail: service.summary })
+
+  const publishedPaths: ['/m'] | ['/m', '/remote'] = target.includeRemote ? ['/m', '/remote'] : ['/m']
+  const ingress: SetupPlan['ingress'] = {
+    rules: [
+      { hostname: target.hostname, path: '^/m($|/.*)', service: preflight.dsh.localOrigin, purpose: 'mobile-pairing' },
+      ...(target.includeRemote ? [{ hostname: target.hostname, path: '^/remote($|/.*)', service: preflight.dsh.localOrigin, purpose: 'remote-transport-only' as const }] : []),
+      { service: 'http_status:404', purpose: 'deny-all-other-paths' },
+    ],
+    finalCatchAll: 'http_status:404',
+  }
+  const draft = {
+    readOnly: true as const, executionAvailable: false as const, canApply: false as const,
+    hostname: target.hostname, publicBaseUrl: `https://${target.hostname}`, localOrigin: preflight.dsh.localOrigin,
+    zoneName: inspection.zone.name, tunnelName: target.tunnelName, accessAppName: target.accessAppName,
+    includeRemote: target.includeRemote, publishedPaths, preservesExternalHost: true as const,
+    cloudflarePermissions: { read: 'verified' as const, write: 'unverified' as const },
+    ingress, service, actions, blockers, warnings,
+  }
+  const inspectionFingerprint = sha256(canonicalJson(inspection))
+  const planId = sha256(canonicalJson({ version: 1, draft, inspectionFingerprint, emailHash: target.emailHash }))
+  return { planId, ...draft }
+}
+
+function servicePreview(platform: NodeJS.Platform): SetupServicePreview {
+  if (platform === 'darwin') return {
+    mode: 'launchd-preview', platform,
+    summary: 'Would install a dedicated per-user launchd service after a future explicit confirmation.',
+    steps: [
+      { id: 'write-config', detail: 'Write a dedicated cloudflared ingress file.' },
+      { id: 'write-plist', detail: 'Write a dedicated user LaunchAgent plist.' },
+      { id: 'bootstrap', detail: 'Bootstrap that exact label with launchctl.' },
+    ],
+  }
+  return {
+    mode: 'manual-preview', platform,
+    summary: platform === 'win32' ? 'Windows remains a structured manual-service path in PR1.' : `${platform} remains a structured manual-service path in PR1.`,
+    steps: [
+      { id: 'write-config-manually', detail: 'Review and write the generated ingress config manually.' },
+      { id: 'install-service-manually', detail: 'Install and operate cloudflared with the platform service manager.' },
+      { id: 'verify-manually', detail: 'Verify /m, the optional /remote transport, and the final 404 rule.' },
+    ],
+  }
+}
+
+function defaultTunnelName(hostname: string): string {
+  const safe = hostname.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+  return `dsh-remote-${safe}`.slice(0, 64).replace(/[-.]$/, '')
+}
+
+function defaultAccessAppName(hostname: string): string { return `DSH Remote - ${hostname}`.slice(0, 128) }
+function sha256(value: string): string { return createHash('sha256').update(value).digest('hex') }
+
+/** Deterministic JSON used only for secret-free fingerprints and plan IDs. */
+export function canonicalJson(value: unknown): string {
+  if (value === undefined) return 'null'
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (typeof value === 'object' && value !== null) {
+    return `{${Object.entries(value).sort(([left], [right]) => left.localeCompare(right)).map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`).join(',')}}`
+  }
+  return JSON.stringify(value) ?? 'null'
+}

--- a/packages/dsh-remote-web-ui/src/index.ts
+++ b/packages/dsh-remote-web-ui/src/index.ts
@@ -26,6 +26,8 @@ import { makeMobileApiRoutes } from './mobile-api.ts'
 import { PendingTracker } from './mobile-pending.ts'
 import { makePairedModelCatalogRoutes } from './paired-model-catalog.ts'
 import { makeRemoteApiRoutes, makeRemoteApiUpgradeRoutes } from './remote-api.ts'
+import { createCloudflareSetupPlanner } from './cloudflare-plan.ts'
+import { makeSetupRoutes } from './setup-routes.ts'
 import { claimPostureKey, postureTargets, probePosture, releasePostureKey } from './posture.ts'
 import { lanIPv4Addresses } from './lan.ts'
 import { TunnelManager, type TunnelInfo } from './tunnel.ts'
@@ -293,6 +295,14 @@ function applyImpl(ctx: Context, config?: Config): void {
   if (apiProxy === undefined) {
     console.warn('remote-web-ui: apiProxy service unavailable — the mobile data channel is disabled')
   }
+  const setupPlanner = createCloudflareSetupPlanner({
+    host: ctx.webServer.host,
+    port: ctx.webServer.port,
+    config: () => {
+      const value = resolve()
+      return { autoTunnel: value.autoTunnel, publicBaseUrl: value.publicBaseUrl }
+    },
+  })
   // ── remote update ────────────────────────────────────────────────────────
   // The dsh-web-ui self-update surface: probe the npm registry for family
   // releases and run `pnpm update --latest` in the owning profile. Resolutions
@@ -373,6 +383,7 @@ function applyImpl(ctx: Context, config?: Config): void {
       port: ctx.webServer.port,
       requirePairingForLan: () => resolve().requirePairingForLan,
     }),
+    ...makeSetupRoutes({ service: setupPlanner }),
     ...updateRoutes,
   ]
   const upgrades = makeRemoteApiUpgradeRoutes({

--- a/packages/dsh-remote-web-ui/src/local-control.ts
+++ b/packages/dsh-remote-web-ui/src/local-control.ts
@@ -1,0 +1,60 @@
+/** Browser-trust fence shared by loopback-only control-plane routes. */
+
+import type { IncomingMessage } from 'node:http'
+import { isLoopbackClient } from './gate.ts'
+
+export interface LocalControlFenceOptions {
+  /** Require requests to target this exact HTTP origin and authority. */
+  expectedOrigin?: string
+  /** Require an explicit browser Origin header (recommended for POST controls). */
+  requireOrigin?: boolean
+}
+
+/**
+ * Accept a local control request only when both its socket and Host are
+ * loopback, browser metadata does not identify it as cross-site, and any
+ * supplied Origin exactly matches the addressed local HTTP origin.
+ */
+export function isTrustedLocalControlRequest(
+  request: IncomingMessage,
+  options: LocalControlFenceOptions = {},
+): boolean {
+  if (!isLoopbackClient(request)) return false
+  // Origin is the POST authority gate. Sec-Fetch-Site is an additional veto:
+  // accept it when absent for non-browser local clients, but never ignore an
+  // explicit browser cross-site classification.
+  if (request.headers['sec-fetch-site'] === 'cross-site') return false
+
+  const host = request.headers.host
+  if (typeof host !== 'string') return false
+
+  let hostUrl: URL
+  try {
+    hostUrl = new URL(`http://${host}`)
+  } catch {
+    return false
+  }
+  // WHATWG parsing accepts strings that are not HTTP Host authorities (for
+  // example user@127.0.0.1/path) and then normalizes their origin. Never let
+  // those extra components disappear across the trust comparison.
+  if (hostUrl.username !== '' || hostUrl.password !== '' || hostUrl.pathname !== '/' || hostUrl.search !== '' || hostUrl.hash !== '') {
+    return false
+  }
+  const requestOrigin = hostUrl.origin
+  if (options.expectedOrigin !== undefined && requestOrigin !== options.expectedOrigin) return false
+
+  const origin = request.headers.origin
+  if (origin === undefined) return options.requireOrigin !== true
+  try {
+    const originUrl = new URL(origin)
+    return originUrl.username === ''
+      && originUrl.password === ''
+      && originUrl.pathname === '/'
+      && originUrl.search === ''
+      && originUrl.hash === ''
+      && originUrl.origin === requestOrigin
+      && origin === originUrl.origin
+  } catch {
+    return false
+  }
+}

--- a/packages/dsh-remote-web-ui/src/remote-api.ts
+++ b/packages/dsh-remote-web-ui/src/remote-api.ts
@@ -15,7 +15,8 @@
  *   plane, credentials — the `PRIVILEGED_METHODS` set of client-connection)
  *   are denied here. The set is pinned by tests/remote-contract.spec.ts.
  * - `/api/pair/*`, `/api/update/*`, `/api/plugin-manager/*`,
- *   `/api/dsh-desktop-launcher/*` and `/api/dsh-web-ui-settings/*` stay physically local.
+ *   `/api/dsh-desktop-launcher/*`, `/api/dsh-web-ui-settings/*`, and
+ *   `/api/remote-setup/*` stay physically local.
  * - Everything else is HTTP- or WebSocket-proxied to the local port with
  *   Host rewritten, Origin and cookies dropped, and a synthetic same-origin
  *   browser marker added after authentication. Plugin loopback fences then
@@ -34,6 +35,7 @@ import {
   LOOPBACK_ONLY_METHODS,
   PLUGIN_MANAGER_PATH,
   REMOTE_PREFIX,
+  REMOTE_SETUP_PATH,
   REMOTE_UPGRADE_PATHS,
   WEB_UI_SETTINGS_BRIDGE_PATH,
 } from './remote-methods.ts'
@@ -44,6 +46,7 @@ export {
   PLUGIN_MANAGER_PATH,
   REMOTE_API_PATHS,
   REMOTE_PREFIX,
+  REMOTE_SETUP_PATH,
   REMOTE_UPGRADE_PATHS,
   WEB_UI_SETTINGS_BRIDGE_PATH,
 } from './remote-methods.ts'
@@ -122,6 +125,9 @@ export function loopbackOnlyDenial(innerPath: string): string | undefined {
   }
   if (innerPath === WEB_UI_SETTINGS_BRIDGE_PATH || innerPath.startsWith(`${WEB_UI_SETTINGS_BRIDGE_PATH}/`)) {
     return 'settings-bridge endpoints stay loopback-only and stay unreachable from a paired remote desktop'
+  }
+  if (innerPath === REMOTE_SETUP_PATH || innerPath.startsWith(`${REMOTE_SETUP_PATH}/`)) {
+    return 'remote-setup endpoints stay loopback-only and stay unreachable from a paired remote desktop'
   }
   if (!innerPath.startsWith('/api/')) return undefined
   const method = innerPath.slice('/api/'.length)

--- a/packages/dsh-remote-web-ui/src/remote-methods.ts
+++ b/packages/dsh-remote-web-ui/src/remote-methods.ts
@@ -36,6 +36,9 @@ export const DESKTOP_LAUNCHER_PATH = '/api/dsh-desktop-launcher'
 /** Family settings-bridge HTTP prefix: describe/mutate stay physically local. */
 export const WEB_UI_SETTINGS_BRIDGE_PATH = '/api/dsh-web-ui-settings'
 
+/** Read-only setup planner HTTP prefix: local machine facts and credentials stay local. */
+export const REMOTE_SETUP_PATH = '/api/remote-setup'
+
 /**
  * Loopback-only methods of the host API surface, mirrored from
  * client-connection's `PRIVILEGED_METHODS` (pinned by

--- a/packages/dsh-remote-web-ui/src/setup-contract.ts
+++ b/packages/dsh-remote-web-ui/src/setup-contract.ts
@@ -1,0 +1,202 @@
+/**
+ * Wire contract for the loopback-only HTTPS setup preflight and plan.
+ *
+ * PR1 is deliberately read-only: credentials exist only in plan requests,
+ * while every response describes inspection results and a preview that cannot
+ * be executed. Apply, rollback, persistence, and mutation contracts do not
+ * belong in this module.
+ */
+
+import { z } from 'zod'
+
+/** Exact local control-plane endpoints. Neither endpoint is public ingress. */
+export const SETUP_PATHS = {
+  preflight: '/api/remote-setup/preflight',
+  plan: '/api/remote-setup/plan',
+} as const
+
+/** Tokens may be long, but the complete strict request remains small. */
+export const SETUP_MAX_BODY_BYTES = 16 * 1024
+
+const hostnameSchema = z.string().trim().toLowerCase().min(4).max(253).superRefine((value, context) => {
+  const reservedSuffixes = new Set(['local', 'localhost', 'localdomain', 'internal', 'lan', 'home', 'test', 'invalid', 'example', 'onion'])
+  if (!value.includes('.') || value.endsWith('.') || value === 'localhost') {
+    context.addIssue({ code: 'custom', message: 'expected a complete public hostname' })
+    return
+  }
+  const labels = value.split('.')
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(value) || reservedSuffixes.has(labels.at(-1) ?? '')) {
+    context.addIssue({ code: 'custom', message: 'expected a public DNS hostname, not an IP or local name' })
+    return
+  }
+  if (labels.some(label => label.length < 1 || label.length > 63 || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label))) {
+    context.addIssue({ code: 'custom', message: 'expected an ASCII DNS hostname' })
+  }
+})
+
+const emailSchema = z.string().trim().toLowerCase().min(3).max(254).email()
+const tokenSchema = z.string().min(20).max(4096).regex(/^\S+$/, 'token must not contain whitespace')
+const configuredNameSchema = z.string().trim().min(1).max(256).regex(/^[A-Za-z0-9][A-Za-z0-9 ._:/@+-]*$/)
+const tunnelNameSchema = z.string().trim().min(1).max(64).regex(/^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$/)
+const accessAppNameSchema = z.string().trim().min(1).max(128)
+  .regex(/^[^\u0000-\u001f\u007f]+$/, 'access app name must not contain control characters')
+
+export const setupCredentialSchema = z.discriminatedUnion('source', [
+  z.object({ source: z.literal('request'), token: tokenSchema }).strict(),
+  z.object({ source: z.literal('keychain'), service: configuredNameSchema, account: configuredNameSchema.optional() }).strict(),
+])
+
+/** Strict request for one read-only Cloudflare inspection and pure plan. */
+export const setupPlanRequestSchema = z.object({
+  hostname: hostnameSchema,
+  email: emailSchema,
+  credential: setupCredentialSchema,
+  tunnelName: tunnelNameSchema.optional(),
+  accessAppName: accessAppNameSchema.optional(),
+  /** `/m` is always planned; `/remote` is an explicit transport-only opt-in. */
+  includeRemote: z.boolean().default(false),
+}).strict()
+
+export type SetupCredential = z.infer<typeof setupCredentialSchema>
+export type SetupPlanRequest = z.infer<typeof setupPlanRequestSchema>
+
+export type SetupErrorCode =
+  | 'forbidden'
+  | 'bad-payload'
+  | 'unsupported-platform'
+  | 'dsh-not-loopback'
+  | 'cloudflared-not-found'
+  | 'cloudflare-auth-failed'
+  | 'cloudflare-permission-denied'
+  | 'cloudflare-unavailable'
+  | 'keychain-unavailable'
+  | 'zone-not-found'
+  | 'internal-error'
+
+export type SetupErrorField =
+  | 'hostname'
+  | 'email'
+  | 'credential'
+  | 'tunnelName'
+  | 'accessAppName'
+  | 'includeRemote'
+
+export interface SetupApiError {
+  ok: false
+  error: {
+    code: SetupErrorCode
+    message: string
+    retryable: boolean
+    field?: SetupErrorField
+  }
+}
+
+export interface SetupPreflightResponse {
+  ok: true
+  readOnly: true
+  executionAvailable: false
+  preflight: {
+    platform: NodeJS.Platform
+    dsh: {
+      host: string
+      port: number
+      localOrigin: string
+      loopbackOnly: boolean
+    }
+    cloudflared: {
+      found: boolean
+      version?: string
+    }
+    serviceMode: 'launchd-preview' | 'manual-preview'
+    autoTunnelEnabled: boolean
+    configuredPublicBaseUrl?: string
+  }
+}
+
+export type SetupResourceKind =
+  | 'tunnel'
+  | 'dns'
+  | 'otp-idp'
+  | 'access-app'
+  | 'access-policy'
+  | 'credentials'
+  | 'config'
+  | 'service'
+
+export type SetupPlanOperation = 'create' | 'reuse' | 'write' | 'install' | 'manual'
+
+/** One non-secret preview line. It cannot be submitted for execution in PR1. */
+export interface SetupPlanAction {
+  id: string
+  resource: SetupResourceKind
+  operation: SetupPlanOperation
+  target: string
+  detail: string
+}
+
+export type SetupBlockerCode =
+  | 'execution-unavailable'
+  | 'mobile-ingress-not-ready'
+  | 'dsh-not-loopback'
+  | 'cloudflared-not-found'
+  | 'auto-tunnel-active'
+  | 'zone-apex-not-supported'
+  | 'resource-conflict'
+  | 'remote-transport-only'
+
+export interface SetupBlocker {
+  code: SetupBlockerCode
+  message: string
+}
+
+export interface SetupIngressRulePreview {
+  hostname?: string
+  path?: string
+  service: string
+  purpose: 'mobile-pairing' | 'remote-transport-only' | 'deny-all-other-paths'
+}
+
+export interface SetupServicePreview {
+  mode: 'launchd-preview' | 'manual-preview'
+  platform: NodeJS.Platform
+  summary: string
+  steps: Array<{ id: string; detail: string }>
+}
+
+export interface SetupPlan {
+  planId: string
+  readOnly: true
+  executionAvailable: false
+  canApply: false
+  hostname: string
+  publicBaseUrl: string
+  localOrigin: string
+  zoneName: string
+  tunnelName: string
+  accessAppName: string
+  includeRemote: boolean
+  publishedPaths: ['/m'] | ['/m', '/remote']
+  preservesExternalHost: true
+  cloudflarePermissions: {
+    read: 'verified'
+    write: 'unverified'
+  }
+  ingress: {
+    rules: SetupIngressRulePreview[]
+    finalCatchAll: 'http_status:404'
+  }
+  service: SetupServicePreview
+  actions: SetupPlanAction[]
+  blockers: SetupBlocker[]
+  warnings: string[]
+}
+
+export interface SetupPlanResponse {
+  ok: true
+  readOnly: true
+  executionAvailable: false
+  plan: SetupPlan
+}
+
+export type SetupPreflightApiResponse = SetupPreflightResponse | SetupApiError
+export type SetupPlanApiResponse = SetupPlanResponse | SetupApiError

--- a/packages/dsh-remote-web-ui/src/setup-routes.ts
+++ b/packages/dsh-remote-web-ui/src/setup-routes.ts
@@ -1,0 +1,169 @@
+/** Loopback-only, read-only HTTP routes for Cloudflare setup planning. */
+
+import type { IncomingMessage, OutgoingHttpHeaders, ServerResponse } from 'node:http'
+import type { WebRoute } from '@deepseek-ai/dsh-host-webserver'
+import type { ZodType } from 'zod'
+import { SetupPlanError } from './cloudflare-plan.ts'
+import { readBoundedJson, writeJson } from './http.ts'
+import { isTrustedLocalControlRequest } from './local-control.ts'
+import {
+  SETUP_MAX_BODY_BYTES,
+  SETUP_PATHS,
+  setupPlanRequestSchema,
+  type SetupApiError,
+  type SetupPlanRequest,
+  type SetupPlanResponse,
+  type SetupPreflightResponse,
+} from './setup-contract.ts'
+
+/** Structural seam between the HTTP control plane and the read-only planner. */
+export interface SetupReadService {
+  readonly localOrigin: string
+  preflight(): Promise<SetupPreflightResponse>
+  plan(input: SetupPlanRequest): Promise<SetupPlanResponse>
+}
+
+/** Route-family dependencies (also the test seam). */
+export interface SetupRoutesDeps {
+  service: SetupReadService
+}
+
+const NO_STORE_HEADERS = { 'cache-control': 'no-store' } as const
+
+function writeSetupJson(
+  response: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: OutgoingHttpHeaders = {},
+): void {
+  writeJson(response, status, body, { ...NO_STORE_HEADERS, ...headers })
+}
+
+function apiError(error: unknown): { status: number; body: SetupApiError } {
+  if (error instanceof SetupPlanError) {
+    const status = (() => {
+      switch (error.code) {
+        case 'bad-payload': return 400
+        case 'cloudflare-auth-failed': return 401
+        case 'forbidden':
+        case 'cloudflare-permission-denied': return 403
+        case 'zone-not-found': return 404
+        case 'unsupported-platform':
+        case 'dsh-not-loopback':
+        case 'cloudflared-not-found':
+        case 'keychain-unavailable': return 412
+        case 'cloudflare-unavailable': return 502
+        default: return 500
+      }
+    })()
+    return {
+      status,
+      body: {
+        ok: false,
+        error: {
+          code: error.code,
+          message: error.message,
+          retryable: error.retryable,
+          ...(error.field === undefined ? {} : { field: error.field }),
+        },
+      },
+    }
+  }
+  return {
+    status: 500,
+    body: {
+      ok: false,
+      error: {
+        code: 'internal-error',
+        message: 'The setup planner failed unexpectedly.',
+        retryable: true,
+      },
+    },
+  }
+}
+
+function routeError(code: 'forbidden' | 'bad-payload', message: string): SetupApiError {
+  return { ok: false, error: { code, message, retryable: false } }
+}
+
+async function parseBody<T>(request: IncomingMessage, schema: ZodType<T>): Promise<T | undefined> {
+  const contentType = request.headers['content-type']?.split(';', 1)[0]?.trim().toLowerCase()
+  if (contentType !== 'application/json') return undefined
+  const contentLength = request.headers['content-length']
+  if (contentLength !== undefined) {
+    const bytes = Number(contentLength)
+    if (!Number.isSafeInteger(bytes) || bytes < 0 || bytes > SETUP_MAX_BODY_BYTES) return undefined
+  }
+
+  let body: unknown
+  try {
+    body = await readBoundedJson(request, SETUP_MAX_BODY_BYTES)
+  } catch {
+    return undefined
+  }
+  const parsed = schema.safeParse(body)
+  return parsed.success ? parsed.data : undefined
+}
+
+/** Build the two exact, read-only setup routes. */
+export function makeSetupRoutes({ service }: SetupRoutesDeps): WebRoute[] {
+  const fence = (request: IncomingMessage, requireOrigin: boolean): boolean => isTrustedLocalControlRequest(request, {
+    expectedOrigin: service.localOrigin,
+    requireOrigin,
+  })
+
+  const requireMethod = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    method: 'GET' | 'POST',
+  ): boolean => {
+    if (request.method === method) return true
+    request.resume()
+    writeSetupJson(response, 405, routeError('bad-payload', `Expected ${method}.`), { allow: method })
+    return false
+  }
+
+  const handlePreflight = async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
+    if (!requireMethod(request, response, 'GET')) return
+    if (!fence(request, false)) {
+      request.resume()
+      writeSetupJson(response, 403, routeError('forbidden', 'Local setup access was refused.'))
+      return
+    }
+    try {
+      writeSetupJson(response, 200, await service.preflight())
+    } catch (error) {
+      const failure = apiError(error)
+      writeSetupJson(response, failure.status, failure.body)
+    }
+  }
+
+  const handlePlan = async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
+    if (!requireMethod(request, response, 'POST')) return
+    // Fence before Content-Type, body buffering, schema parsing, or service
+    // dispatch so an untrusted request cannot make us inspect its token.
+    if (!fence(request, true)) {
+      request.resume()
+      writeSetupJson(response, 403, routeError('forbidden', 'Local setup access was refused.'))
+      return
+    }
+
+    const payload = await parseBody(request, setupPlanRequestSchema)
+    if (payload === undefined) {
+      request.resume()
+      writeSetupJson(response, 400, routeError('bad-payload', 'Expected a valid bounded application/json request body.'))
+      return
+    }
+    try {
+      writeSetupJson(response, 200, await service.plan(payload))
+    } catch (error) {
+      const failure = apiError(error)
+      writeSetupJson(response, failure.status, failure.body)
+    }
+  }
+
+  return [
+    { kind: 'exact', path: SETUP_PATHS.preflight, handler: handlePreflight },
+    { kind: 'exact', path: SETUP_PATHS.plan, handler: handlePlan },
+  ]
+}

--- a/packages/dsh-remote-web-ui/tests/cloudflare-plan.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/cloudflare-plan.spec.ts
@@ -1,0 +1,509 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCloudflareSetupPlan,
+  CloudflareHttpReadApi,
+  createCloudflareSetupPlanner,
+  SetupPlanError,
+  type BuildCloudflareSetupPlanInput,
+  type CloudflareInspectionSnapshot,
+  type CloudflareReadApi,
+} from '../src/cloudflare-plan.ts'
+import type { SetupPlanRequest, SetupPreflightResponse } from '../src/setup-contract.ts'
+
+const TOKEN = 'cf_read_token_12345678901234567890'
+const EMAIL = 'owner@acme.com'
+
+function preflight(overrides: Partial<SetupPreflightResponse['preflight']> = {}): SetupPreflightResponse['preflight'] {
+  return {
+    platform: 'darwin',
+    dsh: {
+      host: '127.0.0.1',
+      port: 3080,
+      localOrigin: 'http://127.0.0.1:3080',
+      loopbackOnly: true,
+    },
+    cloudflared: { found: true, version: '2026.8.0' },
+    serviceMode: 'launchd-preview',
+    autoTunnelEnabled: false,
+    ...overrides,
+  }
+}
+
+function inspection(overrides: Partial<CloudflareInspectionSnapshot> = {}): CloudflareInspectionSnapshot {
+  return {
+    zone: { id: 'zone-1', name: 'acme.com', accountId: 'account-1' },
+    tunnels: [],
+    dnsRecords: [],
+    identityProviders: [],
+    accessApps: [],
+    policies: [],
+    ...overrides,
+  }
+}
+
+function buildInput(overrides: Partial<BuildCloudflareSetupPlanInput> = {}): BuildCloudflareSetupPlanInput {
+  return {
+    preflight: preflight(),
+    target: {
+      hostname: 'remote.acme.com',
+      tunnelName: 'dsh-remote-acme',
+      accessAppName: 'DSH Remote - remote.acme.com',
+      includeRemote: false,
+      emailHash: 'secret-free-email-fingerprint',
+    },
+    inspection: inspection(),
+    ...overrides,
+  }
+}
+
+function request(credential: SetupPlanRequest['credential'] = { source: 'request', token: TOKEN }): SetupPlanRequest {
+  return {
+    hostname: 'remote.acme.com',
+    email: EMAIL,
+    credential,
+    includeRemote: false,
+  }
+}
+
+function fakeReadApi(overrides: Partial<CloudflareReadApi> = {}): CloudflareReadApi {
+  return {
+    verifyToken: async () => {},
+    listZones: async () => [{ id: 'zone-1', name: 'acme.com', accountId: 'account-1' }],
+    listTunnels: async () => [],
+    listDnsRecords: async () => [],
+    listIdentityProviders: async () => [],
+    listAccessApps: async () => [],
+    listAccessPolicies: async () => [],
+    ...overrides,
+  }
+}
+
+describe('pure Cloudflare setup planning', () => {
+  it('defaults to /m, preserves Host, ends in 404, and stays non-executable', () => {
+    const plan = buildCloudflareSetupPlan(buildInput())
+
+    expect(plan).toMatchObject({
+      readOnly: true,
+      executionAvailable: false,
+      canApply: false,
+      includeRemote: false,
+      publishedPaths: ['/m'],
+      preservesExternalHost: true,
+      cloudflarePermissions: { read: 'verified', write: 'unverified' },
+    })
+    expect(plan.ingress.rules).toEqual([
+      {
+        hostname: 'remote.acme.com',
+        path: '^/m($|/.*)',
+        service: 'http://127.0.0.1:3080',
+        purpose: 'mobile-pairing',
+      },
+      { service: 'http_status:404', purpose: 'deny-all-other-paths' },
+    ])
+    expect(plan.ingress.finalCatchAll).toBe('http_status:404')
+    expect(plan.blockers.map(blocker => blocker.code)).toEqual(expect.arrayContaining([
+      'execution-unavailable',
+      'mobile-ingress-not-ready',
+    ]))
+    expect(plan.blockers.find(blocker => blocker.code === 'mobile-ingress-not-ready')?.message)
+      .toContain('/api/pair/accept')
+    expect(plan.actions.find(action => action.id === 'credentials')?.operation).toBe('write')
+  })
+
+  it('adds /remote only as an explicit transport-only opt-in', () => {
+    const input = buildInput()
+    input.target.includeRemote = true
+    const plan = buildCloudflareSetupPlan(input)
+
+    expect(plan.publishedPaths).toEqual(['/m', '/remote'])
+    expect(plan.ingress.rules[1]).toMatchObject({
+      path: '^/remote($|/.*)',
+      purpose: 'remote-transport-only',
+    })
+    expect(plan.blockers.map(blocker => blocker.code)).toContain('remote-transport-only')
+    expect(plan.ingress.rules.at(-1)).toEqual({ service: 'http_status:404', purpose: 'deny-all-other-paths' })
+  })
+
+  it('keeps autoTunnel unchanged and reports local readiness blockers', () => {
+    const plan = buildCloudflareSetupPlan(buildInput({
+      preflight: preflight({
+        dsh: { host: '0.0.0.0', port: 3080, localOrigin: 'http://127.0.0.1:3080', loopbackOnly: false },
+        cloudflared: { found: false },
+        autoTunnelEnabled: true,
+      }),
+    }))
+
+    expect(plan.blockers.map(blocker => blocker.code)).toEqual(expect.arrayContaining([
+      'dsh-not-loopback',
+      'cloudflared-not-found',
+      'auto-tunnel-active',
+    ]))
+    expect(plan.warnings.join(' ')).toContain('does not stop or reconfigure autoTunnel')
+  })
+
+  it('previews launchd on Darwin and structured manual service steps on Windows', () => {
+    const darwin = buildCloudflareSetupPlan(buildInput())
+    const windows = buildCloudflareSetupPlan(buildInput({
+      preflight: preflight({ platform: 'win32', serviceMode: 'manual-preview' }),
+    }))
+
+    expect(darwin.service).toMatchObject({ mode: 'launchd-preview', platform: 'darwin' })
+    expect(darwin.service.steps.map(step => step.id)).toContain('write-plist')
+    expect(windows.service).toMatchObject({ mode: 'manual-preview', platform: 'win32' })
+    expect(windows.service.steps.map(step => step.id)).toEqual([
+      'write-config-manually',
+      'install-service-manually',
+      'verify-manually',
+    ])
+  })
+
+  it('makes planId stable for canonical facts and sensitive to inspection changes', () => {
+    const facts = inspection({
+      tunnels: [
+        { id: 'tunnel-b', name: 'other', configSrc: 'local' },
+        { id: 'tunnel-a', name: 'dsh-remote-acme', configSrc: 'local' },
+      ],
+      identityProviders: [
+        { id: 'idp-b', name: 'Other', type: 'github' },
+        { id: 'idp-a', name: 'PIN', type: 'onetimepin' },
+      ],
+    })
+    const reordered = inspection({
+      tunnels: [...facts.tunnels].reverse(),
+      identityProviders: [...facts.identityProviders].reverse(),
+    })
+    const first = buildCloudflareSetupPlan(buildInput({ inspection: facts }))
+    const second = buildCloudflareSetupPlan(buildInput({ inspection: reordered }))
+    const changed = buildCloudflareSetupPlan(buildInput({
+      inspection: inspection({
+        ...facts,
+        tunnels: facts.tunnels.map(tunnel => tunnel.id === 'tunnel-a' ? { ...tunnel, id: 'tunnel-new' } : tunnel),
+      }),
+    }))
+
+    expect(first.planId).toMatch(/^[a-f0-9]{64}$/)
+    expect(second.planId).toBe(first.planId)
+    expect(changed.planId).not.toBe(first.planId)
+  })
+
+  it('never treats a tunnel with an unknown management source as reusable', () => {
+    const plan = buildCloudflareSetupPlan(buildInput({
+      inspection: inspection({ tunnels: [{ id: 'tunnel-1', name: 'dsh-remote-acme' }] }),
+    }))
+
+    expect(plan.actions.find(action => action.id === 'tunnel')?.operation).toBe('manual')
+    expect(plan.actions.find(action => action.id === 'credentials')?.operation).toBe('manual')
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: 'resource-conflict' }))
+  })
+
+  it('reuses only one exact local tunnel, CNAME, OTP provider, Access app, and policy', () => {
+    const plan = buildCloudflareSetupPlan(buildInput({
+      inspection: inspection({
+        tunnels: [{ id: 'tunnel-1', name: 'dsh-remote-acme', configSrc: 'local' }],
+        dnsRecords: [{
+          id: 'dns-1',
+          type: 'CNAME',
+          name: 'remote.acme.com',
+          content: 'tunnel-1.cfargotunnel.com',
+          proxied: true,
+        }],
+        identityProviders: [{ id: 'idp-1', name: 'One-time PIN', type: 'onetimepin' }],
+        accessApps: [{
+          id: 'app-1',
+          name: 'DSH Remote - remote.acme.com',
+          domain: 'remote.acme.com',
+          type: 'self_hosted',
+          destinations: [{ type: 'public', uri: 'remote.acme.com' }],
+          allowedIdps: ['idp-1'],
+          autoRedirectToIdentity: true,
+        }],
+        policies: [{
+          appId: 'app-1',
+          id: 'policy-1',
+          name: 'Exact owner OTP',
+          fingerprint: 'policy-fingerprint',
+          exactEmailOtpId: 'idp-1',
+        }],
+      }),
+    }))
+
+    expect(Object.fromEntries(plan.actions.map(action => [action.id, action.operation]))).toMatchObject({
+      tunnel: 'reuse',
+      credentials: 'manual',
+      dns: 'reuse',
+      'otp-idp': 'reuse',
+      'access-app': 'reuse',
+      'access-policy': 'reuse',
+    })
+    expect(plan.blockers.map(blocker => blocker.code)).not.toContain('resource-conflict')
+  })
+
+  it('marks existing non-exact DNS, app, and policy resources for manual resolution', () => {
+    const plan = buildCloudflareSetupPlan(buildInput({
+      inspection: inspection({
+        tunnels: [{ id: 'tunnel-1', name: 'dsh-remote-acme', configSrc: 'local' }],
+        dnsRecords: [{
+          id: 'dns-wrong-host',
+          type: 'CNAME',
+          name: 'other.acme.com',
+          content: 'tunnel-1.cfargotunnel.com',
+          proxied: true,
+        }],
+        identityProviders: [
+          { id: 'idp-1', name: 'One-time PIN A', type: 'onetimepin' },
+          { id: 'idp-2', name: 'One-time PIN B', type: 'onetimepin' },
+        ],
+        accessApps: [{
+          id: 'app-1',
+          name: 'Existing app',
+          domain: 'remote.acme.com',
+          type: 'self_hosted',
+          destinations: [{ type: 'public', uri: 'remote.acme.com' }],
+          allowedIdps: [],
+          autoRedirectToIdentity: false,
+        }],
+        policies: [{
+          appId: 'app-1',
+          id: 'policy-1',
+          name: 'Wrong policy',
+          fingerprint: 'wrong-policy',
+        }],
+      }),
+    }))
+    const operations = Object.fromEntries(plan.actions.map(action => [action.id, action.operation]))
+
+    expect(operations).toMatchObject({ dns: 'manual', 'otp-idp': 'manual', 'access-app': 'manual', 'access-policy': 'manual' })
+    expect(plan.blockers.map(blocker => blocker.code)).toContain('resource-conflict')
+  })
+
+  it('propagates ambiguous prerequisites without previewing dependent creates', () => {
+    const plan = buildCloudflareSetupPlan(buildInput({
+      inspection: inspection({
+        tunnels: [
+          { id: 'tunnel-1', name: 'dsh-remote-acme', configSrc: 'local' },
+          { id: 'tunnel-2', name: 'dsh-remote-acme', configSrc: 'local' },
+        ],
+        identityProviders: [
+          { id: 'idp-1', name: 'One-time PIN A', type: 'onetimepin' },
+          { id: 'idp-2', name: 'One-time PIN B', type: 'onetimepin' },
+        ],
+      }),
+    }))
+    const operations = Object.fromEntries(plan.actions.map(action => [action.id, action.operation]))
+
+    expect(operations).toMatchObject({
+      tunnel: 'manual',
+      credentials: 'manual',
+      dns: 'manual',
+      'otp-idp': 'manual',
+      'access-app': 'manual',
+      'access-policy': 'manual',
+    })
+  })
+})
+
+describe('read-only collector and factory', () => {
+  it.each([
+    ['0.0.0.0', 'http://127.0.0.1:3080', false],
+    ['::', 'http://127.0.0.1:3080', false],
+    ['localhost', 'http://localhost:3080', true],
+    ['127.0.0.2', 'http://127.0.0.2:3080', true],
+    ['::1', 'http://[::1]:3080', true],
+    ['[::1]', 'http://[::1]:3080', true],
+  ] as const)('builds an accessible loopback authority for host %s', async (host, origin, loopbackOnly) => {
+    const planner = createCloudflareSetupPlanner({
+      host,
+      port: 3080,
+      config: () => ({}),
+      platform: 'linux',
+      cloudflaredProbe: async () => ({ found: true }),
+      readApiFactory: () => fakeReadApi(),
+    })
+
+    expect(planner.localOrigin).toBe(origin)
+    await expect(planner.preflight()).resolves.toMatchObject({
+      preflight: { dsh: { localOrigin: origin, loopbackOnly } },
+    })
+  })
+
+  it('normalizes the default HTTP port for the browser Origin fence', () => {
+    const planner = createCloudflareSetupPlanner({
+      host: '127.0.0.1',
+      port: 80,
+      config: () => ({}),
+      platform: 'linux',
+      cloudflaredProbe: async () => ({ found: true }),
+      readApiFactory: () => fakeReadApi(),
+    })
+
+    expect(planner.localOrigin).toBe('http://127.0.0.1')
+  })
+
+  it('uses the request token only to build the read client and omits token/email from the response', async () => {
+    const calls: string[] = []
+    let collectedToken = ''
+    const api = fakeReadApi({
+      verifyToken: async () => { calls.push('verify') },
+      listZones: async () => { calls.push('zones'); return [{ id: 'zone-1', name: 'acme.com', accountId: 'account-1' }] },
+      listTunnels: async () => { calls.push('tunnels'); return [] },
+      listDnsRecords: async () => { calls.push('dns'); return [] },
+      listIdentityProviders: async () => { calls.push('idps'); return [] },
+      listAccessApps: async () => { calls.push('apps'); return [] },
+    })
+    const planner = createCloudflareSetupPlanner({
+      host: '127.0.0.1',
+      port: 3080,
+      config: () => ({ autoTunnel: true }),
+      platform: 'darwin',
+      cloudflaredProbe: async () => ({ found: false }),
+      readApiFactory: token => { collectedToken = token; return api },
+    })
+
+    const response = await planner.plan(request())
+    expect(collectedToken).toBe(TOKEN)
+    expect(calls).toEqual(expect.arrayContaining(['verify', 'zones', 'tunnels', 'dns', 'idps', 'apps']))
+    expect(response.plan.blockers.map(blocker => blocker.code)).toEqual(expect.arrayContaining([
+      'cloudflared-not-found',
+      'auto-tunnel-active',
+    ]))
+    const wire = JSON.stringify(response)
+    expect(wire).not.toContain(TOKEN)
+    expect(wire).not.toContain(EMAIL)
+  })
+
+  it('keeps planId stable when only the in-memory request token changes', async () => {
+    const planner = createCloudflareSetupPlanner({
+      host: '127.0.0.1',
+      port: 3080,
+      config: () => ({}),
+      platform: 'darwin',
+      cloudflaredProbe: async () => ({ found: true }),
+      readApiFactory: () => fakeReadApi(),
+    })
+
+    const first = await planner.plan(request({ source: 'request', token: TOKEN }))
+    const second = await planner.plan(request({ source: 'request', token: 'cf_other_token_12345678901234567890' }))
+    expect(second.plan.planId).toBe(first.plan.planId)
+  })
+
+  it('resolves a Keychain reference before constructing the token-holding read client', async () => {
+    const references: Array<{ service: string; account?: string }> = []
+    let collectedToken = ''
+    const planner = createCloudflareSetupPlanner({
+      host: '127.0.0.1',
+      port: 3080,
+      config: () => ({}),
+      platform: 'darwin',
+      cloudflaredProbe: async () => ({ found: true }),
+      keychainReader: async reference => { references.push(reference); return TOKEN },
+      readApiFactory: token => { collectedToken = token; return fakeReadApi() },
+    })
+
+    const response = await planner.plan(request({ source: 'keychain', service: 'dsh-cloudflare', account: 'setup' }))
+    expect(references).toEqual([{ service: 'dsh-cloudflare', account: 'setup' }])
+    expect(collectedToken).toBe(TOKEN)
+    expect(JSON.stringify(response)).not.toContain(TOKEN)
+  })
+
+  it('uses fixed security argv for the default macOS Keychain reader', async () => {
+    const calls: Array<{ executable: string; args: readonly string[] }> = []
+    const planner = createCloudflareSetupPlanner({
+      host: '127.0.0.1',
+      port: 3080,
+      config: () => ({}),
+      platform: 'darwin',
+      cloudflaredProbe: async () => ({ found: true }),
+      processRunner: async (executable, args) => {
+        calls.push({ executable, args })
+        return { code: 0, stdout: `${TOKEN}\n`, stderr: '' }
+      },
+      readApiFactory: () => fakeReadApi(),
+    })
+
+    await planner.plan(request({ source: 'keychain', service: 'dsh-cloudflare', account: 'setup' }))
+    expect(calls).toEqual([{
+      executable: '/usr/bin/security',
+      args: ['find-generic-password', '-s', 'dsh-cloudflare', '-a', 'setup', '-w'],
+    }])
+  })
+
+  it('throws a stable API error only when a Cloudflare snapshot cannot be formed', async () => {
+    const planner = createCloudflareSetupPlanner({
+      host: '0.0.0.0',
+      port: 3080,
+      config: () => ({ autoTunnel: true }),
+      platform: 'win32',
+      cloudflaredProbe: async () => ({ found: false }),
+      readApiFactory: () => fakeReadApi({ listZones: async () => [] }),
+    })
+
+    const failure = planner.plan(request())
+    await expect(failure).rejects.toBeInstanceOf(SetupPlanError)
+    await expect(failure).rejects.toMatchObject({
+      code: 'zone-not-found',
+      field: 'hostname',
+      retryable: false,
+    })
+  })
+})
+
+describe('Cloudflare GET-only client', () => {
+  it('uses GET and paginates from total_count/per_page without total_pages', async () => {
+    const calls: Array<{ url: string; method: string | undefined; authorization: string | undefined }> = []
+    const fetchFn = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      const headers = new Headers(init?.headers)
+      calls.push({ url, method: init?.method, authorization: headers.get('authorization') ?? undefined })
+      if (url.endsWith('/user/tokens/verify')) {
+        return Response.json({ success: true, result: { status: 'active' } })
+      }
+      const page = new URL(url).searchParams.get('page')
+      return Response.json({
+        success: true,
+        result: [{ id: `tunnel-${page ?? '1'}`, name: 'dsh-remote-acme', config_src: 'local' }],
+        result_info: { page: Number(page ?? '1'), per_page: 1, count: 1, total_count: 2 },
+      })
+    }) as typeof fetch
+    const api = new CloudflareHttpReadApi(TOKEN, fetchFn)
+
+    await api.verifyToken()
+    const tunnels = await api.listTunnels('account-1', 'dsh-remote-acme')
+    await Promise.all([
+      api.listZones(),
+      api.listDnsRecords('zone-1', 'remote.acme.com'),
+      api.listIdentityProviders('account-1'),
+      api.listAccessApps('account-1'),
+      api.listAccessPolicies('account-1', 'app-1'),
+    ])
+
+    expect(tunnels.map(tunnel => tunnel.id)).toEqual(['tunnel-1', 'tunnel-2'])
+    expect(calls).toHaveLength(13)
+    expect(calls.every(call => call.method === 'GET')).toBe(true)
+    expect(calls.every(call => call.authorization === `Bearer ${TOKEN}`)).toBe(true)
+    expect(calls.some(call => call.url.includes('/zones?'))).toBe(true)
+    expect(calls.some(call => call.url.includes('/cfd_tunnel?'))).toBe(true)
+    expect(calls.some(call => call.url.includes('/dns_records?'))).toBe(true)
+    expect(calls.some(call => call.url.includes('/access/identity_providers?'))).toBe(true)
+    expect(calls.some(call => call.url.includes('/access/apps?'))).toBe(true)
+    expect(calls.some(call => call.url.includes('/access/apps/app-1/policies?'))).toBe(true)
+    expect(calls.filter(call => call.url.includes('/cfd_tunnel?')).at(-1)?.url).toContain('page=2')
+  })
+
+  it('fails instead of planning from a snapshot truncated at the pagination safety limit', async () => {
+    let calls = 0
+    const fetchFn = (async (): Promise<Response> => {
+      calls += 1
+      return Response.json({
+        success: true,
+        result: [{ id: `zone-${String(calls)}`, name: 'acme.com', account: { id: 'account-1' } }],
+        result_info: { page: calls, per_page: 100, count: 1, total_count: 5_001 },
+      })
+    }) as typeof fetch
+    const api = new CloudflareHttpReadApi(TOKEN, fetchFn)
+
+    const failure = api.listZones()
+    await expect(failure).rejects.toBeInstanceOf(SetupPlanError)
+    await expect(failure).rejects.toMatchObject({ code: 'cloudflare-unavailable', retryable: true })
+    expect(calls).toBe(50)
+  })
+})

--- a/packages/dsh-remote-web-ui/tests/remote-api.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/remote-api.spec.ts
@@ -169,6 +169,9 @@ describe('innerPathOf / loopbackOnlyDenial', () => {
     expect(loopbackOnlyDenial('/api/dsh-web-ui-settings')).toBeDefined()
     expect(loopbackOnlyDenial('/api/dsh-web-ui-settings/describe')).toBeDefined()
     expect(loopbackOnlyDenial('/api/dsh-web-ui-settings/mutate')).toBeDefined()
+    expect(loopbackOnlyDenial('/api/remote-setup')).toBeDefined()
+    expect(loopbackOnlyDenial('/api/remote-setup/preflight')).toBeDefined()
+    expect(loopbackOnlyDenial('/api/remote-setup/plan')).toBeDefined()
     expect(loopbackOnlyDenial('/api/session.list')).toBeUndefined()
     expect(loopbackOnlyDenial('/api/pet/state')).toBeUndefined()
     expect(loopbackOnlyDenial('/sidebar/api/fs.tree')).toBeUndefined()
@@ -304,6 +307,13 @@ describe('remote desktop channel (/remote)', () => {
       expect(privileged.status).toBe(403)
       const privilegedBody = JSON.parse(privileged.body) as { result: { error: { code: string } } }
       expect(privilegedBody.result.error.code).toBe('forbidden')
+      for (const setupPath of ['/remote/api/remote-setup/preflight', '/remote/api/remote-setup/plan']) {
+        const setup = await call(port, setupPath.endsWith('/plan') ? 'POST' : 'GET', setupPath, {
+          body: setupPath.endsWith('/plan') ? '{"credential":{"source":"request","token":"must-not-be-forwarded"}}' : undefined,
+        })
+        expect(setup.status, setupPath).toBe(403)
+        expect(JSON.parse(setup.body).result.error.code, setupPath).toBe('forbidden')
+      }
       expect(upstream.hits).toHaveLength(0)
     } finally {
       await close()

--- a/packages/dsh-remote-web-ui/tests/setup-contract.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/setup-contract.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SETUP_PATHS,
+  setupPlanRequestSchema,
+} from '../src/setup-contract.ts'
+
+const VALID_TOKEN = 'cf_test_token_1234567890'
+
+function validRequest(): Record<string, unknown> {
+  return {
+    hostname: 'remote.acme.com',
+    email: 'owner@acme.com',
+    credential: {
+      source: 'request',
+      token: VALID_TOKEN,
+    },
+  }
+}
+
+describe('setup plan request contract', () => {
+  it('keeps the setup endpoints local and defaults to the /m-only selector', () => {
+    expect(SETUP_PATHS).toEqual({
+      preflight: '/api/remote-setup/preflight',
+      plan: '/api/remote-setup/plan',
+    })
+
+    const parsed = setupPlanRequestSchema.parse({
+      ...validRequest(),
+      hostname: ' Remote.Acme.COM ',
+      email: ' Owner@Acme.COM ',
+    })
+
+    expect(parsed.hostname).toBe('remote.acme.com')
+    expect(parsed.email).toBe('owner@acme.com')
+    expect(parsed.includeRemote).toBe(false)
+  })
+
+  it('allows /remote only through an explicit boolean opt-in', () => {
+    const parsed = setupPlanRequestSchema.parse({
+      ...validRequest(),
+      includeRemote: true,
+    })
+
+    expect(parsed.includeRemote).toBe(true)
+    expect(setupPlanRequestSchema.safeParse({
+      ...validRequest(),
+      includeRemote: 'true',
+    }).success).toBe(false)
+  })
+
+  it('accepts either an inline request token or a Keychain reference', () => {
+    const inline = setupPlanRequestSchema.parse(validRequest())
+    expect(inline.credential).toEqual({ source: 'request', token: VALID_TOKEN })
+
+    const keychain = setupPlanRequestSchema.parse({
+      ...validRequest(),
+      credential: {
+        source: 'keychain',
+        service: 'dsh-cloudflare',
+        account: 'remote-setup',
+      },
+    })
+    expect(keychain.credential).toEqual({
+      source: 'keychain',
+      service: 'dsh-cloudflare',
+      account: 'remote-setup',
+    })
+  })
+
+  it('rejects unknown fields at both request and credential boundaries', () => {
+    expect(setupPlanRequestSchema.safeParse({
+      ...validRequest(),
+      apply: true,
+    }).success).toBe(false)
+
+    expect(setupPlanRequestSchema.safeParse({
+      ...validRequest(),
+      credential: {
+        source: 'request',
+        token: VALID_TOKEN,
+        service: 'unexpected',
+      },
+    }).success).toBe(false)
+
+    expect(setupPlanRequestSchema.safeParse({
+      ...validRequest(),
+      credential: {
+        source: 'keychain',
+        service: 'dsh-cloudflare',
+        token: VALID_TOKEN,
+      },
+    }).success).toBe(false)
+  })
+
+  it.each([
+    'Remote\nAdmin',
+    'Remote\u0000Admin',
+    'Remote\u007fAdmin',
+  ])('rejects control characters in accessAppName: %j', (accessAppName) => {
+    expect(setupPlanRequestSchema.safeParse({
+      ...validRequest(),
+      accessAppName,
+    }).success).toBe(false)
+  })
+
+  it.each([
+    'localhost',
+    'remote.internal',
+    'remote.example',
+    '192.0.2.1',
+    'bad_label.acme.com',
+  ])('rejects a non-public hostname: %s', (hostname) => {
+    expect(setupPlanRequestSchema.safeParse({
+      ...validRequest(),
+      hostname,
+    }).success).toBe(false)
+  })
+
+  it.each([
+    { field: 'email', value: 'not-an-email' },
+    { field: 'credential', value: { source: 'request', token: 'too-short' } },
+    { field: 'credential', value: { source: 'request', token: 'token with whitespace 1234567890' } },
+  ])('rejects invalid $field input', ({ field, value }) => {
+    expect(setupPlanRequestSchema.safeParse({
+      ...validRequest(),
+      [field]: value,
+    }).success).toBe(false)
+  })
+})

--- a/packages/dsh-remote-web-ui/tests/setup-routes.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/setup-routes.spec.ts
@@ -1,0 +1,432 @@
+import { createServer, request as httpRequest, type IncomingHttpHeaders, type IncomingMessage, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import type { WebRoute } from '@deepseek-ai/dsh-host-webserver'
+import { describe, expect, it } from 'vitest'
+import { SetupPlanError } from '../src/cloudflare-plan.ts'
+import {
+  SETUP_MAX_BODY_BYTES,
+  SETUP_PATHS,
+  type SetupErrorCode,
+  type SetupPlanRequest,
+  type SetupPlanResponse,
+  type SetupPreflightResponse,
+} from '../src/setup-contract.ts'
+import { isTrustedLocalControlRequest } from '../src/local-control.ts'
+import { REMOTE_SETUP_PATH } from '../src/remote-methods.ts'
+import { makeSetupRoutes, type SetupReadService } from '../src/setup-routes.ts'
+
+const LOCAL_ORIGIN = 'http://127.0.0.1:3080'
+const LOCAL_HOST = '127.0.0.1:3080'
+const TOKEN = 'request-token-value-1234567890'
+
+const PREFLIGHT_RESPONSE: SetupPreflightResponse = {
+  ok: true,
+  readOnly: true,
+  executionAvailable: false,
+  preflight: {
+    platform: 'darwin',
+    dsh: {
+      host: '127.0.0.1',
+      port: 3080,
+      localOrigin: LOCAL_ORIGIN,
+      loopbackOnly: true,
+    },
+    cloudflared: { found: true, version: '2026.8.0' },
+    serviceMode: 'launchd-preview',
+    autoTunnelEnabled: false,
+  },
+}
+
+const PLAN_RESPONSE: SetupPlanResponse = {
+  ok: true,
+  readOnly: true,
+  executionAvailable: false,
+  plan: {
+    planId: 'plan-read-only',
+    readOnly: true,
+    executionAvailable: false,
+    canApply: false,
+    hostname: 'remote.valid-domain.com',
+    publicBaseUrl: 'https://remote.valid-domain.com',
+    localOrigin: LOCAL_ORIGIN,
+    zoneName: 'valid-domain.com',
+    tunnelName: 'dsh-remote',
+    accessAppName: 'DSH Remote',
+    includeRemote: false,
+    publishedPaths: ['/m'],
+    preservesExternalHost: true,
+    cloudflarePermissions: { read: 'verified', write: 'unverified' },
+    ingress: {
+      rules: [
+        { path: '/m', service: LOCAL_ORIGIN, purpose: 'mobile-pairing' },
+        { service: 'http_status:404', purpose: 'deny-all-other-paths' },
+      ],
+      finalCatchAll: 'http_status:404',
+    },
+    service: {
+      mode: 'launchd-preview',
+      platform: 'darwin',
+      summary: 'read-only preview',
+      steps: [{ id: 'preview', detail: 'No service is installed.' }],
+    },
+    actions: [],
+    blockers: [{ code: 'execution-unavailable', message: 'PR1 cannot execute this plan.' }],
+    warnings: [],
+  },
+}
+
+const VALID_REQUEST = {
+  hostname: 'remote.valid-domain.com',
+  email: 'owner@valid-domain.com',
+  credential: { source: 'request', token: TOKEN },
+} as const
+
+interface Calls {
+  preflight: number
+  plans: SetupPlanRequest[]
+}
+
+function fakeService(overrides: Partial<SetupReadService> = {}): { service: SetupReadService; calls: Calls } {
+  const calls: Calls = { preflight: 0, plans: [] }
+  const service: SetupReadService = {
+    localOrigin: LOCAL_ORIGIN,
+    preflight: async () => {
+      calls.preflight += 1
+      return PREFLIGHT_RESPONSE
+    },
+    plan: async (input) => {
+      calls.plans.push(input)
+      return PLAN_RESPONSE
+    },
+    ...overrides,
+  }
+  return { service, calls }
+}
+
+interface TestServer {
+  port: number
+  close(): Promise<void>
+}
+
+async function serve(routes: WebRoute[]): Promise<TestServer> {
+  const server: Server = createServer((request, response) => {
+    const pathname = new URL(request.url ?? '/', 'http://x').pathname
+    const route = routes.find(candidate => candidate.kind === 'exact' && candidate.path === pathname)
+    if (route === undefined) {
+      response.writeHead(404)
+      response.end()
+      return
+    }
+    void route.handler(request, response)
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+  return {
+    port,
+    close: async () => await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error === undefined || error === null) resolve()
+        else reject(error)
+      })
+    }),
+  }
+}
+
+interface CallOptions {
+  host?: string
+  origin?: string
+  body?: string
+  contentType?: string
+  secFetchSite?: string
+}
+
+async function call(
+  port: number,
+  method: string,
+  path: string,
+  options: CallOptions = {},
+): Promise<{ status: number; raw: string; body: Record<string, unknown>; headers: IncomingHttpHeaders }> {
+  return await new Promise((resolve, reject) => {
+    const headers: Record<string, string> = { host: options.host ?? LOCAL_HOST }
+    if (options.origin !== undefined) headers.origin = options.origin
+    if (options.secFetchSite !== undefined) headers['sec-fetch-site'] = options.secFetchSite
+    if (options.body !== undefined) {
+      headers['content-type'] = options.contentType ?? 'application/json'
+      headers['content-length'] = String(Buffer.byteLength(options.body))
+    }
+    const request = httpRequest({ hostname: '127.0.0.1', port, method, path, headers }, (response) => {
+      const chunks: Buffer[] = []
+      response.on('data', chunk => chunks.push(chunk as Buffer))
+      response.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8')
+        resolve({
+          status: response.statusCode ?? 0,
+          raw,
+          body: raw === '' ? {} : JSON.parse(raw) as Record<string, unknown>,
+          headers: response.headers,
+        })
+      })
+    })
+    request.on('error', reject)
+    request.end(options.body)
+  })
+}
+
+function expectPrivateJson(result: { headers: IncomingHttpHeaders }): void {
+  expect(result.headers['content-type']).toContain('application/json')
+  expect(result.headers['cache-control']).toBe('no-store')
+  expect(result.headers['referrer-policy']).toBe('no-referrer')
+}
+
+function requestShape(remoteAddress: string, host: string, headers: Record<string, string> = {}): IncomingMessage {
+  return {
+    headers: { host, ...headers },
+    socket: { remoteAddress },
+  } as unknown as IncomingMessage
+}
+
+describe('local control request classification', () => {
+  it('requires both the socket and Host to be loopback and ignores forwarded-address claims', () => {
+    expect(isTrustedLocalControlRequest(requestShape('127.0.0.1', LOCAL_HOST))).toBe(true)
+    expect(isTrustedLocalControlRequest(requestShape('192.0.2.10', LOCAL_HOST, {
+      'x-forwarded-for': '127.0.0.1',
+    }))).toBe(false)
+    expect(isTrustedLocalControlRequest(requestShape('::1', 'remote.valid-domain.com'))).toBe(false)
+  })
+
+  it('rejects malformed Host values whose extra URL components would otherwise normalize away', () => {
+    for (const host of [
+      `user@${LOCAL_HOST}`,
+      `${LOCAL_HOST}/unexpected-path`,
+      `${LOCAL_HOST}?unexpected=query`,
+      `${LOCAL_HOST}#unexpected-fragment`,
+    ]) {
+      expect(isTrustedLocalControlRequest(requestShape('127.0.0.1', host)), host).toBe(false)
+    }
+  })
+
+  it('uses exact Origin as the POST gate and Sec-Fetch-Site as an explicit cross-site veto', () => {
+    const options = { expectedOrigin: LOCAL_ORIGIN, requireOrigin: true }
+    expect(isTrustedLocalControlRequest(requestShape('127.0.0.1', LOCAL_HOST, {
+      origin: LOCAL_ORIGIN,
+    }), options)).toBe(true)
+    expect(isTrustedLocalControlRequest(requestShape('127.0.0.1', LOCAL_HOST, {
+      origin: LOCAL_ORIGIN,
+      'sec-fetch-site': 'cross-site',
+    }), options)).toBe(false)
+    expect(isTrustedLocalControlRequest(requestShape('127.0.0.1', LOCAL_HOST, {
+      origin: 'http://127.0.0.1:9999',
+    }), options)).toBe(false)
+    expect(isTrustedLocalControlRequest(requestShape('127.0.0.1', LOCAL_HOST, {
+      origin: `${LOCAL_ORIGIN}/unexpected-path`,
+    }), options)).toBe(false)
+    expect(isTrustedLocalControlRequest(requestShape('127.0.0.1', LOCAL_HOST, {
+      origin: `${LOCAL_ORIGIN}/`,
+    }), options)).toBe(false)
+  })
+})
+
+describe('read-only setup route registration', () => {
+  it('registers only the two exact preflight and plan paths', async () => {
+    const { service } = fakeService()
+    const routes = makeSetupRoutes({ service })
+    expect(routes.map(route => ({ kind: route.kind, path: route.path }))).toEqual([
+      { kind: 'exact', path: SETUP_PATHS.preflight },
+      { kind: 'exact', path: SETUP_PATHS.plan },
+    ])
+    expect(Object.values(SETUP_PATHS).every(path => path.startsWith(`${REMOTE_SETUP_PATH}/`))).toBe(true)
+
+    const server = await serve(routes)
+    try {
+      expect((await call(server.port, 'POST', '/api/remote-setup/apply', {
+        origin: LOCAL_ORIGIN,
+        body: JSON.stringify(VALID_REQUEST),
+      })).status).toBe(404)
+      expect((await call(server.port, 'POST', '/api/remote-setup/rollback', {
+        origin: LOCAL_ORIGIN,
+        body: '{}',
+      })).status).toBe(404)
+    } finally {
+      await server.close()
+    }
+  })
+})
+
+describe('read-only setup route fence and parsing order', () => {
+  it('allows loopback preflight, rejects a public Host, and marks every response private', async () => {
+    const { service, calls } = fakeService()
+    const server = await serve(makeSetupRoutes({ service }))
+    try {
+      const allowed = await call(server.port, 'GET', SETUP_PATHS.preflight)
+      expect(allowed.status).toBe(200)
+      expect(allowed.body).toEqual(PREFLIGHT_RESPONSE)
+      expectPrivateJson(allowed)
+      expect(calls.preflight).toBe(1)
+
+      const denied = await call(server.port, 'GET', SETUP_PATHS.preflight, { host: 'remote.valid-domain.com' })
+      expect(denied.status).toBe(403)
+      expect(denied.body).toMatchObject({ ok: false, error: { code: 'forbidden' } })
+      expectPrivateJson(denied)
+      expect(calls.preflight).toBe(1)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('rejects POST trust failures before malformed token-bearing JSON reaches the service', async () => {
+    const { service, calls } = fakeService()
+    const server = await serve(makeSetupRoutes({ service }))
+    const malformedSecretBody = `{"credential":{"source":"request","token":"${TOKEN}"}`
+    try {
+      const cases: CallOptions[] = [
+        { body: malformedSecretBody },
+        { origin: 'http://127.0.0.1:9999', body: malformedSecretBody },
+        { origin: LOCAL_ORIGIN, secFetchSite: 'cross-site', body: malformedSecretBody },
+        { host: 'remote.valid-domain.com', origin: 'http://remote.valid-domain.com', body: malformedSecretBody },
+      ]
+      for (const options of cases) {
+        const denied = await call(server.port, 'POST', SETUP_PATHS.plan, options)
+        expect(denied.status).toBe(403)
+        expect(denied.body).toMatchObject({ ok: false, error: { code: 'forbidden' } })
+        expect(denied.raw).not.toContain(TOKEN)
+        expectPrivateJson(denied)
+      }
+      expect(calls.plans).toHaveLength(0)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('requires JSON, a bounded body, and the strict contract before service dispatch', async () => {
+    const { service, calls } = fakeService()
+    const server = await serve(makeSetupRoutes({ service }))
+    const validBody = JSON.stringify(VALID_REQUEST)
+    const invalidBodies: Array<{ body: string; contentType?: string }> = [
+      { body: validBody, contentType: 'text/plain' },
+      { body: '{"hostname":' },
+      { body: JSON.stringify({ ...VALID_REQUEST, extra: true }) },
+      { body: JSON.stringify({ ...VALID_REQUEST, credential: { ...VALID_REQUEST.credential, extra: true } }) },
+      { body: JSON.stringify({ ...VALID_REQUEST, credential: { source: 'request', token: 'x'.repeat(SETUP_MAX_BODY_BYTES) } }) },
+    ]
+    try {
+      for (const invalid of invalidBodies) {
+        const rejected = await call(server.port, 'POST', SETUP_PATHS.plan, {
+          origin: LOCAL_ORIGIN,
+          secFetchSite: 'same-site',
+          ...invalid,
+        })
+        expect(rejected.status).toBe(400)
+        expect(rejected.body).toMatchObject({ ok: false, error: { code: 'bad-payload' } })
+        expectPrivateJson(rejected)
+      }
+      expect(calls.plans).toHaveLength(0)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('passes normalized strict input to the planner and returns its complete wire response', async () => {
+    const { service, calls } = fakeService()
+    const server = await serve(makeSetupRoutes({ service }))
+    try {
+      const result = await call(server.port, 'POST', SETUP_PATHS.plan, {
+        origin: LOCAL_ORIGIN,
+        secFetchSite: 'same-site',
+        contentType: 'application/json; charset=utf-8',
+        body: JSON.stringify({
+          ...VALID_REQUEST,
+          hostname: 'REMOTE.VALID-DOMAIN.COM',
+          email: 'OWNER@VALID-DOMAIN.COM',
+        }),
+      })
+      expect(result.status).toBe(200)
+      expect(result.body).toEqual(PLAN_RESPONSE)
+      expectPrivateJson(result)
+      expect(calls.plans).toEqual([{
+        ...VALID_REQUEST,
+        hostname: 'remote.valid-domain.com',
+        email: 'owner@valid-domain.com',
+        includeRemote: false,
+      }])
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('returns private 405 responses without dispatching either service method', async () => {
+    const { service, calls } = fakeService()
+    const server = await serve(makeSetupRoutes({ service }))
+    try {
+      const preflight = await call(server.port, 'POST', SETUP_PATHS.preflight, {
+        body: '{not-json',
+        origin: LOCAL_ORIGIN,
+      })
+      expect(preflight.status).toBe(405)
+      expect(preflight.headers.allow).toBe('GET')
+      expectPrivateJson(preflight)
+
+      const plan = await call(server.port, 'GET', SETUP_PATHS.plan)
+      expect(plan.status).toBe(405)
+      expect(plan.headers.allow).toBe('POST')
+      expectPrivateJson(plan)
+      expect(calls).toEqual({ preflight: 0, plans: [] })
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('never reflects an unexpected planner error', async () => {
+    const secret = 'never-reflect-this-token'
+    const { service } = fakeService({
+      plan: async () => { throw new Error(`planner failed with ${secret}`) },
+    })
+    const server = await serve(makeSetupRoutes({ service }))
+    try {
+      const result = await call(server.port, 'POST', SETUP_PATHS.plan, {
+        origin: LOCAL_ORIGIN,
+        body: JSON.stringify(VALID_REQUEST),
+      })
+      expect(result.status).toBe(500)
+      expect(result.body).toMatchObject({ ok: false, error: { code: 'internal-error', retryable: true } })
+      expect(result.raw).not.toContain(secret)
+      expectPrivateJson(result)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('maps stable planner errors without changing their safe wire code', async () => {
+    let failure = new SetupPlanError('bad-payload', 'Safe planner failure.')
+    const { service } = fakeService({
+      plan: async () => { throw failure },
+    })
+    const server = await serve(makeSetupRoutes({ service }))
+    const cases: Array<{ code: SetupErrorCode; status: number }> = [
+      { code: 'bad-payload', status: 400 },
+      { code: 'cloudflare-auth-failed', status: 401 },
+      { code: 'forbidden', status: 403 },
+      { code: 'cloudflare-permission-denied', status: 403 },
+      { code: 'zone-not-found', status: 404 },
+      { code: 'unsupported-platform', status: 412 },
+      { code: 'dsh-not-loopback', status: 412 },
+      { code: 'cloudflared-not-found', status: 412 },
+      { code: 'keychain-unavailable', status: 412 },
+      { code: 'cloudflare-unavailable', status: 502 },
+      { code: 'internal-error', status: 500 },
+    ]
+    try {
+      for (const entry of cases) {
+        failure = new SetupPlanError(entry.code, 'Safe planner failure.', entry.code === 'cloudflare-unavailable')
+        const result = await call(server.port, 'POST', SETUP_PATHS.plan, {
+          origin: LOCAL_ORIGIN,
+          body: JSON.stringify(VALID_REQUEST),
+        })
+        expect(result.status, entry.code).toBe(entry.status)
+        expect(result.body, entry.code).toMatchObject({ ok: false, error: { code: entry.code } })
+        expectPrivateJson(result)
+      }
+    } finally {
+      await server.close()
+    }
+  })
+})


### PR DESCRIPTION
> Draft for maintainer design review. This is the first read-only slice agreed in #731; it deliberately does not include an executor or setup UI.
>
> Part of #731.

## 摘要（Summary）

Adds a loopback-only HTTPS setup preflight and a deterministic, read-only Cloudflare plan for `dsh-remote-web-ui`.

The plan defaults to `/m`, adds `/remote` only through explicit opt-in, preserves the external Host, and ends with `http_status:404`. It keeps the existing `autoTunnel` path unchanged and reports the current `/m` pairing-acceptance and `/remote` boot limitations as blockers.

Security and scope boundaries:

- exposes only exact `GET /api/remote-setup/preflight` and `POST /api/remote-setup/plan` routes behind a loopback socket + exact Host/Origin fence;
- explicitly blocks the entire setup prefix from the paired `/remote` proxy;
- uses a GET-only Cloudflare client and reports read permission as verified while write permission remains unverified;
- keeps a request token in memory only, with an optional host-side macOS Keychain reference;
- provides launchd / Windows service previews only; no Cloudflare mutation, local file write, service installation/start, `publicBaseUrl` write, apply endpoint, or rollback endpoint exists;
- treats ambiguous or conflicting existing resources as manual resolution, never as an automatic create/reuse plan.

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [ ] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream dev
git rebase upstream/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch upstream dev && git rebase upstream/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

N/A: this PR has no visual or user-facing UI change.

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：

GPT-5.6 Codex

使用的编码 Agent 工具：

Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行文档检查。

## 贡献者版权声明（Contributor Copyright）

N/A.

## 新皮肤收录（New Skin）

N/A.

## 新宠物收录（New Pet）

N/A.

## 社区插件索引登记（Community Plugin Index）

N/A.

## 本地验证（Local Validation）

执行的命令：

```bash
cd packages/dsh-remote-web-ui
node node_modules/vitest/vitest.mjs run
node node_modules/typescript/bin/tsc -b --pretty false
./node_modules/.bin/tsdown

cd ../..
node scripts/verify-docs.mjs
node scripts/runtime-deps-check.mjs
git diff --check
git fetch upstream dev
git rebase upstream/dev
```

结果摘要：

- package tests: 41 files, 425 tests passed;
- package TypeScript build/typecheck: passed;
- package bundle build: all host, client, and mobile entries passed;
- documentation gates: passed;
- runtime dependency check: 3/3 scanned packages passed;
- secret / emoji scan and `git diff --check`: passed;
- final upstream sync: branch was up to date with `upstream/dev` (`688e81de`).

Additional local-environment note: the root `node --test scripts/*.test.mjs` baseline reported 154 passed, 11 failed, and 4 skipped. All 11 failures were `ENOENT` for `gallery` / `market` paths intentionally absent from this sparse worktree; no changed-package test failed. Full-checkout GitHub CI is the authority for those repository-wide lanes.

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A: this PR adds a host-side read-only contract and planner with no setup UI or other user-visible surface.
