### PR TITLE
fix(remote-web-ui): 手机端弱网可靠性——mobile.js gzip + SW 不缓存动态 bundle

### DIFF
--- a/packages/dsh-remote-web-ui/assets/mobile-service-worker.js
+++ b/packages/dsh-remote-web-ui/assets/mobile-service-worker.js
@@ -1,9 +1,12 @@
 /* PWA worker for the standalone /m mobile shell. */
-const CACHE_NAME = 'dsh-remote-mobile-shell-v1'
+/* Local patch (2026-08-23): never cache /m/mobile.js — on weak phone links the
+   network-first fallback served a stale bundle (poll:A0Q0, no question panel).
+   The bundle must always come from the network. Bumped the cache name so old
+   cached bundles are purged on activate. */
+const CACHE_NAME = 'dsh-remote-mobile-shell-v2'
 const OFFLINE_URL = '/m/offline.html'
 const SHELL_PATHS = new Set([
   '/m/',
-  '/m/mobile.js',
   '/m/manifest.webmanifest',
   '/m/apple-touch-icon.png',
   '/m/icon-192.png',

--- a/packages/dsh-remote-web-ui/src/mobile-routes.ts
+++ b/packages/dsh-remote-web-ui/src/mobile-routes.ts
@@ -7,6 +7,7 @@
 
 import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
 import { fileURLToPath } from 'node:url'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { WebRoute } from '@deepseek-ai/dsh-host-webserver'
@@ -147,7 +148,8 @@ export function makeMobileRoutes(): WebRoute[] {
   // The bundle is immutable for the process lifetime (a rebuild requires a
   // host restart), so the body is read from disk once, not per phone.
   let bundleBody: string | undefined
-  const handleBundle = async (_req: IncomingMessage, res: ServerResponse): Promise<void> => {
+  let bundleGzip: Buffer | undefined
+  const handleBundle = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     if (bundleBody === undefined) {
       const path = mobileBundlePath()
       if (!existsSync(path)) {
@@ -160,6 +162,21 @@ export function makeMobileRoutes(): WebRoute[] {
         writeStatic(res, 500, 'text/plain', 'failed to read the mobile bundle')
         return
       }
+    }
+    // Local patch (2026-08-23): gzip the mobile bundle (493KB -> ~116KB) so
+    // phones on weak links load /m/ reliably instead of timing out.
+    const accept = (req.headers['accept-encoding'] || '').toString()
+    if (accept.includes('gzip')) {
+      if (bundleGzip === undefined) bundleGzip = gzipSync(Buffer.from(bundleBody, 'utf8'))
+      res.writeHead(200, {
+        'content-type': 'text/javascript; charset=utf-8',
+        'content-encoding': 'gzip',
+        'cache-control': 'no-store',
+        'referrer-policy': 'no-referrer',
+        'vary': 'Accept-Encoding',
+      })
+      res.end(bundleGzip)
+      return
     }
     writeStatic(res, 200, 'text/javascript', bundleBody)
   }

--- a/packages/dsh-remote-web-ui/tests/mobile-service-worker.spec.ts
+++ b/packages/dsh-remote-web-ui/tests/mobile-service-worker.spec.ts
@@ -3,7 +3,7 @@ import { runInNewContext } from 'node:vm'
 import { describe, expect, it, vi } from 'vitest'
 
 const ORIGIN = 'https://dsh.example'
-const CACHE_NAME = 'dsh-remote-mobile-shell-v1'
+const CACHE_NAME = 'dsh-remote-mobile-shell-v2'
 
 type WorkerRequest = { method: string; mode: string; url: string }
 type FetchListener = (event: { request: WorkerRequest; respondWith(response: Promise<Response> | Response): void }) => void
@@ -69,14 +69,16 @@ describe('mobile service worker', () => {
     expect(fetcher).toHaveBeenCalledTimes(1)
   })
 
-  it('uses cached static bundle content only when its network request fails', async () => {
+  it('does not cache the mobile bundle (network-only, no stale fallback)', async () => {
     const fetcher = vi.fn().mockRejectedValue(new TypeError('offline'))
     const worker = await loadWorker(fetcher)
     worker.setCached('/m/mobile.js', new Response('cached mobile bundle'))
 
     const response = await worker.dispatch({ method: 'GET', mode: 'same-origin', url: ORIGIN + '/m/mobile.js' })
-    expect(response).toBeDefined()
-    expect(await response?.text()).toBe('cached mobile bundle')
+    // The bundle is not in SHELL_PATHS: the worker does not intercept it, so
+    // no cached fallback is served on network failure (weak links must always
+    // get the current bundle, never a stale one).
+    expect(response).toBeUndefined()
   })
 
   it('does not intercept the paired-device mobile API channel', async () => {


### PR DESCRIPTION
## 摘要（Summary）

手机端 `/m/` 弱网场景下的加载与缓存可靠性修复：

1. **gzip 传输**：`/m/mobile.js` 对 `Accept-Encoding: gzip` 的请求返回 gzip 压缩（约 493KB → 116KB），弱网加载可靠；
2. **SW 加固**：Service Worker 不再缓存 `/m/mobile.js`（动态 bundle 始终走网络，弱网也绝不回退旧版），缓存名 v1 → v2 以清理旧缓存。

关联 Issue：#1066（手机端弱网加载与缓存可靠性——mobile.js gzip + Service Worker 不缓存动态 bundle）

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [x] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-ui-all` / `packages/dsh-web-ui-settings`
- [ ] 其他（请说明）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [ ] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch upstream dev && git rebase upstream/dev`（已基于 `05c57c8`，领先 0 落后 0）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

N/A（非视觉修复）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改动 README。）

## 贡献者版权声明（Contributor Copyright）

N/A（不声明，维持现有版权归属）。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm --filter @linxin666/dsh-remote-web-ui build
pnpm --filter @linxin666/dsh-remote-web-ui typecheck
pnpm --filter @linxin666/dsh-remote-web-ui test
```

结果摘要：

- build：通过
- typecheck：通过（exit 0）
- test：**376/376 通过**（含 SW 测试同步更新：不再缓存 bundle）

## 用户可见变更证据（Local Feature Evidence）

证据（真实 dsh 实例实测）：

[弱网可靠性证据](https://raw.githubusercontent.com/Eternalloveone/dsh-web-ui/feat/mobile-weaknet-fixes/docs/archive/mobile-weaknet-fixes/weaknet-evidence.png)

- `GET /m/mobile.js`（Accept-Encoding: gzip）→ `content-encoding: gzip`，wire size **116.7 KB**（未压缩约 502 KB）；
- `/m/service-worker.js` → `dsh-remote-mobile-shell-v2`，`SHELL_PATHS` 不含 `/m/mobile.js`（弱网下 bundle 始终走网络、绝不回退旧缓存）。

## 改动记录（Change Log）

| 提交 | 内容 |
|---|---|
| `1c2f0fe` | perf(mobile): mobile.js gzip 传输——`mobile-routes.ts` bundle 路由按 `Accept-Encoding` 返回 `gzipSync` 产物（`content-encoding: gzip` + `no-store` + `vary`），进程内缓存压缩结果 |
| `c4f57ca` | fix(mobile): Service Worker 不再缓存 `/m/mobile.js` + cache v2——`assets/mobile-service-worker.js` 从 `SHELL_PATHS` 移除 bundle、`CACHE_NAME` v1→v2；测试同步更新 |
