### PR TITLE
feat(community): register dsh-fulltext-search plugin index

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-24-register-dsh-fulltext-search-community-index.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-24-register-dsh-fulltext-search-community-index.i18n.yaml
@@ -1,0 +1,5 @@
+# Bilingual-pair consistency record (docs/i18n.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with git hash-object.
+2026-08-24-register-dsh-fulltext-search-community-index.md: 399764cc4581af11a0abc2179fde548c30eb7fb8
+2026-08-24-register-dsh-fulltext-search-community-index.zh.md: c4e21cfe2a57e68fb8035f587cec1d720b9b9639

--- a/.agents/notes/implemented/feature/2026-08-24-register-dsh-fulltext-search-community-index.md
+++ b/.agents/notes/implemented/feature/2026-08-24-register-dsh-fulltext-search-community-index.md
@@ -1,0 +1,44 @@
+# Agent Note: Register dsh-fulltext-search in the community plugin index
+
+Status: implemented
+
+## Problem
+
+dsh-fulltext-search (a DSH Web GUI plugin that greps file contents in the
+session working directory from the better-sidebar file manager) was developed
+and needed a distribution channel. The family monorepo never vendors third-party
+plugin code, so the plugin cannot ship inside `packages/` as an embedded asset;
+the established community route is an index entry that points at the
+contributor's own public repository.
+
+## Decision
+
+dsh-fulltext-search is registered as a community plugin entry in
+`packages/dsh-community-plugins/community.json` with `category: "tools"` and
+`repo: https://github.com/termanli/dsh-fulltext-search`. The `npm` field is
+left out until the package is actually published. The market manifest
+(`market/dist/manifest/plugins.json`) is regenerated with
+`node scripts/market-build` because it derives from community.json, so the
+Workshop store card and dsh-market.com list the plugin and users can install it
+with `dsh plugin add https://github.com/termanli/dsh-fulltext-search`.
+
+## Alternatives considered
+
+- Family inclusion as an aggregate member (`packages/dsh-fulltext-search` with
+  the restructured `dsh_web_ui_comp` branch): rejected. The restructured branch
+  builds only inside the family monorepo — its tsdown preset imports the shared
+  `shared/tsdown.client.ts` and `lib/` is gitignored — so a standalone clone
+  cannot build or install. The community route needs none of the family package
+  machinery.
+- Publishing to npm and filling the `npm` field: deferred. The plugin is not
+  published yet, and filling `npm` before a real publish would point users at an
+  install that fails.
+
+## Consequences
+
+- The plugin stays installable from its own public repository; the family repo
+  carries only index metadata, never the plugin code.
+- The entry appears in the Workshop store and dsh-market.com only after the
+  maintainer merges the index PR.
+- A future family inclusion can reuse the preserved `dsh_web_ui_comp` branch
+  through the documented adoption flow; the index entry would then be removed.

--- a/.agents/notes/implemented/feature/2026-08-24-register-dsh-fulltext-search-community-index.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-24-register-dsh-fulltext-search-community-index.zh.md
@@ -1,0 +1,22 @@
+# Agent Note：将 dsh-fulltext-search 登记进社区插件索引
+
+Status: implemented
+
+## Problem
+
+dsh-fulltext-search（一个 DSH Web GUI 插件，在 better-sidebar 文件管理器里按文件内容搜索会话工作目录）已完成开发，需要一个分发渠道。全家桶仓库从不内嵌第三方插件代码，插件不能作为内嵌资产放进 `packages/`；既有的社区路线是在索引里加一条指向贡献者自己公开仓库的条目。
+
+## Decision
+
+dsh-fulltext-search 已作为社区插件条目登记进 `packages/dsh-community-plugins/community.json`，`category: "tools"`，`repo: https://github.com/termanli/dsh-fulltext-search`。在包真正发布前不填 `npm` 字段。由于 `market/dist/manifest/plugins.json` 由 community.json 派生，已用 `node scripts/market-build` 重新生成市场清单，创意工坊卡片与 dsh-market.com 会列出该插件，用户可用 `dsh plugin add https://github.com/termanli/dsh-fulltext-search` 安装。
+
+## Alternatives considered
+
+- 作为聚合成员收编进全家桶（`packages/dsh-fulltext-search`，用改造分支 `dsh_web_ui_comp`）：否决。改造分支只能在全家桶 monorepo 内构建——它的 tsdown 预设 import 了共享的 `shared/tsdown.client.ts`，且 `lib/` 被 gitignore——独立 clone 无法构建、无法安装。社区路线不需要任何家族包机制。
+- 发布 npm 并填 `npm` 字段：延后。插件尚未发布，提前填 `npm` 会把用户指向一个装不上的安装命令。
+
+## Consequences
+
+- 插件保持从其自己的公开仓库安装；家族仓库只携带索引元数据，绝不携带插件代码。
+- 条目在维护者合并索引 PR 后才出现在创意工坊与 dsh-market.com。
+- 将来若收编进全家桶，可复用保留的 `dsh_web_ui_comp` 分支走文档化的收编流程；届时移除该索引条目即可。

--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -430,6 +430,17 @@
       "repo": "https://github.com/GreenLv/dsh-session-insights",
       "npm": "dsh-session-insights",
       "category": "tools"
+    },
+    {
+      "id": "dsh-fulltext-search",
+      "name": "全文搜索",
+      "rank": 38,
+      "nameEn": "Fulltext Search",
+      "author": "termanli",
+      "description": "侧边栏按文件内容全文搜索当前会话工作目录（ripgrep 优先、纯 JS 引擎回退），支持正则、大小写与整词匹配，点击结果行在编辑器中打开文件。",
+      "descriptionEn": "Full-text content search over the session working directory in the sidebar (ripgrep-first with a pure-JS engine fallback), with regex, case and whole-word matching; click a result row to open the file in the editor.",
+      "repo": "https://github.com/termanli/dsh-fulltext-search",
+      "category": "tools"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -388,5 +388,15 @@
     "repo": "https://github.com/GreenLv/dsh-session-insights",
     "npm": "dsh-session-insights",
     "category": "tools"
+  },
+  {
+    "id": "dsh-fulltext-search",
+    "name": "全文搜索",
+    "nameEn": "Fulltext Search",
+    "author": "termanli",
+    "description": "侧边栏按文件内容全文搜索当前会话工作目录（ripgrep 优先、纯 JS 引擎回退），支持正则、大小写与整词匹配，点击结果行在编辑器中打开文件。",
+    "descriptionEn": "Full-text content search over the session working directory in the sidebar (ripgrep-first with a pure-JS engine fallback), with regex, case and whole-word matching; click a result row to open the file in the editor.",
+    "repo": "https://github.com/termanli/dsh-fulltext-search",
+    "category": "tools"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

将 dsh-fulltext-search（DSH Web GUI 侧边栏全文搜索插件）登记进社区插件索引：在 `packages/dsh-community-plugins/community.json` 追加条目（`category: tools`，`repo: https://github.com/termanli/dsh-fulltext-search`，未发布 npm 故不填 `npm` 字段），并重新生成 `market/dist/manifest/plugins.json`（由 community.json 派生）。合并后该插件将出现在设置 → 创意工坊 → 插件 与 dsh-market.com，用户可一键安装。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`
- [x] 其他（请说明）：社区插件索引 `packages/dsh-community-plugins` 与 `market/dist/manifest/plugins.json`

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```sh
git fetch origin dev && git rebase origin/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

N/A（纯数据改动，无视觉修复）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

## 贡献者版权声明（Contributor Copyright）

- [x] 社区条目 `dsh-fulltext-search` 版权归原作者 termanli，仓库 [termanli/dsh-fulltext-search](https://github.com/termanli/dsh-fulltext-search)（Apache-2.0），索引只收录链接、不搬代码，本仓库不主张版权。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

https://github.com/termanli/dsh-fulltext-search

插件详细说明：

dsh-fulltext-search 是 DSH Web GUI 侧边栏全文搜索插件：按文件内容搜索当前会话工作目录（ripgrep 优先、纯 JS 引擎回退），支持正则、大小写与整词匹配，点击结果行在编辑器中打开文件。依赖 dsh-better-sidebar 文件管理器；仓库 main 分支纯 JS、`lib/` 已提交，`dsh plugin add https://github.com/termanli/dsh-fulltext-search` 可零构建安装，公开仓库已验证可达。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表。注：当前仓库该包已无 `src/client/generated/community.ts` 产物（此前重构移除），实际数据流为 community.json → `scripts/market-build` → `market/dist/manifest/plugins.json`，该生成物已随本 PR 提交。
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本地经 `dsh plugin --profile web add link:` 挂载验证可用（重启 DSH 后生效）。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index --check          # OK (38 entries)
node scripts/market-build                     # wrote 1009 files (38 plugins)
node scripts/market-build --check             # dist up to date (233 files)
node --test scripts/community-index.test.mjs  # 7/7 passed（CLI gate 含新条目）
pnpm --filter @linxin666/dsh-client-ui-community-plugins test       # 2/2 passed
pnpm --filter @linxin666/dsh-client-ui-community-plugins typecheck  # passed
pnpm --filter @linxin666/dsh-client-ui-community-plugins build      # passed
node scripts/verify-docs.mjs                  # all documentation gates passed
pnpm typecheck                                # full monorepo passed (20/21, aionui 例外)
pnpm test                                     # 全仓通过；仅 dsh-doctor POSIX 用例在 Windows 预置失败（与本改动无关）
node --test scripts/*.test.mjs                # 179 pass；5 个 Windows 预置失败（pnpm.cmd EINVAL / URL pathname），与本改动无关
```

结果摘要：

全部与本改动相关的门禁通过：community:check、market:check、社区插件包 test/typecheck/build、docs:check、全仓 typecheck。全仓 `pnpm test` 与 `pnpm test:scripts` 中仅有的失败均为 Windows 环境预存在问题（dsh-doctor 的 POSIX 路径 / Unix socket 断言、`pnpm.cmd` spawn EINVAL、market-build-clean 测试的 URL pathname 前导斜杠），与本次纯数据改动无关，CI（Linux）不受影响。

## 用户可见变更证据（Local Feature Evidence）

证据：

合并后，设置 → 创意工坊 → 插件 与 dsh-market.com 将列出「全文搜索 / Fulltext Search」（rank 38）。本次提交的确定性产物即 `market/dist/manifest/plugins.json` 新增条目（id / name / nameEn / author / repo / description / category），见本 PR diff；条目指向的公开仓库 https://github.com/termanli/dsh-fulltext-search 已验证可达（`git ls-remote` 返回 HEAD = f3ec808）。纯数据改动，无 GUI 截图。
