### PR TITLE
feat(community-plugins): register dsh-codekin

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -567,8 +567,8 @@
       "rank": 45,
       "nameEn": "Codekin",
       "author": "Nath-Vikky",
-      "description": "把 DSH 使用事件转化为码灵遭遇、收集与三消战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、编队养成、捕捉、挂机补给和无尽塔；状态保存在 DSH 主目录的 codekinsave/state.json，首次启动会无损迁移旧的 tracewild/state.json，卸载后默认保留，不修改提示词、工具或模型请求。",
-      "descriptionEn": "A Web creature-collection and match-three RPG driven by DSH activity events, with 25 Codekin, five computing attributes, squads, growth, capture, idle supplies and an endless tower. State is stored in codekinsave/state.json under the DSH home directory; the former tracewild/state.json is migrated losslessly on first launch, and progress remains after uninstall by default. Prompts, tools and model requests are unchanged.",
+      "description": "把 DSH 使用事件转化为码灵遭遇、收集与战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、8×8 指令三消、三只编队共享运行值、阶段伤害与防护、Boss 机制、捕捉养成、挂机补给和无尽塔；状态保存在 DSH 主目录的 codekinsave/state.json，首次启动会无损迁移旧的 tracewild/state.json，卸载后默认保留，不修改提示词、工具或模型请求。",
+      "descriptionEn": "A Web creature-collection RPG driven by DSH activity events, with 25 Codekin, five computing attributes, an 8×8 command-match battle system, shared squad runtime, phase damage and defense, Boss mechanics, capture, growth, idle supplies and an endless tower. State is stored in codekinsave/state.json under the DSH home directory; the former tracewild/state.json is migrated losslessly on first launch, and progress remains after uninstall by default. Prompts, tools and model requests are unchanged.",
       "repo": "https://github.com/Nath-Vikky/dsh-codekin",
       "category": "ui",
       "subcategory": "panel"

--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -560,6 +560,18 @@
       "npm": "dsh-free-search",
       "category": "tools",
       "subcategory": "dev"
+    },
+    {
+      "id": "dsh-codekin",
+      "name": "码灵",
+      "rank": 45,
+      "nameEn": "Codekin",
+      "author": "Nath-Vikky",
+      "description": "把 DSH 使用事件转化为码灵遭遇、收集与三消战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、编队养成、捕捉、挂机补给和无尽塔；状态保存在 DSH 主目录的 tracewild/state.json，卸载后保留，不修改提示词、工具或模型请求。",
+      "descriptionEn": "A Web creature-collection and match-three RPG driven by DSH activity events, with 25 Codekin, five computing attributes, squads, growth, capture, idle supplies and an endless tower. State is stored in tracewild/state.json under the DSH home directory and remains after uninstall; prompts, tools and model requests are unchanged.",
+      "repo": "https://github.com/Nath-Vikky/dsh-codekin",
+      "category": "ui",
+      "subcategory": "panel"
     }
   ]
 }

--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -567,8 +567,8 @@
       "rank": 45,
       "nameEn": "Codekin",
       "author": "Nath-Vikky",
-      "description": "把 DSH 使用事件转化为码灵遭遇、收集与三消战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、编队养成、捕捉、挂机补给和无尽塔；状态保存在 DSH 主目录的 tracewild/state.json，卸载后保留，不修改提示词、工具或模型请求。",
-      "descriptionEn": "A Web creature-collection and match-three RPG driven by DSH activity events, with 25 Codekin, five computing attributes, squads, growth, capture, idle supplies and an endless tower. State is stored in tracewild/state.json under the DSH home directory and remains after uninstall; prompts, tools and model requests are unchanged.",
+      "description": "把 DSH 使用事件转化为码灵遭遇、收集与三消战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、编队养成、捕捉、挂机补给和无尽塔；状态保存在 DSH 主目录的 codekinsave/state.json，首次启动会无损迁移旧的 tracewild/state.json，卸载后默认保留，不修改提示词、工具或模型请求。",
+      "descriptionEn": "A Web creature-collection and match-three RPG driven by DSH activity events, with 25 Codekin, five computing attributes, squads, growth, capture, idle supplies and an endless tower. State is stored in codekinsave/state.json under the DSH home directory; the former tracewild/state.json is migrated losslessly on first launch, and progress remains after uninstall by default. Prompts, tools and model requests are unchanged.",
       "repo": "https://github.com/Nath-Vikky/dsh-codekin",
       "category": "ui",
       "subcategory": "panel"

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -520,8 +520,8 @@
     "name": "码灵",
     "nameEn": "Codekin",
     "author": "Nath-Vikky",
-    "description": "把 DSH 使用事件转化为码灵遭遇、收集与三消战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、编队养成、捕捉、挂机补给和无尽塔；状态保存在 DSH 主目录的 codekinsave/state.json，首次启动会无损迁移旧的 tracewild/state.json，卸载后默认保留，不修改提示词、工具或模型请求。",
-    "descriptionEn": "A Web creature-collection and match-three RPG driven by DSH activity events, with 25 Codekin, five computing attributes, squads, growth, capture, idle supplies and an endless tower. State is stored in codekinsave/state.json under the DSH home directory; the former tracewild/state.json is migrated losslessly on first launch, and progress remains after uninstall by default. Prompts, tools and model requests are unchanged.",
+    "description": "把 DSH 使用事件转化为码灵遭遇、收集与战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、8×8 指令三消、三只编队共享运行值、阶段伤害与防护、Boss 机制、捕捉养成、挂机补给和无尽塔；状态保存在 DSH 主目录的 codekinsave/state.json，首次启动会无损迁移旧的 tracewild/state.json，卸载后默认保留，不修改提示词、工具或模型请求。",
+    "descriptionEn": "A Web creature-collection RPG driven by DSH activity events, with 25 Codekin, five computing attributes, an 8×8 command-match battle system, shared squad runtime, phase damage and defense, Boss mechanics, capture, growth, idle supplies and an endless tower. State is stored in codekinsave/state.json under the DSH home directory; the former tracewild/state.json is migrated losslessly on first launch, and progress remains after uninstall by default. Prompts, tools and model requests are unchanged.",
     "repo": "https://github.com/Nath-Vikky/dsh-codekin",
     "category": "ui",
     "subcategory": "panel"

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -514,5 +514,16 @@
     "npm": "dsh-free-search",
     "category": "tools",
     "subcategory": "dev"
+  },
+  {
+    "id": "dsh-codekin",
+    "name": "码灵",
+    "nameEn": "Codekin",
+    "author": "Nath-Vikky",
+    "description": "把 DSH 使用事件转化为码灵遭遇、收集与三消战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、编队养成、捕捉、挂机补给和无尽塔；状态保存在 DSH 主目录的 tracewild/state.json，卸载后保留，不修改提示词、工具或模型请求。",
+    "descriptionEn": "A Web creature-collection and match-three RPG driven by DSH activity events, with 25 Codekin, five computing attributes, squads, growth, capture, idle supplies and an endless tower. State is stored in tracewild/state.json under the DSH home directory and remains after uninstall; prompts, tools and model requests are unchanged.",
+    "repo": "https://github.com/Nath-Vikky/dsh-codekin",
+    "category": "ui",
+    "subcategory": "panel"
   }
 ]

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -520,8 +520,8 @@
     "name": "码灵",
     "nameEn": "Codekin",
     "author": "Nath-Vikky",
-    "description": "把 DSH 使用事件转化为码灵遭遇、收集与三消战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、编队养成、捕捉、挂机补给和无尽塔；状态保存在 DSH 主目录的 tracewild/state.json，卸载后保留，不修改提示词、工具或模型请求。",
-    "descriptionEn": "A Web creature-collection and match-three RPG driven by DSH activity events, with 25 Codekin, five computing attributes, squads, growth, capture, idle supplies and an endless tower. State is stored in tracewild/state.json under the DSH home directory and remains after uninstall; prompts, tools and model requests are unchanged.",
+    "description": "把 DSH 使用事件转化为码灵遭遇、收集与三消战斗的 Web 游戏插件：包含 25 只码灵、五类计算属性、编队养成、捕捉、挂机补给和无尽塔；状态保存在 DSH 主目录的 codekinsave/state.json，首次启动会无损迁移旧的 tracewild/state.json，卸载后默认保留，不修改提示词、工具或模型请求。",
+    "descriptionEn": "A Web creature-collection and match-three RPG driven by DSH activity events, with 25 Codekin, five computing attributes, squads, growth, capture, idle supplies and an endless tower. State is stored in codekinsave/state.json under the DSH home directory; the former tracewild/state.json is migrated losslessly on first launch, and progress remains after uninstall by default. Prompts, tools and model requests are unchanged.",
     "repo": "https://github.com/Nath-Vikky/dsh-codekin",
     "category": "ui",
     "subcategory": "panel"


### PR DESCRIPTION
## 摘要（Summary）

将社区插件 Codekin（码灵）登记到 dsh-web 的社区插件索引与 Workshop 市场清单。条目采用 GitHub 仓库安装，不声明 npm 包；当前默认分支为 GitHub-only `0.3.2`，面向 DSH `0.1.2-alpha.1`，与 dsh-web 当前 Alpha SDK cohort 对齐。

## 涉及包（Affected Packages）

- [x] 其他：`packages/dsh-community-plugins/community.json`、`market/dist/manifest/plugins.json`

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream dev
git rebase upstream/dev
```

本次更新已同步到上游 `dev` 提交 `fd78713b58289bb2127c9ac12eeaff38abc7d9c3`，无冲突。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

同步后重新运行了社区索引、市场清单、社区插件聚焦测试和包级 TypeScript 检查；结果全部通过，详见下方「本地验证」。本 PR 为纯索引数据登记，不涉及视觉修复。

## 视觉修复要求（Visual Fix Requirements）

N/A：本 PR 仅登记社区索引数据，不修改 dsh-web UI 实现或视觉样式。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：OpenAI GPT-5（Codex）

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 `@deepseek-ai/*` SDK 开发插件。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 未新增仓库内包目录；外部插件仓库及插件 id 均使用 `dsh-` 命名。
- [x] 所有新增 / 修改文件不含 emoji 字符。
- [x] 本 PR 未修改包 README；Codekin 外部仓库维护中英文 README。

## 贡献者版权声明（Contributor Copyright）

Codekin：Nath-Vikky，MIT License。源码与资源版权说明见插件仓库。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

https://github.com/Nath-Vikky/dsh-codekin

插件详细说明：

Codekin（码灵）是一款由 DSH 使用事件驱动的本地 Web 收集与三消战斗插件：

- 25 只可收集码灵，分属五类计算属性，包含地图遭遇、捕捉、编队、1–100 级养成和图鉴。
- 8×8 指令三消战斗支持三只出战、共享队伍运行值、属性克制、阶段伤害 / 恢复 / 护盾、主动 / 被动能力和通用 SKIP。
- Boss 拥有独立数值、多段行动、意图提示、持续增幅、危险珠、锁珠、冻结、棋盘重排与阶段防护等机制；另有无尽塔长期挑战。
- 包含挂机补给、升级素材、放生回收、地图区域平衡和低血量多次捕捉流程。
- 游戏状态保存在 `$DSH_HOME/codekinsave/state.json`（首次启动会无损迁移旧的 `tracewild/state.json`），卸载插件后仍会保留；插件不修改提示词、工具列表或模型请求，不自动调用 agent。
- 默认分支当前为 GitHub-only `0.3.2` 预览，目标运行时为 DSH `0.1.2-alpha.1`；旧 `0.2.x` 稳定代码保留在 `stable/0.2.x`。
- Workshop 安装使用公开 GitHub 仓库地址；本条目刻意不填写 `npm`，正式 npm 版本将在 Alpha 接口稳定后另行发布。
- 主要运行依赖为官方 DSH Alpha Web / Cordis SDK、React 与 ReactDOM；未修改或复制 DSH 官方源码。

- [x] 已在 `packages/dsh-community-plugins/community.json` 追加条目，运行 `node scripts/community-index`，并由 `node scripts/market-build` 生成、提交 `market/dist/manifest/plugins.json`。
- [x] 已确认插件遵循官方 Cordis bundle 约定：`package.json` 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`，并声明 `dsh.client` 浏览器半区；类型与运行时依赖均来自官方 `@deepseek-ai/*` SDK。
- [x] 已用官方 DSH `0.1.2-alpha.1` 源码 CLI 从 GitHub 仓库 URL 安装，`--dump-config` 成功解析并挂载 `@nath-vikky/dsh-codekin`。
- [x] 承诺持续跟进 DSH / dsh-web Alpha 破坏性更新；兼容性、条目信息或发布渠道变化时会及时更新或移除索引。

可复现 Release：

https://github.com/Nath-Vikky/dsh-codekin/releases/tag/v0.3.2

SHA-256：`1f991ca62102d55b8a51ce8473b53bd1af3aa00d6415bf5057ab70513ae944b3`

## 本地验证（Local Validation）

执行的命令：

```bash
# Codekin 外部仓库
node --run check
dsh plugin --profile web add https://github.com/Nath-Vikky/dsh-codekin
dsh --profile web --dump-config

# dsh-web 最新 dev
node scripts/community-index
node scripts/community-index --check
node scripts/market-build
node scripts/market-build --check
node packages/dsh-community-plugins/node_modules/vitest/vitest.mjs run packages/dsh-community-plugins/tests
node packages/dsh-community-plugins/node_modules/typescript/bin/tsc -p packages/dsh-community-plugins/tsconfig.json --noEmit
git diff --check upstream/dev...HEAD
```

结果摘要：

- Codekin `0.3.2`：28 项测试、双 TypeScript project 与 Host / Client production build 全部通过。
- Codekin GitHub CI：Linux / macOS / Windows，Node 22 / 24 共 6 组官方 DSH Alpha 构建与产物复现检查全部通过。
- GitHub URL 实装：Alpha CLI 安装成功，组合配置包含 `@nath-vikky/dsh-codekin` bundle 行。
- dsh-web：community index 45 entries；market `dist` 369 files、tryon hash manifest 756 files，均 up to date。
- 社区插件聚焦测试：1 file / 2 tests passed；对应 package TypeScript 检查与 `git diff --check` 通过。
- 本 PR 最终差异仍仅两份社区索引生成链约定文件，共新增 23 行；无 lockfile、源码、文档或依赖变更。

## 用户可见变更证据（Local Feature Evidence）

N/A：本 PR 只新增社区索引记录，不修改 dsh-web 的 UI 代码。插件实际界面、码灵图鉴与中英文使用说明可在公开仓库查看：

https://github.com/Nath-Vikky/dsh-codekin

最新跨平台 Alpha 验证记录：

https://github.com/Nath-Vikky/dsh-codekin/actions/runs/33292972104
