### PR TITLE
fix(doctor): preserve Electron Node mode in macOS LaunchAgent

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-25-doctor-electron-launchagent-node-mode.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-25-doctor-electron-launchagent-node-mode.i18n.yaml
@@ -1,0 +1,5 @@
+# Bilingual-pair consistency record (docs/i18n.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with git hash-object.
+2026-08-25-doctor-electron-launchagent-node-mode.md: 40c1efb3add1451781e4bfedc9f05cac93a744e4
+2026-08-25-doctor-electron-launchagent-node-mode.zh.md: bd98b1c70c9267a7b52046de793ff4744a55c147

--- a/.agents/notes/implemented/bug-fix/2026-08-25-doctor-electron-launchagent-node-mode.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-25-doctor-electron-launchagent-node-mode.md
@@ -1,0 +1,25 @@
+# Agent Note: Doctor Electron LaunchAgent Node Mode
+
+Status: implemented
+
+## Problem
+
+On macOS, DSH Desktop hosts Harness in an Electron utility process. Doctor therefore sees the Electron Helper as `process.execPath`, while the live Harness process relies on `ELECTRON_RUN_AS_NODE=1` to make child invocations use Node semantics. Doctor persisted the Helper path in `com.dsh.doctor.plist` but only persisted `DSH_DOCTOR_HOME`; launchd later started the Helper without Node mode. The Helper entered Electron startup, crashed with `EXC_BREAKPOINT` / `SIGTRAP`, and `KeepAlive` repeated the failure roughly every ten seconds. The repeated launches could steal focus from the user's current application.
+
+## Decision
+
+The macOS service adapter now preserves `ELECTRON_RUN_AS_NODE=1` in the LaunchAgent whenever the installing Doctor CLI inherited that flag. A normal Node-hosted installation does not add the variable. The existing idempotent service deployment replaces an affected plist and restarts the Supervisor, so the repaired definition is applied during Doctor reconciliation.
+
+## Alternatives considered
+
+- **Detect Electron from the executable filename or bundle path**: Helper names and application paths vary between development, packaged, and rebranded builds. Preserving the explicit runtime flag is a stronger signal than path heuristics.
+- **Always set `ELECTRON_RUN_AS_NODE=1` on macOS**: harmless for a real Node executable in current environments, but it adds an Electron-specific contract where none is required. Conditional propagation keeps ordinary Node services unchanged.
+- **Make DSH Desktop rewrite third-party LaunchAgents**: the service definition belongs to Doctor. Repairing it at the owner avoids Desktop-specific knowledge of one plugin and also covers other Electron-hosted Harness distributions.
+
+## Consequences
+
+Doctor Supervisors installed from Electron-hosted Harness processes start as Node programs instead of entering Electron startup. Existing affected installations are repaired when Doctor's normal ensure flow redeploys the service. Users who removed the plugin before receiving the fix still need to unregister the orphaned LaunchAgent because the package code is no longer present to reconcile it.
+
+## Testing
+
+The service adapter tests cover propagation when Electron Node mode is present and omission for a normal Node installation. Package typecheck, test, and build gates validate the shipped source and CLI bundle.

--- a/.agents/notes/implemented/bug-fix/2026-08-25-doctor-electron-launchagent-node-mode.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-25-doctor-electron-launchagent-node-mode.zh.md
@@ -1,0 +1,25 @@
+# Agent Note: Doctor Electron LaunchAgent Node 模式
+
+Status: implemented
+
+## Problem
+
+在 macOS 上，DSH Desktop 通过 Electron utility process 托管 Harness。因此 Doctor 看到的 `process.execPath` 是 Electron Helper，而运行中的 Harness 依赖 `ELECTRON_RUN_AS_NODE=1` 让子进程按 Node 语义执行。Doctor 把 Helper 路径写入 `com.dsh.doctor.plist` 时只保留了 `DSH_DOCTOR_HOME`；launchd 随后在没有 Node 模式的情况下启动 Helper。Helper 进入 Electron 启动流程并以 `EXC_BREAKPOINT` / `SIGTRAP` 崩溃，`KeepAlive` 约每十秒重复一次失败，反复启动可能抢占用户当前应用的焦点。
+
+## Decision
+
+macOS 服务适配器在安装 Doctor CLI 继承到 `ELECTRON_RUN_AS_NODE=1` 时，将该变量保留到 LaunchAgent。普通 Node 宿主安装不会加入该变量。现有幂等服务部署会替换受影响的 plist 并重启 Supervisor，因此 Doctor reconcile 时会应用修复后的定义。
+
+## Alternatives considered
+
+- **根据可执行文件名或 bundle 路径判断 Electron**：Helper 名称和应用路径在开发版、打包版及改名版本之间不同。保留明确的运行时标志比路径启发式判断更可靠。
+- **在 macOS 上始终设置 `ELECTRON_RUN_AS_NODE=1`**：在当前环境中对真实 Node 可执行文件无害，但会在不需要的位置引入 Electron 专属契约。条件传播可以保持普通 Node 服务不变。
+- **让 DSH Desktop 重写第三方 LaunchAgent**：服务定义属于 Doctor。在归属方修复可以避免 Desktop 硬编码某个插件，同时覆盖其他基于 Electron 托管 Harness 的发行版。
+
+## Consequences
+
+从 Electron 托管的 Harness 安装的 Doctor Supervisor 会作为 Node 程序启动，不再进入 Electron 启动流程。已有受影响安装会在 Doctor 的正常 ensure 流程重新部署服务时得到修复。若用户在收到修复前已经删除插件，包代码已不存在，无法执行 reconcile，仍需手动注销遗留 LaunchAgent。
+
+## Testing
+
+服务适配器测试覆盖 Electron Node 模式存在时的传播，以及普通 Node 安装时不写入该变量。包级 typecheck、test 和 build 门禁验证发布源码与 CLI bundle。

--- a/packages/dsh-doctor/src/agent/service.ts
+++ b/packages/dsh-doctor/src/agent/service.ts
@@ -14,7 +14,10 @@ export function servicePlan(spec: ServiceSpec, env: NodeJS.ProcessEnv = process.
   if (spec.platform === 'darwin') {
     const path = join(home, 'Library', 'LaunchAgents', `${spec.label}.plist`)
     const args = [executable, ...spec.args].map(value => `<string>${quoteXml(value)}</string>`).join('')
-    const content = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>Label</key><string>${quoteXml(spec.label)}</string><key>ProgramArguments</key><array>${args}</array><key>EnvironmentVariables</key><dict><key>DSH_DOCTOR_HOME</key><string>${quoteXml(spec.doctorHome)}</string></dict><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>ProcessType</key><string>Background</string></dict></plist>
+    const electronNodeMode = env.ELECTRON_RUN_AS_NODE === '1'
+      ? '<key>ELECTRON_RUN_AS_NODE</key><string>1</string>'
+      : ''
+    const content = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>Label</key><string>${quoteXml(spec.label)}</string><key>ProgramArguments</key><array>${args}</array><key>EnvironmentVariables</key><dict><key>DSH_DOCTOR_HOME</key><string>${quoteXml(spec.doctorHome)}</string>${electronNodeMode}</dict><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>ProcessType</key><string>Background</string></dict></plist>
 `
     const user = `gui/${process.getuid?.() ?? 0}`
     return { files: [{ path, content, mode: 0o600 }], install: ['launchctl', 'bootstrap', user, path], uninstall: ['launchctl', 'bootout', user, path], restart: ['launchctl', 'kickstart', '-k', `${user}/${spec.label}`] }

--- a/packages/dsh-doctor/tests/agent-service.spec.ts
+++ b/packages/dsh-doctor/tests/agent-service.spec.ts
@@ -22,6 +22,19 @@ describe('service adapters', () => {
     expect(plan.files[0]!.content).toContain('Anders &amp; Co')
   })
 
+  it('preserves Electron Node mode in a macOS LaunchAgent', () => {
+    const plan = servicePlan(
+      { ...base, executable: '/Applications/DSH Desktop.app/Contents/Frameworks/DSH Desktop Helper.app/Contents/MacOS/DSH Desktop Helper', platform: 'darwin' },
+      { HOME: '/Users/u', ELECTRON_RUN_AS_NODE: '1' },
+    )
+    expect(plan.files[0]!.content).toContain('<key>ELECTRON_RUN_AS_NODE</key><string>1</string>')
+  })
+
+  it('does not force Electron Node mode for a real Node executable', () => {
+    const plan = servicePlan({ ...base, platform: 'darwin' }, { HOME: '/Users/u' })
+    expect(plan.files[0]!.content).not.toContain('ELECTRON_RUN_AS_NODE')
+  })
+
   it('renders a systemd user unit with restart policy', () => {
     const plan = servicePlan({ ...base, platform: 'linux' }, { XDG_CONFIG_HOME: '/home/u/.config' })
     expect(plan.files[0]!.path).toBe('/home/u/.config/systemd/user/com.dsh.doctor.service')


### PR DESCRIPTION
## 摘要（Summary）

Preserve `ELECTRON_RUN_AS_NODE=1` in the macOS Doctor LaunchAgent when the installing CLI inherited that runtime contract. This prevents launchd from starting an Electron Helper as a GUI Electron process and entering a `SIGTRAP` restart loop.

Fixes #1146
Related to dataelement/dsh-desktop#157

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`
- [x] 其他：`packages/dsh-doctor`

## PR 类别（PR Category）

- [x] 插件功能（Doctor service adapter）

## PR 类型（PR Type）

- [x] Bug 修复

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch origin dev
git rebase origin/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支，并附上同步后重新测试通过的证据。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：GPT-5 Codex

使用的编码 Agent 工具：Codex Desktop

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录规则不适用；未新增包。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 未修改包 README；新增的 Agent Note 已提供英文、中文和 i18n sidecar。

## 本地验证（Local Validation）

```bash
pnpm --filter @linxin666/dsh-doctor typecheck
pnpm --filter @linxin666/dsh-doctor test
pnpm --filter @linxin666/dsh-doctor build
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
ELECTRON_RUN_AS_NODE=1 node packages/dsh-doctor/lib/cli.mjs service-plan
plutil -lint /tmp/com.dsh.doctor.test.plist
git diff --check origin/dev..HEAD
```

结果摘要：Doctor 39 个测试文件、369 项测试通过；全仓 typecheck/test 通过；脚本测试 199 通过、4 跳过；文档门禁通过；生成的 plist 通过 `plutil -lint` 并包含 `<key>ELECTRON_RUN_AS_NODE</key><string>1</string>`。

## 用户可见变更证据（Local Feature Evidence）

N/A。该修复是 macOS 用户级后台服务定义的内部修复，不涉及视觉界面。现场复现证据记录在 #1146 和 dataelement/dsh-desktop#157。