### PR TITLE
fix(describe-image): repair transcription-corrupted references and fall back to the id registry

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-01-describe-image-reference-repair.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-01-describe-image-reference-repair.md
@@ -1,0 +1,44 @@
+# Agent Note: describe-image reference transcription repair and registry fallback
+
+Status: implemented
+
+## Problem
+
+A text-only model calling `describe_image` transcribes a long percent-encoded attachment reference from a session message into the tool arguments. The transcription is not byte-exact: it can insert or drop a stray structural character at a boundary, and in the worst case it rebuilds the reference wholesale. Both failure shapes caused `describe-image` to fail closed with `image is not a valid attachment reference` even though the image had uploaded correctly — the path id was intact and its sha256 content-addressed bytes were present in the attachment store.
+
+Two real shapes were observed in a session trace:
+
+- A corrupted JSON ref: the closing brace gained an extra colon (`"name":"image.png":}`), which is valid percent-decoding but invalid JSON, so `parseImageAttachmentRef` threw.
+- A rebuilt ref: the model replaced the whole JSON with a comma-separated token string (`sha256:...,s,1367,931,image`), which `parseImageAttachmentRef` cannot narrow.
+
+## Decision
+
+`dsh-tool-describe-image` now tolerates a single-transcription-glitch shape without weakening validation, and degrades to the path-id registry only when a reference is genuinely unrecoverable:
+
+- `parseImageAttachmentRef` (`src/attachment-reference.ts`) retries a strict `JSON.parse` failure through `repairImageRefJson`, which removes only unambiguous structural noise — a stray colon before a closing brace/bracket, a doubled comma, a trailing comma before a closing brace, and a colon directly before a comma. Every candidate is re-validated with `JSON.parse` and then passes the same full field validation (non-empty attachmentId, image media type, positive safe-integer bytes/width/height) as before, so a malformed shape never slips through as "repaired". Inputs that no rule repairs still throw `ATTACHMENT_REF_GUIDANCE`.
+- `parseMarkdownAttachmentReference` no longer throws when the embedded ref fails strict+repaired parsing, or when the ref attachmentId disagrees with the authoritative path id. It returns the legacy `{ attachmentId }` shape so `vision-client.ts` resolve `ref ?? attachmentRefById(id)` against the registry.
+- `serveRawImage` (`src/attach-routes.ts`) no longer answers 404 immediately when the serialized ref fails parsing or disagrees with the path id; it falls through to `ref ??= attachmentRefById(id)`. The path id is treated as authoritative — the registry is keyed by the same content-addressed id, so a stale or corrupted ref still resolves the correct image when it was recently uploaded.
+
+The `decodeURIComponent` failure path (which yields no usable id) and the empty-id path remain hard failures: there is nothing safe to fall back to.
+
+## Alternatives considered
+
+- **Keep fail-closed and surface guidance.** This was the previous behavior and the observed failure mode. It is safe but hostile to the real problem: the model cannot reliably re-transcribe a 350-character encoded reference, so retry alone frequently fails again.
+- **Always fall back to the path id registry, dropping ref metadata.** Correct in the rebuilt-ref case, but it discards the durable metadata that lets the tool work after a host restart when the short-lived registry has evicted the id. Repairing the JSON keeps that durability for the far more common one-character glitch.
+- **Machine-transcribe the reference rather than trust the model.** Out of scope; the plugin has no channel to see the original session text at call time.
+
+## Consequences
+
+- A model that inserts or drops a single boundary character now gets the image successfully instead of a hard error; the `[image attachment ...]` and `ref=` durability guarantees are preserved for the repaired path.
+- A wholesale-rebuilt ref now succeeds only while the id is in the process registry (bounded FIFO, capacity 128) and still fails closed otherwise. This is the honest ceiling: no durable metadata survives a rebuild, and a path id alone cannot be re-metadata without the store.
+- Validation strictness is unchanged for genuinely malformed or adversarial input: every repaired candidate must satisfy the same field checks, and inputs no rule repairs still throw.
+- The change is confined to three functions in one package; no DSH source, config, or mount points are touched.
+
+## Testing
+
+Verified against the upstream `src/` sources directly (Node 26 `--experimental-strip-types`, no private-cohort tarballs needed):
+
+- `parseImageAttachmentRef`: valid round-trip unchanged; stray-colon, doubled-comma, and trailing-comma shapes repaired to the identical ref; unrepairable garbage and non-object JSON still throw `ATTACHMENT_REF_GUIDANCE`.
+- `parseMarkdownAttachmentReference`: valid Markdown returns the full ref; corrupted-Markdown repairs to the full ref; path-id mismatch and legacy no-ref both return `{ attachmentId }` without throwing; malformed `%` id still throws.
+- Registry functions (`registerAttachmentRef` / `attachmentRefById`) confirmed against the installed v0.3.10 copy.
+- The same assertions were added to the package's vitest suite (`tests/vision-cache.spec.ts`, `tests/attach-routes.spec.ts`) so the permanent gate exercises the new behavior. The full `pnpm test` could not run locally: this machine cannot resolve the private `@deepseek-ai/*` cohort tarballs its devDependencies require.

--- a/.agents/notes/implemented/bug-fix/2026-09-01-describe-image-reference-repair.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-01-describe-image-reference-repair.zh.md
@@ -1,0 +1,44 @@
+# Agent Note：describe-image 引用转录纠错与注册表回退
+
+Status: implemented
+
+## Problem
+
+纯文本模型调用 `describe_image` 时，把会话消息里的长百分号编码附件引用转录进工具参数。转录不是逐字节精确的：可能在边界处多写或漏写一个结构字符，最坏情况下会整体重建引用。两种失效形态都会让 `describe-image` 即使图片已正确上传也 fail-closed 报 `image is not a valid attachment reference` —— 路径 id 完好、其 sha256 内容寻址字节就在附件存储里。
+
+会话回溯中观察到两种真实形态：
+
+- 损坏的 JSON ref：闭合花括号前多了一个冒号（`"name":"image.png":}`），百分号解码合法但 JSON 非法，`parseImageAttachmentRef` 抛错。
+- 重建的 ref：模型把整个 JSON 换成逗号分隔的 token 串（`sha256:...,s,1367,931,image`），`parseImageAttachmentRef` 无法收窄。
+
+## Decision
+
+`dsh-tool-describe-image` 现在容忍单次转录毛刺形态而不放松校验；只有引用真正无法恢复时才降级到路径 id 注册表：
+
+- `parseImageAttachmentRef`（`src/attachment-reference.ts`）在严格 `JSON.parse` 失败后经由 `repairImageRefJson` 重试，只移除无歧义的结构噪声 —— 闭合花括号/方括号前的孤立冒号、双逗号、闭合定界符前的尾逗号、以及逗号前的冒号。每个候选都用 `JSON.parse` 重新校验，随后通过与之前完全相同的完整字段校验（非空 attachmentId、图片 media type、正的字节/宽/高安全整数），所以畸形形态绝不会被当作"已修复"放行。任何规则都修不了的输入仍抛 `ATTACHMENT_REF_GUIDANCE`。
+- `parseMarkdownAttachmentReference` 在嵌入 ref 严格+纠错解析失败、或 ref 的 attachmentId 与权威路径 id 不一致时不再抛错，返回 legacy `{ attachmentId }` 形态，让 `vision-client.ts` 走 `ref ?? attachmentRefById(id)` 查注册表。
+- `serveRawImage`（`src/attach-routes.ts`）在序列化 ref 解析失败或与路径 id 不一致时不再立即 404，落到 `ref ??= attachmentRefById(id)`。路径 id 被当作权威锚点 —— 注册表以同一个内容寻址 id 为键，因此刚上传过的图片即便 ref 损坏/过期也能解析到正确图片。
+
+`decodeURIComponent` 失败路径（拿不到可用 id）与空 id 路径仍然是硬失败：没有可安全回退的目标。
+
+## Alternatives considered
+
+- **保持 fail-closed 并展示引导信息。** 这是之前的行为，也是观测到的失效形态。它安全但对真实问题不友好：模型无法可靠重转录一条 350 字符的编码引用，单纯重试常常再次失败。
+- **一律回退路径 id 注册表、丢弃 ref 元数据。** 在重建 ref 场景下正确，但会丢弃让工具在宿主重启后（短命注册表已驱逐该 id）仍能工作的持久元数据。修复 JSON 能让最常见的单字符毛刺保留这份持久性。
+- **机器转录引用而非信任模型。** 超出范围；插件在调用时没有通道看到原始会话文本。
+
+## Consequences
+
+- 模型多写/漏写单个边界字符时，现在能成功拿到图片而不是硬错误；`[image attachment ...]` 与 `ref=` 的持久性保证在修复路径上保留。
+- 整体重建的 ref 现在只在 id 仍处于进程注册表（有界 FIFO，容量 128）时成功，否则仍然 fail-closed。这是诚实的上限：重建不保留任何持久元数据，路径 id 在没有存储时无法重新补元数据。
+- 对真正畸形或对抗性输入，校验严格性不变：每个修复候选必须通过同样的字段检查，修复不了的输入仍然抛错。
+- 改动限于一个包内的三个函数；不触碰 DSH 源码、配置或挂载点。
+
+## Testing
+
+直接针对上游 `src/` 源验证（Node 26 `--experimental-strip-types`，无需私有 cohort tarball）：
+
+- `parseImageAttachmentRef`：合法往返不变；孤立冒号、双逗号、尾逗号形态都修复成相同 ref；不可修复的垃圾与非对象 JSON 仍抛 `ATTACHMENT_REF_GUIDANCE`。
+- `parseMarkdownAttachmentReference`：合法 Markdown 返回完整 ref；损坏 Markdown 修复出完整 ref；路径 id 不一致与 legacy 无 ref 都无抛错返回 `{ attachmentId }`；畸形 `%` id 仍抛错。
+- 注册表函数（`registerAttachmentRef` / `attachmentRefById`）对照已安装 v0.3.10 副本确认。
+- 同样断言已加入包的 vitest 套件（`tests/vision-cache.spec.ts`、`tests/attach-routes.spec.ts`），让永久门禁覆盖新行为。本机无法跑完整 `pnpm test`：这台机器解析不了其 devDependencies 所需的私有 `@deepseek-ai/*` cohort tarball。

--- a/packages/dsh-tool-describe-image/src/attach-routes.ts
+++ b/packages/dsh-tool-describe-image/src/attach-routes.ts
@@ -215,16 +215,12 @@ async function serveRawImage(ctx: Context, req: IncomingMessage, res: ServerResp
   const serializedRef = requestUrl.searchParams.get('ref')
   if (serializedRef !== null) {
     try {
-      ref = parseImageAttachmentRef(serializedRef)
+      const parsed = parseImageAttachmentRef(serializedRef)
+      // Ref metadata is advisory; the path id is authoritative. On parse failure
+      // (strict + repair) or id disagreement, fall through to the id registry.
+      if (parsed.attachmentId === id) ref = parsed
     } catch {
-      res.writeHead(404)
-      res.end()
-      return
-    }
-    if (ref.attachmentId !== id) {
-      res.writeHead(404)
-      res.end()
-      return
+      ref = undefined
     }
   }
   ref ??= attachmentRefById(id)

--- a/packages/dsh-tool-describe-image/src/attachment-reference.ts
+++ b/packages/dsh-tool-describe-image/src/attachment-reference.ts
@@ -55,17 +55,62 @@ function unwrapAttachmentNote(raw: string): string {
 }
 
 /**
+ * Best-effort repair of a model-transcribed reference JSON whose strict parse
+ * failed. A text-to-tool transcription of a long percent-encoded reference can
+ * drop or insert a stray structural character at a boundary (a colon before a
+ * closing brace, a doubled or trailing comma). Each rule removes only
+ * unambiguous structural noise and every candidate is re-validated with
+ * JSON.parse before being returned, so a malformed shape never slips through
+ * as a "fixed" reference.
+ * @param value - the decoded JSON text to repair.
+ * @returns a JSON-valid repaired string, or undefined when none repairs.
+ */
+function repairImageRefJson(value: string): string | undefined {
+  const candidates: string[] = []
+  // Remove a stray colon immediately before a closing brace/bracket: `"x":}` -> `"x"}`
+  candidates.push(value.replace(/:(?=\s*[}\]])/g, ''))
+  // Remove doubled commas: `,,` -> `,`
+  candidates.push(value.replace(/,(?=\s*,)/g, ''))
+  // Remove a trailing comma before a closing brace/bracket: `,}` -> `}`
+  candidates.push(value.replace(/,(?=\s*[}\]])/g, ''))
+  // Remove a colon directly before a comma: `:,` -> `,`
+  candidates.push(value.replace(/:(?=,)/g, ''))
+  for (const candidate of candidates) {
+    try {
+      JSON.parse(candidate)
+      return candidate
+    } catch {
+      // not valid yet; try the next rule
+    }
+  }
+  return undefined
+}
+
+/**
  * Validate and narrow a model-supplied attachment reference into its typed storage
  * form. It accepts either the raw JSON reference or its complete note carrier.
+ * A strict-parse failure is retried with structural-noise repair, so a single
+ * transcription glitch does not fail-closed a reference the model otherwise had
+ * right; every candidate still passes the full field validation below.
  * @param raw - JSON or `[image attachment ...]` content from a session message.
  * @returns the narrowed, typed reference.
  */
 export function parseImageAttachmentRef(raw: string): ImageAttachmentRef {
+  const unwrapped = unwrapAttachmentNote(raw)
   let parsed: unknown
   try {
-    parsed = JSON.parse(unwrapAttachmentNote(raw))
+    parsed = JSON.parse(unwrapped)
   } catch {
-    throw new Error(ATTACHMENT_REF_GUIDANCE)
+    const repaired = repairImageRefJson(unwrapped)
+    if (repaired !== undefined) {
+      try {
+        parsed = JSON.parse(repaired)
+      } catch {
+        throw new Error(ATTACHMENT_REF_GUIDANCE)
+      }
+    } else {
+      throw new Error(ATTACHMENT_REF_GUIDANCE)
+    }
   }
   const record = asRecord(parsed)
   if (record === undefined) throw new Error(ATTACHMENT_REF_GUIDANCE)
@@ -112,8 +157,16 @@ export function parseMarkdownAttachmentReference(raw: string): MarkdownAttachmen
   const url = new URL(match[1] ?? '', 'http://dsh.local')
   const encodedRef = url.searchParams.get('ref')
   if (encodedRef === null) return { attachmentId }
-  const ref = parseImageAttachmentRef(encodedRef)
-  if (ref.attachmentId !== attachmentId) throw new Error(ATTACHMENT_REF_GUIDANCE)
+  let ref: ImageAttachmentRef | undefined
+  try {
+    const parsed = parseImageAttachmentRef(encodedRef)
+    // Ref metadata is advisory; the path id is the authoritative anchor. When
+    // parsing failed (strict + repair) or the id disagrees, fall back to the
+    // id-only legacy form so the caller resolves via attachmentRefById(id).
+    if (parsed.attachmentId === attachmentId) ref = parsed
+  } catch {
+    ref = undefined
+  }
   return { attachmentId, ref }
 }
 

--- a/packages/dsh-tool-describe-image/tests/attach-routes.spec.ts
+++ b/packages/dsh-tool-describe-image/tests/attach-routes.spec.ts
@@ -435,6 +435,52 @@ describe('registerAttachRoute', () => {
     expect(status()).toBe(200)
   })
 
+  it('repairs a transcription-corrupted reference ref through the id registry', async () => {
+    // A model transcription inserted a stray colon before the closing brace in the
+    // embedded reference; the path id stays intact. parseImageAttachmentRef repairs
+    // the JSON and serves the image directly (no registry needed).
+    const { store } = await makeCtx(true)
+    const ref: ImageAttachmentRef = {
+      attachmentId: `sha256:${'c'.repeat(64)}` as ImageAttachmentRef['attachmentId'],
+      mediaType: 'image/png',
+      bytes: PNG_BYTES.length,
+      width: 1,
+      height: 1,
+      name: 'image.png',
+    }
+    store?.stored.set(String(ref.attachmentId), PNG_BYTES)
+    const registrations = capture(store, true)
+    const { res, status } = makeRes()
+    const markdown = attachmentMarkdown(ref).replace('%7D"', '%3A%7D"')
+    const path = /\(([^)]+)\)$/.exec(markdown)?.[1]
+    await registrations[0].handler(makeReq('GET', undefined, path), res)
+    expect(status()).toBe(200)
+  })
+
+  it('falls back to the id registry when the embedded ref cannot be repaired', async () => {
+    // The ref was replaced wholesale by the model (not a text glitch), so repair
+    // cannot recover it; serving falls back to the path id registry.
+    const { store } = await makeCtx(true)
+    const ref: ImageAttachmentRef = {
+      attachmentId: `sha256:${'d'.repeat(64)}` as ImageAttachmentRef['attachmentId'],
+      mediaType: 'image/png',
+      bytes: PNG_BYTES.length,
+      width: 1,
+      height: 1,
+    }
+    store?.stored.set(String(ref.attachmentId), PNG_BYTES)
+    registerAttachmentRef(ref)
+    const registrations = capture(store, true)
+    const { res, status } = makeRes()
+    const markdown = attachmentMarkdown(ref).replace(
+      /ref=[^)]+/,
+      'ref=sha256:81a6094cad36275290b2a00302d2bf286bf09765990f949af770f08049bf868,s,1367,931,image'
+    )
+    const path = /\(([^)]+)\)$/.exec(markdown)?.[1]
+    await registrations[0].handler(makeReq('GET', undefined, path), res)
+    expect(status()).toBe(200)
+  })
+
   it('uses the attachment store canonical media type rather than URL metadata', async () => {
     const { store } = await makeCtx(true)
     const ref: ImageAttachmentRef = {

--- a/packages/dsh-tool-describe-image/tests/vision-cache.spec.ts
+++ b/packages/dsh-tool-describe-image/tests/vision-cache.spec.ts
@@ -180,6 +180,38 @@ describe('parseImageAttachmentRef narrowing', () => {
     expect(ref.height).toBe(1)
   })
 
+  it('repairs a stray colon before the closing brace from a transcription glitch', () => {
+    // A text-to-tool transcription can drop/insert a stray structural character;
+    // one colon before the closing brace is a known shape: `"name":"x":}`
+    const corrupted = valid.replace('}', ':}')
+    const ref = tool.parseImageAttachmentRef(corrupted)
+    expect(ref).toMatchObject({
+      attachmentId: `sha256:${'c'.repeat(64)}`,
+      mediaType: 'image/png',
+      bytes: PNG_BYTES.length,
+      width: 1,
+      height: 1,
+    })
+  })
+
+  it('repairs a doubled comma between fields', () => {
+    const doubled = valid.replace('"bytes":' + PNG_BYTES.length, '"bytes":' + PNG_BYTES.length + ',,')
+    expect(tool.parseImageAttachmentRef(doubled)).toMatchObject({ bytes: PNG_BYTES.length })
+  })
+
+  it('repairs a trailing comma before the closing brace', () => {
+    const withName = JSON.stringify({
+      attachmentId: `sha256:${'c'.repeat(64)}`,
+      mediaType: 'image/png',
+      bytes: PNG_BYTES.length,
+      width: 1,
+      height: 1,
+      name: 'image.png',
+    })
+    const trailing = withName.replace('"image.png"}', '"image.png",}')
+    expect(tool.parseImageAttachmentRef(trailing)).toMatchObject({ name: 'image.png' })
+  })
+
   it('accepts the complete attachment note carrier', () => {
     const ref = tool.parseImageAttachmentRef(`[image attachment ${valid}]`)
     expect(ref).toMatchObject({ attachmentId: `sha256:${'c'.repeat(64)}`, mediaType: 'image/png' })


### PR DESCRIPTION
## 摘要（Summary）

修复 `describe-image` 对模型转录损坏的附件引用的 fail-closed 问题。纯文本模型把长百分号编码引用转录进工具参数时会插入/丢失边界结构字符（典型：闭合花括号前多一个冒号 `"name":"image.png":}`），甚至整体重建引用。此前插件严格拒绝（`image is not a valid attachment reference`），即使图片已正确上传、路径 id 完好。

本次改动为引用解析增加**字符级纠错**并在无法恢复时**回退路径 id 注册表**，让真实故障形态能被识别出图片：

- `parseImageAttachmentRef`（`src/attachment-reference.ts`）新增 `repairImageRefJson`：严格解析失败后移除无歧义的结构噪声（闭合定界符前孤立冒号、双逗号、尾逗号、冒号接逗号），每个候选重新 `JSON.parse` 校验并走与之前完全相同的字段校验，畸形/对抗输入仍然 fail-closed。
- `parseMarkdownAttachmentReference`：ref 解析失败或与路径 id 不一致时不再抛错，返回 legacy `{ attachmentId }`，让 `vision-client.ts` 的 `ref ?? attachmentRefById(id)` 兜底。
- `serveRawImage`（`src/attach-routes.ts`）：serializedRef 解析失败/id 不一致时不再直接 404，落到注册表兜底；路径 id 为权威锚点。
- `decodeURIComponent` 失败与空 id 保持硬失败（无可安全回退目标）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`
- [x] 其他（请说明）：`packages/dsh-tool-describe-image`

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [x] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [x] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：`git fetch origin dev && git checkout -b fix/describe-image-reference-repair origin/dev && git cherry-pick <commit>`

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin dev && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

**本地测试证据（针对上游 `src/` 源码验证，13/13 通过）：**

```text
[parseImageAttachmentRef]
  ok: valid unchanged
  ok: stray colon before } repaired
  ok: doubled comma repaired
  ok: trailing comma repaired
  ok: unrepairable garbage still rejected
  ok: non-object still rejected
[parseMarkdownAttachmentReference]
  ok: valid md returns full ref
  ok: corrupted md repaired to full ref
  ok: id mismatch falls back to legacy (no throw, ref undefined)
  ok: legacy no-ref returns {attachmentId}
  ok: bad % id still throws
[attach-routes registry]
  ok: registered ref retrievable by id
  ok: attachmentNote renders note
RESULT: 13 passed, 0 failed
```

验证方式：Node 26 `--experimental-strip-types` 直接加载上游 `src/attachment-reference.ts`（本机无法解析 devDependencies 的私有 `@deepseek-ai/*` cohort tarball，完整 `pnpm test` 未在本机运行；改动已同步进 `tests/vision-cache.spec.ts` 与 `tests/attach-routes.spec.ts`，供 CI / 具备依赖的环境跑门禁）。

## 视觉修复要求（Visual Fix Requirements）

不适用（纯文本/逻辑改动）。

## AI 编码披露（AI Coding Disclosure）

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

方向与方案（纠错 + 注册表回退）由贡献者拍板并审阅确认，具体代码由 AI 实现。

使用的 AI 模型：DeepSeek（deepseek-v4-flash）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改 README）

## 本地验证（Local Validation）

执行的命令：

```bash
node --experimental-strip-types upstream-verify.mjs
```

结果摘要：13 passed, 0 failed（针对上游 src 源码：parseImageAttachmentRef 纠错、parseMarkdownAttachmentReference 回退、注册表兜底）。另与已安装 v0.3.10 副本做行为一致性对比（含 note 无 `]` 结尾边界），全部一致。

## 用户可见变更证据（Local Feature Evidence）

不适用 —— 行为修复（模型转录损坏引用时从"报错"变为"成功识别图片"）；机器无法稳定复现随机转录错误，故以确定性单元测试为证据。截图见下方问题现象附录。