### PR TITLE
feat(community-index): register dsh-milestone in community plugin index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -494,6 +494,19 @@
       "npm": "@wingsky-1/dsh-provider-usage",
       "category": "tools",
       "subcategory": "model"
+    },
+    {
+      "id": "dsh-milestone",
+      "name": "会话里程碑导航条",
+      "rank": 40,
+      "nameEn": "dsh-milestone",
+      "author": "SnowCrescenter-tech",
+      "description": "DSH Web UI 右侧的圆点时间轴：每条提问一个圆点，悬停查看内容与元信息（时间、轮次、耗时、TTFT、token），点击即跳转；附带全会话消息列表、站内与跨会话搜索、书签深链接（#msg=）和键盘导航。",
+      "descriptionEn": "Git-style dot timeline on the right edge of the DSH web UI: one dot per user message, hover for content and metadata (time, turn, duration, TTFT, tokens), click to jump; full-session list, in-session and cross-session search, #msg= deep-link bookmarks, keyboard navigation.",
+      "repo": "https://github.com/SnowCrescenter-tech/dsh-milestone",
+      "npm": "dsh-milestone",
+      "category": "ui",
+      "subcategory": "chat"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -453,5 +453,17 @@
     "npm": "@wingsky-1/dsh-provider-usage",
     "category": "tools",
     "subcategory": "model"
+  },
+  {
+    "id": "dsh-milestone",
+    "name": "会话里程碑导航条",
+    "nameEn": "dsh-milestone",
+    "author": "SnowCrescenter-tech",
+    "description": "DSH Web UI 右侧的圆点时间轴：每条提问一个圆点，悬停查看内容与元信息（时间、轮次、耗时、TTFT、token），点击即跳转；附带全会话消息列表、站内与跨会话搜索、书签深链接（#msg=）和键盘导航。",
+    "descriptionEn": "Git-style dot timeline on the right edge of the DSH web UI: one dot per user message, hover for content and metadata (time, turn, duration, TTFT, tokens), click to jump; full-session list, in-session and cross-session search, #msg= deep-link bookmarks, keyboard navigation.",
+    "repo": "https://github.com/SnowCrescenter-tech/dsh-milestone",
+    "npm": "dsh-milestone",
+    "category": "ui",
+    "subcategory": "chat"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

将 [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) 登记进社区插件索引（`packages/dsh-community-plugins/community.json`），使其出现在 Workshop 商店供一键安装。对应 issue #1034 维护者建议的通道。

**本轮已按评审意见修复（见下方证据）**：
- 上游 jsdom 环境下的 localStorage 测试失败已修复（`vitest.config.ts` 钉死非 opaque jsdom origin + `setup.ts` 防御性 localStorage polyfill）
- 上游新增 GitHub Actions CI（Linux / macOS / Windows × Node 22 / 24 矩阵），首次运行 6/6 全绿

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-community-plugins/community.json` 与生成的 `market/dist/manifest/plugins.json`

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：
```bash
git fetch origin && git rebase origin/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

**上游修复与 CI（评审意见第 1、2 项）**：

- 修复提交：`fix(test): pin jsdom origin and polyfill localStorage; add 3-OS CI`（dsh-milestone@`3bc2a64`，main 与 dev 均已推送）
  - `vitest.config.ts`：显式 `environmentOptions.jsdom.url = http://localhost/`——jsdom 只在 http(s) origin 下暴露 `window.localStorage`，此前默认 opaque origin 下访问即抛 `SecurityError`（即评审中复现的"localStorage 不是函数"）
  - `src/test/setup.ts`：新增探测式内存 localStorage polyfill（探测失败才启用），保证任何环境下测试确定性
  - 本机复现确认：`url=about:blank` 场景修复前 worker 启动即失败，修复后 397/397 通过
- CI：`.github/workflows/ci.yml`（main + dev 推送 / PR 触发），矩阵 `ubuntu-latest / macos-latest / windows-latest × Node 22 / 24`，步骤 `pnpm install --frozen-lockfile → pnpm typecheck → pnpm build → pnpm test`
- **首次运行结果 6/6 全绿**：https://github.com/SnowCrescenter-tech/dsh-milestone/actions/runs/32965289576 （各 job 均通过 typecheck / build / 397 项测试）
- 本地完整套件：`pnpm test` → `397 passed (40 files)`

**真实 GUI 共存证据（评审意见第 4 项，尽力提供）**：

- 挂载方式：纯运行时注入（`shell.overlay` 官方 slot，附加式、点击穿透），不修改 harness 源码、不 patch 现有 DOM——这是代码层面的共存保证
- 键盘导航：`rail-keyboard.test.ts`（8 项）+ `MilestoneRail.keyboard.test.tsx`（5 项）单测覆盖 ↑↓/Enter/Home/End 与搜索框焦点隔离
- 样式隔离：组件样式走独立类名 + 注入层内作用域，不触碰现有 UI 样式
- 卸载清理：client half 由 cordis 生命周期装载/拆卸，禁用或卸载时注入的 DOM 与监听一并移除（与官方 slot 语义一致）
- 局限：仓库暂无连接真实 DSH 实例的 GUI 截图（`qa/surface.spec.ts` 为 Playwright surface 测试，需 harness 运行时）；如需要，我可以在本地起 `dsh web` 补一组共存截图

## 视觉修复要求（Visual Fix Requirements）

N/A（非视觉修复）

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：
DeepSeek（deepseek-v4-flash）

使用的编码 Agent 工具：
DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [ ] 新增包目录以 `dsh-` 前缀命名（N/A：未新增包，仅登记索引条目）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 改动 README 时同步维护中英双语三件套（N/A：未改动 README）

## 贡献者版权声明（Contributor Copyright）

N/A（社区索引条目为指向作者仓库的链接登记，不涉及本仓库内代码）

## 新皮肤收录（New Skins）

N/A

## 新宠物收录（New Pets）

N/A

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：
https://github.com/SnowCrescenter-tech/dsh-milestone

插件详细说明：
dsh-milestone 是 DeepSeek Harness Web UI 的会话导航插件：右侧圆点时间轴（每条提问一个圆点，悬停查看内容与元信息——时间 / 轮次 / 耗时 / TTFT / token 用量，点击平滑跳转），附带全会话消息列表、站内与跨会话搜索、书签深链接（`#msg=`）与键盘导航。纯前端经官方 `shell.overlay` slot 挂载，node 半区零依赖；npm 包 `dsh-milestone`（v0.6.6）。已知限制见其仓库 README「已知限制」一节。

- [x] 已按 `docs/plugins.md` 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表（提交生成的 `packages/dsh-community-plugins/src/client/generated/community.ts`）。
  - 注：当前 dev 分支上该脚本仅做校验（`community-index: OK (38 entries)`），不再生成 `src/client/generated/community.ts`（该文件已随社区插件卡下线移除，索引消费方为 `market-build`）；CI 门禁 `pnpm community:check` / `pnpm market:check` 均已通过。
- [x] 已确认插件与 dsh-web-ui 插件体系兼容：遵循官方 cordis bundle 独立标准（`package.json` 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；可被 `dsh plugin --profile web add dsh-milestone` 正常挂载运行。
  - 稳定性证据更新：评审指出的 jsdom localStorage 测试失败已修复；上游 CI（3 OS × 2 Node 矩阵）首次运行 6/6 全绿，397 项测试在全部矩阵上通过。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web-ui 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：
```bash
git fetch origin && git rebase origin/dev
node scripts/community-index --check
node scripts/market-build
pnpm community:check
pnpm market:check
# 上游（dsh-milestone 仓库）
pnpm install --frozen-lockfile && pnpm typecheck && pnpm build && pnpm test
```

结果摘要：
- rebase 到最新 `origin/dev` 无冲突；`community-index: OK (38 entries)`；`market-build: wrote 1009 files`；`community:check` / `market:check` 通过
- 本 PR 改动 5 个文件：`community.json`（+12 行条目）、生成的 `market/dist/manifest/plugins.json`（+15 行）、其余 3 个 manifest 为 market-build 日期字段更新
- 上游完整套件：`397 passed (40 files)`；CI 矩阵 6/6 全绿（https://github.com/SnowCrescenter-tech/dsh-milestone/actions/runs/32965289576）

## 用户可见变更证据（Local Feature Evidence）

证据：
N/A（登记类改动，非功能变更；商店条目在 PR 合入后随 market 部署自动生效。GUI 共存说明见「测试证据与上游同步」节）