### PR TITLE
feat(community-plugins): register dsh-bg-image in community index

### DIFF
--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -429,5 +429,7 @@
     "npm": "dsh-session-insights",
     "category": "tools",
     "subcategory": "dev"
-  }
+  },
+  { "id": "dsh-bg-image", "name": "背景图插件", "nameEn": "Background Image", "author": "lyh9712", "description": "为 DSH Web 自定义背景壁纸：图片链接 / 本地图片 / 面板不透明度 / 磨砂模糊，侧边栏与聊天区半透明磨砂，设置保存在浏览器（localStorage），卸载零残留。", "descriptionEn": "Custom wallpaper for the DSH Web GUI: image URL / local image / panel opacity / frosted blur; translucent frosted sidebar and chat; settings persist in the browser (localStorage); zero-residue uninstall.", "repo": "https://github.com/lyh9712/dsh-bg-image", "category": "ui", "subcategory": "theme" }
+
 ]


### PR DESCRIPTION
## 摘要（Summary）

向 `packages/dsh-community-plugins/community.json` 追加社区插件索引条目 **dsh-bg-image**（DSH Web 背景图插件）。纯索引登记，不修改任何代码与样式。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`
- [x] 其他（请说明）：`packages/dsh-community-plugins/community.json`（社区插件索引登记）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin && git rebase origin/dev`（fork 的 dev 与上游 dev 当前 SHA 一致：`b5e2bc40`）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

证据：`node scripts/community-index --check` → `community-index: OK (38 entries)`（官方校验器通过）。插件本体（https://github.com/lyh9712/dsh-bg-image）已在 dsh `0.1.0-rc.6` web profile 上实测挂载运行（设置界面、样式注入、localStorage 持久化均正常，见仓库 README 截图）。

## 视觉修复要求（Visual Fix Requirements）

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

（非视觉修复 PR，跳过。）

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。（本次未新增包目录，不适用）
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改 README，不适用）

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/lyh9712/dsh-bg-image

插件详细说明：

- 功能：为 DSH Web 自定义背景壁纸 —— 图片链接 / 本地图片 / 面板不透明度（50–100%）/ 磨砂模糊（0–40px）；侧边栏与聊天区呈半透明磨砂效果；设置保存在浏览器（localStorage），重启服务不丢失；卸载 = 删除注册行 + 删除目录，零残留。
- 形态：标准 cordis bundle（`package.json` 声明 `dsh.client` 浏览器半区 + `exports["./client"]`），纯客户端插件，不改 DSH 源码、不写宿主配置、不触碰模型请求。
- 依赖：仅官方 `@deepseek-ai/*` NPM SDK 与标准 web profile 自带服务（connection / runtime / locale / ui-settings / api-remotes）。
- 已知限制：CSS 覆盖目标类名带构建期哈希前缀，dsh 大版本升级后可能需要同步选择器（README 已说明）；设置按浏览器保存（localStorage）。
- 协议：MIT；含效果截图与中英安装文档。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表（提交生成的 `packages/dsh-community-plugins/src/client/generated/community.ts`）。

> 说明：`node scripts/community-index` 实际是校验器（validate），不会改写文件；`src/client/generated/` 目录在仓库中不存在，注册表由 CI / 部署流程（market-build）生成，故本次无生成物可提交。已运行 `node scripts/community-index --check` 通过（OK, 38 entries）。

- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本仓库最新代码上验证插件可被 `dsh web` 挂载并正常运行。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index --check
```

结果摘要：`community-index: OK (38 entries)` —— 校验通过（37 条原有 + 1 条新增 dsh-bg-image）。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A —— 本 PR 为纯索引登记，不改变任何用户可见界面；插件本体效果见 https://github.com/lyh9712/dsh-bg-image （README 含真实运行截图）。