### PR TITLE
fix(dsh-doctor): supervisor 已运行时跳过重启，避免每次命令弹出 cmd 窗口

### DIFF
--- a/packages/dsh-doctor/src/agent/service.ts
+++ b/packages/dsh-doctor/src/agent/service.ts
@@ -1,7 +1,7 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { posix, win32 } from 'node:path'
-import { spawn } from 'node:child_process'
+import { execFile, spawn } from 'node:child_process'
 
 export interface ServiceSpec { platform: NodeJS.Platform; label: string; executable: string; args: string[]; doctorHome: string }
 export interface ServicePlan { files: Array<{ path: string; content: string; mode?: number }>; install: string[]; uninstall: string[]; restart: string[] }
@@ -59,14 +59,22 @@ export type ServiceRunner = (command: string[]) => Promise<void>
 
 /**
  * Idempotent service redeploy: drop any previous registration (a first
- * install fails harmlessly), write the definition, bootstrap it, then restart
- * it so the running process picks up the current package code.
+ * install fails harmlessly), write the definition, then bootstrap it.
+ * The service is only (re)started when no supervisor is already alive —
+ * unconditional restarts spawn a visible cmd.exe window on Windows and
+ * fail with EADDRINUSE when an instance is already running.
  */
-export async function ensureServiceInstalled(plan: ServicePlan, run: ServiceRunner = runCommand): Promise<void> {
+export async function ensureServiceInstalled(plan: ServicePlan, run: ServiceRunner = runCommand, platform: NodeJS.Platform = process.platform): Promise<void> {
   await run(plan.uninstall).catch(() => undefined)
   await writeServiceFiles(plan)
   await run(plan.install)
-  await run(plan.restart).catch(() => undefined)
+  // Only (re)start the supervisor when it is not already alive. Running
+  // `schtasks /Run` unconditionally on every invocation spawns a visible
+  // cmd.exe window (captured by the default terminal app) and the fresh
+  // instance dies with EADDRINUSE because the named pipe is already owned.
+  if (!(await supervisorAlive(platform))) {
+    await run(plan.restart).catch(() => undefined)
+  }
 }
 
 /** Unregister the service and remove its definition files (tolerates absence). */
@@ -77,9 +85,28 @@ export async function removeService(plan: ServicePlan, run: ServiceRunner = runC
 
 export async function runCommand(command: string[], timeoutMs = 30_000): Promise<void> {
   await new Promise<void>((resolvePromise, reject) => {
-    const child = spawn(command[0]!, command.slice(1), { stdio: 'inherit' })
+    const child = spawn(command[0]!, command.slice(1), { stdio: 'inherit', windowsHide: true })
     const timer = setTimeout(() => child.kill(), timeoutMs)
     child.once('close', code => { clearTimeout(timer); code === 0 ? resolvePromise() : reject(new Error(`doctor: command failed (${code ?? 'signal'}): ${command.join(' ')}`)) })
     child.once('error', reject)
+  })
+}
+
+/** True when at least one supervisor process is currently alive. */
+function supervisorAlive(platform: NodeJS.Platform): Promise<boolean> {
+  return new Promise(resolve => {
+    if (platform === 'win32') {
+      execFile(
+        'powershell.exe',
+        ['-NoProfile', '-NonInteractive', '-Command',
+          "(Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -match 'dsh-doctor' -and $_.CommandLine -match 'supervisor' } | Measure-Object).Count"],
+        { windowsHide: true },
+        (err, stdout) => { resolve(err ? false : Number.parseInt(stdout.trim(), 10) > 0) },
+      )
+    } else {
+      execFile('ps', ['-eo', 'command'], (err, stdout) => {
+        resolve(err ? false : stdout.split('\n').some(line => /dsh-doctor[^\n]*supervisor/.test(line)))
+      })
+    }
   })
 }


### PR DESCRIPTION
## 问题

每次执行 `dsh` 命令（如 `dsh web`）都会弹出一个新的 Windows Terminal 窗口，显示 `EADDRINUSE` 后退出。

## 根因

`ensureServiceInstalled()` 每次调用都无条件执行 `schtasks /Run`：

1. 任务调度服务启动 `supervisor.cmd`（cmd.exe），在交互式登录会话中弹出控制台窗口，被默认终端应用（Windows Terminal）接管 → 新开一个 WT 窗口；
2. 新启动的 supervisor 随后监听 `\\.\pipe\dsh-doctor-*` 时发现已被占用 → 以 `EADDRINUSE`（退出码 1）退出。

进程树佐证：弹出的 `cmd.exe` 其父进程为 `svchost.exe -k netsvcs -s Schedule`。

## 修改内容

1. `ensureServiceInstalled()`：重启前先探测 supervisor 是否已存活（Windows 通过 Win32_Process 查询 `node.exe` 且命令行含 `dsh-doctor` + `supervisor`；其他平台用 `ps`）。已运行则跳过 `schtasks /Run`。
2. `runCommand()`：spawn 时增加 `windowsHide: true`，避免 `schtasks` 自身闪出控制台窗口。

## 影响范围

- 消除每次执行 `dsh` 命令时的重复弹窗与 `EADDRINUSE`；
- 首次安装（supervisor 未运行）时行为不变，仍会启动；
- 探测函数跨平台实现，macOS / Linux 分支逻辑不受影响（仅 Windows 行为有实质变化）。

## 关联

- Fixes #1268
- Related #1267（#1267 关注登录时 ONLOGON 任务弹出并常驻窗口；本 PR 未改窗口隐藏方式，建议与 #1267 的方向一并处理）

## 测试说明

- 已通过语法检查（`node --experimental-strip-types --check`）；
- 本地因环境限制未能完整 `pnpm build`，建议由 CI 完成类型检查与构建验证。
