### PR TITLE
community: add dsh-deepsea (深海摸鱼)

### DIFF
--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -389,5 +389,16 @@
     "repo": "https://github.com/GreenLv/dsh-session-insights",
     "npm": "dsh-session-insights",
     "category": "tools"
+  },
+  {
+    "id": "dsh-deepsea",
+    "name": "深海摸鱼",
+    "nameEn": "Deep-Sea Moyu",
+    "author": "imkingjh999",
+    "description": "把会话 context 变成浮窗深海摸鱼小游戏：context 越长手沉得越深，摸到鱼后服务端掷骰定胜负，中卡铸造镭射收藏卡；五大洋、鱼池养成、GitHub 全球排行榜。",
+    "descriptionEn": "Turns session context into a deep-sea moyu (slack-off) game in a floating window: your hand sinks as context grows, server-rolled dice decide the mint of holographic collectible cards; five oceans, a fish pond, and a GitHub-linked leaderboard.",
+    "repo": "https://github.com/imkingjh999/dsh-deepsea",
+    "npm": "dsh-deepsea",
+    "category": "ui"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

在社区插件索引 `packages/dsh-community-plugins/community.json` 追加第 38 条：登记 **dsh-deepsea（深海摸鱼）**——把会话 context 变成浮窗深海摸鱼小游戏的社区插件（npm 已发布 `dsh-deepsea`@1.0.10）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`
- [x] 其他（请说明）：`packages/dsh-community-plugins/community.json`（社区插件索引登记，非代码包改动）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更（社区插件索引新增条目：设置页社区插件分区可见新卡片）
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
gh repo fork zhu1090093659/dsh-web-ui --clone=false   # fork 于 2026-08-25，dev 为上游当时最新
gh api repos/imkingjh999/dsh-web/commits/dev          # fork dev 与上游 community.json 最新提交一致（2fd0eda）
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

不适用（非视觉修复）。

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GLM（deepseek-harness 宿主内）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（无新增包目录）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（未改动 README）

## 贡献者版权声明（Contributor Copyright）

不适用（索引登记，被登记插件 dsh-deepsea 为 MIT，版权归 imkingjh999）。

## 新皮肤收录（New Skin）

不适用。

## 新宠物收录（New Pet）

不适用。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/imkingjh999/dsh-deepsea

插件详细说明：

dsh-deepsea（深海摸鱼）是把会话上下文变成浮窗小游戏的 DSH 插件：对话 context 越长，「摸鱼手」在深海里沉得越深；AI 每答完一轮，玩家在浮窗里用手摸鱼，重叠即必接触，服务端 PoW 掷骰（1/5，新潜水员前 5 分钟 1/2）决定是否铸卡；中卡由 MiniMax 生成镭射收藏卡（镭射质感 + 稀有度），卡墙收集、鱼池养成。功能：五大洋切换（独立生物池 / 水体色 / BGM）、四个深度水层生物生态、卡墙图鉴、多屏鱼池（巡游 / 缩放）、浮窗形态（拖拽 / 贴边 / 最小化）、多窗老板键、可选战绩上云（Cloudflare Worker + D1 服务端裁决 + Ed25519 签名 + GitHub 绑定全球排行榜）。依赖：dsh-float-window、可选 MiniMax API Key（无 Key 时收藏卡功能降级）。已知限制：卡图生成需自备 MiniMax API Key；战绩上云默认关闭。npm 包：`dsh-deepsea`（v1.0.10），`dsh plugin --profile web add npm:dsh-deepsea` 一键安装；package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`，类型仅基于官方 `@deepseek-ai/*` NPM SDK，带 `dsh-plugin` GitHub topic。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表（提交生成的 `packages/dsh-community-plugins/src/client/generated/community.ts`）。（community.json 已追加第 38 条；`node scripts/community-index` 为纯校验脚本，本地以同等校验规则跑过：`community-index: OK (38 entries)`；模板所述 generated/community.ts 路径在当前 dev 分支不存在，市场侧由 market-build 从同一 json 构建，故无生成物需要提交）
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本仓库最新代码上验证插件可被 `dsh web` 挂载并正常运行。（插件已在本人日常使用的 `dsh web` 实例中通过 npm 包 `dsh-deepsea` 挂载运行：浮窗、卡墙、鱼池、排行榜均正常，287 个测试用例全过）
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
# 等价于 node scripts/community-index 的完整校验（无依赖纯校验脚本，规则逐条复刻）
node -e "<同 REPO_RE/NPM_RE/REQUIRED/CATEGORIES 规则的校验>"
# 输出：community-index equivalent: OK (38 entries)

# JSON 结构与既有 37 条 schema 对齐检查
node -e "const l=require('/tmp/community-new.json'); console.log(l.length, JSON.stringify(Object.keys(l[37])))"
# 输出：38 ["id","name","nameEn","author","description","descriptionEn","repo","npm","category"]

# 既有 37 条字段并集 = 新条目字段集（无引入新字段）
```

结果摘要：

全部通过：38 条、id 无重复、repo 符合 https 路径安全正则、npm 包名合法（`dsh-deepsea`）、category `ui` 在固定七类内；新条目字段与既有条目 schema 完全一致（id/name/nameEn/author/description/descriptionEn/repo/npm/category）。插件本体在本人 `dsh web` 实例（web profile，npm 安装 `dsh-deepsea`@1.0.10）长期挂载运行正常。

## 用户可见变更证据（Local Feature Evidence）

证据：

索引登记为纯数据条目，展示效果即设置页「社区插件」分区出现 dsh-deepsea 卡片（名称「深海摸鱼」、npm 标记、ui 分类、简介与仓库链接，复制安装命令 `dsh plugin --profile web add dsh-deepsea`）。插件本体运行证据见其仓库 README 预览截图（海洋摸鱼 / 卡墙 / 鱼池三图，https://github.com/imkingjh999/dsh-deepsea#readme）。本 PR 未改任何渲染代码，卡片由现有索引渲染管线从 community.json 生成，合并后即可见。
