### PR TITLE
fix(git-graph): measure only real chips for hero-row placement

### DIFF
--- a/packages/dsh-git-graph/src/client/chips/BranchChip.tsx
+++ b/packages/dsh-git-graph/src/client/chips/BranchChip.tsx
@@ -65,19 +65,30 @@ function useStockLightTheme(): boolean {
 }
 
 /**
- * The right edge of the rightmost painted descendant of `root`, excluding
- * `root` itself. The hero row's direct children can be display:contents
- * slot outlets, so the visible chip boundary must be found by walking.
+ * The right edge of the rightmost painted chip of `root`, excluding `root`
+ * itself. The hero row's direct children can be display:contents slot
+ * outlets, so the visible chip boundary must be found by walking. Only
+ * interactive chips (button / role=button / role=switch) are measured by
+ * default: the official seats' outlet wrappers and label spans can be laid
+ * out wider than what they actually paint (invisible measurement padding),
+ * which used to push this chip past the agent-preset seat instead of hugging
+ * it with the official row gap. Falls back to the full walk for shells that
+ * render non-button chips.
  */
 function paintedRight(root: Element): number | null {
   let right: number | null = null
-  const visit = (node: Element): void => {
-    if (node !== root) {
-      const rect = node.getBoundingClientRect()
-      if (rect.width > 0 && rect.height > 0) {
-        right = right === null ? rect.right : Math.max(right, rect.right)
-      }
+  const consider = (node: Element): void => {
+    const rect = node.getBoundingClientRect()
+    if (rect.width > 0 && rect.height > 0) {
+      right = right === null ? rect.right : Math.max(right, rect.right)
     }
+  }
+  root.querySelectorAll('button, [role="button"], [role="switch"]').forEach((el) => {
+    if (el !== root) consider(el)
+  })
+  if (right !== null) return right
+  const visit = (node: Element): void => {
+    if (node !== root) consider(node)
     for (const child of Array.from(node.children)) visit(child)
   }
   visit(root)


### PR DESCRIPTION
## 问题

新会话 hero 行的分支选择 chip 通过绝对定位贴到 agent 预设座位右侧：`paintedRight(heroRow)` 取「最右可见后代」右缘再加官方 2px 行距。但 hero 行的官方座位都渲染在 `display:contents` 的 slot outlet 里，其包裹层 / 标签 span 的布局宽度比实际绘制内容宽约 10px（不可见的测量留白）。这段幽灵宽度被计入后，chip 落在预设座位可见右缘外约 10–12px 处，且随字体度量漂移，视觉上就是「位置偏了」。

## 修复

`paintedRight()` 改为默认只测量真实绘制的交互 chip（`button` / `[role="button"]` / `[role="switch"]`）；若 shell 渲染非按钮 chip，则回退到原来的完整遍历，保持兼容。

## 验证

dsh web shell（WSL agent 预设座位，260810+ 快照）实测：

- chip 与预设座位的间距从 ~12px 收紧为**恰好 2px（HERO_CHIP_GAP）**
- 侧边栏折叠 / 窗口宽度变化触发的重排后位置依然正确（ResizeObserver 重测路径未动）
- 分支弹窗仍与 chip 左缘对齐，开合正常

## 备注

- 仅改动 `BranchChip.tsx` 一个函数；无导出面变化。
