### PR TITLE
feat(community): add dsh-genui npm package

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -126,6 +126,7 @@
       "description": "给模型输出配交互式 UI：助手回复内联渲染 dsh-ui 围栏（布局、图表、表格、表单、Mermaid、3D、原生音视频），双通道渲染兼容原版 DSH 与新构建，支持流式渲染、面板停靠与组件交互回传模型。",
       "descriptionEn": "Interactive UI inside assistant replies via the dsh-ui fence: layouts, charts, tables, forms, quizzes, Mermaid, 3D and native audio/video. Dual-channel rendering covers stock DSH and newer builds, with streaming render, panel docking and component actions that loop back to the model.",
       "repo": "https://github.com/omdsh-dev/dsh-genui",
+      "npm": "@changfenhuang/dsh-genui",
       "category": "ui"
     },
     {

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -113,6 +113,7 @@
     "description": "给模型输出配交互式 UI：助手回复内联渲染 dsh-ui 围栏（布局、图表、表格、表单、Mermaid、3D、原生音视频），双通道渲染兼容原版 DSH 与新构建，支持流式渲染、面板停靠与组件交互回传模型。",
     "descriptionEn": "Interactive UI inside assistant replies via the dsh-ui fence: layouts, charts, tables, forms, quizzes, Mermaid, 3D and native audio/video. Dual-channel rendering covers stock DSH and newer builds, with streaming render, panel docking and component actions that loop back to the model.",
     "repo": "https://github.com/omdsh-dev/dsh-genui",
+    "npm": "@changfenhuang/dsh-genui",
     "category": "ui"
   },
   {


### PR DESCRIPTION
## 摘要（Summary）

为现有 dsh-genui 社区插件条目补充公开 npm 包名，让 Workshop 可从 npm 安装当前公开版本。同步重建市场插件清单；未把尚未发布到 npm 的问题单处理内容混入本 PR。

## 涉及包（Affected Packages）

- [x] 其他（请说明）

packages/dsh-community-plugins 与市场插件清单。

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 增强 / 优化（现有功能的改进、性能 / 体验优化）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin dev`；分支直接基于 `origin/dev` 创建。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## 视觉修复要求（Visual Fix Requirements）

不适用：只更新插件安装元数据，无视觉布局变化。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码

使用的 AI 模型：GPT-5.6-sol

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。

本 PR 未新增包目录、未改动包 README。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/omdsh-dev/dsh-genui

插件详细说明：为现有插件条目增加 npm 安装入口 `@changfenhuang/dsh-genui`。已核对公共仓库当前版本为 0.9.2；本 PR 不宣称尚未发布到 npm 的源码改动。

- [x] 已按登记说明更新 `packages/dsh-community-plugins/community.json`，并重建市场插件清单。
- [x] 已确认插件与 dsh-web 插件体系兼容，继续采用官方 cordis bundle 与 dsh.client 结构。
- [x] 承诺负责后续更新跟进。

## 本地验证（Local Validation）

执行的命令：

```bash
pnpm community:check
pnpm market:check
pnpm --filter @linxin666/dsh-client-ui-community-plugins typecheck
pnpm --filter @linxin666/dsh-client-ui-community-plugins test
git diff --check
```

结果摘要：

同步最新 dev 后全部通过：社区索引 37 个条目；市场产物一致；类型检查通过；1 个测试文件、2 个测试通过；差异格式检查通过。同一基线此前完整 `pnpm typecheck`、`pnpm test:scripts`、`pnpm test` 均通过。

## 用户可见变更证据（Local Feature Evidence）

不适用：安装元数据变更，无视觉界面变化。
