### PR TITLE
feat(community-plugins): register dsh-delete-message in the community plugin index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -507,6 +507,19 @@
       "npm": "dsh-milestone",
       "category": "ui",
       "subcategory": "chat"
+    },
+    {
+      "id": "dsh-delete-message",
+      "name": "消息删除",
+      "rank": 41,
+      "nameEn": "Delete Message",
+      "author": "viplocco",
+      "description": "每条消息操作区的垃圾桶按钮：确认后经官方 surface-replace 契约将消息从模型上下文移除并从转录隐藏，原始日志不动、随时可恢复；覆盖用户/助手/注入行/工具调用/Think 卡，失败回合整窗清理与步骤级删除，删除前预检置灰、过渡动画，中英双语界面。",
+      "descriptionEn": "A trash icon in every message action bar: confirmed deletes remove the message from model context via the official surface-replace contract and hide it from the transcript, while raw logs stay intact and recoverable. Covers user/assistant/injected rows, tool calls and Think cards; whole-window cleanup of failed turns, step-level deletion, preflight graying, transition animations, bilingual zh/en UI.",
+      "repo": "https://github.com/viplocco/dsh-delete-message",
+      "npm": "dsh-delete-message",
+      "category": "ui",
+      "subcategory": "chat"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -465,5 +465,17 @@
     "npm": "dsh-milestone",
     "category": "ui",
     "subcategory": "chat"
+  },
+  {
+    "id": "dsh-delete-message",
+    "name": "消息删除",
+    "nameEn": "Delete Message",
+    "author": "viplocco",
+    "description": "每条消息操作区的垃圾桶按钮：确认后经官方 surface-replace 契约将消息从模型上下文移除并从转录隐藏，原始日志不动、随时可恢复；覆盖用户/助手/注入行/工具调用/Think 卡，失败回合整窗清理与步骤级删除，删除前预检置灰、过渡动画，中英双语界面。",
+    "descriptionEn": "A trash icon in every message action bar: confirmed deletes remove the message from model context via the official surface-replace contract and hide it from the transcript, while raw logs stay intact and recoverable. Covers user/assistant/injected rows, tool calls and Think cards; whole-window cleanup of failed turns, step-level deletion, preflight graying, transition animations, bilingual zh/en UI.",
+    "repo": "https://github.com/viplocco/dsh-delete-message",
+    "npm": "dsh-delete-message",
+    "category": "ui",
+    "subcategory": "chat"
   }
 ]


### PR DESCRIPTION

# PR 正文

## 摘要（Summary）

在社区插件索引登记第三方插件 **dsh-delete-message（消息删除）**：仅在 `packages/dsh-community-plugins/community.json` 追加一个条目。插件本体由作者在自己仓库维护，本仓库不内嵌任何第三方代码。

## 涉及包（Affected Packages）

- [x] 其他：`packages/dsh-community-plugins`（community.json 数据源登记，其余包均不涉及）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新的皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch origin && git rebase origin/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

本地执行记录：

```text
$ node scripts/community-index
community-index: OK (38 entries)

$ node scripts/community-index --check
community-index: OK (38 entries)   # exit 0

$ pnpm install --filter "@linxin666/dsh-client-ui-community-plugins"
Done in 56.5s using pnpm v11.21.0

$ pnpm --filter "@linxin666/dsh-client-ui-community-plugins" build
✔ [@linxin666/dsh-client-ui-community-plugins] lib\index.js  2.13 kB | gzip: 1.06 kB
✔ Build complete in 35ms

$ pnpm --filter "@linxin666/dsh-client-ui-community-plugins" test
Test Files  1 passed (1)
     Tests  2 passed (2)

$ pnpm --filter "@linxin666/dsh-client-ui-community-plugins" typecheck
tsc --noEmit   # exit 0
```

rebase 到上游最新 dev（246a08a）后已复跑 `node scripts/community-index --check`，仍为 OK (38 entries)；分支提交为单提交 `feat(community-plugins): register dsh-delete-message in the community plugin index`（仅 community.json +12 行）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek
使用的编码 Agent 工具：DeepSeek Harness

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/viplocco/dsh-delete-message

插件详细说明：

消息级删除插件，避免误发或错误的消息污染模型上下文。每条消息操作区提供垃圾桶按钮，确认后经宿主官方 surface-replace 契约（与 /compact 同一机制）把目标从**模型上下文**移除，并从可见转录隐藏；原始日志字节不改写、随时可恢复。要点：

- 覆盖全部消息类型：助手回复挂官方 `conversation.chat.assistant-actions` 槽位；用户输入、注入上下文行、工具调用卡、Think 卡经 DOM 增强；
- 失败 / 中断回合整窗清理（注入行、回复、工具调用一并清除，真实用户输入永不受影响）；多步回合支持步骤级删除；
- 删除前 TTL 缓存预检：不可删目标置灰并给本地化原因；删除过渡 pending 态防重复提交、失败可原地重试、成功播退场动画；
- 服务端重跑完整校验（仅闭合回合的表面节点、携带工具调用的消息拒删、机器原因码）；HTTP 写路径仅接受回环地址；
- 零运行时依赖、中英双语界面，MIT 许可，npm 包已发布：https://www.npmjs.com/package/dsh-delete-message

已知限制：可见转录的隐藏台账按浏览器存储（localStorage），换浏览器或清存储后靠 `/status` 预检自动治愈。

- [x] 已按 docs/plugins.md 的登记说明完成全部三步：①追加条目 → ②`node scripts/community-index` 校验通过（38 entries）→ ③`node scripts/market-build` 重新生成 `market/dist/manifest/plugins.json` 并随第二个提交 `chore(market): regenerate dist manifest for the new community entry` 一并加入。
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在 DSH 0.1.1-rc.2 + 本仓库聚合包 0.3.3 环境实测挂载与删除功能正常。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息变动或插件停更时及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index
node scripts/community-index --check
pnpm install --filter "@linxin666/dsh-client-ui-community-plugins"
pnpm --filter "@linxin666/dsh-client-ui-community-plugins" build
pnpm --filter "@linxin666/dsh-client-ui-community-plugins" test
pnpm --filter "@linxin666/dsh-client-ui-community-plugins" typecheck
```

结果摘要：

```text
node scripts/community-index          -> community-index: OK (38 entries)
node scripts/community-index --check  -> community-index: OK (38 entries)，exit 0
pnpm install --filter ...             -> Done in 56.5s using pnpm v11.21.0
pnpm build  （同 filter）              -> Build complete，lib/index.js 2.13 kB | gzip 1.06 kB
pnpm test   （同 filter）              -> Test Files 1 passed (1)；Tests 2 passed (2)
pnpm typecheck（同 filter）            -> tsc --noEmit 无输出，exit 0
```

全部通过；rebase 到上游 dev 后复跑 --check 仍为 OK (38 entries)。

## 用户可见变更证据（Local Feature Evidence）

本次为纯索引数据登记（无代码行为变更），证据以校验输出与 npm 包公开页为准：

- npm 包：https://www.npmjs.com/package/dsh-delete-message （v0.2.1 已上线）
- 合并后该条目将经 `scripts/market-build` 自动进入 dsh-market.com 插件清单与 Web GUI 创意工坊卡的插件分区，用户经插件管理器一键安装。

本登记对应的插件实机运行效果（截图取自插件仓库 docs/screenshots/，与 npm v0.2.1 一致）：

![消息操作区的删除按钮](https://raw.githubusercontent.com/viplocco/dsh-delete-message/main/docs/screenshots/delete-action.png)

![删除确认弹窗](https://raw.githubusercontent.com/viplocco/dsh-delete-message/main/docs/screenshots/confirm-dialog.png)

![删除后消息从转录隐藏](https://raw.githubusercontent.com/viplocco/dsh-delete-message/main/docs/screenshots/deleted-hidden.png)

合并后该条目将经 `scripts/market-build` 自动进入 dsh-market.com 插件清单与 Web GUI 创意工坊卡的插件分区，用户经插件管理器一键安装。
