### PR TITLE
fix(remote-web-ui): 手机端消息渲染修复——空气泡 + 长消息/表格显示不完整

### DIFF
--- a/packages/dsh-remote-web-ui/src/mobile/views/ChatView.tsx
+++ b/packages/dsh-remote-web-ui/src/mobile/views/ChatView.tsx
@@ -602,6 +602,12 @@ const MessageRow = memo(function MessageRow({ message, showToolCalls, showSystem
     && !showSystemMessages) {
     return null
   }
+  // 关闭"工具调用"显示后，仅含工具调用、无正文/思维链的消息不再渲染空气泡
+  // （只显示时间）。有正文/思维链/可见工具/失败标记才渲染。
+  const hasReasoning = message.kind === 'assistant' && message.reasoning !== undefined && message.reasoning !== ''
+  const hasTools = showToolCalls && message.kind === 'assistant' && message.tools !== undefined && message.tools.length > 0
+  const hasText = message.text !== undefined && message.text !== ''
+  if (!hasReasoning && !hasTools && !hasText && message.failed !== true) return null
   return (
     <div className={`chat-msg chat-msg-${message.kind}${message.pending === true ? ' chat-msg-pending' : ''}${message.failed === true ? ' chat-msg-failed' : ''}`}>
       {message.kind === 'assistant' && message.reasoning !== undefined && message.reasoning !== '' && (
@@ -750,7 +756,9 @@ function MarkdownText({ text, pending }: { text: string; pending: boolean }) {
       if (timerRef.current !== undefined) clearTimeout(timerRef.current)
     }
   }, [])
-  const long = text.length > LONG_TEXT_LIMIT
+  // 流式输出期间不折叠（45vh + overflow:hidden 会把新内容藏起来且不可滚动，
+  // 手机上看不到"输出中"的长自然段/表格）；结束后超过 LONG_TEXT_LIMIT 才折叠。
+  const long = !pending && text.length > LONG_TEXT_LIMIT
   const collapsed = long && !open
   return (
     <div className={'chat-msg-text chat-md' + (collapsed ? ' chat-md-collapsed' : '')}>
@@ -781,7 +789,8 @@ function CollapsibleText({ text }: { text: string }) {
   )
 }
 
-const LONG_TEXT_LIMIT = 1600
+// 阈值 1600 -> 6000：常规表格/段落回复完整显示；超大消息结束后才折叠。
+const LONG_TEXT_LIMIT = 6000
 const LONG_TEXT_PREVIEW = 800
 
 /** Latest non-empty line of a streaming reasoning buffer. */


### PR DESCRIPTION
## 摘要（Summary）

手机端 `/m/` 消息渲染两个体验问题修复：

1. **空气泡**：关闭"工具调用"显示后，仅含工具调用、无正文/思维链的消息整行不渲染（不再出现"只有时间"的空气泡）；
2. **长消息/表格显示不完整**：流式输出期间不再折叠（新内容完整可见，与节流渲染兼容），折叠阈值 1600 → 6000。

关联 Issue：#1065（手机端消息渲染修复——关闭工具调用后的空气泡 + 长消息/表格显示不完整）

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [ ] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch upstream dev && git rebase upstream/dev`（已基于 `05c57c8`，领先 0 落后 0）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

N/A（非视觉修复）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改动 README。）

## 贡献者版权声明（Contributor Copyright）

N/A（不声明，维持现有版权归属）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui build
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
pnpm --filter @linxin666/dsh-remote-web-ui test
```

结果摘要：

- build：通过
- typecheck：通过（exit 0）
- test：**376/376 通过**

## 用户可见变更证据（Local Feature Evidence）

证据（手机视口 390x780 渲染，真实 mobile 样式表）：

**修复前**（空气泡 + 长消息折叠）：
[修复前](https://raw.githubusercontent.com/Eternalloveone/dsh-web-ui/feat/mobile-render-fixes/docs/archive/mobile-render-fixes/render-before.png)

**修复后**（无空气泡 + 长消息完整显示）：
[修复后](https://raw.githubusercontent.com/Eternalloveone/dsh-web-ui/feat/mobile-render-fixes/docs/archive/mobile-render-fixes/render-after.png)

- 修复前：仅含工具调用、无正文/思维链的消息渲染为空气泡（只显示时间）；>1600 字长消息折叠到 45vh（渐变遮罩 + "展开全文"按钮）；
- 修复后：空气泡整行不渲染；长消息完整显示（无折叠/遮罩/展开按钮）。

## 改动记录（Change Log）

| 提交 | 内容 |
|---|---|
| `eea72b9` | fix(mobile): 消息渲染修复——`MessageRow` 增加空气泡可见性守卫（无思维链/无可见工具/无正文/非失败 → 整行不渲染）；`MarkdownText` 折叠判定改为 `!pending && length > LONG_TEXT_LIMIT`（流式不折叠）+ 阈值 1600 → 6000 |
