### PR TITLE
登记 SunshineR04/dsh-session-manager（归档会话管理）到社区插件索引

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -687,6 +687,18 @@
       "repo": "https://github.com/jcaiagent7143-ui/linkdigest-mcp",
       "category": "integration",
       "subcategory": "remote"
+    },
+    {
+      "id": "dsh-session-manager",
+      "name": "会话管理",
+      "rank": 55,
+      "nameEn": "Session Manager",
+      "author": "SunshineR04",
+      "description": "在设置页管理已归档会话：列出、恢复或彻底删除（直接物理删除，无备份层）。会话菜单新增红色彻底删除项，附三个 agent 工具；已打开的会话也能立即删除，残留内存副本以归档集墓碑隐藏、重启后自动清理。",
+      "descriptionEn": "Manage archived DeepSeek Harness sessions from a Settings page: list, restore or permanently delete them (direct physical delete, no backup layer). Adds a red permanently-delete item to the session context menu and three agent tools. Open sessions delete immediately; the leftover in-memory copy is hidden via an archive-set tombstone until the next restart.",
+      "repo": "https://github.com/SunshineR04/dsh-session-manager",
+      "category": "utility",
+      "subcategory": "cleanup"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -631,5 +631,16 @@
     "repo": "https://github.com/jcaiagent7143-ui/linkdigest-mcp",
     "category": "integration",
     "subcategory": "remote"
+  },
+  {
+    "id": "dsh-session-manager",
+    "name": "会话管理",
+    "nameEn": "Session Manager",
+    "author": "SunshineR04",
+    "description": "在设置页管理已归档会话：列出、恢复或彻底删除（直接物理删除，无备份层）。会话菜单新增红色彻底删除项，附三个 agent 工具；已打开的会话也能立即删除，残留内存副本以归档集墓碑隐藏、重启后自动清理。",
+    "descriptionEn": "Manage archived DeepSeek Harness sessions from a Settings page: list, restore or permanently delete them (direct physical delete, no backup layer). Adds a red permanently-delete item to the session context menu and three agent tools. Open sessions delete immediately; the leftover in-memory copy is hidden via an archive-set tombstone until the next restart.",
+    "repo": "https://github.com/SunshineR04/dsh-session-manager",
+    "category": "utility",
+    "subcategory": "cleanup"
   }
 ]


### PR DESCRIPTION
> 提 PR 前请阅读 CONTRIBUTING.md 与 AGENTS.md；提交信息用 Conventional Commits，禁止 emoji。
## 摘要（Summary）


登记第三方插件 `dsh-session-manager`（SunshineR04）进社区插件索引：在 `packages/dsh-community-plugins/community.json` 追加 1 条（category: `utility` / subcategory: `cleanup`），并运行 `node scripts/market-build` 重新生成 `market/dist` 清单一并提交。


插件功能：在设置页管理已归档会话——列出、恢复、彻底删除（直接物理删除，无备份层）；会话三点菜单红色彻底删除项；三个 agent 工具；已打开的会话也能立即删除（登记与文件当场清除，残留内存副本以归档集墓碑隐藏、重启后自动清理）。
## 涉及包（Affected Packages）


- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`
- [x] 其他（请说明）：`packages/dsh-community-plugins`（社区插件索引登记）与 `market/dist` 清单再生成
## PR 类别（PR Category）


- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他
## PR 类型（PR Type）


- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构
## 最新代码确认（Latest Codebase Confirmation）


- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。


同步命令：
```bash
git fetch https://github.com/zhu1090093659/dsh-web.git dev && git checkout -B add-dsh-session-manager FETCH_HEAD
```
## 测试证据与上游同步（Test Evidence & Upstream Sync）


- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。


本地验证输出：`node scripts/community-index --check` → community-index: OK (55 entries)；`node scripts/market-build` → market-build: wrote 1257 files (29 skins, 5 pets, 55 plugins)。同步上游 dev（3e011bb）后重新执行，均通过。
## 视觉修复要求（Visual Fix Requirements）


- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。


（纯索引登记，不涉及视觉修复，本节跳过。）
## AI 编码披露（AI Coding Disclosure）


- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。


使用的 AI 模型：GLM


使用的编码 Agent 工具：ZCode
## 仓库规范检查（Repo Rules）


- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（如 `packages/dsh-xxx`）。本次未新增包目录。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [ ] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`。（本次未改动包 README）
## 贡献者版权声明（Contributor Copyright）


（可选）建议在插件上游仓库 README 的版权表中声明 @SunshineR04 的版权；本索引条目按规范只携带链接与元数据。
## 社区插件索引登记（Community Plugin Index）


插件 GitHub 仓库链接：https://github.com/SunshineR04/dsh-session-manager


插件详细说明：在设置页（设置 → 会话管理）管理已归档会话——列出全部归档会话（标题/工作区/项目目录/更新时间/运行状态），支持恢复（回到原工作区位置）与彻底删除（直接物理删除，无备份层）；会话三点菜单新增红色彻底删除项；提供三个 agent 工具（session_list_archived / session_restore_archived / session_delete_permanently，删除需 confirm: true 且拒绝运行中会话）。差异点：已打开的会话也能立即删除——登记与文件当场清除，残留内存副本以归档集墓碑隐藏、重启后自动清理。依赖：仅官方 `@deepseek-ai/schemastery`（peer）。已知限制：斜杠命令形态已移除（桌面端无斜杠入口）。


- [x] 已按 docs/plugins.md 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表。
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本仓库最新代码上验证插件可被 `dsh web` 挂载并正常运行。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息变动或插件停更时，及时更新索引登记或提交移除。
## 本地验证（Local Validation）


执行的命令：
```bash
node scripts/community-index --check
node scripts/market-build
```
结果摘要：


community-index: OK (55 entries)；market-build: wrote 1257 files (29 skins, 5 pets, 55 plugins)。清单差异：community.json +1 条、market/dist/manifest/plugins.json 与 manifest.js 相应更新。
## 用户可见变更证据（Local Feature Evidence）


证据：合并后条目将出现在 设置 → 创意工坊 → 插件 目录（utility / cleanup 分类）。本 PR 只登记索引链接、不搬代码，故无本地运行截图；插件自身功能见其仓库 README 与测试（19 项单测/渲染测试通过）。