### PR TITLE
feat(community-plugins): register dsh-conversation-navigator

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -532,6 +532,19 @@
       "repo": "https://github.com/Zhiyi-Zhao/dsh-notion-skill",
       "category": "integration",
       "subcategory": "sync"
+    },
+    {
+      "id": "dsh-conversation-navigator",
+      "name": "会话导航",
+      "rank": 43,
+      "nameEn": "Conversation Navigator",
+      "author": "gjj-star",
+      "description": "按轮折叠的会话导航面板：右侧悬浮轮次大纲（直接展示提问文字与步次徽标，区别于点阵时间轴），点击跳转与阅读位置实时高亮，关键词过滤（仅检索提问与回复），悬停气泡查看提问全文；四种形态（显示/隐藏/极简·右/极简·左）、拖拽定位、UI 状态持久化，纯浏览器零依赖。",
+      "descriptionEn": "A turn-folded conversation navigator panel: floating turn outline on the right (shows question text and step badges directly, unlike dot timelines), click-to-jump with live reading-position highlight, keyword filter over questions and replies, hover bubble for the full prompt; four modes (full / hidden / minimal-right / minimal-left), draggable docking and UI persistence - browser-only, zero dependencies.",
+      "repo": "https://github.com/gjj-star/dsh-conversation-navigator",
+      "npm": "dsh-conversation-navigator",
+      "category": "ui",
+      "subcategory": "chat"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -488,5 +488,17 @@
     "repo": "https://github.com/Zhiyi-Zhao/dsh-notion-skill",
     "category": "integration",
     "subcategory": "sync"
+  },
+  {
+    "id": "dsh-conversation-navigator",
+    "name": "会话导航",
+    "nameEn": "Conversation Navigator",
+    "author": "gjj-star",
+    "description": "按轮折叠的会话导航面板：右侧悬浮轮次大纲（直接展示提问文字与步次徽标，区别于点阵时间轴），点击跳转与阅读位置实时高亮，关键词过滤（仅检索提问与回复），悬停气泡查看提问全文；四种形态（显示/隐藏/极简·右/极简·左）、拖拽定位、UI 状态持久化，纯浏览器零依赖。",
+    "descriptionEn": "A turn-folded conversation navigator panel: floating turn outline on the right (shows question text and step badges directly, unlike dot timelines), click-to-jump with live reading-position highlight, keyword filter over questions and replies, hover bubble for the full prompt; four modes (full / hidden / minimal-right / minimal-left), draggable docking and UI persistence - browser-only, zero dependencies.",
+    "repo": "https://github.com/gjj-star/dsh-conversation-navigator",
+    "npm": "dsh-conversation-navigator",
+    "category": "ui",
+    "subcategory": "chat"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

登记 gjj-star 的会话导航插件 dsh-conversation-navigator 进社区插件索引：右侧悬浮按轮折叠大纲（展示提问文字与步次徽标），点击跳转、阅读位置高亮、关键词过滤、悬停全文气泡，四态切换 + 拖拽定位 + 状态持久化，纯浏览器零依赖；与现有点阵类时间轴（milestone / history-tree）互补。

## 涉及包（Affected Packages）

- [x] 其他（请说明）

说明：`packages/dsh-community-plugins`（community.json + market/dist/manifest/plugins.json 生成物）。

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

<!-- 本 PR 为索引登记，非面向用户的功能 / 视觉变更，不勾选类型项。 -->

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch origin && git rebase origin/dev
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

证据：`node scripts/community-index` 输出 `community-index: OK (43 entries)`；market/dist/manifest/plugins.json 按 market-build 的 scanPlugins 转换逻辑确定性重生成（generated=2026-08-28，与已提交值一致，43 items / rank 1-43）；分支基于上游最新 dev 创建，提交时未落后。

## 视觉修复要求（Visual Fix Requirements）

<!-- 本 PR 非视觉修复，跳过本节。 -->

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：

DeepSeek V4 Pro（deepseek-v4-pro）

使用的编码 Agent 工具：

DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

（本 PR 无新增包目录、无 README 改动，其余两项不适用。）

## 贡献者版权声明（Contributor Copyright）

插件版权归原作者（gjj-star）所有，索引仅收录链接。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

https://github.com/gjj-star/dsh-conversation-navigator

插件详细说明：

会话导航面板（npm: dsh-conversation-navigator，MIT，已发布 0.2.1）：右侧悬浮按轮折叠的对话大纲，点击任意节点平滑跳转、滚动时实时高亮阅读位置；步次徽标与 DSH 轨迹视图配色一致；关键词过滤仅检索提问与回复；悬停气泡显示提问全文；四种形态（显示 / 隐藏 / 极简·右 / 极简·左）；面板可拖拽定位、UI 状态持久化（localStorage）。纯浏览器插件、零 npm 依赖，仅依赖 DSH 公开 DOM 锚点（data-chat-anchor-key / data-conversation-scroll）。已知限制：锚点若随 DSH 升级变化需跟进适配（由作者维护跟进）。

- [x] 已按 docs/plugins.md 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表。
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在最新代码上验证插件可被 `dsh web` 挂载并正常运行。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index
```

结果摘要：

`community-index: OK (43 entries)`；plugins.json 生成物与脚本输出一致（43 items，rank 1-43）。

## 用户可见变更证据（Local Feature Evidence）

<!-- 本 PR 为索引登记（无用户可见变更），填 N/A。 -->

证据：

N/A