### PR TITLE
feat(community): add dsh-annotation npm package

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -137,6 +137,7 @@
       "description": "选中助手文字即可批注，回车随消息发送；自己的气泡只显示问题与「批注 ×N」标签，模型按 Annotation N 逐条对照回复（悬浮芯片）；UI 与批注块跟随 DSH 语言切换 zh/en，Cmd/Ctrl+Enter 可直发纯批注，斜杠命令原样放行。",
       "descriptionEn": "Select text in an assistant reply to annotate it; annotations ride along with your next message, hidden in your own bubble behind an Annotations xN chip, and the model replies per Annotation N with hoverable chips. UI and annotation block follow the DSH locale (zh/en); Cmd/Ctrl+Enter sends annotations alone; slash commands pass through.",
       "repo": "https://github.com/omdsh-dev/dsh-annotation",
+      "npm": "@changfenhuang/dsh-annotation",
       "category": "ui"
     },
     {

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -123,6 +123,7 @@
     "description": "选中助手文字即可批注，回车随消息发送；自己的气泡只显示问题与「批注 ×N」标签，模型按 Annotation N 逐条对照回复（悬浮芯片）；UI 与批注块跟随 DSH 语言切换 zh/en，Cmd/Ctrl+Enter 可直发纯批注，斜杠命令原样放行。",
     "descriptionEn": "Select text in an assistant reply to annotate it; annotations ride along with your next message, hidden in your own bubble behind an Annotations xN chip, and the model replies per Annotation N with hoverable chips. UI and annotation block follow the DSH locale (zh/en); Cmd/Ctrl+Enter sends annotations alone; slash commands pass through.",
     "repo": "https://github.com/omdsh-dev/dsh-annotation",
+    "npm": "@changfenhuang/dsh-annotation",
     "category": "ui"
   },
   {


### PR DESCRIPTION
## 摘要（Summary）

为现有 dsh-annotation 社区插件条目补充公开 npm 包名，让 Workshop 可从 npm 安装当前公开版本。同步重建市场插件清单；未提前写入尚未发布到 npm 的源码新功能。

## 涉及包（Affected Packages）

- [x] 其他（请说明）

packages/dsh-community-plugins 与市场插件清单。

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin dev && git rebase origin/dev`。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

不适用：只更新插件安装元数据，无视觉布局变化。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码

使用的 AI 模型：GPT-5.6-sol

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

本 PR 未新增包目录、未改动包 README。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/omdsh-dev/dsh-annotation

插件详细说明：为现有插件条目增加 npm 安装入口 `@changfenhuang/dsh-annotation`。已核对公共仓库当前版本为 1.4.2；本 PR 不宣称尚未发布到 npm 的源码改动。

- [x] 已按登记说明更新 `packages/dsh-community-plugins/community.json`，并重建市场插件清单。
- [x] 已确认插件与 dsh-web 插件体系兼容，继续采用官方 cordis bundle 与 dsh.client 结构。
- [x] 承诺负责后续更新跟进。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm community:check
pnpm market:check
pnpm --filter @linxin666/dsh-client-ui-community-plugins typecheck
pnpm --filter @linxin666/dsh-client-ui-community-plugins test
git diff --check
```

结果摘要：

同步最新 dev 后全部通过：社区索引 37 个条目；市场产物一致；类型检查通过；1 个测试文件、2 个测试通过；差异格式检查通过。同一基线此前完整 `pnpm typecheck`、`pnpm test:scripts`、`pnpm test` 均通过。

## 用户可见变更证据（Local Feature Evidence）

不适用：安装元数据变更，无视觉界面变化。
