### PR TITLE
feat(community): register dsh-workbench plugin index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -431,6 +431,18 @@
       "repo": "https://github.com/GreenLv/dsh-session-insights",
       "npm": "dsh-session-insights",
       "category": "tools"
+    },
+    {
+      "id": "dsh-workbench",
+      "name": "DSH 工作台",
+      "rank": 38,
+      "nameEn": "DSH Workbench",
+      "author": "mtdx2001",
+      "description": "DSH Web GUI 执行工作台：中央工作模式、模块导航、会话状态、Agent 回退、主工作区扩展与 Workbench-owned 右侧面板。",
+      "descriptionEn": "An execution workbench for the DSH Web GUI with central modes, modular navigation, session status, Agent fallback, main-surface extensions, and a Workbench-owned right sidebar.",
+      "repo": "https://github.com/mtdx2001/dsh-web-ui",
+      "npm": "@mtdx2001/dsh-client-ui-workbench",
+      "category": "tools"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -389,5 +389,16 @@
     "repo": "https://github.com/GreenLv/dsh-session-insights",
     "npm": "dsh-session-insights",
     "category": "tools"
+  },
+  {
+    "id": "dsh-workbench",
+    "name": "DSH 工作台",
+    "nameEn": "DSH Workbench",
+    "author": "mtdx2001",
+    "description": "DSH Web GUI 执行工作台：中央工作模式、模块导航、会话状态、Agent 回退、主工作区扩展与 Workbench-owned 右侧面板。",
+    "descriptionEn": "An execution workbench for the DSH Web GUI with central modes, modular navigation, session status, Agent fallback, main-surface extensions, and a Workbench-owned right sidebar.",
+    "repo": "https://github.com/mtdx2001/dsh-web-ui",
+    "npm": "@mtdx2001/dsh-client-ui-workbench",
+    "category": "tools"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

将 DSH Workbench 本体登记到社区插件索引。本次只登记 `@mtdx2001/dsh-client-ui-workbench`；Workbench Suite 不作为申请主体，其他插件仅作为可选集成或案例。

## 涉及包（Affected Packages）

- [x] 其他（社区插件索引 `packages/dsh-community-plugins` 与生成的 market manifest）

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git clone --depth 1 --branch dev https://github.com/zhu1090093659/dsh-web.git .workbench-community-clean
git log -1 --format=%H
# deb45afe606bd008ed81e05ca2b51fb302525f0c
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

本 PR 从上游 `dev@deb45afe606bd008ed81e05ca2b51fb302525f0c` 的干净浅克隆创建；同步后重新运行社区索引与 market 门禁均通过，详见“本地验证”。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：GPT-5.6 Sol

使用的编码 Agent 工具：DeepSeek Harness / Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录；登记 id 为 `dsh-workbench`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`（本 PR 未改 README）。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

https://github.com/mtdx2001/dsh-web-ui

插件详细说明：

DSH Workbench 是 DSH Web GUI 执行工作台，提供中央工作模式、模块导航、会话状态、Agent 回退、主工作区扩展与 Workbench-owned 右侧面板。包 `@mtdx2001/dsh-client-ui-workbench@0.1.20` 自身声明 `dsh.bundle.patch`、`cordis.patch.yml`、`dsh.client.platform: web`、Host/Client 入口和四项官方服务注入。AionUI、Task Board、SSH 与其他仓库插件只是可选集成或案例，不属于本索引条目。已知限制以公开仓库 README 为准。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表（当前 `dev` 的生成链同时更新 `market/dist/manifest/plugins.json`）。
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在隔离 DSH_HOME/profile 与 Desktop BOOT 中验证挂载、四项注入和无插件加载失败。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index
node scripts/community-index --check
pnpm community:check
node scripts/market-build
node scripts/market-build --check
pnpm --filter @mtdx2001/dsh-client-ui-workbench typecheck
pnpm --filter @mtdx2001/dsh-client-ui-workbench test
pnpm --filter @mtdx2001/dsh-client-ui-workbench build
```

结果摘要：

```text
community-index                         PASS, 38 entries
community:check                         PASS
market-build                            PASS, 38 plugins
market-build --check                    PASS, dist up to date
Workbench typecheck / test / build      PASS
Workbench tests                         38 files, 231 tests
Isolated npm 0.1.20 install and BOOT     PASS, four injections, no plugin-load failure
Final PR diff                           2 files, +23/-0
```

上游完整脚本测试中有一个与本索引无关的 Windows + Node `fs.cpSync` fixture 原生退出 `0xC0000409`；直接 market 生成和校验均通过。本 PR 不包含该测试修复。

## 用户可见变更证据（Local Feature Evidence）

证据：纯索引 metadata 与生成清单改动，N/A。独立安装与 GUI BOOT 验证已在提交前完成。

## 说明

PR #1040 登记的是聚合 Suite，已关闭。本次改为登记契约完整的 Workbench 本体，不搬运源码，只更新社区索引 metadata 和生成的 market manifest。