### PR TITLE
feat(community): add dsh-session-enhance to community plugins

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -623,6 +623,18 @@
       "npm": "dsh-archived-chats",
       "category": "ui",
       "subcategory": "panel"
+    },
+    {
+      "id": "dsh-session-enhance",
+      "name": "会话增强（dsh-session-enhance）",
+      "rank": 50,
+      "nameEn": "Session Enhance",
+      "author": "Tinger-X",
+      "description": "会话管理增强插件：支持真实物理删除、跨工作区分组拖拽搬移会话、一键物理文件与 storages JSON 对账及墓碑防复活机制。",
+      "descriptionEn": "Enhanced session management plugin: physical transcript deletion, cross-workspace drag-and-drop migration, physical file reconciliation, and tombstone anti-resurrection.",
+      "repo": "https://github.com/Tinger-X/dsh-session-enhance",
+      "npm": "dsh-session-enhance",
+      "category": "utility"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -572,5 +572,16 @@
     "npm": "dsh-archived-chats",
     "category": "ui",
     "subcategory": "panel"
+  },
+  {
+    "id": "dsh-session-enhance",
+    "name": "会话增强（dsh-session-enhance）",
+    "nameEn": "Session Enhance",
+    "author": "Tinger-X",
+    "description": "会话管理增强插件：支持真实物理删除、跨工作区分组拖拽搬移会话、一键物理文件与 storages JSON 对账及墓碑防复活机制。",
+    "descriptionEn": "Enhanced session management plugin: physical transcript deletion, cross-workspace drag-and-drop migration, physical file reconciliation, and tombstone anti-resurrection.",
+    "repo": "https://github.com/Tinger-X/dsh-session-enhance",
+    "npm": "dsh-session-enhance",
+    "category": "utility"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

按 [docs/plugins.md](https://github.com/zhu1090093659/dsh-web/blob/dev/docs/plugins.md) 登记流程，将社区插件 `dsh-session-enhance`（会话管理增强插件，npm 已发布 0.2.7）收录进创意工坊社区插件索引 `community.json`，并重新生成市场清单 `market/dist/manifest/plugins.json`。

## 涉及包（Affected Packages）

- 其他（请说明）：`packages/dsh-community-plugins/community.json` 新增索引条目 + 重新生成 `market/dist/manifest/plugins.json`

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更（新插件收录，用户可在创意工坊 / dsh-market.com 一键安装）

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin && git rebase origin/dev`

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

证据：

```
node scripts/community-index      # community-index: OK
node scripts/market-build         # 重新生成 market/dist/manifest/plugins.json
node -e "JSON.parse(require('fs').readFileSync('packages/dsh-community-plugins/community.json','utf8'))"
node -e "JSON.parse(require('fs').readFileSync('market/dist/manifest/plugins.json','utf8'))"
git diff --stat                   # community.json +N 行；plugins.json +N 行
# 插件仓库侧（dsh-session-enhance）：
pnpm build                        # 包结构校验 OK
pnpm test                         # 全部单测通过
```

## 视觉修复要求（Visual Fix Requirements）

纯索引数据变更，无视觉改动，跳过。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：DeepSeek
使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。—— 本 PR 未新增包目录
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。—— 未改动 README，不适用

## 贡献者版权声明（Contributor Copyright）

暂不声明，维持现有版权归属。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/Tinger-X/dsh-session-enhance

插件详细说明：

`dsh-session-enhance`（npm: `dsh-session-enhance`，Apache-2.0）是 DeepSeek Harness Web 会话管理增强插件：

- **归档管理**：侧栏菜单归档；设置页「归档管理」搜索 / 排序 / 按工作区筛选 / 批量恢复 / 确认后删除。
- **真实物理删除**：转录目录删除（3 次重试，应对 Windows 句柄延迟）+ 子代理级联 + spill 清理 + 直接清扫 `~/storages/*.json`（原子写，递归移除归档标记 / 工作区记账 / 投影缓存行）+ 删除后磁盘验证并告警残留。
- **跨工作区分组拖拽搬移**：会话拖到其他工作区分组时，转录目录物理迁移到目标工作区 `sessions` 目录，工件 header 的 `cwd` 同步改写（`node:zlib` zstd 帧布局感知、首帧校验、失败自动回滚）；实时会话先 flush + detach；拖到「未分组」解除归属（文件保留原地）。
- **一键对账（同步记录）**：按物理 session 文件同步 storages JSON——清理无物理文件的幽灵记录、修正记错工作区的归属、补记漏记；投影缓存幽灵行直接删除（不登记墓碑，便于文件恢复后重建）。
- **墓碑防复活**：删除墓碑（FIFO，上限 4096）阻止 stale list 复活已删会话；冷复用身份探针（createdAt / cwd）区分同 id 新生命周期。
- **对话通知**：后台对话结束或需要你操作时弹系统通知。
- **复制会话 ID**：侧栏菜单一键复制，已归档会话同样可用。

已知限制：peer 依赖精确钉版 `0.1.1-rc.2`（与当前 DSH 宿主一致），Node 需 `^22.19 || >=24`（依赖 `node:zlib` zstd）；会话归属与归档状态正交，移动不改变归档标记。

- 已按 [docs/plugins.md](https://github.com/zhu1090093659/dsh-web/blob/dev/docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表（提交生成的 `market/dist/manifest/plugins.json`）。
- 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在 DSH `0.1.1-rc.2` 上验证插件模块可被宿主加载、单测全部通过、npm 包 `dsh-session-enhance@0.2.7` 已发布。
- 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```
node scripts/community-index
node scripts/market-build
node -e "JSON.parse(require('fs').readFileSync('packages/dsh-community-plugins/community.json','utf8'))"
node -e "JSON.parse(require('fs').readFileSync('market/dist/manifest/plugins.json','utf8'))"
# 插件仓库侧：
pnpm build
pnpm test
```

结果摘要：

- `node scripts/community-index` → `community-index: OK`（CI 门禁同款校验通过）
- 两个 JSON 文件解析通过；`git diff --stat` 仅新增索引条目，无其他改动
- 插件仓库：`pnpm build` 包结构校验 OK；`pnpm test` 全部单测通过
- `dsh-session-enhance@0.2.7` 已发布至 npm（发布流程完整跑通，含 `prepublishOnly` build + test）

## 用户可见变更证据（Local Feature Evidence）

纯索引数据变更（社区插件索引登记），上线后可在创意工坊 / dsh-market.com 的插件列表查看 `dsh-session-enhance` 条目。插件效果截图见仓库 README：

![会话设置](https://raw.githubusercontent.com/Tinger-X/dsh-session-enhance/main/img/session-settings.png)

![归档管理](https://raw.githubusercontent.com/Tinger-X/dsh-session-enhance/main/img/session-archive-manage.png)