### PR TITLE
feat(community): register dsh-reasoning-effort

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -545,6 +545,19 @@
       "npm": "dsh-passwords",
       "category": "security",
       "subcategory": "access"
+    },
+    {
+      "id": "dsh-reasoning-effort",
+      "name": "思考强度配置器",
+      "rank": 44,
+      "nameEn": "Reasoning Effort",
+      "author": "Jamsharden",
+      "description": "为第三方 API 的模型提供可视化思考强度配置：支持自定义 reasoning effort 档位、Provider 默认强度、思考协议与参数开关，让 DSH 用户使用第三方 API 时也能调节思考强度。",
+      "descriptionEn": "Adds a visual reasoning-effort editor for models served by third-party APIs, with custom levels, provider defaults, thinking-format and parameter controls, so DSH users can tune thinking strength when using external endpoints.",
+      "repo": "https://github.com/Jamsharden/dsh-reasoning-effort",
+      "npm": "@megen-lebar/dsh-reasoning-effort",
+      "category": "tools",
+      "subcategory": "model"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -500,5 +500,17 @@
     "npm": "dsh-passwords",
     "category": "security",
     "subcategory": "access"
+  },
+  {
+    "id": "dsh-reasoning-effort",
+    "name": "思考强度配置器",
+    "nameEn": "Reasoning Effort",
+    "author": "Jamsharden",
+    "description": "为第三方 API 的模型提供可视化思考强度配置：支持自定义 reasoning effort 档位、Provider 默认强度、思考协议与参数开关，让 DSH 用户使用第三方 API 时也能调节思考强度。",
+    "descriptionEn": "Adds a visual reasoning-effort editor for models served by third-party APIs, with custom levels, provider defaults, thinking-format and parameter controls, so DSH users can tune thinking strength when using external endpoints.",
+    "repo": "https://github.com/Jamsharden/dsh-reasoning-effort",
+    "npm": "@megen-lebar/dsh-reasoning-effort",
+    "category": "tools",
+    "subcategory": "model"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

本 PR 将社区插件 dsh-reasoning-effort 登记到 dsh-web 的社区插件索引，让 DeepSeek Harness 用户在使用第三方 API 模型时也能调节思考强度。本 PR 只登记插件链接与元数据，不复制或修改第三方插件源码。

## 涉及包（Affected Packages）

- [x] 其他（请说明）

说明：改动涉及社区插件索引源文件 packages/dsh-community-plugins/community.json，以及由它生成的市场清单 market/dist/manifest/plugins.json。

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 维护 / 重构

说明：本 PR 是社区索引数据登记与市场清单同步；插件的用户功能由独立 npm 包提供。

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

git fetch origin dev
git rebase origin/dev

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

同步结果：同步前后上游 origin/dev 均为提交 89829ef2173eceab6e6950e46eeea5c87d4b9a29，rebase 显示当前分支已是最新。

## 视觉修复要求（Visual Fix Requirements）

不适用：本 PR 不包含视觉修复。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：GPT-5

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（@deepseek-ai/*）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig extends / paths / references。
- [x] 新增包目录以 dsh- 前缀命名（本 PR 未新增 dsh-web 包目录；登记的插件 ID 为 dsh-reasoning-effort）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 改动包 README 时同步维护中英双语三件套（本 PR 未改动 README，不适用）。

## 贡献者版权声明（Contributor Copyright）

插件源码与版权归插件作者 Jamsharden 所有；本 PR 仅登记公开仓库和 npm 安装入口。

## 新皮肤收录（New Skin）

不适用：本 PR 不新增皮肤。

## 新宠物收录（New Pet）

不适用：本 PR 不新增宠物。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

https://github.com/Jamsharden/dsh-reasoning-effort

插件详细说明：

dsh-reasoning-effort 是一个独立的 DSH Web GUI 插件，在侧边栏提供“思考强度”入口，用可视化面板管理第三方 API 各模型的 reasoning effort。它支持自动带出官方思考档位、搜索与同步档位、全部关闭和恢复当前配置；每档可单独启用并自定义线上拼写，还可设置 Provider 默认思考强度、compat.thinkingFormat 与 supportsReasoningEffort。模型级关闭推理会保留同一 Provider 的默认强度与协议设置，并隐藏当前对话的推理等级入口。插件通过 llm-pi-ai settings 命名空间写回配置，下一轮对话生效。

安装包：@megen-lebar/dsh-reasoning-effort@0.2.4
依赖：插件无运行时 dependencies，使用官方 DSH 插件协议与 React peer dependency。
已知限制：API key、baseURL 与模型列表仍需在官方 Models 页面配置；官方档位优先读取当前 DSH 运行时的 pi-ai 目录，不可用时使用内置快照。

- [x] 已按 docs/plugins.md 的登记说明在 packages/dsh-community-plugins/community.json 追加条目，并运行 node scripts/community-index 重新生成注册表。
- [x] 已确认插件包声明 dsh.bundle.patch 与 dsh.client，使用官方 NPM SDK 的插件接口，源码与 npm 包可独立安装。
- [x] 已确认本 PR 基于最新 dev 分支完成索引校验；完整 dsh web 挂载验证不在本次索引数据改动范围内，插件自身测试证据见下方。

说明：当前版本仓库没有模板中提到的 packages/dsh-community-plugins/src/client/generated/community.ts；node scripts/community-index --check 实际校验 community.json，市场派生产物为 market/dist/manifest/plugins.json，因此未凭空新增该文件。

- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

node scripts/community-index
node scripts/community-index --check
node scripts/market-build
git diff --check
git fetch origin dev
git rebase origin/dev
node --check lib/index.js
node --check lib/client.js
npm test（插件目录 E:\8.15\dsh-reasoning-effort）

结果摘要：

- community-index 校验通过，索引包含 44 个条目。
- node scripts/market-build 已生成并同步 market/dist/manifest/plugins.json。
- git diff --check 通过。
- 同步 origin/dev 后 rebase 显示已是最新。
- 插件语法检查通过；npm test 通过，2/2 测试通过。
- node scripts/market-build --check 在当前机器上因仓库现有 skin-center 构建依赖 lightningcss 未安装而无法执行（Error [ERR_MODULE_NOT_FOUND]）；该环境问题不涉及本 PR 的两处索引文件。CI 安装完整依赖后应执行同一检查。

## 用户可见变更证据（Local Feature Evidence）

证据：

N/A：本 PR 仅更新社区插件索引与市场生成清单，不修改 dsh-web 运行时代码；插件自身可见功能与测试结果见社区插件说明及本地验证。