### PR TITLE
fix(doctor): Windows service install + rescue capsule provisioning

### DIFF
--- a/packages/dsh-doctor/src/agent/capsule.ts
+++ b/packages/dsh-doctor/src/agent/capsule.ts
@@ -107,7 +107,7 @@ export async function removeCapsuleCredentialFiles(paths: DoctorPaths): Promise<
 
 async function run(command: string, args: string[], env: NodeJS.ProcessEnv, timeoutMs = 6 * 60_000): Promise<{ code: number; stdout: string; stderr: string }> {
   return await new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, { env, stdio: ['ignore', 'pipe', 'pipe'] })
+    const child = spawn(command, args, { env, shell: process.platform === 'win32', stdio: ['ignore', 'pipe', 'pipe'] })
     let stdout = '', stderr = ''
     child.stdout.on('data', b => { stdout += b })
     child.stderr.on('data', b => { stderr += b })
@@ -156,9 +156,9 @@ export async function provisionCapsule(options: CapsuleOptions): Promise<Capsule
   }
   await writeFile(join(staging, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n', { mode: 0o600 })
   await rm(previous, { recursive: true, force: true })
-  try { await cp(current, previous, { recursive: true }) } catch {}
+  try { await cp(current, previous, { recursive: true, dereference: true }) } catch {}
   await rm(current, { recursive: true, force: true })
-  await cp(staging, current, { recursive: true })
+  await cp(staging, current, { recursive: true, dereference: true })
   await rm(staging, { recursive: true, force: true })
   manifest.rescueHome = join(current, 'rescue-home')
   await writeFile(join(current, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n', { mode: 0o600 })

--- a/packages/dsh-doctor/src/agent/service.ts
+++ b/packages/dsh-doctor/src/agent/service.ts
@@ -33,13 +33,21 @@ export function servicePlan(spec: ServiceSpec, env: NodeJS.ProcessEnv = process.
   if (spec.platform === 'win32') {
     const localAppData = env.LOCALAPPDATA?.trim() || win32.join(home, 'AppData', 'Local')
     const path = win32.join(localAppData, 'DSH Doctor', 'supervisor.cmd')
-    const content = `@echo off\r\nset "DSH_DOCTOR_HOME=${spec.doctorHome}"\r\n"${executable}" ${spec.args.map(quoteExec).join(' ')}\r\n`
+    // cmd.exe does not unescape `\\`; JSON.stringify would produce "C:\\Users\\..." which cmd cannot resolve.
+    // Wrap each argument in plain double quotes instead.
+    const cmdQuote = (value: string): string => `"${value}"`
+    const content = `@echo off\r\nset "DSH_DOCTOR_HOME=${spec.doctorHome}"\r\n"${executable}" ${spec.args.map(cmdQuote).join(' ')}\r\n`
     const task = 'DSH Doctor Supervisor'
+    // `schtasks /SC ONLOGON` requires elevation on many Windows setups ("Access is denied").
+    // The TaskScheduler COM API (via PowerShell) lets a standard user register a logon-trigger
+    // task for the current user, so prefer Register-ScheduledTask over schtasks /Create.
+    const ps = ['powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command']
+    const escapedPath = path.replace(/'/g, "''")
     return {
       files: [{ path, content, mode: 0o600 }],
-      install: ['schtasks', '/Create', '/F', '/SC', 'ONLOGON', '/TN', task, '/TR', `"${path}"`],
-      uninstall: ['schtasks', '/Delete', '/F', '/TN', task],
-      restart: ['schtasks', '/Run', '/TN', task],
+      install: [...ps, `Register-ScheduledTask -TaskName '${task}' -Action (New-ScheduledTaskAction -Execute '${escapedPath}') -Trigger (New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME) -Settings (New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero)) -Force | Out-Null`],
+      uninstall: [...ps, `Unregister-ScheduledTask -TaskName '${task}' -Confirm:$false -ErrorAction SilentlyContinue`],
+      restart: [...ps, `Start-ScheduledTask -TaskName '${task}'`],
     }
   }
   throw new Error(`doctor: unsupported service platform ${spec.platform}`)


### PR DESCRIPTION
## Problem

`@linxin666/dsh-doctor` fails to provision on a non-elevated Windows account. After install, `/api/doctor/status` is stuck on `SUPERVISOR_UNPROVISIONED` and the GUI "????" / "Install now" button silently does nothing: `supervisor.cmd` is never written, no `DSH Doctor Supervisor` scheduled task exists, `supervisor.token` is never generated, and the rescue capsule never builds.

## Root causes (4 Windows bugs)

### 1. `service.ts` - win32 `supervisor.cmd` content escapes backslashes
`quoteExec = JSON.stringify`, so the cli.mjs path becomes `"C:\\Users\\...\\cli.mjs"`. cmd.exe does not unescape `\\`, so the supervisor daemon can never start.

**Fix:** wrap win32 args in plain double quotes instead of `JSON.stringify`.

### 2. `service.ts` - `schtasks /SC ONLOGON` requires elevation
On many Windows setups `schtasks /Create /SC ONLOGON` returns `Access is denied` for a standard user, so `ensureServiceInstalled` aborts before writing/starting anything.

**Fix:** register the logon task via the TaskScheduler COM API through PowerShell (`Register-ScheduledTask -AtLogon -User $env:USERNAME`), which lets a standard user register a logon-trigger task for the current user without elevation. Uninstall/restart use `Unregister-ScheduledTask` / `Start-ScheduledTask`.

### 3. `capsule.ts` - `run()` cannot spawn `dsh.cmd`
Spawning the dsh executable (`dsh.cmd` on Windows) without `shell: true` throws `EINVAL` (Node ? 18 security change for `.cmd`/`.bat`).

**Fix:** add `shell: process.platform === 'win32'`.

### 4. `capsule.ts` - `fs.cp` recreates symlinks ? EPERM
`cp(current, previous)` / `cp(staging, current)` recreate symlinks verbatim by default, which throws `EPERM` on Windows without Developer Mode / admin when copying the rescue-home profile `node_modules`.

**Fix:** add `dereference: true` so symlinked packages are copied as real files. The rescue capsule is self-contained and does not rely on the global install.

> Note: the CLI direct-execution guard (`isDirectCliRun`) and the win32 `path.resolve`/`path.join` handling are already correct on `dev`; the installed `0.3.5` bundle predates those fixes. This PR addresses what is still broken on `dev`.

## Verification

End-to-end on Windows 11, non-elevated account:

- `supervisor.cmd` written with correct content (`"C:\Program Files\nodejs\node.exe" "...\cli.mjs" "supervisor"`)
- `DSH Doctor Supervisor` scheduled task registered and state `Running`
- `~/.dsh-doctor/state/supervisor.token` generated, named pipe listening
- rescue capsule `provision` succeeds, manifest `status: "verified"`
- `GET /api/doctor/status` ? `ok: true`, `phase: "armed"`

## Files changed

- `packages/dsh-doctor/src/agent/service.ts`
- `packages/dsh-doctor/src/agent/capsule.ts`
