### PR TITLE
chore(community-plugins): register dsh-session-insights in the community plugin index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -418,6 +418,18 @@
       "descriptionEn": "A floating pet exclusively for Miku: hand-drawn frame animations, 5s random idle with a pity timer, a continuous work loop earning coins, a shop restoring hunger, stat bars and a two-level hover menu; coexists with the built-in dsh-pet under the /miku-pet namespace.",
       "repo": "https://github.com/stushansusu/miku-pet",
       "category": "ui"
+    },
+    {
+      "id": "dsh-session-insights",
+      "name": "会话复盘",
+      "rank": 37,
+      "nameEn": "Session Insights",
+      "author": "GreenLv",
+      "description": "通过 /session-insights 把 DSH 会话历史生成为本地、基于证据的工作流复盘：自包含 HTML Dashboard 与配套 JSON，支持确定性分析与可选的模型辅助分析。",
+      "descriptionEn": "Generates local, evidence-backed workflow retrospectives from DSH session history through /session-insights: a self-contained HTML dashboard plus companion JSON, with deterministic and optional model-assisted analysis.",
+      "repo": "https://github.com/GreenLv/dsh-session-insights",
+      "npm": "dsh-session-insights",
+      "category": "tools"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -377,5 +377,16 @@
     "descriptionEn": "A floating pet exclusively for Miku: hand-drawn frame animations, 5s random idle with a pity timer, a continuous work loop earning coins, a shop restoring hunger, stat bars and a two-level hover menu; coexists with the built-in dsh-pet under the /miku-pet namespace.",
     "repo": "https://github.com/stushansusu/miku-pet",
     "category": "ui"
+  },
+  {
+    "id": "dsh-session-insights",
+    "name": "会话复盘",
+    "nameEn": "Session Insights",
+    "author": "GreenLv",
+    "description": "通过 /session-insights 把 DSH 会话历史生成为本地、基于证据的工作流复盘：自包含 HTML Dashboard 与配套 JSON，支持确定性分析与可选的模型辅助分析。",
+    "descriptionEn": "Generates local, evidence-backed workflow retrospectives from DSH session history through /session-insights: a self-contained HTML dashboard plus companion JSON, with deterministic and optional model-assisted analysis.",
+    "repo": "https://github.com/GreenLv/dsh-session-insights",
+    "npm": "dsh-session-insights",
+    "category": "tools"
   }
 ]


### PR DESCRIPTION
# 社区插件索引登记：dsh-session-insights

在社区插件索引中加入 `dsh-session-insights`（GreenLv/dsh-session-insights），使其出现在 dsh-market.com 创意工坊插件目录与应用内「创意工坊 → 插件」。

## 变更内容

- `packages/dsh-community-plugins/community.json` 新增一条记录（`id` / `name` / `nameEn` / `author` / `repo` / `description` / `descriptionEn` / `npm` / `category`）；
- `node scripts/market-build` 重新生成 `market/dist/manifest/plugins.json`（36 → 37 entries）。

插件信息：仓库 https://github.com/GreenLv/dsh-session-insights（MIT）；npm `dsh-session-insights`（0.2.0）；分类 tools。插件提供 host 侧 `/session-insights` 命令与技能语义，没有 `dsh.client` 浏览器半区。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-community-plugins`（数据登记，无代码逻辑变更）

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 其他（社区插件索引数据登记，非代码逻辑变更）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch upstream && git rebase upstream/dev`（本分支基于 upstream/dev `688e81de`）

## 本地验证（Local Validation）

执行的命令：`node scripts/community-index`；`node scripts/community-index --check`；`pnpm market:check`

结果摘要：community.json 由 36 条增至 37 条；`node scripts/market-build` 重新生成 `market/dist/manifest/plugins.json`；`community-index --check` 通过（37 entries），`market-build --check` 通过（dist up to date, 233 files）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。

- `node scripts/community-index` → OK (37 entries)
- `node scripts/community-index --check` → 通过
- `pnpm market:check`（`node scripts/market-build --check`）→ dist up to date (233 files)

- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

本分支基于 upstream/dev `688e81de` 建立，上述验证均在该基础之上重新执行；文本 / 数据类改动，不附截图。

## 视觉修复要求（Visual Fix Requirements）

纯文本 / 数据类改动，跳过本节。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助

使用的 AI 模型：DeepSeek Harness agent（deepseek-v4-pro）
