### PR TITLE
feat: add dsh-free-search to community plugin index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -1,22 +1,20 @@
 {
-  "generated": "2026-08-27",
-  "items": [
+  "plugins": [
     {
       "id": "dsh-data-agent",
       "name": "Data Agent",
-      "rank": 1,
       "nameEn": "Data Agent",
       "author": "omdsh-dev",
       "description": "为 DSH 定义专用 Data Agent 预设，让 AI 帮你查询、更新、分析数据。",
       "descriptionEn": "Defines a dedicated Data Agent preset for DSH so the AI can query, update and analyze data.",
       "repo": "https://github.com/omdsh-dev/dsh-data-agent",
       "category": "agent",
-      "subcategory": "preset"
+      "subcategory": "preset",
+      "rank": 1
     },
     {
       "id": "dsh-tui",
       "name": "dsh-TUI",
-      "rank": 2,
       "nameEn": "dsh-TUI",
       "author": "ccch1mneyyy",
       "description": "Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时工作状态行、思考流式展开、双击 Esc 回滚、上下文进度条与 TPS 仪表。",
@@ -24,24 +22,24 @@
       "repo": "https://github.com/ccch1mneyyy/dsh-TUI",
       "npm": "@deepseek-harness-tui/dsh-tui",
       "category": "ui",
-      "subcategory": "terminal"
+      "subcategory": "terminal",
+      "rank": 2
     },
     {
       "id": "dsh-tianshu-tui",
       "name": "天书 TUI",
-      "rank": 3,
       "nameEn": "Tianshu TUI",
       "author": "huiliyi37",
       "description": "基于官方 DeepSeek Harness 的交互式终端 UI 插件，在官方基础上增加 TDD 与证据门等工作流。",
       "descriptionEn": "An interactive terminal UI plugin for DeepSeek Harness that adds TDD and evidence-gate workflows on top of the official base.",
       "repo": "https://github.com/huiliyi37/dsh-tianshu-tui",
       "category": "ui",
-      "subcategory": "terminal"
+      "subcategory": "terminal",
+      "rank": 3
     },
     {
       "id": "dsh-context",
       "name": "上下文可视化",
-      "rank": 4,
       "nameEn": "Context Visualizer",
       "author": "bowenliang123",
       "description": "一站式 DeepSeek Harness 上下文洞察与可视化插件：Context 面板与浏览器加 /context 命令，透视上下文构成、历史演进与压缩/剪枝等事件，并展示消息与图片的 token 占用。",
@@ -49,12 +47,12 @@
       "repo": "https://github.com/bowenliang123/dsh-context",
       "npm": "dsh-context",
       "category": "tools",
-      "subcategory": "context"
+      "subcategory": "context",
+      "rank": 4
     },
     {
       "id": "dsh-builtin-toggles",
       "name": "内置能力检查器",
-      "rank": 5,
       "nameEn": "Built-in Capability Inspector",
       "author": "Starfie1d1272",
       "description": "Evidence-backed 内置 capability Inspector：展示 DSH Web built-in capability 的 provenance、compatibility 与 structural drift；仅对 9 个经过审阅的 UI leaves 提供 fail-closed 开关。",
@@ -62,36 +60,36 @@
       "repo": "https://github.com/Starfie1d1272/dsh-builtin-toggles",
       "npm": "dsh-builtin-toggles",
       "category": "tools",
-      "subcategory": "context"
+      "subcategory": "context",
+      "rank": 5
     },
     {
       "id": "dsh-pilot",
       "name": "Pilot 浏览器驾驶舱",
-      "rank": 6,
       "nameEn": "Pilot Browser Cockpit",
       "author": "guo6x",
       "description": "给 agent 一双会开车的手：零依赖 CDP 浏览器操控（8 个 pilot_* 工具：导航/点击/输入/按键/JS/截图）+ Web GUI 可拖拽驾驶舱面板，无需 Playwright、无需 API key。",
       "descriptionEn": "Give your agent hands: zero-dependency CDP browser control (8 pilot_* tools: navigate/click/type/keys/eval/screenshot) plus a draggable cockpit panel in the Web GUI - no Playwright, no API key.",
       "repo": "https://github.com/guo6x/dsh-pilot",
       "category": "tools",
-      "subcategory": "browser"
+      "subcategory": "browser",
+      "rank": 6
     },
     {
       "id": "dsh-housekeeper",
       "name": "环境管家",
-      "rank": 7,
       "nameEn": "Environment Housekeeper",
       "author": "guo6x",
       "description": "管住 agent 的脏手：工具链台账（node/pnpm/git/gh/ffmpeg 等自动探测）、缓存与临时目录扫描 + 白名单安全一键清理、机器规则 AGENTS.md 查看编辑，全在设置面板完成。",
       "descriptionEn": "Keep your agent's hands clean: toolchain inventory, scratch/cache scan with whitelist-guarded one-click cleanup, and the machine rules file (AGENTS.md) view/edit - all in the settings panel.",
       "repo": "https://github.com/guo6x/dsh-housekeeper",
       "category": "utility",
-      "subcategory": "cleanup"
+      "subcategory": "cleanup",
+      "rank": 7
     },
     {
       "id": "dsh-deepread",
       "name": "DeepRead 精读助手",
-      "rank": 8,
       "nameEn": "DeepRead Assistant",
       "author": "xiehuan123",
       "description": "五种模式精读插件（quick / deep / map / feynman / book），支持公众号链接与文件输入、批量对比、预算预检与后台任务进度透明，导出 md / mm / html，Web UI 提供工具结果卡片与精读面板。",
@@ -99,12 +97,12 @@
       "repo": "https://github.com/xiehuan123/dsh-deepread",
       "npm": "dsh-deepread",
       "category": "knowledge",
-      "subcategory": "reading"
+      "subcategory": "reading",
+      "rank": 8
     },
     {
       "id": "dsh-mnemon",
       "name": "Mnemon 记忆系统",
-      "rank": 9,
       "nameEn": "Mnemon Memory",
       "author": "omdsh-dev",
       "description": "与 Mnemon CLI 集成的跨 Agent、本地优先持久记忆插件：用户画像 / 工作记忆 / 项目档案与长期 Memory Spaces，支持导入导出。",
@@ -112,12 +110,12 @@
       "repo": "https://github.com/omdsh-dev/dsh-mnemon",
       "npm": "dsh-mnemon",
       "category": "knowledge",
-      "subcategory": "memory"
+      "subcategory": "memory",
+      "rank": 9
     },
     {
       "id": "dsh-plugin-hub",
       "name": "插件中心（dsh-plugin-hub）",
-      "rank": 10,
       "nameEn": "Plugin Hub",
       "author": "Noob-stupid",
       "description": "插件管理面板：已安装插件一键启用/停用，内置 GitHub dsh-plugin 插件市场（官方/聚合识别、子包浏览、一键安装与本地 AI 兜底修复、删除卸载），版本检测与一键更新、框架一键升级。",
@@ -125,36 +123,36 @@
       "repo": "https://github.com/Noob-stupid/dsh-plugin-hub",
       "npm": "@noob-stupid/dsh-plugin-console",
       "category": "tools",
-      "subcategory": "dev"
+      "subcategory": "dev",
+      "rank": 10
     },
     {
       "id": "dsh-genui",
       "name": "GenUI 生成式 UI",
-      "rank": 11,
       "nameEn": "GenUI",
       "author": "omdsh-dev",
       "description": "给模型输出配交互式 UI：助手回复内联渲染 dsh-ui 围栏（布局、图表、表格、表单、Mermaid、3D、原生音视频），双通道渲染兼容原版 DSH 与新构建，支持流式渲染、面板停靠与组件交互回传模型。",
       "descriptionEn": "Interactive UI inside assistant replies via the dsh-ui fence: layouts, charts, tables, forms, quizzes, Mermaid, 3D and native audio/video. Dual-channel rendering covers stock DSH and newer builds, with streaming render, panel docking and component actions that loop back to the model.",
       "repo": "https://github.com/omdsh-dev/dsh-genui",
       "category": "ui",
-      "subcategory": "render"
+      "subcategory": "render",
+      "rank": 11
     },
     {
       "id": "dsh-annotation",
       "name": "选中批注",
-      "rank": 12,
       "nameEn": "Selection Annotation",
       "author": "omdsh-dev",
       "description": "选中助手文字即可批注，回车随消息发送；自己的气泡只显示问题与「批注 ×N」标签，模型按 Annotation N 逐条对照回复（悬浮芯片）；UI 与批注块跟随 DSH 语言切换 zh/en，Cmd/Ctrl+Enter 可直发纯批注，斜杠命令原样放行。",
       "descriptionEn": "Select text in an assistant reply to annotate it; annotations ride along with your next message, hidden in your own bubble behind an Annotations xN chip, and the model replies per Annotation N with hoverable chips. UI and annotation block follow the DSH locale (zh/en); Cmd/Ctrl+Enter sends annotations alone; slash commands pass through.",
       "repo": "https://github.com/omdsh-dev/dsh-annotation",
       "category": "ui",
-      "subcategory": "chat"
+      "subcategory": "chat",
+      "rank": 12
     },
     {
       "id": "deepseek-harness-auth",
       "name": "DeepSeek Harness Auth",
-      "rank": 13,
       "nameEn": "DeepSeek Harness Auth",
       "author": "taichuy",
       "description": "为 DSH Web 公网部署提供登录认证前置代理，支持账号密码、验证码、失败锁定和 IP/CIDR 白名单。",
@@ -162,12 +160,12 @@
       "repo": "https://github.com/taichuy/deepseek-harness-auth",
       "npm": "deepseek-harness-auth",
       "category": "security",
-      "subcategory": "access"
+      "subcategory": "access",
+      "rank": 13
     },
     {
       "id": "dsh-cloud-sync",
       "name": "云同步服务",
-      "rank": 14,
       "nameEn": "Cloud Sync",
       "author": "dickpy",
       "description": "支持 WebDAV、S3、阿里云 OSS、腾讯云 COS 与 MinIO 的 DSH 云同步插件，可同步 profile、插件配置及本地插件源码归档。",
@@ -175,12 +173,12 @@
       "repo": "https://github.com/dickpy/dsh-cloud-sync",
       "npm": "@dickpy/dsh-cloud-sync",
       "category": "integration",
-      "subcategory": "sync"
+      "subcategory": "sync",
+      "rank": 14
     },
     {
       "id": "dsh-auto-memory",
       "name": "自动记忆",
-      "rank": 15,
       "nameEn": "Auto Memory",
       "author": "Aik358",
       "description": "三层自动记忆插件：用户级/项目笔记/每日日志自动注入与检索、每轮自动沉淀、AI 时段问候、智能检索、日历与工作区思维导图，支持继承 WorkBuddy/CodeBuddy/Claude Code/Codex 等其他 AI 工具的记忆。",
@@ -188,25 +186,25 @@
       "repo": "https://github.com/Aik358/dsh-auto-memory",
       "npm": "@a9i5k4/dsh-auto-memory",
       "category": "knowledge",
-      "subcategory": "memory"
+      "subcategory": "memory",
+      "rank": 15
     },
     {
       "id": "dsh-memoir",
       "name": "项目记忆 Memoir",
-      "rank": 16,
       "nameEn": "Project Memory Memoir",
       "author": "Qinling-Melon-Farmers",
       "description": "项目持久化记忆与会话经验沉淀：memoir_record / memoir_read 工具（BM25 相关度排序检索）、每轮工作自动蒸馏、记忆诊断面板与跨项目全局检索，纯本地零外部依赖。",
       "descriptionEn": "Project persistent memory and session-lessons distillation: memoir_record / memoir_read tools with BM25-ranked retrieval, per-turn auto-distill, a memory diagnostics panel and cross-project search - fully local, no external dependency.",
       "repo": "https://github.com/Qinling-Melon-Farmers/dsh-memoir",
-      "npm": "dsh-memoir",
       "category": "knowledge",
-      "subcategory": "memory"
+      "subcategory": "memory",
+      "npm": "dsh-memoir",
+      "rank": 16
     },
     {
       "id": "dsh-worktime-board",
       "name": "牛马修仙看板",
-      "rank": 17,
       "nameEn": "Worktime Cultivation Board",
       "author": "spacexun2",
       "description": "DeepSeek Harness 工时统计 × 修仙养成：日/周/月/学年四档汇总 agent 活跃时长、token、输入与工具调用，十二重境界（炼气→宇宙洪荒）量化进度，纯本地存储。",
@@ -214,12 +212,12 @@
       "repo": "https://github.com/spacexun2/dsh-worktime-board",
       "npm": "dsh-worktime-board",
       "category": "utility",
-      "subcategory": "stats"
+      "subcategory": "stats",
+      "rank": 17
     },
     {
       "id": "dsh-skill-explorer",
       "name": "技能中心（Skill Explorer）",
-      "rank": 18,
       "nameEn": "Skill Explorer",
       "author": "wingsky-1",
       "description": "DSH 技能中心：按来源分级浏览已加载 skill（系统内置 / 项目 / 用户 / 自定义 / 运行时），支持启用/禁用、创建与删除（移入 .trash）。",
@@ -227,24 +225,24 @@
       "repo": "https://github.com/wingsky-1/dsh-skill-explorer",
       "npm": "@linxin666/dsh-client-ui-skill-explorer",
       "category": "tools",
-      "subcategory": "dev"
+      "subcategory": "dev",
+      "rank": 18
     },
     {
       "id": "dsh-friendly-steps",
       "name": "过程精简 Friendly Steps",
-      "rank": 19,
       "nameEn": "Friendly Steps",
       "author": "dongwenxiu83-web",
       "description": "面向文字工作者的过程精简：纯 CSS 折叠 Think / 工具调用等技术过程行，右下角浮条「已完成 N 步」一键展开收起，失败步骤红色计数反馈；不注入 React 列表、无全量扫描，零侵入。",
       "descriptionEn": "Writer-friendly process collapse: hides Think / tool-call rows via pure CSS behind a floating 'N steps done' pill with red failure counts and one-click expand/collapse. No foreign nodes in React lists, no full-DOM scans — zero interference.",
       "repo": "https://github.com/dongwenxiu83-web/dsh-friendly-steps",
       "category": "ui",
-      "subcategory": "chat"
+      "subcategory": "chat",
+      "rank": 19
     },
     {
       "id": "dsh-full-remote",
       "name": "全功能远程访问",
-      "rank": 20,
       "nameEn": "Full Remote Access",
       "author": "JUANWANG-BUAA",
       "description": "令牌门控反向代理：公网隧道或局域网下，在手机等设备上远程使用 DeepSeek Harness，设置、凭据与文件访问保持可用，支持按设备会话。",
@@ -252,12 +250,12 @@
       "repo": "https://github.com/JUANWANG-BUAA/dsh-full-remote",
       "npm": "dsh-full-remote",
       "category": "integration",
-      "subcategory": "remote"
+      "subcategory": "remote",
+      "rank": 20
     },
     {
       "id": "dsh-history-tree",
       "name": "历史树",
-      "rank": 21,
       "nameEn": "History Tree",
       "author": "z953218350",
       "description": "在聊天消息左侧提供 Codex 风格对话轮次时间线点阵与悬浮历史概览卡片，支持鱼眼放大动效与点击直达对应轮次。",
@@ -265,12 +263,12 @@
       "repo": "https://github.com/z953218350/dsh-history-tree",
       "npm": "dsh-history-tree",
       "category": "ui",
-      "subcategory": "chat"
+      "subcategory": "chat",
+      "rank": 21
     },
     {
       "id": "dsh-gzip",
       "name": "dsh-gzip",
-      "rank": 22,
       "nameEn": "dsh-gzip",
       "author": "wingsky-1",
       "description": "/api 响应 gzip 压缩插件：为远程 / 低带宽链路开启 /api 响应压缩，解决会话历史因大响应无压缩而超时加载失败的问题；SSE / zip / 已编码响应自动豁免，无全局副作用。",
@@ -278,48 +276,48 @@
       "repo": "https://github.com/wingsky-1/dsh-plugin-hub/tree/main/packages/dsh-gzip",
       "npm": "@wingsky-1/dsh-gzip",
       "category": "utility",
-      "subcategory": "net"
+      "subcategory": "net",
+      "rank": 22
     },
     {
       "id": "dsh-wsl-bridge",
       "name": "WSL Windows 桥",
-      "rank": 23,
       "nameEn": "WSL Windows Bridge",
       "author": "ch1bug",
       "description": "让 WSL 里的 agent 访问 Windows 侧：读写 C:\\ 文件、运行 .exe、Explorer 打开、wslpath 路径互转与盘符枚举（win_ls/read/write/run/open/path/drives）。",
       "descriptionEn": "Lets a WSL agent reach the Windows host: read/write C:\\ files, run .exe programs, open in Explorer, convert paths via wslpath and list drives (win_ls/read/write/run/open/path/drives).",
       "repo": "https://github.com/ch1bug/dsh-wsl-bridge",
       "category": "integration",
-      "subcategory": "bridge"
+      "subcategory": "bridge",
+      "rank": 23
     },
     {
       "id": "dsh-mimo-agent-tools",
       "name": "MiMo 多模态工具",
-      "rank": 24,
       "nameEn": "MiMo Multimodal Tools",
       "author": "ch1bug",
       "description": "把小米 MiMo API 封装为 agent 工具：联网搜索、图像/音频/视频理解、语音转写、语音合成与音色克隆（mimo_search/vision/audio/video/asr/tts/voiceclone）。",
       "descriptionEn": "Turns the Xiaomi MiMo API into agent tools: web search, image/audio/video understanding, speech-to-text, text-to-speech and voice cloning (mimo_search/vision/audio/video/asr/tts/voiceclone).",
       "repo": "https://github.com/ch1bug/dsh-mimo-agent-tools",
       "category": "tools",
-      "subcategory": "model"
+      "subcategory": "model",
+      "rank": 24
     },
     {
       "id": "dsh-skill-fuzzy",
       "name": "技能模糊搜索",
-      "rank": 25,
       "nameEn": "Skill Fuzzy Search",
       "author": "ch1bug",
       "description": "Codex 风格模糊技能搜索：/bug、/diag、/regression 都能在 / 技能菜单里命中 diagnosing-bugs（名称子序列 + 描述连续子串匹配）。",
       "descriptionEn": "Codex-style fuzzy skill search: /bug, /diag and /regression all find diagnosing-bugs in the / skill menu (name subsequence + description substring matching).",
       "repo": "https://github.com/ch1bug/dsh-skill-fuzzy",
       "category": "ui",
-      "subcategory": "chat"
+      "subcategory": "chat",
+      "rank": 25
     },
     {
       "id": "dsh-approve-for-me",
       "name": "自动审批审核",
-      "rank": 26,
       "nameEn": "Approve for Me",
       "author": "DamonKoy",
       "description": "只读工具自动放行、危险命令自动拒绝，可配置全自动模式。",
@@ -327,12 +325,12 @@
       "repo": "https://github.com/DamonKoy/dsh-plugins/tree/main/packages/dsh-approve-for-me",
       "npm": "dsh-approve-for-me",
       "category": "security",
-      "subcategory": "policy"
+      "subcategory": "policy",
+      "rank": 26
     },
     {
       "id": "dsh-memories",
       "name": "项目记忆",
-      "rank": 27,
       "nameEn": "Project Memories",
       "author": "DamonKoy",
       "description": "按项目作用域持久化的键值记忆，支持增删查列与搜索。",
@@ -340,12 +338,12 @@
       "repo": "https://github.com/DamonKoy/dsh-plugins/tree/main/packages/dsh-memories",
       "npm": "dsh-memories",
       "category": "knowledge",
-      "subcategory": "memory"
+      "subcategory": "memory",
+      "rank": 27
     },
     {
       "id": "dsh-notifier",
       "name": "dsh-notifier",
-      "rank": 28,
       "nameEn": "dsh-notifier",
       "author": "wingsky-1",
       "description": "审批/完成/错误事件通知：浏览器 Notification + 系统原生 toast（Windows PowerShell WinRT / Linux·macOS notify-send，零依赖）；提示音可配、错误同类合并、免打扰时段、通知历史与配置面板；非安全上下文自动降级横幅。",
@@ -353,24 +351,24 @@
       "repo": "https://github.com/wingsky-1/dsh-plugin-hub/tree/main/packages/dsh-notifier",
       "npm": "@wingsky-1/dsh-notifier",
       "category": "utility",
-      "subcategory": "notify"
+      "subcategory": "notify",
+      "rank": 28
     },
     {
       "id": "dsh-logicprobe",
       "name": "逻辑探针",
-      "rank": 29,
       "nameEn": "Logic Probe",
       "author": "AmethystLuna",
       "description": "AI 智能体声明核查技能：枚举设计文档与重构计划中的每个可验证声明，对照代码库事实逐条核验；行为类声明升级为状态机/数据模型逻辑原语验证，支持前后回归、领域约束与并发风险挖掘，输出 file:line 证据。",
       "descriptionEn": "Claim verification for AI coding agents: enumerate every verifiable claim in design docs and refactoring plans, verify against codebase facts, then escalate behavioral claims to state-machine/data-model logic-primitive verification with before/after regression, domain constraints, and concurrency risk mining.",
       "repo": "https://github.com/AmethystLuna/logicprobe",
       "category": "tools",
-      "subcategory": "dev"
+      "subcategory": "dev",
+      "rank": 29
     },
     {
       "id": "dsh-chatgpt-subscription",
       "name": "子代理管理",
-      "rank": 30,
       "nameEn": "Subagent Management",
       "author": "Aa728848",
       "description": "让 DSH 通过 ChatGPT 订阅使用 GPT 系列模型：PKCE OAuth 登录、DPAPI/钥匙串/0600 凭据存储、流式 Responses、图片生成、Codex 搜索、额度展示与子代理管理。",
@@ -378,12 +376,12 @@
       "repo": "https://github.com/Aa728848/dsh-chatgpt-subscription",
       "npm": "@eddyskywalker/dsh-chatgpt-subscription",
       "category": "integration",
-      "subcategory": "external-ai"
+      "subcategory": "external-ai",
+      "rank": 30
     },
     {
       "id": "dsh-imagegen",
       "name": "AI 生图",
-      "rank": 31,
       "nameEn": "AI ImageGen",
       "author": "dickpy",
       "description": "AI 生图插件：通过可配置的 OpenAI 兼容端点（gpt-image-2 / gpt-image-1 / dall-e-3）实现文生图与图生图，提供生成历史、提示词模板库与 API 设置卡片。",
@@ -391,36 +389,36 @@
       "repo": "https://github.com/dickpy/dsh-imagegen",
       "npm": "@dickpy/dsh-imagegen",
       "category": "tools",
-      "subcategory": "model"
+      "subcategory": "model",
+      "rank": 31
     },
     {
       "id": "dsh-api-visualizer",
       "name": "接口捕获",
-      "rank": 32,
       "nameEn": "API Capture",
       "author": "lemonmmice",
       "description": "Fiddler 式实时抓包面板：tail 客户端 System.Net 跟踪日志自动解析 HTTP 请求/响应（gzip 自动解包）并实时入库，内置本地 MITM 代理可抓任意进程，支持筛选 / 详情 / 导出 / 重放 / 标记。",
       "descriptionEn": "Fiddler-style realtime capture panel: tails the client's System.Net trace log into live HTTP request/response records (gzip auto-decompressed), plus a built-in local MITM proxy for arbitrary processes, with filters, detail view, export, replay and flags.",
       "repo": "https://github.com/lemonmmice/dsh-api-visualizer",
       "category": "tools",
-      "subcategory": "api"
+      "subcategory": "api",
+      "rank": 32
     },
     {
       "id": "dsh-postman",
       "name": "接口调试",
-      "rank": 33,
       "nameEn": "API Debugger",
       "author": "lemonmmice",
       "description": "类 Postman 接口调试面板：由宿主服务端发起 HTTP 请求（绕过浏览器 CORS），支持 WebSocket / 原始 TCP / gRPC、鉴权助手、环境变量、cURL 导入导出、请求集合与历史。",
       "descriptionEn": "Postman-style API debug panel: host-side HTTP requests without browser CORS limits, plus WebSocket / raw TCP / gRPC, auth helpers, env variables, cURL import/export, request collections and history.",
       "repo": "https://github.com/lemonmmice/dsh-postman",
       "category": "tools",
-      "subcategory": "api"
+      "subcategory": "api",
+      "rank": 33
     },
     {
       "id": "dsh-workspace-api",
       "name": "企业信息查询 Agent",
-      "rank": 34,
       "nameEn": "Workspace API",
       "author": "liaoyonghong",
       "description": "把企业文档变成可对话的聊天机器人：员工或应用系统用自然语言提问，AI 代理查阅文档后带出处回答；同时提供 workspace 内容 HTTP API。",
@@ -428,12 +426,12 @@
       "repo": "https://github.com/liaoyonghong/dsh-workspace-api",
       "npm": "dsh-workspace-api",
       "category": "knowledge",
-      "subcategory": "qa"
+      "subcategory": "qa",
+      "rank": 34
     },
     {
       "id": "dsh-llm-verifier",
       "name": "LLM 裁判复核",
-      "rank": 35,
       "nameEn": "LLM Verifier",
       "author": "Aa728848",
       "description": "DSH 原生可配置 LLM 裁判复核插件：成对比较、锦标赛择优、进度判定与自动验收门控（verifier_compare/select/track/current_session），A–T 标尺 + 期望评分，自带 Web 设置面板。",
@@ -441,12 +439,12 @@
       "repo": "https://github.com/Aa728848/dsh-llm-verifier",
       "npm": "dsh-llm-verifier",
       "category": "tools",
-      "subcategory": "model"
+      "subcategory": "model",
+      "rank": 35
     },
     {
       "id": "dsh-session-id",
       "name": "会话 ID",
-      "rank": 36,
       "nameEn": "Session ID",
       "author": "yufengnigel",
       "description": "侧边栏底部会话 ID 面板：列出全部会话的完整 ID 并一键复制（纯浏览器、只读，不修改会话状态）。",
@@ -454,12 +452,12 @@
       "repo": "https://github.com/zhu1090093659/dsh-web/tree/main/packages/dsh-session-id",
       "npm": "@linxin666/dsh-client-ui-session-id",
       "category": "ui",
-      "subcategory": "panel"
+      "subcategory": "panel",
+      "rank": 36
     },
     {
       "id": "dsh-session-insights",
       "name": "会话复盘",
-      "rank": 37,
       "nameEn": "Session Insights",
       "author": "GreenLv",
       "description": "通过 /session-insights 把 DSH 会话历史生成为本地、基于证据的工作流复盘：自包含 HTML Dashboard 与配套 JSON，支持确定性分析与可选的模型辅助分析。",
@@ -467,12 +465,12 @@
       "repo": "https://github.com/GreenLv/dsh-session-insights",
       "npm": "dsh-session-insights",
       "category": "tools",
-      "subcategory": "dev"
+      "subcategory": "dev",
+      "rank": 37
     },
     {
       "id": "dsh-mcp-manager",
       "name": "MCP 管理器",
-      "rank": 38,
       "nameEn": "MCP Manager",
       "author": "wingsky-1",
       "description": "MCP 服务器管理插件：分工作目录维护项目级 / 全局两级 MCP 配置（项目级随仓库走、可提交 git），模型面经中间层恒定两个原子工具（ws_mcp_search / ws_mcp_call）按会话 cwd 路由、不同仓库互不串台；支持 stdio / streamable-http 双传输、JSON 导入与浮窗状态面板。",
@@ -480,12 +478,12 @@
       "repo": "https://github.com/wingsky-1/dsh-plugin-hub",
       "npm": "@wingsky-1/dsh-mcp-manager",
       "category": "tools",
-      "subcategory": "dev"
+      "subcategory": "dev",
+      "rank": 38
     },
     {
       "id": "dsh-provider-usage",
       "name": "用量统计悬浮框",
-      "rank": 39,
       "nameEn": "Provider Usage",
       "author": "wingsky-1",
       "description": "多 provider 通用用量统计框架：内置 DeepSeek 官方（余额 + 峰谷倒计时徽标 + 每日用量推算）与 OpenCode Go 开箱即用，自写一个 mjs 适配器文件即可接入任意数据源并在设置页热插拔；渲染在宿主端完成，密钥不进浏览器。",
@@ -493,12 +491,12 @@
       "repo": "https://github.com/wingsky-1/dsh-plugin-hub",
       "npm": "@wingsky-1/dsh-provider-usage",
       "category": "tools",
-      "subcategory": "model"
+      "subcategory": "model",
+      "rank": 39
     },
     {
       "id": "dsh-milestone",
       "name": "会话里程碑导航条",
-      "rank": 40,
       "nameEn": "dsh-milestone",
       "author": "SnowCrescenter-tech",
       "description": "DSH Web UI 右侧的圆点时间轴：每条提问一个圆点，悬停查看内容与元信息（时间、轮次、耗时、TTFT、token），点击即跳转；附带全会话消息列表、站内与跨会话搜索、书签深链接（#msg=）和键盘导航。",
@@ -506,12 +504,12 @@
       "repo": "https://github.com/SnowCrescenter-tech/dsh-milestone",
       "npm": "dsh-milestone",
       "category": "ui",
-      "subcategory": "chat"
+      "subcategory": "chat",
+      "rank": 40
     },
     {
       "id": "dsh-delete-message",
       "name": "消息删除",
-      "rank": 41,
       "nameEn": "Delete Message",
       "author": "viplocco",
       "description": "每条消息操作区的垃圾桶按钮：确认后经官方 surface-replace 契约将消息从模型上下文移除并从转录隐藏，原始日志不动、随时可恢复；覆盖用户/助手/注入行/工具调用/Think 卡，失败回合整窗清理与步骤级删除，删除前预检置灰、过渡动画，中英双语界面。",
@@ -519,7 +517,21 @@
       "repo": "https://github.com/viplocco/dsh-delete-message",
       "npm": "dsh-delete-message",
       "category": "ui",
-      "subcategory": "chat"
+      "subcategory": "chat",
+      "rank": 41
+    },
+    {
+      "id": "dsh-free-search",
+      "name": "免费搜索",
+      "nameEn": "Free Search",
+      "author": "DDDMUC",
+      "description": "无需 API key 的多引擎网络搜索：10 个引擎自动回退（Bing/DDG/AnySearch/SearXNG/Exa/Tavily/Keenable/Perplexity/DeepSeek 等）+ 时间过滤 + 8 个平台搜索 + Web 设置面板。",
+      "descriptionEn": "Multi-engine web search without API keys: 10 engines with auto-fallback, time filtering, 8 platform searches and a web settings panel.",
+      "repo": "https://github.com/DDDMUC/dsh-free-search",
+      "npm": "dsh-free-search",
+      "category": "tools",
+      "subcategory": "dev",
+      "rank": 42
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -477,5 +477,17 @@
     "npm": "dsh-delete-message",
     "category": "ui",
     "subcategory": "chat"
+  },
+  {
+    "id": "dsh-free-search",
+    "name": "免费搜索",
+    "nameEn": "Free Search",
+    "author": "DDDMUC",
+    "description": "无需 API key 的多引擎网络搜索：10 个引擎自动回退（Bing/DDG/AnySearch/SearXNG/Exa/Tavily/Keenable/Perplexity/DeepSeek 等）+ 时间过滤 + 8 个平台搜索 + Web 设置面板。",
+    "descriptionEn": "Multi-engine web search without API keys: 10 engines with auto-fallback, time filtering, 8 platform searches and a web settings panel.",
+    "repo": "https://github.com/DDDMUC/dsh-free-search",
+    "npm": "dsh-free-search",
+    "category": "tools",
+    "subcategory": "dev"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

新增社区插件 `dsh-free-search`（免费搜索 / Free Search）到创意工坊插件索引。插件提供无需 API key 的多引擎网络搜索（10 引擎自动回退）+ 时间过滤 + 8 平台搜索 + Web 设置面板。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-community-plugins`（社区插件索引登记）

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin && git rebase origin/dev`（已基于 2026-08-27 的 dev 最新代码，commit fb64665）

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据。

执行的命令：

```bash
node scripts/community-index
# community-index: OK (42 entries)
```

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/DDDMUC/dsh-free-search

插件详细说明：无需 API key 的多引擎搜索，10 个引擎（Bing/DDG/AnySearch/SearXNG/Exa/Tavily/Keenable/Perplexity/DeepSeek）自动回退，支持时间过滤、8 个平台搜索、结果缓存与 Web 设置面板。已发布 npm `dsh-free-search@0.4.15`，声明 `dsh.engines.dsh: >=0.1.1-rc.1`。

- [x] 已按 docs/plugins.md 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表。
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK。
- [x] 承诺负责后续更新跟进。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index
```

结果摘要：`community-index: OK (42 entries)` — 新增条目 `dsh-free-search` 校验通过，`market/dist/manifest/plugins.json` 已重新生成（rank 42）。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：Muse Spark (opencode/muse-spark-1.2-contributor-free)

使用的编码 Agent 工具：DeepSeek Harness, opencode

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK 开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 新增包目录以 `dsh-` 前缀命名。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。