### PR TITLE
community: register dsh-archive-button in the marketplace index

### DIFF
--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -388,5 +388,15 @@
     "repo": "https://github.com/GreenLv/dsh-session-insights",
     "npm": "dsh-session-insights",
     "category": "tools"
+  },
+  {
+    "id": "dsh-archive-button",
+    "name": "归档按钮",
+    "nameEn": "Archive Button",
+    "author": "FFWITHCC",
+    "description": "在左侧会话列表每一行加一个一点即归档的「归档」按钮：悬停会话行即可看到（「…」菜单旁），点击立即归档。纯 host 插件、不改磁盘源码、升级 App 自动恢复、幂等不重复注入。",
+    "descriptionEn": "Adds a one-click Archive button on every row of the left sidebar session list: hover a session row and it appears next to the ellipsis menu; click to archive instantly. A pure host plugin that never modifies files on disk, survives app upgrades and never double-injects.",
+    "repo": "https://github.com/FFWITHCC/dsh-archive-button",
+    "category": "ui"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

在社区插件索引 `community.json` 中登记 dsh-archive-button：一个 DSH web 插件，在左侧会话列表每一行加一个直接可见的「归档」按钮（原本藏在「…」菜单里）。纯 host 插件，伺服时注入、不改磁盘源码、升级 App 自动恢复、幂等不重复注入。

## 涉及包（Affected Packages）

- [x] 其他（`packages/dsh-community-plugins/community.json`，仅索引登记）

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch upstream && git rebase upstream/dev`（已通过 reset --hard 到最新 upstream/dev 后重新追加本次登记，分支基于最新 dev，无冲突）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch upstream && git rebase upstream/dev`），并附上同步后重新测试通过的证据。

本地测试：
- `node scripts/community-index` → `community-index: OK (38 entries)`（通过）。
- 在一次性 throwaway profile 中 `dsh plugin --profile web add git+https://github.com/FFWITHCC/dsh-archive-button.git`，随后 `dsh --profile <tmp> --dump-config` 组合通过（exit 0，`archive-button` 条目出现在组合树）。
- 注入逻辑端到端 mock 验证：results 与手动补丁逐字节一致，且对已打补丁文件幂等（不重复注入）。

## 视觉修复要求（Visual Fix Requirements）

纯功能改动，非视觉修复，跳过。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（`dsh-archive-button`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。（本 PR 仅改 `community.json`，未新增/修改包 README，不适用。）

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

https://github.com/FFWITHCC/dsh-archive-button

插件详细说明：

dsh-archive-button 是一个 DSH web 插件：在左侧会话列表的每一行加一个直接可见的「归档」按钮（原本藏在「…」菜单里）。悬停会话行即可看到（「…」旁），点击立即归档；对「按工作区分组」和「平铺列表」两种视图都生效。实现为纯 host 插件：注册一条更具体的 webServer 前缀路由 `/plugins/@deepseek-ai/dsh-client-ui-workspace`，在伺服该 bundle 时向 `rowActions` 注入按钮代码（复用内置 `onArchive` 与 `IconArchiveOutline20` 图标）——不改磁盘源码、升级 App 自动恢复、幂等不重复注入、官方大改组件时优雅降级（原样伺服 + warn）。安装：`dsh plugin --profile web add FFWITHCC/dsh-archive-button`（或 `git+https://github.com/FFWITHCC/dsh-archive-button.git`）。依赖：无（仅复用官方 `@deepseek-ai/*` 运行时）。已知限制：官方若重构会话行组件导致找不到注入锚点，按钮会暂时不可用（记录 warn，不崩溃）。

- [x] 已按 `docs/plugins.md` 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表。（说明：`src/client/generated/community.ts` 为该仓库构建时生成的产物且未提交入库；本次登记的唯一来源 `community.json` 已由 `node scripts/community-index` 校验通过。）
- [x] 已确认插件与 dsh-web-ui 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本仓库最新代码上验证插件可被 `dsh web` 挂载并正常运行（throwaway profile `--dump-config` 组合通过 + 端到端 mock 测试）。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web-ui 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index   # community-index: OK (38 entries)
# 在 throwaway profile 验证安装与组合：
dsh plugin --profile <tmp> add git+https://github.com/FFWITHCC/dsh-archive-button.git
dsh --profile <tmp> --dump-config   # archive-button 条目出现在组合树，exit 0
```

结果摘要：community.json 校验通过；插件可从 GitHub 正常安装、自动登记进 `dsh.profile.bundles`，组合树无报错。注入逻辑经 mock webServer 端到端测试，结果与手动补丁逐字节一致且幂等。

## 用户可见变更证据（Local Feature Evidence）

证据：本插件为独立仓库（非本仓库包），其 UI 效果图见 https://github.com/FFWITHCC/dsh-archive-button 的 README。本 PR 仅涉及 community.json 索引登记，无本仓库内的用户可见界面改动。