### PR TITLE
feat(community-plugins): register dsh-quote-followup in the community index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -687,6 +687,19 @@
       "repo": "https://github.com/jcaiagent7143-ui/linkdigest-mcp",
       "category": "integration",
       "subcategory": "remote"
+    },
+    {
+      "id": "dsh-quote-followup",
+      "name": "引用追问",
+      "rank": 55,
+      "nameEn": "Quote Follow-up",
+      "author": "tr1v3r",
+      "description": "在 Web 对话里划选任意文本，一键以原生引用 chip 追加进输入框进行针对性追问；发送时自动展开为模型可读的 Markdown 引文，旧宿主降级为纯文本引用。",
+      "descriptionEn": "Select any text in the Web transcript and append it to the composer as a native quote chip for a targeted follow-up; chips expand into model-readable Markdown quotes on send, with a plain-text fallback on older hosts.",
+      "repo": "https://github.com/tr1v3r/dsh-quote-followup",
+      "npm": "dsh-quote-followup",
+      "category": "ui",
+      "subcategory": "chat"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -631,5 +631,17 @@
     "repo": "https://github.com/jcaiagent7143-ui/linkdigest-mcp",
     "category": "integration",
     "subcategory": "remote"
+  },
+  {
+    "id": "dsh-quote-followup",
+    "name": "引用追问",
+    "nameEn": "Quote Follow-up",
+    "author": "tr1v3r",
+    "description": "在 Web 对话里划选任意文本，一键以原生引用 chip 追加进输入框进行针对性追问；发送时自动展开为模型可读的 Markdown 引文，旧宿主降级为纯文本引用。",
+    "descriptionEn": "Select any text in the Web transcript and append it to the composer as a native quote chip for a targeted follow-up; chips expand into model-readable Markdown quotes on send, with a plain-text fallback on older hosts.",
+    "repo": "https://github.com/tr1v3r/dsh-quote-followup",
+    "npm": "dsh-quote-followup",
+    "category": "ui",
+    "subcategory": "chat"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

社区插件索引登记一个条目：`dsh-quote-followup`（引用追问）。在 DSH Web 对话里划选任意文本，一键以原生引用 chip 追加进输入框进行针对性追问；发送时 codec 自动把 chip 展开为模型可读的 Markdown 引文，旧宿主降级为纯文本引用。

改动只有两个文件，纯新增，无删除：`packages/dsh-community-plugins/community.json` 追加一条，以及重新生成后的 `market/dist/manifest/plugins.json`。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-community-plugins`（索引条目）与 `market/dist`（重新生成的市场产物）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

说明：本 PR 是「插件申请（社区插件索引登记）」，纯索引数据新增，不含任何代码或 UI 改动，故勾选最接近的「维护 / 重构」；真正决定分派的类别在上一节（社区插件索引）。

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream dev
git rev-list --count HEAD..upstream/dev   # 0，已与最新 dev 齐平
```

基线为 `dev` HEAD `3e011bb`（`docs(notes): record the v0.3.17 release run`）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

自测记录（与最新 `upstream/dev` 齐平后执行）：

```
$ node scripts/community-index --check
community-index: OK (55 entries)

$ node scripts/market-build
market-build: wrote 1257 files (29 skins, 5 pets, 55 plugins)

$ node scripts/market-build --check
market-build: tryon/ verified against hash manifest (756 files)
market-build: dist up to date (471 files)

$ node --test scripts/community-index.test.mjs
tests 9 / pass 9 / fail 0

$ git diff --stat
 market/dist/manifest/plugins.json             | 13 +++++++++++++
 packages/dsh-community-plugins/community.json | 12 +++++++++++
 2 files changed, 25 insertions(+)
```

插件自身仓库（`tr1v3r/dsh-quote-followup`，v0.2.3）的回归 harness 同样通过：

```
$ npm test
[web-repeat] native quote chips + draft spacing + Firefox fallback + stale takeover PASS
```

本 PR 为纯索引数据登记，无 UI 改动；插件本体的运行演示动图见下方「用户可见变更证据」。

## 视觉修复要求（Visual Fix Requirements）

不适用：本 PR 未勾选「视觉修复」。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：GLM-5.3

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。本 PR 未新增包目录；插件仓库自身的包名为 `dsh-quote-followup`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本 PR 未改 README。）

## 贡献者版权声明（Contributor Copyright）

插件 `dsh-quote-followup` 版权归原作者 tr1v3r（MIT），本仓库索引仅收录链接。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/tr1v3r/dsh-quote-followup

插件详细说明：

- 功能：Web 对话 transcript 内划选任意文本（含助手回复片段、代码块），浮层一键「引用追问」，以 DSH 原生 `ReferenceChipNode` chip 插入 composer（复用宿主已注册 chip 能力，非自绘 DOM）；发送时 codec 把 chip 展开为模型可读 Markdown 引文；重复引用自动以草稿分隔；旧 host 缺 chip 能力时降级纯文本。
- 实现标准：官方 cordis bundle 独立标准——`package.json` 声明 `dsh.bundle.patch` 指向包内 `cordis.patch.yml`，`dsh.client` 浏览器半区（`inject: ["inputTriggers"]`，platform web），零框架纯 DOM client，无构建产物入库；`dsh.engines.dsh: ">=0.1.2-rc.1"`；仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码。
- 依赖：无运行时依赖（host 半区 inert；client 为纯 DOM 模块，经 `window.__ModuleLoader__` 加载）。
- 分发：npm `dsh-quote-followup@0.2.3`（MIT），GitHub 仓库公开。
- 已知限制：Web-only（TUI 不适用，刻意不支持）；要求 DSH >= 0.1.2-rc.1；Firefox 合成 ClipboardEvent 有已知兼容处理（走 Lexical PASTE_COMMAND 主路径）。
- 运行验证：插件已在作者的日常 Web profile（DSH 0.1.2-rc.1 + 本仓库发布的 `@linxin666/dsh-web-all@0.3.16` 聚合包）持续挂载运行，chip 展示 / 发送展开 / 重复引用 / 刷新接管均正常；随附回归 harness（fake DOM + fake editor）覆盖上述路径。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表（提交生成的 `packages/dsh-community-plugins/src/client/generated/community.ts`）。（当前仓库该数据源已改为直接消费 `community.json` 并派生 `market/dist/manifest/plugins.json`，无 `generated/community.ts` 生成物，已按现状提交派生产物。）
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本仓库最新代码上验证插件可被 `dsh web` 挂载并正常运行（作者日常 Web profile 即本仓库发布的聚合包 `@linxin666/dsh-web-all` 0.3.16 + DSH 0.1.2-rc.1，插件挂载运行正常）。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index --check
node scripts/market-build
node scripts/market-build --check
node --test scripts/community-index.test.mjs
```

结果摘要：

全部通过：索引校验 OK（55 entries）；market-build 重新生成后 `--check` 报 dist up to date；脚本测试 9/9 通过。改动范围仅为 `community.json`（+12）与 `market/dist/manifest/plugins.json`（+13），纯新增。

## 用户可见变更证据（Local Feature Evidence）

插件本体运行演示（GIF，960x540，来自插件仓库 `tr1v3r/dsh-quote-followup` 的 `docs/assets/quote-followup-demo.gif`，录制自作者的 DSH Web 日常环境，即本仓库发布的 `@linxin666/dsh-web-all` 聚合包 + DSH 0.1.2-rc.1）：

![quote-followup demo](https://raw.githubusercontent.com/tr1v3r/dsh-quote-followup/master/docs/assets/quote-followup-demo.gif)

演示内容：在 Web 对话 transcript 内划选一段文本，浮层出现「引用追问」按钮，点击后选中内容以 DSH 原生引用 chip 插入 composer，随后输入针对性追问并发送。

说明：本 PR 自身是纯索引数据登记（无代码 / UI 改动），上图为插件仓库既有功能的运行证据，供协作者评审参考。
