### PR TITLE
Add dsh-memory plugin to community index

### DIFF
--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -514,5 +514,16 @@
     "npm": "dsh-free-search",
     "category": "tools",
     "subcategory": "dev"
+  },
+  {
+    "id": "dsh-memory",
+    "name": "会话记忆",
+    "nameEn": "Session Memory",
+    "author": "yyspoem",
+    "description": "轻量会话记忆插件：每轮对话自动提取关键词并本地记录，下次对话按相似度唤起最相关的历史记忆，回答中自然提及旧话题。",
+    "descriptionEn": "A lightweight session-memory plugin: extracts keywords from every turn and stores them locally; on later conversations it ranks past memories by similarity and injects the most relevant ones, so the assistant naturally recalls earlier topics.",
+    "repo": "https://github.com/yyspoem/dshstore",
+    "category": "knowledge",
+    "subcategory": "memory"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

登记社区插件 dsh-memory（会话记忆插件）到社区插件索引。

- repo: https://github.com/yyspoem/dshstore
- category: knowledge / memory

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 dev 分支开发。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据。
- [x] 我已同步上游最新 dev 分支。

本地验证：新增条目字段符合 community.json 契约（id/name/nameEn/author/repo 必填，category/subcategory 为合法枚举），与现有条目格式一致。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助

使用的 AI 模型：DeepSeek

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码。
- [x] 新增包目录以 dsh- 前缀命名。
- [x] 所有新增/修改文件不含 emoji。