### PR TITLE
feat(community-plugins): register plugin-effort-slider in the community index

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -700,6 +700,19 @@
       "npm": "dsh-quote-followup",
       "category": "ui",
       "subcategory": "chat"
+    },
+    {
+      "id": "plugin-effort-slider",
+      "name": "Effort Slider",
+      "rank": 56,
+      "nameEn": "Effort Slider",
+      "author": "mrSutivu",
+      "description": "输入框内的模型选择与推理强度滑杆二合一胶囊：带刻度拖拽、最高档流光动画，跟随主题变量，中英法三语。",
+      "descriptionEn": "Model picker and reasoning-effort slider in one composer pill: notched drag, max-effort shimmer, theme variables, English, French and Chinese labels.",
+      "repo": "https://github.com/mrSutivu/plugin-effort-slider",
+      "npm": "plugin-effort-slider",
+      "category": "ui",
+      "subcategory": "chat"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -643,5 +643,17 @@
     "npm": "dsh-quote-followup",
     "category": "ui",
     "subcategory": "chat"
+  },
+  {
+    "id": "plugin-effort-slider",
+    "name": "Effort Slider",
+    "nameEn": "Effort Slider",
+    "author": "mrSutivu",
+    "description": "输入框内的模型选择与推理强度滑杆二合一胶囊：带刻度拖拽、最高档流光动画，跟随主题变量，中英法三语。",
+    "descriptionEn": "Model picker and reasoning-effort slider in one composer pill: notched drag, max-effort shimmer, theme variables, English, French and Chinese labels.",
+    "repo": "https://github.com/mrSutivu/plugin-effort-slider",
+    "npm": "plugin-effort-slider",
+    "category": "ui",
+    "subcategory": "chat"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

社区插件索引登记一个条目：`plugin-effort-slider`（输入框模型 + 推理强度滑杆）。输入框内的模型选择与推理强度滑杆二合一胶囊：带刻度拖拽、最高档流光动画，跟随主题变量，中英法三语。

改动只有两个文件，纯新增，无删除：`packages/dsh-community-plugins/community.json` 追加一条，以及同步后的 `market/dist/manifest/plugins.json`。

## 涉及包（Affected Packages）

- [x] 其他（请说明）：`packages/dsh-community-plugins`（索引条目）与 `market/dist`（同步后的市场产物）

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [ ] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新预设收录（内容贡献，欢迎直接提交，无需先提 issue）
- [x] 维护 / 重构

说明：本 PR 是「插件申请（社区插件索引登记）」，纯索引数据新增，不含任何代码或 UI 改动，故勾选最接近的「维护 / 重构」；真正决定分派的类别在上一节（社区插件索引）。

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch upstream dev
git rev-list --count HEAD..upstream/dev   # 0，已与最新 dev 齐平
```

基线为 `dev` HEAD `c21bf50`。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

说明：fork 内 `origin` 即本 fork，实际执行等价命令 `git fetch upstream dev`，`rev-list --count HEAD..upstream/dev` 为 0，已与最新 dev 齐平，无需 rebase；下述测试即在该齐平状态下重新执行通过。

自测记录（基线 `c21bf50` 上执行）：

```
$ node scripts/community-index --check
community-index: OK (56 entries)

$ npx vitest run tests/community-json.spec.ts
Test Files  1 passed (1)
Tests 2 passed (2)
```

`market/dist/manifest/plugins.json` 按构建脚本的确定性格式同步（字段顺序/rank/缩进/LF 与 scanPlugins 输出一致，共 56 条，rank 连续），待 CI market:check 复核。

```bash
$ git diff --stat
 market/dist/manifest/plugins.json             | 13 +++++++++++++
 packages/dsh-community-plugins/community.json | 12 ++++++++++++
 2 files changed, 25 insertions(+)
```

本 PR 为纯索引数据登记，无 UI 改动。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。
- [ ] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：Muse Spark

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。

其余两项不适用：未新增包目录，未改动包 README。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

https://github.com/mrSutivu/plugin-effort-slider

插件详细说明：

输入框内的模型选择与推理强度滑杆二合一胶囊。用途：在官方 DSH web 对话输入框里一键选模型、拖动推理强度（2～7+ 档，取决于模型），无需经过 Model/Effort 二级菜单。依赖：无（纯前端，不引入 NPM 依赖，host 为空行为）。已知限制：仅当模型开放推理档位时显示；无推理档位的模型自动隐藏，不影响原生选择器。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表（提交生成的 `packages/dsh-community-plugins/src/client/generated/community.ts`）。

说明：`node scripts/community-index` 在当前树中为纯校验（校验通过，56 条），未产生需提交的 `community.ts` 文件；`market/dist/manifest/plugins.json` 已按构建脚本的确定性格式同步（见下文测试证据）。

- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client` 浏览器半区），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本仓库最新代码上验证插件可被 `dsh web` 挂载并正常运行。

说明：本插件无任何 NPM 依赖（host 为空行为，client 仅使用运行时注入的全局 React 与标准 composer slots / 主题变量），挂载验证在官方 DSH 0.1.2-alpha web profile 上通过；如维护者在 dsh-web 发行版上的挂载检查发现差异，请指出，我即刻跟进。

- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index --check
npx vitest run tests/community-json.spec.ts
```

结果摘要：

```
community-index: OK (56 entries)
Test Files  1 passed (1), Tests 2 passed (2)
manifest: 56 items, ranks 1..56 连续, 0 CRLF, diff +25/-0（两个文件）
```

全部通过，无失败。

## 用户可见变更证据（Local Feature Evidence）

本 PR 本身为纯索引数据登记（dsh-web 侧无 UI 改动）；插件本体的运行效果证据取自插件自有仓库（Xhigh 档位 + 统计行）：

https://raw.githubusercontent.com/mrSutivu/plugin-effort-slider/main/docs/banner-slider.png

https://raw.githubusercontent.com/mrSutivu/plugin-effort-slider/main/docs/screenshot-composer.png
