### PR TITLE
Add dsh-plugin-bwm-friend (BWM Friend 数字人工作台)

### DIFF
--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -680,4 +680,16 @@
     "category": "tools",
     "subcategory": "context"
   }
+,
+{
+    "id": "dsh-plugin-bwm-friend",
+    "name": "BWM Friend 数字人工作台",
+    "nameEn": "BWM Friend",
+    "author": "laikaton",
+    "description": "数字人沉浸式工作台：原生 DSH 业务流 + 数字人视频 + 半透明幕布 + 青色边框。语音输入/回复朗读、跨会话记忆、人格切换（Mira 陪伴/Mentor 导师）、数字人主动行为、多会话工作区弹窗。UI 与业务分离——原生 DSH 100% 不动。",
+    "descriptionEn": "Digital human immersive workspace: native DSH flow + avatar video + frosted scrim + teal border. Voice input/read-aloud replies, cross-session memory, persona switching (Mira companion / Mentor advisor), proactive digital-human behaviors, multi-session workspace popup. UI separated from business — native DSH untouched.",
+    "repo": "https://gitee.com/zeng-tian818/dsh-plugin-bwm-friend",
+    "npm": "dsh-plugin-bwm-friend",
+    "category": "ui"
+  }
 ]


### PR DESCRIPTION
## 新插件收录申请

- **npm**: `dsh-plugin-bwm-friend@0.6.0`（已发布，shasum 37f411766c0ba4a439e9c7da5753de6620dab9e2）
- **仓库**: https://gitee.com/zeng-tian818/dsh-plugin-bwm-friend
- **功能**: 数字人沉浸式工作台——原生 DSH 业务流 100% 保留（iframe 原生，根路径零侵入），数字人视频外壳/语音双向（MiMo ASR+TTS）/跨会话记忆/模板⇒音色⇒人格三联动/主动陪伴行为
- **安全基线**: CSRF 同源校验/XSS 转义/凭据掩码/路径白名单，九防线威胁模型；干净机安装冒烟 + 全新 DSH 装载验证自动化
- **变更**: `community.json` 末尾追加 1 条（13 行），其余零改动

Thanks for maintaining the market! 🙌