### PR TITLE
feat(community-plugins): register dsh-linkdigest in the community index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -675,6 +675,18 @@
       "npm": "dsh-audiogen",
       "category": "tools",
       "subcategory": "model"
+    },
+    {
+      "id": "dsh-linkdigest",
+      "name": "LinkDigest",
+      "rank": 54,
+      "nameEn": "LinkDigest",
+      "author": "jcaiagent7143-ui",
+      "description": "把小红书、抖音、TikTok、YouTube 或 X 链接转成文本：带时间戳的转写、屏幕文字、逐图描述与 OCR、正文与元数据。挂载托管的 MCP 服务，不需要本地浏览器和登录。",
+      "descriptionEn": "Turns a Xiaohongshu, Douyin, TikTok, YouTube or X link into text: transcript with timecodes, on-screen text, a description and OCR of every image, caption and metadata. Mounts a hosted MCP server over streamable HTTP, with no local browser or login step.",
+      "repo": "https://github.com/jcaiagent7143-ui/linkdigest-mcp",
+      "category": "integration",
+      "subcategory": "remote"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -620,5 +620,16 @@
     "npm": "dsh-audiogen",
     "category": "tools",
     "subcategory": "model"
+  },
+  {
+    "id": "dsh-linkdigest",
+    "name": "LinkDigest",
+    "nameEn": "LinkDigest",
+    "author": "jcaiagent7143-ui",
+    "description": "把小红书、抖音、TikTok、YouTube 或 X 链接转成文本：带时间戳的转写、屏幕文字、逐图描述与 OCR、正文与元数据。挂载托管的 MCP 服务，不需要本地浏览器和登录。",
+    "descriptionEn": "Turns a Xiaohongshu, Douyin, TikTok, YouTube or X link into text: transcript with timecodes, on-screen text, a description and OCR of every image, caption and metadata. Mounts a hosted MCP server over streamable HTTP, with no local browser or login step.",
+    "repo": "https://github.com/jcaiagent7143-ui/linkdigest-mcp",
+    "category": "integration",
+    "subcategory": "remote"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

社区插件索引登记一个条目：`dsh-linkdigest`。把小红书、抖音、TikTok、YouTube 或 X 链接转成文本（带时间戳的转写、屏幕文字、逐图描述与 OCR、正文与元数据），通过官方 `@deepseek-ai/dsh-mcp-client` 桥接挂载一个托管的 MCP 服务，不需要本地浏览器和登录。

改动只有两个文件，纯新增，无删除：`packages/dsh-community-plugins/community.json` 追加一条，以及重新生成后的 `market/dist/manifest/plugins.json`。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-community-plugins`（索引条目）与 `market/dist`（重新生成的市场产物）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

说明：本 PR 是「插件申请（社区插件索引登记）」，PR 类型一节没有对应的「新插件收录」选项。我最初勾的是「面向用户的功能或行为变更」，机器人因此要求补截图；但本 PR 只新增一条索引数据，不含任何代码或 UI 改动，没有可截图的界面变化，所以改勾最接近的「维护 / 重构」。真正决定分派的类别在上一节，是「社区插件索引」。如果维护者认为应当归到别的类型，请指出，我改。

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream dev
git rev-list --count HEAD..upstream/dev   # 0，已与最新 dev 齐平
```

基线为 `dev` HEAD `bacb1ab`（`fix(desktop): accept the host LAN suffix when parsing the token URL line (#1377)`）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

自测记录：

```
$ node scripts/community-index --check
community-index: OK (54 entries)

$ node scripts/market-build --check      # 追加条目后、重新生成前
market-build: market/dist stale - run scripts/market-build and commit: manifest/plugins.json

$ node scripts/market-build
market-build: wrote 1257 files (29 skins, 5 pets, 54 plugins)

$ node scripts/market-build --check      # 重新生成后
market-build: tryon/ verified against hash manifest (756 files)
market-build: dist up to date (471 files)
```

同步上游最新 `dev` 后重新测试（本次 bot 提醒后重跑）：

```
$ git fetch upstream dev && git rev-list --count HEAD..upstream/dev
0

$ node scripts/community-index --check
community-index: OK (54 entries)

$ node scripts/market-build --check
market-build: tryon/ verified against hash manifest (756 files)
market-build: dist up to date (471 files)

$ git diff --stat
 market/dist/manifest/plugins.json             | 12 ++++++++++++
 packages/dsh-community-plugins/community.json | 11 +++++++++++
 2 files changed, 23 insertions(+)
```

本 PR 为纯索引数据登记，无 UI 改动，故无截图。

## 视觉修复要求（Visual Fix Requirements）

不适用：本 PR 未勾选「视觉修复」。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：Claude Opus 5

使用的编码 Agent 工具：Claude Code

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。本 PR 未新增包目录；插件仓库自身的包名为 `dsh-linkdigest`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套。本 PR 未改动任何包 README。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/jcaiagent7143-ui/linkdigest-mcp

插件详细说明：

**功能。** 一个工具 `digest_url(url, format, job_id)`。传入贴文链接，返回 Markdown 或 JSON：转写（带时间戳）、屏幕文字、每张图片的描述与 OCR、正文与元数据。长视频超过单次请求预算时，第一次调用返回 job id，第二次调用凭 id 取结果。

**平台（只列实测结果）。** 可用：小红书（图文与视频笔记，无需登录）、抖音、TikTok、YouTube、X、网页文章。**不可用**：Bilibili 对我们服务器的地址返回 HTTP 412；Instagram 已接线但未端到端验证；Facebook 不在范围内，登出状态下不返回任何贴文内容。

**依赖与实现。** 仓库本身不含产品源码，只是一个 cordis bundle：`cordis.patch.yml` 通过官方 `@deepseek-ai/dsh-mcp-client` 挂载托管的 streamable HTTP 端点 `https://linkdigest.dev/mcp`，另带一个 `skills/linkdigest/SKILL.md`。`toolCallTimeoutMs` 设为 180000 是实测值：一条 17 图的小红书笔记逐图描述加 OCR 需要约 119 秒，默认 60 秒会正好卡死在这个插件存在的意义上。

**已知限制。** 需要一个 `LINKDIGEST_API_KEY` 环境变量；没有 key 时工具会以 401 明确失败而不是静默返回空结果。免费额度是三次，无需信用卡；命中缓存的链接不计费。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表。

  说明一处与模板文字的出入：模板要求提交生成的 `packages/dsh-community-plugins/src/client/generated/community.ts`，但该路径在当前 `dev` 上并不存在（`git ls-files packages/dsh-community-plugins/src/` 只有 `index.ts` 与 `mount-once.ts`）。我运行了 `node scripts/community-index`，它没有产生额外的文件改动，`--check` 通过。如果这条模板说明已经过时可以忽略；如果我漏了步骤，请指出，我补上。

- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已验证插件可被 `dsh web` 挂载并正常运行。

  这一条我最初没有勾，因为当时只验证了安装、没有实际跑 `dsh web`。现在按 [docs/plugins.md](../docs/plugins.md) 第 84 行的方法补做了，证据如下（DSH 0.1.2-rc.1）：

  **1. 安装到 web profile**

  ```
  $ dsh plugin --profile web add "github:jcaiagent7143-ui/linkdigest-mcp#main"
  + dsh-linkdigest github:jcaiagent7143-ui/linkdigest-mcp#main
  Packages: +1
  Done in 2.3s using pnpm v11.25.0

  $ dsh plugin --profile web list
  dsh-profile-web /Users/.../.dsh/profiles/web (PRIVATE)
  └── dsh-linkdigest@1.0.0

  profile package.json -> dsh.profile.bundles:
  ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', 'dsh-linkdigest']
  ```

  **2. 启动 `dsh web`，在 设置 → 插件 → 插件列表 中搜索 "linkdigest"**，Global plugins 下命中一项：

  ```
  mcp-client                     Enabled
    include:mcp-linkdigest
    Module          @deepseek-ai/dsh-mcp-client
    Configuration   Enabled
    Status          Running
  ```

  `include:mcp-linkdigest` 正是本插件 `cordis.patch.yml` 里 insert 的 id。

  **3. 让 agent 自己报告工具列表**（新会话，DeepSeek-V4-Flash，提示词要求只列名不调用）。agent 原话：

  > None of them is named exactly `digest_url`. The closest is `mcp__linkdigest__digest_url`, whose name ends in `digest_url` (it digests social-media/URL content).

  即 `@deepseek-ai/dsh-mcp-client` 完成了与远端 `https://linkdigest.dev/mcp` 的握手（`initialize` + `tools/list`），并以 `mcp__linkdigest__digest_url` 的命名把工具注册给了模型。插件的 `skills/linkdigest/SKILL.md` 第 4 行 `allowed-tools: mcp__linkdigest__digest_url` 用的就是这个名字。

  两张截图（插件列表面板、agent 回复）我留着，需要的话可以贴到评论里。

  **关于 `dsh.client`**：本插件是一个远端 MCP 的桥接，不提供任何浏览器 UI，所以 package.json 只声明了 `dsh.bundle`，没有 `dsh.client` 半区。如果索引登记要求必须带 `dsh.client`，请告诉我。

  **顺带补上的**：按 docs/plugins.md 第 116 行的要求，在插件仓库 package.json 里加了 `"dsh": { "engines": { "dsh": ">=0.1.2-rc.1" } }`（提交 `c5e8a97`），值就是这次验证所用的版本。

- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index --check
node scripts/market-build
node scripts/market-build --check
git fetch upstream dev && git rev-list --count HEAD..upstream/dev
```

结果摘要：全部通过。`community-index: OK (54 entries)`；`market-build: dist up to date (471 files)`；与 `upstream/dev` 相差 0 个提交。改动为两个文件、23 行新增、0 行删除。

## 用户可见变更证据（Local Feature Evidence）

证据：N/A —— 本 PR 只是索引数据登记，不含代码或 UI 改动。插件能力说明见上方「插件详细说明」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpGW9DbqX9bkgv4RTETBmV
