### PR TITLE
fix(liangshen): read session events via ownEvents() on DSH 0.1.2-alpha.4

### DIFF
--- a/packages/dsh-liangshen/presets/liangshen/tool-bootstrap.mjs
+++ b/packages/dsh-liangshen/presets/liangshen/tool-bootstrap.mjs
@@ -341,7 +341,15 @@ function decidePromotion(state, config) {
 
 /** Scan newly appended session events and update promotion state. */
 function scanEvents(state, session) {
-  const events = session.events
+  // DSH >= 0.1.2-alpha.4 reads the append-only log through Session.ownEvents();
+  // older builds exposed a plain `session.events` array. Either way the events
+  // are contiguous in seq order, so the scan resumes by absolute index. Without
+  // this the first pre-step/assembly crashed on 0.1.2-alpha.4 with
+  // "Cannot read properties of undefined (reading 'length')".
+  const events = typeof session?.ownEvents === 'function'
+    ? session.ownEvents()
+    : session?.events
+  if (!Array.isArray(events)) return
   for (; state.next < events.length; state.next += 1) {
     const event = events[state.next]
     if (event === undefined) continue


### PR DESCRIPTION
## 问题

在 DSH 0.1.2-alpha.4 下，选择「梁神模式」（liangshen preset）的会话在首轮预处理阶段崩溃——turn/start 后直接 turn/end(error)，连 step/start 都没有，报错：

    Cannot read properties of undefined (reading 'length')

同一模型切到 standard 预设则完全正常。

## 根因

DSH 0.1.2-alpha.4 把 Session 改为 append-only log：事件需通过 Session.ownEvents() 读取，旧的 session.events 数组属性已移除（dsh-session 文档：ownEvents() returns events at and after that cut）。

而 tool-bootstrap.mjs 的 scanEvents() 仍写死 session.events：

    const events = session.events   // undefined on 0.1.2-alpha.4
    for (; state.next < events.length; ...)   // TypeError: Cannot read properties of undefined (reading 'length')

首次请求的 agent/pre-step（prepend 过滤器）→ refresh() → scanEvents() 即触发崩溃，发生在真正请求模型之前。

## 修复

scanEvents() 优先调用 session.ownEvents()（0.1.2-alpha.4+），回退到旧的 session.events 数组，并对两者都缺失的情况做防御（直接返回）。事件仍按 seq 连续有序，扫描指针 next 语义不变。

## 验证

- 修复后的 scanEvents 单测通过：legacy session.events / ownEvents() / 无事件 API / 增量续扫 四种形态均正常；
- 已在本地 0.1.2-alpha.4 环境将修复同步到 .agent-presets/liangshen 与插件 bundled 副本，node --check 语法校验通过。

## 影响

仅 presets/liangshen/tool-bootstrap.mjs 一个文件；行为与旧版本完全兼容（旧 API 仍走回退分支）。