### PR TITLE
feat(community-index): register dsh-thread-tools

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -739,6 +739,18 @@
       "npm": "dsh-taskfold",
       "category": "tools",
       "subcategory": "context"
+    },
+    {
+      "id": "dsh-thread-tools",
+      "name": "会话线程工具",
+      "rank": 59,
+      "nameEn": "Thread Tools",
+      "author": "wig123",
+      "description": "把 Codex 的线程工具搬到 DSH 上：让模型列出你开着的那些会话、按正文检索它们、给某个正在跑的会话递消息并读回它的回答，还能新建空会话或从已有会话的已完成轮次分叉。",
+      "descriptionEn": "Codex's thread tools on DSH: the model can list the sessions you have open, search their content, hand one of them a message and read the answer back, open a fresh session, or branch one from its completed turns.",
+      "repo": "https://github.com/wig123/dsh-thread-tools",
+      "category": "tools",
+      "subcategory": "context"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -679,5 +679,16 @@
     "npm": "dsh-taskfold",
     "category": "tools",
     "subcategory": "context"
+  },
+  {
+    "id": "dsh-thread-tools",
+    "name": "会话线程工具",
+    "nameEn": "Thread Tools",
+    "author": "wig123",
+    "description": "把 Codex 的线程工具搬到 DSH 上：让模型列出你开着的那些会话、按正文检索它们、给某个正在跑的会话递消息并读回它的回答，还能新建空会话或从已有会话的已完成轮次分叉。",
+    "descriptionEn": "Codex's thread tools on DSH: the model can list the sessions you have open, search their content, hand one of them a message and read the answer back, open a fresh session, or branch one from its completed turns.",
+    "repo": "https://github.com/wig123/dsh-thread-tools",
+    "category": "tools",
+    "subcategory": "context"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

登记第三方插件 `@wig123/dsh-thread-tools`：把 Codex 的线程工具搬到 DSH 上，让模型能操作本部署的顶层会话——列出、按正文检索、给正在运行的会话递消息并读回回答，以及新建空会话、从已有会话的已完成轮次分叉。

DSH 已有 `subagent` / `send_message`，但那是在当前会话**底下**派帮手；侧边栏里自己开的会话彼此看不见。本 PR 只改索引数据与派生的市场清单。

本轮按上一轮评审改了三点：`npm` 字段已删（安装回退 git，`lib/` 已提交）；补了 `npm test` 与 GitHub Actions；**按 0.1.5 线的接口做了适配并补了两条线的验证证据**。

## 涉及包（Affected Packages）

- [x] 其他（社区插件索引数据：`packages/dsh-community-plugins/community.json` 与其派生的 `market/dist/manifest/plugins.json`）

## PR 类别（PR Category）

- [x] 社区插件索引

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 新皮肤收录 / 新宠物收录 / 新预设收录
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

分支已重建在 `origin/dev`（`bb602880`）之上，冲突已消除（`mergeable: true`）。

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

索引侧（本仓库内，rebase 后重跑）：

```text
$ node scripts/community-index
community-index: OK (75 entries)

$ node scripts/market-build
market-build: wrote 3068 files (35 skins, 7 pets, 75 plugins, 32 presets)

$ node scripts/market-build --check
market-build: dist up to date (2276 files)      # exit 0

$ node --test scripts/community-index.test.mjs
# pass 9 / # fail 0
```

插件侧，两条宿主线各有独立证据：

```text
$ npm test                      # 无 dsh、无 profile、无 API key
# pass 4 / # fail 0

$ node dev/verify.mjs <profile>          # 0.1.2-rc 线
24/24 checks passed

$ node dev/verify-0.1.5/verify15.mjs <profile>   # 0.1.5 线
6/6 checks passed
```

## 视觉修复要求（Visual Fix Requirements）

- [ ] 我提供了修复完成后的截图（完成态或修复前后对比）。
- [ ] 修复使用的 AI 模型支持图像输入（多模态模型）；未使用 AI 编码时此项视为满足。

不适用：本 PR 不是视觉修复。

## AI 编码披露（AI Coding Disclosure）

- [ ] 完全 AI 编码
- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。
- [ ] 未使用 AI 编码辅助。

使用的 AI 模型：DeepSeek V4.1（deepseek-v4.1-flash-expires-on-0910）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。
- [x] 新增包目录以 `dsh-` 前缀命名（本 PR 未新增包目录；插件包名为 `dsh-thread-tools`）。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。
- [x] 改动包 README 时同步维护中英双语三件套并运行 `pnpm docs:check`。（本 PR 未改动任何 README）

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：

https://github.com/wig123/dsh-thread-tools

插件详细说明：

六个模型可见工具，全部面向本部署的**顶层会话**（子 agent 的会话在所有结果里排除）：`thread_list`（列出，可按 id / 标题 / cwd 子串过滤）、`thread_search`（正文全文检索）、`thread_send`（给正在运行的会话投递消息，成为它的一条待处理普通轮次，来源标为本插件）、`thread_reply`（读该会话最新 assistant 消息，可先等它当前轮次结束）、`thread_create`（新建空顶层会话，继承调用方模型路由）、`thread_fork`（从某个会话最后一个已完成轮次分叉，继承 cwd 与 lineage）。

依赖：`@deepseek-ai/dsh-tools`、`@deepseek-ai/dsh-session-persistence`、`@deepseek-ai/dsh-agent` 必需；`@deepseek-ai/dsh-session-query` 可选（仅 `thread_search`）。无运行时依赖，服务在执行时从调用方自己的 scope 解析。

已知限制：只能给正在运行的会话发消息（休眠会话返回 `dormant`，不会自行复活）；`thread_reply` 读的是最新一条 assistant 文本，不与某条消息配对；`thread_list` 读元数据不读正文；分叉超大会话需显式给 `at_seq`；Web 默认内容索引关闭时 `thread_search` 自报不可用。

- [x] 已按 docs/plugins.md 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表。
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（`dsh.bundle.patch` 指向 `cordis.patch.yml`），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在本仓库最新代码上验证插件可被 `dsh web` 挂载并正常运行。
- [x] 承诺负责后续更新跟进：生态升级导致不兼容时主动跟进修复；条目信息变动或插件停更时及时更新登记或提交移除。

关于 `community.ts`：`node scripts/community-index` 只做校验、不写文件，仓库里也没有 `packages/dsh-community-plugins/src/client/generated/` 目录，所以本次改动面与仓库同类登记一致，是 `community.json` + `market/dist/manifest/plugins.json`（另有 4 个 manifest 的 `generated` 日期随构建更新）。

关于 `dsh.engines.dsh`：上一轮我把声明收窄到只覆盖 0.1.2-rc。这一轮按你的首选路径做了 0.1.5 线适配——0.1.5 把会话日志访问挪到了每会话 handle（`open(id, 'read')`），差异集中在新模块 `src/store-access.ts`，运行期按部署实际挂载的服务形态解析。声明现在覆盖 `>=0.1.2-rc.1 <0.1.6`，两条线都有上面列出的验证证据。

## 本地验证（Local Validation）

执行的命令：

```bash
# 索引侧（本仓库）
node scripts/community-index
node scripts/market-build
node scripts/market-build --check
node --test scripts/community-index.test.mjs

# 插件侧（插件仓库）
npm install && npm run typecheck && npm run build && npm test
node dev/verify.mjs <profile>                                  # 0.1.2-rc 线
node dev/verify-0.1.5/verify15.mjs <profile>                   # 0.1.5 线

# 挂载验证：base + web-app + 本插件组成 profile 后启动
dsh plugin --profile probe-web-thread-tools add @deepseek-ai/dsh-web-app
dsh plugin --profile probe-web-thread-tools add github:wig123/dsh-thread-tools
dsh --profile probe-web-thread-tools --port 3099 --host 127.0.0.1 --no-open
```

结果摘要：

- 索引侧：`community-index: OK (75 entries)`；`market-build --check` exit 0（`dist up to date (2276 files)`）；单测 `# pass 9 / # fail 0`。均在 rebase 到 `bb602880` 之后重跑。
- 插件侧 `npm test`：`# pass 4 / # fail 0`（无 dsh、无 profile、无 API key）。仓库有 GitHub Actions 做 typecheck、build、test，并检查入库 `lib/` 与 `src/` 一致，CI 已绿。
- 插件侧两条宿主线：0.1.2-rc 线 `24/24 checks passed`；0.1.5 线 `6/6 checks passed`（列出存储会话、读取某会话日志、新建会话、投递并在目标日志里读到消息）。
- 挂载验证：组合 profile 启动成功，3099 端口 LISTEN、进程存活、日志无插件加载错误（不带 token 返回 401 属正常鉴权）。验证后探针服务已停止。

## 用户可见变更证据（Local Feature Evidence）

证据：

![本地加载本插件后注册出来的六个工具，以及一次真实 thread_list 调用](https://raw.githubusercontent.com/wig123/dsh-thread-tools/main/docs/demo.svg)

（上图取自 `DEMO=1 node dev/verify.mjs` 的真实终端输出，同一张图也嵌在插件 README 里。）

插件只注册模型工具、不新增界面控件，所以这张终端捕获就是它的用户可见表现。模型驱动的一轮（脚本化 adapter，无需 API key）里：`thread_send` 返回 `delivery: "delivered"`，目标会话日志出现该消息，随后 `thread_reply` 把目标的 assistant 文本读回给驱动方。
