### PR TITLE
fix(skins): restore maid atelier rc8 overlay compatibility

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-24-maid-atelier-rc8-overlays.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-maid-atelier-rc8-overlays.i18n.yaml
@@ -1,0 +1,5 @@
+# Bilingual-pair consistency record (docs/i18n.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with git hash-object.
+2026-08-24-maid-atelier-rc8-overlays.md: 5a1b8304d96e1d3434e155fcce9a6c718f0e7f71
+2026-08-24-maid-atelier-rc8-overlays.zh.md: 487739b2f1f06612d923593af9639c4260ff8906

--- a/.agents/notes/implemented/bug-fix/2026-08-24-maid-atelier-rc8-overlays.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-maid-atelier-rc8-overlays.md
@@ -1,0 +1,54 @@
+# Agent Note: maid-atelier rc.8 attachments and overlays
+
+Status: implemented
+
+## Problem
+
+DeepSeek Harness rc.8 renders draft attachments through the
+`conversation.input.attachments` Slot and renders settings selectors through
+portaled Menu surfaces. The maid-atelier composer frame established a stacking
+context above the nested attachment branch, so decoded `blob:` previews stayed
+hidden behind the ornate card even though the remove control remained visible.
+The skin's sidebar chrome also allowed conversation code-block headers to paint
+above the settings modal. Raising the entire sidebar to an unbounded z-index
+fixed that symptom but then placed the settings panel above DSH's portaled
+menus, making agent-preset and permission selectors unclickable. Cordis approval
+buttons had the same ancestor/hit-target conflict with the ornate sidebar.
+
+## Decision
+
+Keep the fixes in `packages/skins/skin-center/skins/maid-atelier/patches.css`
+and preserve DSH's existing overlay scale instead of inventing a higher one.
+The complete attachment Slot branch is promoted locally above the composer
+frame, and every CSS-module fallback selector is anchored below
+`[data-slot="conversation.input.attachments"]`. Cordis enters the ordinary menu
+range (`80` for the necessary sidebar context and `100` for the panel).
+Settings enters the modal range (`900` for its sidebar ancestor and `1000` for
+the full-viewport presentation layer), leaving DSH's portaled Menu at its
+official `1100` above the modal. Icon children do not capture approval-button
+pointer events, while the actual action buttons remain hit-testable.
+
+The built-in skin acceptance test locks the attachment Slot scope, modal layer,
+and a maximum custom numeric z-index of `1000`. The skin version advances from
+`0.3.1` to `0.3.2` so Workshop installations can receive the compatibility
+fixes.
+
+## Alternatives considered
+
+Raising the settings and Cordis ancestors to `214748xxxx` values was tested and
+rejected. It hid code-block chrome and made approval circles visible, but broke
+the host's `modal 1000 < portaled Menu 1100` contract, so controls inside the
+settings panel could no longer open usable menus.
+
+Raising only the attachment `<img>` was also tested and rejected. A child cannot
+escape its parent's lower stacking context, so the browser reported the
+`blob:` image as loaded while the ornate composer frame still covered it.
+
+## Consequences
+
+Future maid-atelier compatibility selectors for generated CSS-module names must
+remain under a semantic Slot or plugin anchor. Future modal fixes must preserve
+the host overlay scale rather than using unbounded z-index values. The repair
+was verified in the live DSH Web GUI with visible attachment thumbnails,
+clickable settings selectors, settings above markdown code headers, and usable
+Cordis approval controls.

--- a/.agents/notes/implemented/bug-fix/2026-08-24-maid-atelier-rc8-overlays.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-maid-atelier-rc8-overlays.zh.md
@@ -1,0 +1,43 @@
+# Agent Note: maid-atelier rc.8 附件与浮层兼容
+
+Status: implemented
+
+## 问题
+
+DeepSeek Harness rc.8 通过 `conversation.input.attachments` Slot 渲染草稿
+附件，并通过 Portal Menu 渲染设置选择器。maid-atelier 的 composer 边框创建了
+高于深层附件分支的层叠上下文，因此即使 `blob:` 预览已经解码、删除按钮也可见，
+缩略图仍被华丽卡框覆盖。皮肤的侧边栏装饰还会让会话代码块标题绘制在设置模态框
+之上。把整个侧边栏提升到无限大的 z-index 虽能暂时消除该症状，却会让设置面板
+反过来压住 DSH 的 Portal 菜单，导致 Agent 预设与权限选择器无法点击。Cordis
+审批按钮也受到同一类侧边栏祖先层级与命中目标冲突影响。
+
+## 决策
+
+修复保留在 `packages/skins/skin-center/skins/maid-atelier/patches.css` 中，
+复用 DSH 既有浮层尺度，而不是发明更大的层级。完整附件 Slot 分支只在 composer
+内部提升到装饰框上方，所有 CSS Module 后备选择器都锚定在
+`[data-slot="conversation.input.attachments"]` 之下。Cordis 进入普通菜单层级
+（必要侧边栏上下文为 `80`、面板为 `100`）。设置进入模态层级（侧边栏祖先为
+`900`、全屏 presentation 层为 `1000`），从而保留 DSH 官方 Portal Menu 的
+`1100` 位于模态框之上。图标子节点不再截获审批按钮指针事件，实际操作按钮仍可
+命中。
+
+内置皮肤验收测试锁定附件 Slot 作用域、模态层级以及自定义数值 z-index 最大为
+`1000`。皮肤版本从 `0.3.1` 升到 `0.3.2`，使 Workshop 安装能收到这些兼容修复。
+
+## 考虑过的替代方案
+
+曾测试把设置与 Cordis 祖先提升到 `214748xxxx`，但予以否决。它虽然能压住代码块
+装饰并让审批圆形按钮可见，却破坏了宿主的 `modal 1000 < portaled Menu 1100`
+契约，导致设置面板内的控制项无法打开可用菜单。
+
+也测试过只提升附件 `<img>`，同样予以否决。子元素无法逃出父元素较低的层叠
+上下文，因此浏览器虽报告 `blob:` 图片已经加载，华丽 composer 边框仍会覆盖它。
+
+## 影响
+
+今后 maid-atelier 针对生成式 CSS Module 类名的兼容选择器必须位于语义 Slot 或
+插件锚点之下；模态修复必须保留宿主浮层尺度，不能使用无限大的 z-index。修复已在
+运行中的 DSH Web GUI 验证：附件缩略图可见、设置选择器可点击、设置模态框高于
+Markdown 代码块标题、Cordis 审批按钮可用。

--- a/packages/skins/skin-center/skins/maid-atelier/patches.css
+++ b/packages/skins/skin-center/skins/maid-atelier/patches.css
@@ -784,6 +784,33 @@ body[data-ds-dark-theme] [data-cordis-panel] :is([data-cordis-approve], [data-co
   border-color: #8fa3d357;
 }
 
+/* Keep Cordis above the ornate sidebar chrome without escaping DSH's global
+   overlay scale: menus use 100/1100 and modals use 1000. */
+body:has([data-cordis-panel]) :is([data-pane="sidebar"], [class*="sidebarCol"]) {
+  z-index: 80 !important;
+  overflow: visible !important;
+}
+
+body:has([data-cordis-panel]) :is([data-pane="sidebar"], [class*="sidebarCol"]) > div,
+body:has([data-cordis-panel]) :has(> [data-cordis-panel]) {
+  overflow: visible !important;
+}
+
+[data-cordis-panel] {
+  z-index: 100 !important;
+  pointer-events: auto !important;
+  isolation: isolate !important;
+}
+
+[data-cordis-panel] :is([data-cordis-approve], [data-cordis-approve-plugin], [data-cordis-decline]) {
+  pointer-events: auto !important;
+  position: relative !important;
+}
+
+[data-cordis-panel] :is([data-cordis-approve], [data-cordis-approve-plugin], [data-cordis-decline]) > * {
+  pointer-events: none !important;
+}
+
 [data-dsh-better-sidebar] {
   --dsw-specific-sidebar-fill: #e6edfaf5;
   --dsw-alias-bg-base: #f8fafff5;
@@ -2394,4 +2421,106 @@ body[data-ds-dark-theme] [class*="titlebar"] {
     opacity: 0;
     transform: translate(calc(100vw + 240px));
   }
+}
+
+/* DSH rc.8 draft-image rail compatibility. Promote the complete attachment
+   Slot above the ornate composer frame; a nested image cannot escape a parent
+   stacking context on its own. Every fallback stays inside the attachment
+   Slot so unrelated CSS-module classes are not affected. */
+[data-slot="conversation.input.attachments"],
+[data-slot="conversation.input.attachments"] > *,
+[data-slot="conversation.input.attachments"] :is(.JVDQca_root, .JVDQca_rail, .JVDQca_item) {
+  z-index: 6 !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  filter: none !important;
+  mix-blend-mode: normal !important;
+  position: relative !important;
+}
+
+[data-slot="conversation.input.attachments"]
+  :is(button.JVDQca_thumbnail, button[class*="_thumbnail"]) {
+  box-sizing: border-box;
+  isolation: isolate;
+  width: 64px !important;
+  min-width: 64px !important;
+  height: 64px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  filter: none !important;
+  transform: none !important;
+  background: #f6f0e4 !important;
+  border: 2px solid #e2c57f !important;
+  border-radius: 14px !important;
+  box-shadow: 0 3px 10px #02081c8f, inset 0 0 0 1px #fff9 !important;
+  position: relative !important;
+}
+
+[data-slot="conversation.input.attachments"]
+  :is(button.JVDQca_thumbnail, button[class*="_thumbnail"])::before,
+[data-slot="conversation.input.attachments"]
+  :is(button.JVDQca_thumbnail, button[class*="_thumbnail"])::after {
+  content: none !important;
+  display: none !important;
+}
+
+[data-slot="conversation.input.attachments"]
+  :is(button.JVDQca_thumbnail, button[class*="_thumbnail"]) > img {
+  z-index: 10 !important;
+  object-fit: cover !important;
+  width: 100% !important;
+  height: 100% !important;
+  max-width: none !important;
+  max-height: none !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  filter: brightness(1.16) contrast(1.1) saturate(1.1) !important;
+  mix-blend-mode: normal !important;
+  display: block !important;
+  position: absolute !important;
+  inset: 0 !important;
+}
+
+[data-slot="conversation.input.attachments"]
+  :is(button.JVDQca_thumbnail, button[class*="_thumbnail"]):hover {
+  transform: translateY(-1px) !important;
+  border-color: #f4d899 !important;
+  box-shadow: 0 5px 14px #02081cb3, 0 0 0 2px #e2c57f4d !important;
+}
+
+/* Preserve DSH's global overlay contract instead of using unbounded values:
+   ordinary chrome < modal 1000 < portaled Menu 1100. Settings is mounted
+   below the sidebar slot, so only its necessary ancestry enters that scale. */
+body:has([data-slot="sidebar.settings"] [role="dialog"][aria-modal="true"])
+  :is([data-pane="sidebar"], [class*="sidebarCol"]) {
+  z-index: 900 !important;
+  overflow: visible !important;
+  isolation: isolate !important;
+}
+
+body:has([data-slot="sidebar.settings"] [role="dialog"][aria-modal="true"])
+  :is([data-pane="sidebar"], [class*="sidebarCol"]) > div {
+  overflow: visible !important;
+  isolation: auto !important;
+}
+
+body:has([data-slot="sidebar.settings"] [role="dialog"][aria-modal="true"])
+  [data-slot="sidebar.settings"] {
+  overflow: visible !important;
+}
+
+body:has([data-slot="sidebar.settings"] [role="dialog"][aria-modal="true"])
+  [data-slot="sidebar.settings"] > [role="presentation"] {
+  z-index: 1000 !important;
+  overflow: visible !important;
+  position: fixed !important;
+  inset: 0 !important;
+}
+
+body:has([data-slot="sidebar.settings"] [role="dialog"][aria-modal="true"])
+  [data-slot="sidebar.settings"] [role="dialog"][aria-modal="true"] {
+  z-index: 1 !important;
+  position: relative !important;
 }

--- a/packages/skins/skin-center/skins/maid-atelier/skin.json
+++ b/packages/skins/skin-center/skins/maid-atelier/skin.json
@@ -17,7 +17,7 @@
   ],
   "accent": "#c5a468",
   "order": 13,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "CC BY-NC-SA 4.0",
   "licenseUrl": "https://github.com/Small-tailqwq/dsh-deep-whale/blob/main/maid-atelier/LICENSE",
   "noticeUrl": "https://github.com/Small-tailqwq/dsh-deep-whale/blob/main/maid-atelier/NOTICE",

--- a/packages/skins/skin-center/tests/builtin-skins.spec.ts
+++ b/packages/skins/skin-center/tests/builtin-skins.spec.ts
@@ -145,6 +145,23 @@ describe('built-in v2 skins: catalog and stylesheets', () => {
       expect(contrastRatio(fg!, bg!), `${selector}: tooltip contrast`).toBeGreaterThanOrEqual(4.5)
     }
   })
+
+  it('maid-atelier: rc.8 compatibility stays slot-scoped and within the overlay scale', () => {
+    const css = readFileSync(join(SKINS_DIR, 'maid-atelier', 'patches.css'), 'utf8')
+
+    expect(css).toContain('[data-slot="conversation.input.attachments"]')
+    expect(css).toMatch(
+      /\[data-slot="conversation\.input\.attachments"\]\s*\n\s*:is\(button\.JVDQca_thumbnail, button\[class\*="_thumbnail"\]\)/,
+    )
+    expect(css).not.toMatch(/(?:^|\n):is\(button\.JVDQca_thumbnail/m)
+
+    expect(css).toMatch(
+      /\[data-slot="sidebar\.settings"\] > \[role="presentation"\]\s*\{[\s\S]*?z-index: 1000 !important;/,
+    )
+    const numericZIndexes = [...css.matchAll(/z-index:\s*(-?\d+)/g)].map((match) => Number(match[1]))
+    expect(Math.max(...numericZIndexes)).toBeLessThanOrEqual(1000)
+    expect(css).not.toContain('214748')
+  })
 })
 
 describe('built-in v2 skins: hooks lifecycle', () => {


### PR DESCRIPTION
## 摘要（Summary）

Fixes #1131. 修复 maid-atelier 在 DSH rc.8 下的附件缩略图遮挡、设置模态/Portal 菜单层级冲突和 Cordis 审批按钮命中问题。修复保持 DSH 官方 `menu 100 < modal 1000 < portaled Menu 1100` 层级契约，并将皮肤版本升级到 0.3.2。

## 涉及包（Affected Packages）

- [x] 皮肤 / 皮肤中心 `packages/skins`

## PR 类别（PR Category）

- [x] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [x] Bug 修复
- [x] 视觉修复（UI / 视觉类问题的修复）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch origin dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

同步结果：`origin/dev` 为 `c34878c8c1ffcf3cdbd0cb0349c759531cc66968`，当前修复提交直接基于该提交。静态皮肤契约、完整 Vitest（31 个文件、548 个测试）、类型检查、skin-center 构建、`dsh-skin validate` 与 `skin-center:check` 均通过。

## 视觉修复要求（Visual Fix Requirements）

- [x] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [x] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码

使用的 AI 模型： GPT-5.6-sol

使用的编码 Agent 工具： DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码。
- [x] 未新增指向 DSH 源码 checkout 的 TypeScript 配置。
- [x] 所有新增 / 修改文件不含 emoji。
- [x] 皮肤兼容规则限制在语义 Slot 内；未使用无限大 z-index。
- [x] 新增中英文 Agent Note 及哈希 sidecar。

## 本地验证（Local Validation）

执行的命令：

```bash
python3 -m json.tool packages/skins/skin-center/skins/maid-atelier/skin.json
node --check packages/skins/skin-center/skins/maid-atelier/hooks.mjs
git diff --check
pnpm --filter @linxin666/dsh-client-ui-skin-center test
pnpm skin-center:check
```

结果摘要：

- 静态检查通过。
- 完整皮肤中心测试：31 个测试文件、548 个测试通过。
- 类型检查、skin-center 构建、`dsh-skin validate`、`skin-center:check` 全部通过。

## 用户可见变更证据（Local Feature Evidence）

在 DSH Desktop rc.8 与 skin-center 0.3.2 环境中验证：

- 附件诊断为 `blob:` URL 且 `<img>` `loaded`，确认原问题来自 stacking context。
- 完整附件 Slot 分支提升后，上传图片缩略图正常可见。
- 设置模态框仍位于 Markdown 代码块标题之上。
- Agent 预设与权限 Portal 菜单位于设置模态框上方且可点击。
- Cordis 审批按钮可点击并成功完成审批。

复现与修复截图：

- 修复前附件空框：
  ![attachment before fix](https://raw.githubusercontent.com/WsXiaoYao/dsh-web/evidence/maid-atelier-rc8/.github/issue-evidence/maid-atelier-rc8/attachment-before.jpg)
- 诊断确认 blob URL / loaded：
  ![diagnostic layer](https://raw.githubusercontent.com/WsXiaoYao/dsh-web/evidence/maid-atelier-rc8/.github/issue-evidence/maid-atelier-rc8/diagnostic-layer.jpg)
- 修复后设置模态框：
  ![settings after fix](https://raw.githubusercontent.com/WsXiaoYao/dsh-web/evidence/maid-atelier-rc8/.github/issue-evidence/maid-atelier-rc8/settings-after.png)
