### PR TITLE
community: add dsh-search-router plugin

### DIFF
--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -516,6 +516,18 @@
     "subcategory": "dev"
   },
   {
+    "id": "dsh-search-router",
+    "name": "搜索路由",
+    "nameEn": "Search Router",
+    "author": "bottledkzk",
+    "description": "多后端搜索路由插件：将 DeepSeek 官方 / AnySearch / Bing / DuckDuckGo / SearXNG 统一包装为 web_search 的 router provider，支持即时切换、当前后端与回退链查询、失败自动回退 DeepSeek 官方搜索；设置面板中英文自适应并支持 Key 脱敏显示。",
+    "descriptionEn": "Multi-backend search router: wraps DeepSeek official / AnySearch / Bing / DuckDuckGo / SearXNG behind one web_search router provider, with live switching, status/fallback-chain visibility, automatic fallback to DeepSeek official search, and a bilingual settings panel with masked key display.",
+    "repo": "https://github.com/bottledkzk/dsh-search-router",
+    "npm": "dsh-search-router",
+    "category": "tools",
+    "subcategory": "dev"
+  },
+  {
     "id": "dsh-agent-plugins-market",
     "name": "Agent Plugins市场（兼容Claude Code Plugin）",
     "nameEn": "Agent Plugins Market",


### PR DESCRIPTION
Add the dsh-search-router plugin to the community plugin index.

- Repo: https://github.com/bottledkzk/dsh-search-router
- npm: dsh-search-router
- Category: tools / dev
- Summary: multi-backend web_search router (DeepSeek official / AnySearch / Bing / DuckDuckGo / SearXNG) with live switching, fallback-chain status, automatic fallback to DeepSeek official, and a bilingual settings panel.