### PR TITLE
fix(settings): expose dsh-web-ui-market / skin-custom-theme / skin-wallpaper in the settings bridge allowlist

### DIFF
--- a/packages/dsh-web-settings/src/allowlist.ts
+++ b/packages/dsh-web-settings/src/allowlist.ts
@@ -22,8 +22,11 @@ export const FAMILY_NAMESPACES = [
   'aionui-panel',
   'describe-image',
   'skin-background',
+  'skin-custom-theme',
+  'skin-wallpaper',
   'community-plugins',
   'desktop-launcher',
+  'dsh-web-ui-market',
 ] as const
 
 /**
@@ -45,6 +48,8 @@ const NAMESPACE_ALIASES: Readonly<Record<string, string | null>> = {
   'dsh-client-ui-skin-center': 'skin-background',
   'skin-center': 'skin-background',
   'skin-background': 'skin-background',
+  'skin-custom-theme': 'skin-custom-theme',
+  'skin-wallpaper': 'skin-wallpaper',
   'describe-image': 'describe-image',
   'dsh-tool-describe-image': 'describe-image',
   'community-plugins': 'community-plugins',
@@ -55,6 +60,10 @@ const NAMESPACE_ALIASES: Readonly<Record<string, string | null>> = {
   'dsh-client-ui-aionui-panel': 'aionui-panel',
   'desktop-launcher': 'desktop-launcher',
   'dsh-desktop-launcher': 'desktop-launcher',
+  'dsh-web-ui-market': 'dsh-web-ui-market',
+  'dsh-client-ui-market': 'dsh-web-ui-market',
+  'dsh-market': 'dsh-web-ui-market',
+  'market': 'dsh-web-ui-market',
   'dsh-git-graph': null,
   'dsh-client-ui-git-graph': null,
   'dsh-web': null,


### PR DESCRIPTION
## 摘要（Summary）

设置桥接白名单补上缺失的三个家族命名空间：`dsh-web-ui-market`（创意工坊卡片）、`skin-custom-theme`、`skin-wallpaper`（皮肤中心）。修复默认安装（未配置 `web_settings_namespaces`）下 设置 → 创意工坊 整卡显示「该设置段未暴露（宿主命名空间缺失）」、无法浏览 / 安装皮肤、宠物与插件的问题。Fixes #1176。

## 涉及包（Affected Packages）

- [x] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`

## PR 类别（PR Category）

- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）

## PR 类型（PR Type）

- [x] Bug 修复
- [x] 面向用户的功能或行为变更

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

本 PR 分支直接基于 `origin/dev` 创建（072c865），无冲突。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

分支基于 2026-08-25 的 `dev`（072c865）；改动与本地验证一致，详见「本地验证」与「用户可见变更证据」。

## 视觉修复要求（Visual Fix Requirements）

N/A（非视觉样式修复；用户可见行为证据见「用户可见变更证据」）。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：

DeepSeek（deepseek-v4-flash）

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（N/A：未新增包目录）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（N/A：未改动 README）。

## 贡献者版权声明（Contributor Copyright）

N/A（未引入第三方代码；改动仅为白名单常量补全）。

## 新皮肤收录（New Skins）

N/A

## 新宠物收录（New Pets）

N/A

## 社区插件索引登记（Community Plugin Index）

N/A

## 本地验证（Local Validation）

执行的命令：

```bash
# 本地等价验证：将相同三处改动应用到用户 profile 的 web-ui-settings 包并重启 host 后
curl -s -X POST "http://127.0.0.1:3080/api/dsh-web-ui-settings/describe" -H "Content-Type: application/json" -d "{}"
node --check <patched bridge index.js>   # 语法校验通过
```

结果摘要：

- 补丁前：`POST /api/dsh-web-ui-settings/describe` 的 namespaces 不含 dsh-web-ui-market / skin-custom-theme / skin-wallpaper，设置 → 创意工坊 整卡显示「该设置段未暴露（宿主命名空间缺失）」。
- 补丁后（重启 host）：describe 出现 dsh-web-ui-market / skin-custom-theme / skin-wallpaper 三个命名空间；创意工坊分区恢复正常（皮肤 21 / 宠物 4 / 插件 37 目录可浏览，卡片总开关可用）；皮肤中心的自定义主题与壁纸面板同步变为可写。

## 用户可见变更证据（Local Feature Evidence）

证据：

- 修复前（复现，详见 issue #1176）：![创意工坊分区显示 该设置段未暴露（宿主命名空间缺失）](https://raw.githubusercontent.com/waHAHJIAHAO/dsh-issue-evidence/main/04-market-bug.png)
- 修复后：![创意工坊分区恢复正常目录（皮肤/宠物/插件）](https://raw.githubusercontent.com/waHAHJIAHAO/dsh-issue-evidence/main/05-market-fixed.png)
