### PR TITLE
feat(dsh-web-all): replace bundled archive manager with dsh-session-enhance; register both in community index

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -128,7 +128,7 @@ Rescue mode (`dsh-doctor`) is a transactional rescue system for DSH profiles, **
 - **Plugin manager** (`dsh-client-ui-plugin-manager`): install plugins from npm or git through the official host channels; manage enablement and configuration.
 - **Chat recovery** (`dsh-chat-recovery`): fork-based editing of past messages and one-click retry of a failed turn, leaving the original session intact.
 - **Desktop launcher** (`dsh-desktop-launcher`): a double-click desktop icon starts `dsh web` and opens the Web GUI; a floating power button exits the host process gracefully.
-- **Archive manager** (external plugin [@mlgbnb/dsh-archive-manager](https://github.com/z953218350/dsh-archive-manager), bundled in the aggregate): group sessions by project, search and filter, preview conversations, restore or delete in one click.
+- **Session enhancement / Archive manager** (external plugin [dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance), bundled in the aggregate): archive management (search and filter, batch restore, confirmed delete), true physical deletion, cross-workspace drag-and-drop session migration, message editing (edit / retry / reroll), and physical-file to storages JSON reconciliation.
 
 ### Skins
 
@@ -355,7 +355,7 @@ This repository is licensed under [Apache-2.0](LICENSE). Third-party code merged
 - **dsh-tool-describe-image** — ported from [whitelonng/dsh-plugin-describe-image](https://github.com/whitelonng/dsh-plugin-describe-image) (deepseek-harness `packages/vision/tool-describe-image`), Apache-2.0 (zhu1090093659)
 - **dsh-liangshen** — plugin body original; preset derives from the DeepSeek Harness builtin Minimal / Standard presets and [xiaobright/dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard), Apache-2.0 (zhu1090093659) + MIT (preset derivations)
 - **dsh-better-sidebar** — external integrated plugin [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) (right panel, npm dependency reference), MIT (omdsh-dev)
-- **dsh-archive-manager** — external integrated plugin [z953218350/dsh-archive-manager](https://github.com/z953218350/dsh-archive-manager) (settings-page archive manager, npm dependency reference), MIT (z953218350)
+- **dsh-session-enhance** — external integrated plugin [Tinger-X/dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance) (session enhancement / archive manager, npm dependency reference), Apache-2.0 (Tinger-X)
 - **dsh-ssh** — implemented against the capability list of [badseal/ssh-skill](https://github.com/badseal/ssh-skill); code is this repository's Apache-2.0 (zhu1090093659), the upstream capability list belongs to badseal/ssh-skill
 - **dsh-miku-pet** — code and asset layout follow [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet) structure (MIT); the Hatsune Miku name, image and likeness belong to Crypton Future Media, INC. and usage follows the Piapro Character License (see [NOTICE.md](packages/dsh-miku-pet/NOTICE.md) in the package)
 - **Community plugin index** — 37 external plugins with sources and licenses declared by their authors, registered in [community.json](packages/dsh-community-plugins/community.json), browsable in Settings → Community Plugins and on dsh-market.com

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ dsh-web 是 DeepSeek Harness（DSH）Web GUI 的插件聚合生态包（DSH Web 
 - **插件管理器**（`dsh-client-ui-plugin-manager`）：经官方 host 通道从 npm / git 安装插件，管理启停与配置。
 - **会话恢复**（`dsh-chat-recovery`）：fork 编辑历史消息、失败轮次一键重试，原会话不受损。
 - **桌面启动器**（`dsh-desktop-launcher`）：双击桌面图标启动 `dsh web` 并打开 Web GUI，悬浮电源按钮优雅退出宿主进程。
-- **归档管理**（外部插件 [@mlgbnb/dsh-archive-manager](https://github.com/z953218350/dsh-archive-manager)，聚合包内置）：按项目分组、搜索筛选、预览对话、一键恢复与删除。
+- **会话增强 / 归档管理**（外部插件 [dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance)，聚合包内置）：归档管理（搜索筛选 / 批量恢复 / 确认删除）、真实物理删除、跨工作区分组拖拽搬移会话、消息编辑（edit / retry / reroll）、物理文件与 storages JSON 对账。
 
 ### 皮肤
 
@@ -354,7 +354,7 @@ A: 可以。聚合包的行 id 统一带 `web-ui-` 前缀（如 `web-ui-describe
 - **dsh-tool-describe-image** — 移植自 [whitelonng/dsh-plugin-describe-image](https://github.com/whitelonng/dsh-plugin-describe-image)（deepseek-harness `packages/vision/tool-describe-image`），Apache-2.0（zhu1090093659）
 - **dsh-liangshen** — 插件本体原创；preset 派生自 DeepSeek Harness 内置 Minimal / Standard preset 与 [xiaobright/dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard)，Apache-2.0（zhu1090093659）+ MIT（preset 派生件）
 - **dsh-better-sidebar** — 外部集成插件 [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（右侧面板，npm 依赖引用），MIT（omdsh-dev）
-- **dsh-archive-manager** — 外部集成插件 [z953218350/dsh-archive-manager](https://github.com/z953218350/dsh-archive-manager)（设置页归档管理，npm 依赖引用），MIT（z953218350）
+- **dsh-session-enhance** — 外部集成插件 [Tinger-X/dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance)（会话增强 / 归档管理，npm 依赖引用），Apache-2.0（Tinger-X）
 - **dsh-ssh** — 依据 [badseal/ssh-skill](https://github.com/badseal/ssh-skill) 的能力清单实现；代码为本仓库 Apache-2.0（zhu1090093659），上游能力清单归属 badseal/ssh-skill
 - **dsh-miku-pet** — 代码与素材布局沿用 [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet) 结构（MIT）；角色「初音未来（Hatsune Miku）」的名称、形象与肖像权归 Crypton Future Media, INC.，使用遵循 Piapro Character License（详见包内 [NOTICE.md](packages/dsh-miku-pet/NOTICE.md)）
 - **社区插件索引** — 37 项外部插件，来源与版权由各作者声明，登记于 [community.json](packages/dsh-community-plugins/community.json)，可在「设置 → 社区插件」与 dsh-market.com 查看

--- a/docs/publish-prep.md
+++ b/docs/publish-prep.md
@@ -32,7 +32,7 @@
 - `@linxin666/dsh-web-ui-all@0.3.2` is the previous release; `0.3.3` is unoccupied and is the first dual-published legacy transition version.
 - `scripts/publish-legacy-aggregate.mjs` limits the legacy transition to two versions and writes `dsh.migrate.to` / `dsh.migrate.since` into the legacy tarball.
 - After the second transition version, deprecate `@linxin666/dsh-web-ui-all` with the migration instruction instead of publishing another version.
-- External aggregate dependencies `dsh-better-sidebar@0.15.2` and `@mlgbnb/dsh-archive-manager@1.0.7` are registry-readable.
+- External aggregate dependencies `dsh-better-sidebar@0.15.2` and `dsh-session-enhance@0.2.0` are registry-readable.
 
 ## Compatibility boundary
 

--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -481,6 +481,19 @@
       "npm": "dsh-session-enhance",
       "category": "utility",
       "subcategory": "cleanup"
+    },
+    {
+      "id": "dsh-archive-manager",
+      "name": "归档管理",
+      "rank": 39,
+      "nameEn": "Archive Manager",
+      "author": "z953218350",
+      "description": "社区版归档管理插件：按项目分组、搜索筛选、预览对话、一键恢复与删除。",
+      "descriptionEn": "Community archive manager plugin: group sessions by project, search and filter, preview conversations, restore and delete in one click.",
+      "repo": "https://github.com/z953218350/dsh-archive-manager",
+      "npm": "@mlgbnb/dsh-archive-manager",
+      "category": "utility",
+      "subcategory": "cleanup"
     }
   ]
 }

--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -468,6 +468,19 @@
       "npm": "dsh-session-insights",
       "category": "tools",
       "subcategory": "dev"
+    },
+    {
+      "id": "dsh-session-enhance",
+      "name": "会话增强（dsh-session-enhance）",
+      "rank": 39,
+      "nameEn": "Session Enhance",
+      "author": "Tinger-X",
+      "description": "会话管理增强插件：真实物理删除、跨工作区分组拖拽搬移会话、消息编辑（edit/retry/reroll 版本分支）、一键物理文件与 storages JSON 对账及墓碑防复活机制。",
+      "descriptionEn": "Enhanced session management plugin: physical transcript deletion, cross-workspace drag-and-drop migration, message editing (edit/retry/reroll version branching), physical file reconciliation, and tombstone anti-resurrection.",
+      "repo": "https://github.com/Tinger-X/dsh-session-enhance",
+      "npm": "dsh-session-enhance",
+      "category": "utility",
+      "subcategory": "cleanup"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -441,5 +441,17 @@
     "npm": "dsh-session-enhance",
     "category": "utility",
     "subcategory": "cleanup"
+  },
+  {
+    "id": "dsh-archive-manager",
+    "name": "归档管理",
+    "nameEn": "Archive Manager",
+    "author": "z953218350",
+    "description": "社区版归档管理插件：按项目分组、搜索筛选、预览对话、一键恢复与删除。",
+    "descriptionEn": "Community archive manager plugin: group sessions by project, search and filter, preview conversations, restore and delete in one click.",
+    "repo": "https://github.com/z953218350/dsh-archive-manager",
+    "npm": "@mlgbnb/dsh-archive-manager",
+    "category": "utility",
+    "subcategory": "cleanup"
   }
 ]

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -429,5 +429,17 @@
     "npm": "dsh-session-insights",
     "category": "tools",
     "subcategory": "dev"
+  },
+  {
+    "id": "dsh-session-enhance",
+    "name": "会话增强（dsh-session-enhance）",
+    "nameEn": "Session Enhance",
+    "author": "Tinger-X",
+    "description": "会话管理增强插件：真实物理删除、跨工作区分组拖拽搬移会话、消息编辑（edit/retry/reroll 版本分支）、一键物理文件与 storages JSON 对账及墓碑防复活机制。",
+    "descriptionEn": "Enhanced session management plugin: physical transcript deletion, cross-workspace drag-and-drop migration, message editing (edit/retry/reroll version branching), physical file reconciliation, and tombstone anti-resurrection.",
+    "repo": "https://github.com/Tinger-X/dsh-session-enhance",
+    "npm": "dsh-session-enhance",
+    "category": "utility",
+    "subcategory": "cleanup"
   }
 ]

--- a/packages/dsh-web-all/README.i18n.yaml
+++ b/packages/dsh-web-all/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   node scripts/verify-docs.mjs --write <dir>
-README.md: 1ef5f709571ca00a6333037b208d5c140ba91b8a
-README.zh.md: d1a3deffc1cdb70202dab254a1ada409603dfc6c
+README.md: b40a1c2b1bd3bda9a07af18c76c431c2d1dab909
+README.zh.md: 25b30bfda30bd87d7c87415a3f00a2c4ee974bd0

--- a/packages/dsh-web-all/README.md
+++ b/packages/dsh-web-all/README.md
@@ -2,12 +2,12 @@
 
 English | [中文](README.zh.md)
 
-The one-click aggregate package for the whole dsh web UI family: installing it brings every functional plugin (task-board / git-graph / pet / remote-web-ui / web-ui-settings / skin-center / community-plugins / aionui-panel) plus the external plugins `dsh-better-sidebar` (right panel) and `@mlgbnb/dsh-archive-manager` (settings-page archive manager) and the skin family (`dsh-skins`, skin assets bundled inside). The compat bridge layer is folded into this package (`src/client`), so no separate compat npm package is needed.
+The one-click aggregate package for the whole dsh web UI family: installing it brings every functional plugin (task-board / git-graph / pet / remote-web-ui / web-ui-settings / skin-center / community-plugins / aionui-panel) plus the external plugins `dsh-better-sidebar` (right panel) and `dsh-session-enhance` (session enhancement / archive manager) and the skin family (`dsh-skins`, skin assets bundled inside). The compat bridge layer is folded into this package (`src/client`), so no separate compat npm package is needed.
 
 ## What it is
 
-- **One install, everything on**: its dependencies pull in all sub-plugin packages (dsh-client-ui-aionui-panel / dsh-client-ui-task-board / dsh-client-ui-git-graph / dsh-pet / dsh-remote-web-ui / dsh-ssh / dsh-client-ui-web-ui-settings / dsh-client-ui-skin-center / dsh-client-ui-community-plugins / dsh-skins) plus the external npm plugins `dsh-better-sidebar` (the default right sidebar: explorer / editor / terminal / git / browser) and `@mlgbnb/dsh-archive-manager` (the default settings-page archive manager: group by project, search and filter, preview conversations, restore and delete).
-- **Aggregation carrier**: `cordis.patch.yml` aggregates the `insert` lines of each sub-plugin plus the external `dsh-better-sidebar` and `@mlgbnb/dsh-archive-manager` rows, mounted through the dsh plugin profile mechanism.
+- **One install, everything on**: its dependencies pull in all sub-plugin packages (dsh-client-ui-aionui-panel / dsh-client-ui-task-board / dsh-client-ui-git-graph / dsh-pet / dsh-remote-web-ui / dsh-ssh / dsh-client-ui-web-ui-settings / dsh-client-ui-skin-center / dsh-client-ui-community-plugins / dsh-skins) plus the external npm plugins `dsh-better-sidebar` (the default right sidebar: explorer / editor / terminal / git / browser) and `dsh-session-enhance` (the default session enhancement & archive manager: archive management with search/filter, true physical deletion, cross-workspace drag-and-drop migration, message editing, and physical-file to storages JSON reconciliation).
+- **Aggregation carrier**: `cordis.patch.yml` aggregates the `insert` lines of each sub-plugin plus the external `dsh-better-sidebar` and `dsh-session-enhance` rows, mounted through the dsh plugin profile mechanism.
 - **Right panel**: the right panel is always `dsh-better-sidebar` (the aionui panel can no longer be enabled). Settings → Web UI Plugins → Side Card declares the right panel comes from [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) and edits its everyday settings inline; the provider choice was removed.
 
 ## Install
@@ -63,5 +63,5 @@ See [issue #513](https://github.com/zhu1090093659/dsh-web/issues/513).
 
 - Every sub-plugin activates together. For only a subset, install that sub-plugin package directly.
 - Aggregate rows are namespaced `web-ui-*`, so the bundle can coexist with a standalone install of the same plugin: the loader no longer rejects the duplicate id, the host half runs once (the second source is a no-op), and the browser half is deduped by package name. Keeping both sources has no benefit; prefer one. When the bundle is the source, profile patch config rows must use the `web-ui-*` id (e.g. `web-ui-remote-web-ui` for the remote-web-ui `autoTunnel` row); standalone installs keep the plugin's own id.
-- `dsh-better-sidebar` and `@mlgbnb/dsh-archive-manager` are external npm dependencies (not authored in this repo); they must be published before this package's release (see `docs/publish-prep.md` for the release order).
+- `dsh-better-sidebar` and `dsh-session-enhance` are external npm dependencies (not authored in this repo); they must be published before this package's release (see `docs/publish-prep.md` for the release order).
 - Dependencies on the `@deepseek-ai/*` SDK are pinned; compatibility follows the repository's release cadence.

--- a/packages/dsh-web-all/README.zh.md
+++ b/packages/dsh-web-all/README.zh.md
@@ -2,12 +2,12 @@
 
 [English](README.md) | 中文
 
-DSH Web UI 全家桶聚合插件：一键安装全部功能插件（task-board / git-graph / pet / remote-web-ui / web-ui-settings / skin-center / community-plugins / aionui-panel），外加外部插件 `dsh-better-sidebar`（右侧面板）与 `@mlgbnb/dsh-archive-manager`（设置页归档管理）以及皮肤全家桶（`dsh-skins`，皮肤资产内置）。compat 桥接层已并入本包（`src/client`），因此无需独立的 compat npm 包。
+DSH Web UI 全家桶聚合插件：一键安装全部功能插件（task-board / git-graph / pet / remote-web-ui / web-ui-settings / skin-center / community-plugins / aionui-panel），外加外部插件 `dsh-better-sidebar`（右侧面板）与 `dsh-session-enhance`（会话增强 / 归档管理）以及皮肤全家桶（`dsh-skins`，皮肤资产内置）。compat 桥接层已并入本包（`src/client`），因此无需独立的 compat npm 包。
 
 ## 是什么
 
-- **一次安装、全部到位**：其 dependencies 引入全部子插件包（dsh-client-ui-aionui-panel / dsh-client-ui-task-board / dsh-client-ui-git-graph / dsh-pet / dsh-remote-web-ui / dsh-ssh / dsh-client-ui-web-ui-settings / dsh-client-ui-skin-center / dsh-client-ui-community-plugins / dsh-skins），外加外部 npm 插件 `dsh-better-sidebar`（默认右侧面板：文件资源管理器 / 编辑器 / 终端 / Git / 浏览器）与 `@mlgbnb/dsh-archive-manager`（默认设置页归档管理：按项目分组、搜索筛选、预览对话、一键恢复与删除）。
-- **聚合载具**：`cordis.patch.yml` 汇总各子插件的 `insert` 行与外部 `dsh-better-sidebar`、`@mlgbnb/dsh-archive-manager` 行，经 dsh 插件 profile 机制挂载。
+- **一次安装、全部到位**：其 dependencies 引入全部子插件包（dsh-client-ui-aionui-panel / dsh-client-ui-task-board / dsh-client-ui-git-graph / dsh-pet / dsh-remote-web-ui / dsh-ssh / dsh-client-ui-web-ui-settings / dsh-client-ui-skin-center / dsh-client-ui-community-plugins / dsh-skins），外加外部 npm 插件 `dsh-better-sidebar`（默认右侧面板：文件资源管理器 / 编辑器 / 终端 / Git / 浏览器）与 `dsh-session-enhance`（默认会话增强与归档管理：搜索筛选、真实物理删除、跨工作区分组拖拽搬移、消息编辑、物理文件与 storages JSON 对账）。
+- **聚合载具**：`cordis.patch.yml` 汇总各子插件的 `insert` 行与外部 `dsh-better-sidebar`、`dsh-session-enhance` 行，经 dsh 插件 profile 机制挂载。
 - **右侧面板**：右侧面板固定为 `dsh-better-sidebar`（aionui-panel 已不可启用）。设置 → Web UI 插件 → 侧边卡片 声明右侧面板来自 [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) 并内嵌其常用设置。
 
 ## 安装
@@ -63,5 +63,5 @@ dsh plugin --profile web add link:$(pwd)/packages/dsh-web-all
 
 - 各子插件随本包一起激活；若只需要其中一部分，请直接安装对应子插件包。
 - 聚合行 id 统一带 `web-ui-` 命名空间，本包可与同名独立插件包共存：loader 不再拒绝重复 id，host 半区只注册一次（第二个来源为空操作），浏览器半区按包名去重。两个来源并存没有额外收益，建议只保留一个。插件来自本包时，profile 里按 id 写的配置行要改用 `web-ui-` 前缀（如 remote-web-ui 的 `autoTunnel` 配置行写成 `web-ui-remote-web-ui`）；独立安装时仍用插件原 id。
-- `dsh-better-sidebar` 与 `@mlgbnb/dsh-archive-manager` 是外部 npm 依赖（均非本仓库出品），本包发版前必须先发布它们（发布顺序见 `docs/publish-prep.md`）。
+- `dsh-better-sidebar` 与 `dsh-session-enhance` 是外部 npm 依赖（均非本仓库出品），本包发版前必须先发布它们（发布顺序见 `docs/publish-prep.md`）。
 - 依赖的 `@deepseek-ai/*` SDK 版本已锁定，兼容性跟随本仓库的发版节奏。

--- a/packages/dsh-web-all/aggregate.yml
+++ b/packages/dsh-web-all/aggregate.yml
@@ -58,8 +58,12 @@ deps:
 # （即将弃用）/ 使用 DSH-better-sidebar」，默认后者），无需行级 config patch。
 rows:
   - {"id": "better-sidebar", "name": "dsh-better-sidebar"}
-  # 外部 npm 插件：dsh-archive-manager（社区版「归档管理」）在设置页提供
-  # Codex 风格会话归档管理（按项目分组、搜索筛选、预览、恢复、物理删除）。
-  # 依赖引用 @mlgbnb/dsh-archive-manager@1.0.7（见 package.json，生成器保留
-  # 非 workspace 依赖），行排在 better-sidebar 之后统一应用。
-  - {"id": "archive-manager", "name": "@mlgbnb/dsh-archive-manager"}
+# 外部 npm 插件 patch 嵌入：dsh-session-enhance（会话管理增强插件，替代原
+# @mlgbnb/dsh-archive-manager「归档管理」，功能升级：真实物理删除、跨工作区
+# 拖拽搬移会话、物理文件与 storages JSON 对账、墓碑防复活）。
+# 生成器读取 node_modules/dsh-session-enhance/cordis.patch.yml，嵌入其禁用
+# 行与三行自身服务（insert 行 id 统一加 web-ui- 前缀与独立安装共存）；
+# 依赖引用 dsh-session-enhance@0.1.1（见 package.json，生成器保留非 workspace
+# 依赖），行排在 better-sidebar 之后统一应用。
+patchFromNpm:
+  - dsh-session-enhance

--- a/packages/dsh-web-all/cordis.patch.yml
+++ b/packages/dsh-web-all/cordis.patch.yml
@@ -98,7 +98,22 @@
     - id: web-ui-better-sidebar
       name: 'dsh-better-sidebar'
 
-# external: @mlgbnb/dsh-archive-manager
+# external patch: dsh-session-enhance
+- id: workspace
+  disabled: true
+- id: session-projection-cache
+  disabled: true
+- id: ui-workspace
+  disabled: true
 - insert:
-    - id: web-ui-archive-manager
-      name: '@mlgbnb/dsh-archive-manager'
+    - id: web-ui-workspace-dsh-session-enhance
+      name: 'dsh-session-enhance/workspace'
+    - id: web-ui-session-projection-cache-dsh-session-enhance
+      name: 'dsh-session-enhance/projcache'
+      config:
+        writeEveryEvents: 200
+        writeIntervalMs: 5000
+    - id: web-ui-message-edit-dsh-session-enhance
+      name: 'dsh-session-enhance/message-edit'
+    - id: web-ui-ui-workspace-dsh-session-enhance
+      name: 'dsh-session-enhance'

--- a/packages/dsh-web-all/package.json
+++ b/packages/dsh-web-all/package.json
@@ -58,7 +58,7 @@
     "@linxin666/dsh-doctor": "workspace:*",
     "@linxin666/dsh-client-ui-web-ui-settings": "workspace:*",
     "@linxin666/dsh-client-ui-skin-center": "workspace:*",
-    "@mlgbnb/dsh-archive-manager": "1.0.7",
-    "dsh-better-sidebar": "0.15.2"
+    "dsh-better-sidebar": "0.15.2",
+    "dsh-session-enhance": "0.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1159,12 +1159,12 @@ importers:
       '@linxin666/dsh-tool-describe-image':
         specifier: workspace:*
         version: link:../dsh-tool-describe-image
-      '@mlgbnb/dsh-archive-manager':
-        specifier: 1.0.7
-        version: 1.0.7(react@18.3.1)
       dsh-better-sidebar:
         specifier: 0.15.2
-        version: 0.15.2(96d11d43015a66f723a480d8d38ac93f)
+        version: 0.15.2(05eab1970bccde03a2d72ea87ffce294)
+      dsh-session-enhance:
+        specifier: 0.2.0
+        version: 0.2.0(6c9d998588613eaeb15df81e7c5f927e)
     devDependencies:
       jsdom:
         specifier: 29.1.1
@@ -2269,11 +2269,6 @@ packages:
   '@mermaid-js/parser@1.2.1':
     resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
 
-  '@mlgbnb/dsh-archive-manager@1.0.7':
-    resolution: {integrity: sha512-OvdrCOJN+gm9VAHvm1B0LNdf1xaRP8uOQ98qSQsstXMVqSa2jXw899P8S8hb153GgEFT9gkd6W4ZT0byjonzjg==}
-    peerDependencies:
-      react: ^18.2.0
-
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
@@ -3320,6 +3315,30 @@ packages:
     peerDependenciesMeta:
       cordis:
         optional: true
+
+  dsh-session-enhance@0.2.0:
+    resolution: {integrity: sha512-O1rVF5GY1DeMew9dqObXgJ7UzMQ32FO4AkkhC7t/kFU6p04SZqgoAAXJkxf4ZmDXgVuw1PiVPpMs3VoiokM4cA==}
+    engines: {node: ^22.19.0 || >=24.0.0}
+    peerDependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2
+      '@deepseek-ai/dsh-agent-presets': 0.1.1-rc.2
+      '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2
+      '@deepseek-ai/dsh-client-ui-primitives': 0.1.1-rc.2
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2
+      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.2
+      '@deepseek-ai/dsh-home-paths': 0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2
+      '@deepseek-ai/dsh-session-projection-cache': 0.1.1-rc.2
+      '@deepseek-ai/dsh-session-query': 0.1.1-rc.2
+      '@deepseek-ai/dsh-spill-local': 0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-registry': 0.1.1-rc.2
+      '@deepseek-ai/dsh-workspace': 0.1.1-rc.2
 
   dts-resolver@3.0.0:
     resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
@@ -5566,10 +5585,6 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mlgbnb/dsh-archive-manager@1.0.7(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
@@ -6481,7 +6496,7 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  dsh-better-sidebar@0.15.2(96d11d43015a66f723a480d8d38ac93f):
+  dsh-better-sidebar@0.15.2(05eab1970bccde03a2d72ea87ffce294):
     dependencies:
       '@codemirror/commands': 6.11.0
       '@codemirror/lang-cpp': 6.0.3
@@ -6507,8 +6522,6 @@ snapshots:
       '@deepseek-ai/dsh-agent': 0.1.1-rc.2(c1537a8836b04097f168b024f1e38d85)
       '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(43fc99526226959f2baf26bb6c2f2030)
       '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(899e679ba1f0bdafa061368d2832faf2)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(4dbe354a86b65d49f703db813cd4806e)
-      '@deepseek-ai/dsh-client-ui-primitives': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(d3fdcf98e7ef536fb615a4984965cd0e))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2(da99b7068576d79a81b7c811567a80d0))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(899e679ba1f0bdafa061368d2832faf2))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-client-ui-slots': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
@@ -6531,6 +6544,21 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  dsh-session-enhance@0.2.0(6c9d998588613eaeb15df81e7c5f927e):
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(c1537a8836b04097f168b024f1e38d85)
+      '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(da99b7068576d79a81b7c811567a80d0)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(43fc99526226959f2baf26bb6c2f2030)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(899e679ba1f0bdafa061368d2832faf2)
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(43fc99526226959f2baf26bb6c2f2030))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(899e679ba1f0bdafa061368d2832faf2))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(a4e4bb24a1f3580ac25e11cfa3c6b8cc)
+      '@deepseek-ai/dsh-session-projection-cache': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(a4e4bb24a1f3580ac25e11cfa3c6b8cc))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session-projection@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(a4e4bb24a1f3580ac25e11cfa3c6b8cc)))(@deepseek-ai/dsh-session@0.1.1-rc.2(a4e4bb24a1f3580ac25e11cfa3c6b8cc))
+      '@deepseek-ai/dsh-session-query': 0.1.1-rc.2(d854f9afd763ce298cb594d238b23507)
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-workspace': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(a4e4bb24a1f3580ac25e11cfa3c6b8cc))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.1-rc.2(a4e4bb24a1f3580ac25e11cfa3c6b8cc))
 
   dts-resolver@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,4 @@ minimumReleaseAgeExclude:
   # minimum-release-age guard must not reject the fresh version. Scoped to
   # that exact version so later upstream publishes get no cooldown bypass.
   - 'dsh-better-sidebar@0.15.2'
-  # The aggregate bundle mounts @mlgbnb/dsh-archive-manager at exactly 1.0.7;
-  # pnpm 11's minimum-release-age guard must not reject the fresh version.
-  # Scoped to that exact version so later upstream publishes get no cooldown bypass.
-  - '@mlgbnb/dsh-archive-manager@1.0.7'
+  - dsh-session-enhance@0.2.0

--- a/scripts/aggregate.mjs
+++ b/scripts/aggregate.mjs
@@ -105,7 +105,7 @@ function findAggregates() {
  * while the generator can JSON.parse each entry).
  */
 function parseManifest(ymlPath, errors) {
-  const manifest = { patchFrom: [], deps: [], self: null, rows: [] }
+  const manifest = { patchFrom: [], deps: [], self: null, rows: [], patchFromNpm: [] }
   let section = null
   for (const raw of readFileSync(ymlPath, 'utf8').split(/\r?\n/)) {
     const line = raw.trim()
@@ -120,6 +120,7 @@ function parseManifest(ymlPath, errors) {
     const entry = entryMatch[1].trim().replace(/\s+#.*$/, '')
     if (section === 'patchFrom') manifest.patchFrom.push(entry)
     else if (section === 'deps') manifest.deps.push(entry)
+    else if (section === 'patchFromNpm') manifest.patchFromNpm.push(entry)
     else if (section === 'rows') {
       let parsed
       try {
@@ -210,8 +211,76 @@ function collectRows(pkgDir, entry, via, visited, errors, blocks) {
   blocks.push({ entry, via, rows })
 }
 
+/** Namespace an external patch insert row id (prefix-only; unlike child rows,
+ * the leading ui-/web-ui- prefixes are NOT stripped, so ids such as
+ * `ui-workspace-<pkg>` stay distinct from the aggregate's own row ids). */
+function namespaceExternalId(id) {
+  return id.startsWith('web-ui-') ? id : `web-ui-${id}`
+}
+
+/**
+ * Parse an external npm package's cordis.patch.yml (read from the hoisted
+ * node_modules directory) into embeddable entries. Two shapes are supported:
+ * top-level `- id: X` + `disabled: true` pairs (kept verbatim) and
+ * `- insert:` blocks whose rows carry `name:` and an optional `config:` block
+ * (re-emitted with namespaced ids so standalone and aggregate installs can
+ * coexist). Comment and blank lines are ignored.
+ */
+function parseExternalPatch(patchPath, errors) {
+  const significant = []
+  for (const [i, raw] of readFileSync(patchPath, 'utf8').split(/\r?\n/).entries()) {
+    const text = raw.trim()
+    if (text && !text.startsWith('#')) significant.push({ text, raw, line: i + 1 })
+  }
+  const disables = []
+  const insertRows = []
+  for (let i = 0; i < significant.length; i++) {
+    const { text } = significant[i]
+    const idMatch = text.match(/^-\s*id:\s*(\S+)\s*$/)
+    if (idMatch) {
+      const next = significant[i + 1]
+      if (next && /^disabled:\s*true\s*$/.test(next.text)) {
+        disables.push(idMatch[1])
+        i++
+        continue
+      }
+    }
+    if (text === '- insert:') {
+      let j = i + 1
+      while (j < significant.length) {
+        const row = significant[j]
+        const rowId = row.text.match(/^-\s*id:\s*(\S+)\s*$/)
+        if (!rowId) {
+          j++
+          continue
+        }
+        const nameLine = significant[j + 1]
+        const nameMatch = nameLine && (nameLine.text.match(/^name:\s*(['"])([^'"]+)\1\s*$/) || nameLine.text.match(/^name:\s*(\S+)\s*$/))
+        if (!nameMatch) {
+          errors.push(`${patchPath}:${row.line}: expected a "name:" line after "- id: ${rowId[1]}"`)
+          j++
+          continue
+        }
+        const name = nameMatch[2] ?? nameMatch[1]
+        const nameIndent = (nameLine.raw.match(/^ */)[0] ?? '').length
+        const configLines = []
+        let k = j + 2
+        while (k < significant.length && !/^-\s*id:\s*\S+\s*$/.test(significant[k].text)) {
+          const indent = (significant[k].raw.match(/^ */)[0] ?? '').length - nameIndent
+          configLines.push(`${' '.repeat(Math.max(0, indent))}${significant[k].text}`)
+          k++
+        }
+        insertRows.push({ id: rowId[1], name, configLines })
+        j = k
+      }
+      i = j - 1
+    }
+  }
+  return { disables, insertRows }
+}
+
 /** Render the aggregate cordis.patch.yml: header + per-source insert blocks. */
-function renderPatch(blocks, externalRows, errors, rel) {
+function renderPatch(blocks, externalRows, externalPatches, errors, rel) {
   const lines = [...PATCH_HEADER]
   const seen = new Set()
   for (const block of blocks) {
@@ -241,6 +310,25 @@ function renderPatch(blocks, externalRows, errors, rel) {
     lines.push('', `# external: ${row.name}`, '- insert:')
     lines.push(`    - id: ${id}`)
     lines.push(`      name: '${row.name}'`)
+  }
+  // External patches: npm packages whose own cordis.patch.yml is embedded
+  // (disables kept verbatim, insert row ids namespaced web-ui-*).
+  for (const ext of externalPatches) {
+    lines.push('', `# external patch: ${ext.name}`)
+    for (const id of ext.parsed.disables) {
+      lines.push(`- id: ${id}`, '  disabled: true')
+    }
+    if (ext.parsed.insertRows.length) {
+      lines.push('- insert:')
+      for (const row of ext.parsed.insertRows) {
+        const id = namespaceExternalId(row.id)
+        if (seen.has(id)) errors.push(`${rel}: duplicate aggregate row id after namespacing: ${id} (${row.name})`)
+        seen.add(id)
+        lines.push(`    - id: ${id}`)
+        lines.push(`      name: '${row.name}'`)
+        for (const config of row.configLines) lines.push(`      ${config}`)
+      }
+    }
   }
   return lines.join('\n') + '\n'
 }
@@ -338,7 +426,16 @@ for (const { pkgDir, ymlPath } of aggregates) {
   if (manifest.patchFrom.length === 0 && !manifest.self) {
     console.log(`[aggregate] WARN ${rel}: aggregate.yml has no patchFrom entries (patch would be empty)`)
   }
-  const patch = renderPatch(blocks, manifest.rows, errors, rel)
+  const externalPatches = []
+  for (const name of manifest.patchFromNpm) {
+    const extPatchPath = join(REPO_ROOT, 'node_modules', name, 'cordis.patch.yml')
+    if (!existsSync(extPatchPath)) {
+      errors.push(`patchFromNpm package not installed: ${ymlPath} -> ${name} (expected ${relative(REPO_ROOT, extPatchPath)}; run pnpm install)`)
+      continue
+    }
+    externalPatches.push({ name, parsed: parseExternalPatch(extPatchPath, errors) })
+  }
+  const patch = renderPatch(blocks, manifest.rows, externalPatches, errors, rel)
   const resolvedDeps = resolveEntries(pkgDir, manifest.deps, 'deps', errors)
   const pkgJson = renderPackageJson(join(pkgDir, 'package.json'), resolvedDeps)
   results.push({ rel, blocks, patch, resolvedDeps, pkgJson })

--- a/scripts/aggregate.test.mjs
+++ b/scripts/aggregate.test.mjs
@@ -100,11 +100,31 @@ test('web-ui-all mounts dsh-better-sidebar as an external row', () => {
   assert.match(lines[idx + 1] ?? '', /^ {6}name: 'dsh-better-sidebar'$/)
 })
 
-test('web-ui-all mounts @mlgbnb/dsh-archive-manager as an external row', () => {
+test('web-ui-all embeds dsh-session-enhance as an external patch (replacing dsh-archive-manager)', () => {
   const patch = readFileSync(join(ROOT, 'packages/dsh-web-all/cordis.patch.yml'), 'utf8')
   const lines = patch.split(/\r?\n/)
-  const idx = lines.findIndex((line) => /^ {4}- id: web-ui-archive-manager$/.test(line))
-  assert.ok(idx >= 0, 'web-ui-archive-manager row is missing from the aggregate patch')
-  // The paired name line resolves the scoped npm package from the profile root.
-  assert.match(lines[idx + 1] ?? '', /^ {6}name: '@mlgbnb\/dsh-archive-manager'$/)
+  // The superseded @mlgbnb/dsh-archive-manager row is gone.
+  assert.equal(lines.some((line) => /^ {4}- id: web-ui-archive-manager$/.test(line)), false, 'web-ui-archive-manager row must be removed')
+  // External patch header.
+  const headerIdx = lines.findIndex((line) => line === '# external patch: dsh-session-enhance')
+  assert.ok(headerIdx >= 0, 'dsh-session-enhance external patch block is missing')
+  // Default service rows are disabled verbatim.
+  const patchTail = lines.slice(headerIdx).join('\n')
+  assert.match(patchTail, /- id: workspace\n  disabled: true/)
+  assert.match(patchTail, /- id: session-projection-cache\n  disabled: true/)
+  assert.match(patchTail, /- id: ui-workspace\n  disabled: true/)
+  // The four replacement rows are namespaced web-ui-* and resolve the package subpaths.
+  for (const row of [
+    ['web-ui-workspace-dsh-session-enhance', 'dsh-session-enhance/workspace'],
+    ['web-ui-session-projection-cache-dsh-session-enhance', 'dsh-session-enhance/projcache'],
+    ['web-ui-message-edit-dsh-session-enhance', 'dsh-session-enhance/message-edit'],
+    ['web-ui-ui-workspace-dsh-session-enhance', 'dsh-session-enhance'],
+  ]) {
+    const idx = lines.findIndex((line) => line === `    - id: ${row[0]}`)
+    assert.ok(idx >= 0, `${row[0]} row is missing from the aggregate patch`)
+    assert.match(lines[idx + 1] ?? '', new RegExp(`^ {6}name: '${row[1].replace(/'/g, "\\'")}'$`))
+  }
+  // The projcache row keeps its config block.
+  const projIdx = lines.findIndex((line) => line === '    - id: web-ui-session-projection-cache-dsh-session-enhance')
+  assert.match(lines[projIdx + 3] ?? '', /^ {8}writeEveryEvents: 200$/)
 })


### PR DESCRIPTION
> 提 PR 前请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 与 [AGENTS.md](../AGENTS.md)；
> 提交信息用 Conventional Commits（`type(scope): subject`），禁止 emoji。

## 摘要（Summary）

两项变更：

1. **聚合包替换**：`dsh-web-all` 内置的 `@mlgbnb/dsh-archive-manager`（`web-ui-archive-manager` 行）替换为 **`dsh-session-enhance`**（npm `0.2.0`，会话增强 / 归档管理升级版，功能覆盖并超越原插件：真实物理删除、跨工作区分组拖拽搬移、消息编辑、物理文件与 storages JSON 对账、墓碑防复活）。聚合生成器新增 `patchFromNpm` 支持，把外部 npm 包的 `cordis.patch.yml`（禁用默认服务行 + 自身服务行）整体嵌入聚合 patch，行 id 统一加 `web-ui-` 前缀与独立安装共存。
2. **插件商店收录**：`community.json` 收录 **`dsh-session-enhance`** 与 **`dsh-archive-manager`** 两个条目（原内置归档管理从未进入社区索引；替换后为偏好经典版的用户保留独立安装入口），并重新生成 `market/dist/manifest/plugins.json`。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [x] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`（聚合清单与生成器）
- [x] 其他（请说明）：`packages/dsh-community-plugins/community.json` + `market/dist/manifest/plugins.json` + `scripts/aggregate.mjs`（`patchFromNpm` 支持）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更（聚合包内置归档管理升级为 dsh-session-enhance；商店新增两个插件条目）
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```
git fetch upstream dev && git rebase origin/dev
```

分支已 rebase 到最新 `dev`（b5e2bc4）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

证据：

```bash
node scripts/aggregate.mjs --check        # check OK: packages/dsh-web-all (18 row(s), 17 dep(s))
node scripts/community-index              # community-index: OK (39 entries)
node scripts/aggregate.test.mjs           # pass 5 / fail 0
node scripts/community-index.test.mjs     # pass 8 / fail 0（CLI 门禁测试因环境无子进程权限跳过，等价门禁 node scripts/community-index 已通过）
git diff --stat                           # 聚合替换 13 文件；商店条目 2 文件
```

说明：`patchFromNpm` 的 `--check` 与生成依赖 `node_modules/<pkg>/cordis.patch.yml`（pnpm install 后即存在，CI 一致）；本 PR 提交的 `cordis.patch.yml` 为生成器输出，可重复验证。

## 视觉修复要求（Visual Fix Requirements）

<!-- 仅当 PR 类型勾选了「视觉修复」时必填；纯文本类改动可跳过本节。 -->

无视觉改动，跳过。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。—— 本 PR 未新增包目录
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。—— 已同步维护并重录 `README.i18n.yaml` blob hash（`git hash-object` 重算）

## 贡献者版权声明（Contributor Copyright）

<!-- 可选。若本 PR 贡献的是插件或皮肤，可在项目 README 末尾「来源与版权」的版权表中追加一行声明你自己的版权（包 / 来源 / 版权三列，格式参考表中现有行）；不声明则维持现有版权归属。 -->

已在根 README「来源与版权」登记 dsh-session-enhance（Apache-2.0，Tinger-X）。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

- dsh-session-enhance: https://github.com/Tinger-X/dsh-session-enhance
- dsh-archive-manager: https://github.com/z953218350/dsh-archive-manager

插件详细说明：

**dsh-session-enhance**（npm: `dsh-session-enhance@0.2.0`，Apache-2.0）—— 会话管理增强插件（替代并超越原 dsh-archive-manager）：

- 归档管理：侧栏菜单归档；设置页「归档管理」搜索 / 排序 / 按工作区筛选 / 批量恢复 / 确认后删除。
- 真实物理删除：转录目录删除（3 次重试）+ 子代理级联 + spill 清理 + 直接清扫 `~/storages/*.json`（原子写）+ 删除后磁盘验证。
- 跨工作区分组拖拽搬移：转录目录物理迁移 + 工件 header `cwd` 改写（zstd 帧感知、失败自动回滚）；实时会话先 flush 再移动。
- 消息编辑：edit / retry / reroll 版本分支（融合自 dsh-message-edit，路径与既有 `message-edit/version` 事件兼容）。
- 一键对账：按物理 session 文件同步 storages JSON（清理幽灵 / 修正归属 / 补记漏记）；墓碑防复活。

已知限制：peer 依赖精确钉版 `0.1.1-rc.2`；Node 需 `^22.19 || >=24`（依赖 `node:zlib` zstd）。

**dsh-archive-manager**（npm: `@mlgbnb/dsh-archive-manager@1.0.7`，MIT）—— 社区版归档管理插件：按项目分组、搜索筛选、预览对话、一键恢复与删除（原 dsh-web-all 聚合包内置，本 PR 替换后保留独立安装入口）。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加两个条目（`category: utility`，`subcategory: cleanup`），并运行 `node scripts/community-index` 校验通过（39 entries）；`market/dist/manifest/plugins.json` 已重新生成（两个条目，rank 38 / 39）。
- [x] 已确认插件与 dsh-web 插件体系兼容：`dsh-session-enhance` 遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在 DSH `0.1.1-rc.2` 上验证插件模块可被宿主加载、单测 38 项全部通过、npm 包 `dsh-session-enhance@0.2.0` 已发布；聚合嵌入路径经 `scripts/aggregate.mjs` 生成并 `--check` 通过。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/aggregate.mjs --check
node scripts/aggregate.mjs            # 重新生成 cordis.patch.yml（幂等）
node scripts/community-index
node scripts/aggregate.test.mjs
node scripts/community-index.test.mjs
```

结果摘要：

- `aggregate.mjs --check` → `check OK: packages/dsh-web-all (18 row(s), 17 dep(s))`；重新生成后 `git diff` 无漂移（幂等）
- 生成后的 `cordis.patch.yml` 包含 `# external patch: dsh-session-enhance` 块：三个禁用行（workspace / session-projection-cache / ui-workspace）+ 四个 `web-ui-*` 命名空间服务行（含 projcache 的 config），原 `web-ui-archive-manager` 行已移除
- `community-index` → `OK (39 entries)`（dsh-session-enhance + dsh-archive-manager 均通过校验：必填字段 / repo https / npm 名 / category + subcategory 合法）
- `aggregate.test.mjs` → pass 5 / fail 0（含新测试：外部 patch 嵌入断言 + 旧行移除断言）
- `community-index.test.mjs` → pass 8；1 个 CLI 门禁测试因本地沙箱禁止子进程未能运行，等价门禁命令已单独通过
- `dsh-session-enhance@0.2.0` 已发布至 npm（CI 全链路 install / build / test / publish 通过），聚合依赖钉版可解析

## 用户可见变更证据（Local Feature Evidence）

证据：

![归档管理设置页（dsh-session-enhance 0.2.0）](https://raw.githubusercontent.com/Tinger-X/dsh-session-enhance/main/assets/screenshots/archived-sessions.png)

设置 → 归档管理：搜索 / 排序 / 按工作区筛选 / 同步记录 / 恢复 / 删除。本 PR 的聚合替换使 `dsh-web-all` 用户直接获得该设置页（含 message-edit 融合能力）。

![侧栏会话菜单「归档会话」](https://raw.githubusercontent.com/Tinger-X/dsh-session-enhance/main/assets/screenshots/archive-session-menu.png)

侧栏会话菜单一键归档入口。
