### PR TITLE
Add dsh-completion-guard

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -545,6 +545,19 @@
       "npm": "dsh-passwords",
       "category": "security",
       "subcategory": "access"
+    },
+    {
+      "id": "dsh-completion-guard",
+      "name": "完成守卫",
+      "rank": 44,
+      "nameEn": "Completion Guard",
+      "author": "GreenLv",
+      "description": "任务合同与完成认证层:八个生命周期 hook 维护不可变需求账本,/compact 或会话恢复后重建有界合同,完成声明必须通过 checkpoint 绑定匹配证据,否则 fail-closed 阻止 Goal 与整任务完成。",
+      "descriptionEn": "Task-contract and completion-certification layer for DeepSeek Harness: eight lifecycle hooks keep an immutable requirement ledger, restore the bounded contract after /compact or resume, and block unsupported completion claims with fail-closed evidence binding.",
+      "repo": "https://github.com/GreenLv/dsh-completion-guard",
+      "npm": "dsh-completion-guard",
+      "category": "tools",
+      "subcategory": "dev"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -500,5 +500,17 @@
     "npm": "dsh-passwords",
     "category": "security",
     "subcategory": "access"
+  },
+  {
+    "id": "dsh-completion-guard",
+    "name": "完成守卫",
+    "nameEn": "Completion Guard",
+    "author": "GreenLv",
+    "description": "任务合同与完成认证层:八个生命周期 hook 维护不可变需求账本,/compact 或会话恢复后重建有界合同,完成声明必须通过 checkpoint 绑定匹配证据,否则 fail-closed 阻止 Goal 与整任务完成。",
+    "descriptionEn": "Task-contract and completion-certification layer for DeepSeek Harness: eight lifecycle hooks keep an immutable requirement ledger, restore the bounded contract after /compact or resume, and block unsupported completion claims with fail-closed evidence binding.",
+    "repo": "https://github.com/GreenLv/dsh-completion-guard",
+    "npm": "dsh-completion-guard",
+    "category": "tools",
+    "subcategory": "dev"
   }
 ]


### PR DESCRIPTION
# 社区插件索引登记:dsh-completion-guard

在社区插件索引中加入 `dsh-completion-guard`(GreenLv/dsh-completion-guard),使其出现在 dsh-market.com 创意工坊插件目录与应用内「创意工坊 → 插件」。

## 变更内容

- `packages/dsh-community-plugins/community.json` 新增一条记录(`id` / `name` / `nameEn` / `author` / `repo` / `description` / `descriptionEn` / `npm` / `category` / `subcategory`);
- `market/dist/manifest/plugins.json` 追加对应条目(rank 44,当时的下一个空闲位)。

插件信息:仓库 https://github.com/GreenLv/dsh-completion-guard(Apache-2.0);npm `dsh-completion-guard`(0.2.1,2026-08-29 发布;由 dsh-context-guard 更名而来,避免与无关项目 kpl0111/dsh-context-guard 撞名);分类 tools / dev。

## 涉及包(Affected Packages)

- [x] 其他(请说明):`packages/dsh-community-plugins`(数据登记,无代码逻辑变更)

## PR 类别(PR Category)

- [x] 社区插件索引

## PR 类型(PR Type)

- [x] 其他(社区插件索引数据登记,非代码逻辑变更)

## 最新代码确认(Latest Codebase Confirmation)

- [x] 我已基于最新 `dev` 分支开发,或在提交前已 rebase / 合并最新 `dev`。

同步命令:分支基于 2026-08-29 克隆的最新 upstream/dev 建立。

## 测试证据与上游同步(Test Evidence & Upstream Sync)

- [x] 我提供了自己本地测试的证据(执行的命令 / 测试结果 / 运行截图)。

- `node scripts/community-index` → OK (44 entries,新增 1 条)
- `node scripts/community-index --check` → 通过
- 两个 JSON 文件解析与结构校验通过,manifest 条目字段与现有条目一致

- [x] 我已同步上游最新 `dev` 分支(`git fetch origin && git rebase origin/dev`),并附上同步后重新测试通过的证据(视觉 / 用户可见变更附截图)。

本分支基于最新 upstream/dev 克隆建立,上述验证均在该基础之上执行;文本 / 数据类改动,不附截图。

## 视觉修复要求(Visual Fix Requirements)

纯文本 / 数据类改动,跳过本节。

## AI 编码披露(AI Coding Disclosure)

- [x] 完全 AI 编码:全部编程改动由 AI 产出,并由贡献者接受 / 审查。

使用的 AI 模型:GLM(Zhipu)

使用的编码 Agent 工具:ZCode

## 仓库规范检查(Repo Rules)

- [x] 未修改 DSH 官方源码,仅基于官方 NPM SDK(`@deepseek-ai/*`)开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名(本 PR 未新增包目录)。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套(本 PR 未改动 README)。

## 贡献者版权声明(Contributor Copyright)

插件为本人(GreenLv)所有,版权归属不变,无需追加声明。

## 社区插件索引登记(Community Plugin Index)

插件 GitHub 仓库链接:https://github.com/GreenLv/dsh-completion-guard

插件详细说明:任务合同与完成认证层(DeepSeek Harness 插件,npm `dsh-completion-guard`)。从用户直接给出的要求 / 验收条件建立任务合同;八个生命周期 hook 维护不可变需求账本,并在会话重建 / 恢复时重新验证完整性;完成声明必须调用注入的 checkpoint 工具绑定匹配的证据 ID,否则 fail-closed 阻止 Goal 与整任务完成。依赖:官方 `@deepseek-ai/*` SDK(peer 依赖)、Node ≥22。已知限制:只识别一小组可审计的 shell / PowerShell 命令,复合命令与非白名单可执行文件保持 incomplete 而非部分信任;精确边界见仓库 docs/COMPATIBILITY.md 与 docs/PRIVACY.md。

- [x] 已按 docs/plugins.md 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目,并运行 `node scripts/community-index`(OK,44 entries;生成的注册表与已提交内容一致,工作区无额外差异)。
- [x] 已确认插件与 dsh-web 插件体系兼容:遵循官方 cordis bundle 独立标准(package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`),类型仅基于官方 `@deepseek-ai/*` NPM SDK,未修改 DSH 源码;已在本仓库对应版本 dsh 0.1.1-rc.2 的真实 web profile 上安装并通过 `dsh --profile web --dump-config` 验证 bundle 正常组合。
- [x] 承诺负责后续更新跟进:插件与 DSH / dsh-web 生态保持同步,生态升级导致不兼容时主动跟进修复;条目信息(description / npm 等)变动或插件停更时,及时更新索引登记或提交移除。

## 本地验证(Local Validation)

执行的命令:

```bash
node scripts/community-index
node scripts/community-index --check
python3 -c "import json; json.load(open('market/dist/manifest/plugins.json')); json.load(open('packages/dsh-community-plugins/community.json'))"
```

结果摘要:community-index OK(44 entries,新增 1 条);--check 通过;两个 JSON 均可解析,manifest 条目 rank=44 为提交时的下一个空闲位。`pnpm install` 在贡献环境失败(pnpm store 读取错误),`node scripts/market-build` 未能本地执行——manifest 条目已按生成器输出形态手工补齐(与 community.json 同步),合并时可用 `node scripts/market-build` 一键重建校验。

## 用户可见变更证据(Local Feature Evidence)

市场条目为数据登记。插件本身的运行证据:已安装于真实 dsh web profile(dsh 0.1.1-rc.2,macOS),`dsh --profile web --dump-config` 回读组合出 `context-guard` bundle;公开包与仓库见 https://www.npmjs.com/package/dsh-completion-guard 。
