### PR TITLE
index: register dsh-notion-skill in community plugin index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -520,6 +520,18 @@
       "npm": "dsh-delete-message",
       "category": "ui",
       "subcategory": "chat"
+    },
+    {
+      "id": "dsh-notion-skill",
+      "name": "Notion 集成",
+      "rank": 42,
+      "nameEn": "Notion Skill",
+      "author": "Zhiyi-Zhao",
+      "description": "DSH Notion 技能：通过官方 REST API 读写 Notion 工作区——搜索/读取页面（转 markdown）、创建/更新页面、查询/新增/更新数据库条目；纯 Python 标准库、零依赖、Windows / macOS / Linux 通用。",
+      "descriptionEn": "A DSH Notion skill: read and write your Notion workspace via the official REST API - search/read pages as markdown, create/update pages, query/add/update database entries; pure Python stdlib, zero dependencies, cross-platform.",
+      "repo": "https://github.com/Zhiyi-Zhao/dsh-notion-skill",
+      "category": "integration",
+      "subcategory": "sync"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -477,5 +477,16 @@
     "npm": "dsh-delete-message",
     "category": "ui",
     "subcategory": "chat"
+  },
+  {
+    "id": "dsh-notion-skill",
+    "name": "Notion 集成",
+    "nameEn": "Notion Skill",
+    "author": "Zhiyi-Zhao",
+    "description": "DSH Notion 技能：通过官方 REST API 读写 Notion 工作区——搜索/读取页面（转 markdown）、创建/更新页面、查询/新增/更新数据库条目；纯 Python 标准库、零依赖、Windows / macOS / Linux 通用。",
+    "descriptionEn": "A DSH Notion skill: read and write your Notion workspace via the official REST API - search/read pages as markdown, create/update pages, query/add/update database entries; pure Python stdlib, zero dependencies, cross-platform.",
+    "repo": "https://github.com/Zhiyi-Zhao/dsh-notion-skill",
+    "category": "integration",
+    "subcategory": "sync"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

在社区插件索引登记 dsh-notion-skill：一个 DSH Notion 技能包（SKILL.md + 零依赖 Python 助手脚本），通过 Notion 官方 REST API 让 agent 读写 Notion 工作区——搜索/读取页面（转 markdown）、创建/更新页面、查询/新增/更新数据库条目。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`
- [x] 其他（请说明）：`packages/dsh-community-plugins/community.json` 追加索引条目 + 重新生成 `market/dist`（manifest/plugins.json）

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin dev && git rebase origin/dev`（本地 dev 已 rebase 到 baf7b401 后新建分支）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（N/A：本次未改动任何包 README）

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/Zhiyi-Zhao/dsh-notion-skill

插件详细说明：dsh-notion-skill 是 DSH 技能包，采用 DSH 官方 skill-filesystem 格式（`SKILL.md` + `notion_api.py`，纯 Python 标准库、零第三方依赖，Windows / macOS / Linux 通用）。功能：通过 Notion 官方 REST API（https://api.notion.com/v1）读写用户 Notion 工作区，子命令包括 whoami / search / page-get / page-blocks（递归转 markdown）/ page-create / page-update / block-append / db-query / db-create / db-entry-create / db-entry-update；自动处理分页（cursor）与分块（每批 ≤100 blocks）。凭据存本机 `~/.dsh/notion/token` 或环境变量 NOTION_TOKEN，不写入任何仓库文件；页面内容按不可信外部输入处理（防 prompt injection），写操作执行前须用户确认。与 dsh-web 插件体系的关系：本条目为技能型扩展，非 cordis bundle——不修改任何 DSH 源码、无宿主进程逻辑，随 DSH 技能目录（`~/.agents/skills/`）加载，与 dsh-web 全家桶无冲突。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 校验（community-index: OK (41 entries)）；已运行 `node scripts/market-build` 重新生成 `market/dist`（manifest/plugins.json 由 community.json 派生）。
- [ ] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本仓库最新代码上验证插件可被 `dsh web` 挂载并正常运行。（说明：本条目是技能型技能包而非 cordis bundle，采用 DSH 官方 skill 格式，不包含宿主插件代码，请维护者按技能条目评审）
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index
node scripts/market-build
node scripts/market-build --check
```

结果摘要：`community-index: OK (41 entries)`；market-build 重新生成 `market/dist`；`market-build --check` 校验通过（生成物一致）。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A（纯索引登记 + 市场清单生成，无用户可见 UI 变更）。技能本身已在 dsh-notion-skill 仓库实测：`whoami` 返回集成信息、`search` 列出已授权页面、`page-blocks` 成功读取页面内容（附于仓库 README 与 CI）。
