### PR TITLE
feat(community): register dsh-archived-chats

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -610,6 +610,19 @@
       "repo": "https://github.com/Nath-Vikky/dsh-codekin",
       "category": "ui",
       "subcategory": "panel"
+    },
+    {
+      "id": "dsh-archived-chats",
+      "name": "会话档案",
+      "rank": 49,
+      "nameEn": "Session Archive",
+      "author": "Ultronen",
+      "description": "本地优先的归档聊天管理插件：按工作区浏览和全文搜索，原生只读预览对话、工具活动与图片，支持标签备注、ZIP 备份恢复、历史版本恢复为副本、可撤销回收站、空间分账、保留策略和来源分支视图。",
+      "descriptionEn": "Local-first archived chat management with workspace browsing and full-text search, native read-only previews of conversations, tool activity and images, tags and notes, ZIP backup restore, History restore-as-copy, an undoable Recycle Bin, storage accounting, retention policies, and lineage views.",
+      "repo": "https://github.com/Ultronen/dsh-archived-chats",
+      "npm": "dsh-archived-chats",
+      "category": "ui",
+      "subcategory": "panel"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -560,5 +560,17 @@
     "repo": "https://github.com/Nath-Vikky/dsh-codekin",
     "category": "ui",
     "subcategory": "panel"
+  },
+  {
+    "id": "dsh-archived-chats",
+    "name": "会话档案",
+    "nameEn": "Session Archive",
+    "author": "Ultronen",
+    "description": "本地优先的归档聊天管理插件：按工作区浏览和全文搜索，原生只读预览对话、工具活动与图片，支持标签备注、ZIP 备份恢复、历史版本恢复为副本、可撤销回收站、空间分账、保留策略和来源分支视图。",
+    "descriptionEn": "Local-first archived chat management with workspace browsing and full-text search, native read-only previews of conversations, tool activity and images, tags and notes, ZIP backup restore, History restore-as-copy, an undoable Recycle Bin, storage accounting, retention policies, and lineage views.",
+    "repo": "https://github.com/Ultronen/dsh-archived-chats",
+    "npm": "dsh-archived-chats",
+    "category": "ui",
+    "subcategory": "panel"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

将作者自研并维护的 `dsh-archived-chats` 登记进社区插件索引，使其可出现在 dsh-market.com 创意工坊与 DSH Web 创意工坊插件目录。同步提交由 `market-build` 生成的插件清单。

## 涉及包（Affected Packages）

- [x] 其他：`packages/dsh-community-plugins/community.json` 与 `market/dist/manifest/plugins.json`

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream dev
git rebase upstream/dev
```

提交前已同步上游 `dev` 至 `d890e0423`，结果为分支已是最新且无冲突。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

本 PR 是纯索引文本与派生 JSON 变更，无视觉修复；完整命令和结果见下方“本地验证”。

## 视觉修复要求（Visual Fix Requirements）

N/A：不涉及视觉修复或仓库内 UI 实现。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：OpenAI GPT-5

使用的编码 Agent 工具：Codex

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 未新增包目录；插件自己的公开仓库与 npm 包均使用 `dsh-` 前缀。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 未改包 README，中英双语三件套规则不适用。

## 贡献者版权声明（Contributor Copyright）

`dsh-archived-chats` 由 Ultronen 维护，来源仓库 https://github.com/Ultronen/dsh-archived-chats，MIT License。本 PR 只登记链接和元数据，不搬运插件代码。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

https://github.com/Ultronen/dsh-archived-chats

插件详细说明：

`dsh-archived-chats` 是本地优先的 DSH 会话档案管理插件：

- 按工作区浏览归档聊天，并对已归档对话内容执行全文搜索。
- 原生只读预览对话、工具活动、JSON、代码和已存储图片。
- 支持标签、备注、ZIP 导入导出、历史版本恢复为新副本、可撤销回收站、空间分账、保留策略以及来源与分支视图。
- 插件数据仅保存在 `$DSH_HOME/plugin-data/archived-chats/`，不会上传或云同步。
- npm：`dsh-archived-chats@1.0.6`；License：MIT；最低运行时声明：`dsh >=0.1.0-rc.7`。
- 依赖官方 `@deepseek-ai/dsh-session` SDK；bundle 由 `dsh.bundle.patch` 指向 `cordis.patch.yml`，并声明 `dsh.client` Web 浏览器半区，不修改 DSH 源码。
- 已知限制：附件读取、恢复写入等功能按 Host capability 检测；Host 缺少能力时对应功能安全降级并返回明确错误。

- [x] 已按 `docs/plugins.md` 在 `packages/dsh-community-plugins/community.json` 追加条目；当前 `dev` 的 `node scripts/community-index` 为校验器，已运行通过；同时运行 `node scripts/market-build` 并提交生成的 `market/dist/manifest/plugins.json`。
- [x] 已确认插件与 dsh-web 插件体系兼容：官方 cordis bundle 独立标准、官方 SDK、无 DSH 源码修改；已在隔离的 DSH 0.1.1-rc.2 环境从 npm 安装并用 `--dump-config` 验证挂载。
- [x] 承诺负责后续更新跟进：生态升级导致不兼容时主动修复；条目信息变化或插件停更时及时更新或移除索引。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index
node scripts/market-build
pnpm community:check
pnpm market:check
pnpm --filter @linxin666/dsh-client-ui-community-plugins test
pnpm typecheck
pnpm test
pnpm test:scripts
pnpm docs:check
git diff --check upstream/dev...HEAD

# 隔离真实安装，不触碰现有 DSH 服务或真实数据
DSH_HOME=<temporary-home> dsh plugin --profile web add --workspace-root dsh-archived-chats@1.0.6 --save-exact
DSH_HOME=<temporary-home> dsh --profile web --dump-config
```

结果摘要：

- 上述仓库门禁连续两轮执行，全部成功退出。
- `community-index: OK (49 entries)`；`market-build --check` 报告 dist up to date。
- 社区包测试 1 个文件、2 项测试全部通过。
- `test:scripts`：225 项，222 通过、3 项按仓库既有条件跳过、0 失败。
- 全仓 20 个 workspace 项目的 typecheck 与 test 均通过；文档门禁通过。
- 插件自有仓库 PR https://github.com/Ultronen/dsh-archived-chats/pull/24 全部 CI 通过后合并；npm Trusted Publishing 成功，`latest` 为 1.0.6。
- 隔离 DSH 0.1.1-rc.2 安装得到精确版本 1.0.6，发布包含 `dsh.engines.dsh >=0.1.0-rc.7`、Web client 声明和存在的 bundle patch；`--dump-config` 成功输出 `id: archived-chats` / `name: dsh-archived-chats`。

## 用户可见变更证据（Local Feature Evidence）

纯社区索引登记，不修改仓库内 UI，截图不适用。可核验的公开发布与运行证据：

- Release：https://github.com/Ultronen/dsh-archived-chats/releases/tag/v1.0.6
- npm：https://www.npmjs.com/package/dsh-archived-chats/v/1.0.6
- 上方隔离 DSH 安装及 `--dump-config` 挂载验证结果。
