### PR TITLE
feat(community-plugins): register dsh-plugin-bwm-friend

### DIFF
--- a/market/dist/manifest/plugins.json
+++ b/market/dist/manifest/plugins.json
@@ -739,6 +739,18 @@
       "npm": "dsh-taskfold",
       "category": "tools",
       "subcategory": "context"
+    },
+    {
+      "id": "dsh-plugin-bwm-friend",
+      "name": "BWM Friend 数字人工作台",
+      "rank": 59,
+      "nameEn": "BWM Friend",
+      "author": "laikaton",
+      "description": "数字人沉浸式工作台：原生 DSH 业务流 + 数字人视频 + 半透明幕布 + 青色边框。语音输入/回复朗读、跨会话记忆、人格切换（Mira 陪伴/Mentor 导师）、数字人主动行为、多会话工作区弹窗。UI 与业务分离——原生 DSH 100% 不动。",
+      "descriptionEn": "Digital human immersive workspace: native DSH flow + avatar video + frosted scrim + teal border. Voice input/read-aloud replies, cross-session memory, persona switching (Mira companion / Mentor advisor), proactive digital-human behaviors, multi-session workspace popup. UI separated from business — native DSH untouched.",
+      "repo": "https://gitee.com/zeng-tian818/dsh-plugin-bwm-friend",
+      "npm": "dsh-plugin-bwm-friend",
+      "category": "ui"
     }
   ]
 }

--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -679,5 +679,16 @@
     "npm": "dsh-taskfold",
     "category": "tools",
     "subcategory": "context"
+  },
+  {
+    "id": "dsh-plugin-bwm-friend",
+    "name": "BWM Friend 数字人工作台",
+    "nameEn": "BWM Friend",
+    "author": "laikaton",
+    "description": "数字人沉浸式工作台：原生 DSH 业务流 + 数字人视频 + 半透明幕布 + 青色边框。语音输入/回复朗读、跨会话记忆、人格切换（Mira 陪伴/Mentor 导师）、数字人主动行为、多会话工作区弹窗。UI 与业务分离——原生 DSH 100% 不动。",
+    "descriptionEn": "Digital human immersive workspace: native DSH flow + avatar video + frosted scrim + teal border. Voice input/read-aloud replies, cross-session memory, persona switching (Mira companion / Mentor advisor), proactive digital-human behaviors, multi-session workspace popup. UI separated from business — native DSH untouched.",
+    "repo": "https://gitee.com/zeng-tian818/dsh-plugin-bwm-friend",
+    "npm": "dsh-plugin-bwm-friend",
+    "category": "ui"
   }
 ]


### PR DESCRIPTION
## 摘要（Summary）

登记社区插件 **dsh-plugin-bwm-friend**（BWM Friend 数字人工作台）进社区插件索引：`community.json` 追加 1 条，并重新生成 `market/dist/manifest/plugins.json`（rank 59）。插件 npm 已发布 `dsh-plugin-bwm-friend@0.6.0`。

> 本 PR 取代 #1487（该 PR 因未按模板填写元数据被机器人自动关闭；本 PR 已完整填写模板）。

## 涉及包（Affected Packages）

- [ ] 任务看板 `packages/dsh-task-board`
- [ ] Git 图谱 `packages/dsh-git-graph`
- [ ] 右侧面板 `packages/dsh-aionui-panel`
- [ ] 远程 Web UI `packages/dsh-remote-web-ui`
- [ ] SSH 远程运维 `packages/dsh-ssh`
- [ ] 宠物 `packages/dsh-pet`
- [ ] 预设中心 `packages/dsh-preset-center`
- [ ] 皮肤 / 皮肤中心 `packages/dsh-skins` / `packages/skins`
- [ ] 聚合包 / 设置 `packages/dsh-web-all` / `packages/dsh-web-settings`
- [x] 其他（请说明）：`packages/dsh-community-plugins`（索引条目）与 `market/dist`（重新生成的市场产物）——纯数据登记，无代码逻辑变更

## PR 类别（PR Category）

- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 预设中心 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

## PR 类型（PR Type）

- [x] 面向用户的功能或行为变更（社区插件索引数据登记，新增市场条目）
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新预设收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

## 最新代码确认（Latest Codebase Confirmation）

- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。

同步命令：

```bash
git fetch up dev && git checkout -B work up/dev   # 本分支直接基于最新 upstream dev（e92a7f5）构建，单一干净提交
```

## 测试证据与上游同步（Test Evidence & Upstream Sync）

- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

证据：

```bash
node scripts/community-index --check
# community-index: OK (59 entries)
```

- 本分支直接基于最新 upstream `dev`（e92a7f5）构建，校验在该基线上执行并通过。
- 插件自身发布证据：npm `dsh-plugin-bwm-friend@0.6.0` 已发布（registry.npmjs.org，shasum `37f411766c0ba4a439e9c7da5753de6620dab9e2`），官方源与 npmmirror 镜像均实测 `npm i` 安装成功。

## 视觉修复要求（Visual Fix Requirements）

纯数据登记（未勾选「视觉修复」），本节不适用。

## AI 编码披露（AI Coding Disclosure）

- [x] 完全 AI 编码：全部编程改动由 AI 产出，并由贡献者接受 / 审查。

使用的 AI 模型：GLM（DeepSeek）

使用的编码 Agent 工具：DeepSeek Harness

## 仓库规范检查（Repo Rules）

- [x] 未修改 DSH 官方源码，仅基于官方 NPM SDK（`@deepseek-ai/*`）开发。（插件仅声明 `dsh.bundle.patch` / `dsh.client` 标准挂载点）
- [x] 未新增指向 DSH 源码 checkout 的 tsconfig `extends` / `paths` / `references`。（本 PR 未新增包目录）
- [x] 新增包目录以 `dsh-` 前缀命名——本 PR 未新增包目录。
- [x] 所有新增 / 修改文件不含任何 emoji 字符。（两个 JSON 文件的追加内容已逐行确认）
- [x] 改动包 README 时同步维护中英双语三件套（`README.md` / `README.zh.md` / `README.i18n.yaml`）并运行 `pnpm docs:check`——本 PR 未改动任何 README。

## 社区插件索引登记（Community Plugin Index）

插件 GitHub 仓库链接：https://github.com/Lawrencezeng818/dsh-plugin-bwm-friend （作者主仓为 https://gitee.com/zeng-tian818/dsh-plugin-bwm-friend ，GitHub 为同步镜像）

插件详细说明：

- 功能：给 DSH 装上「数字人外壳」的入口层插件。work 模式（数字人在侧 + iframe 原生工作台，原生 DSH 业务流 100% 保留、根路径零侵入）与 companion 模式（全屏沉浸数字人 + 半透明幕布 + 语音双向）；模板⇒音色⇒人格三联动、跨会话记忆、主动陪伴行为（幂等防重）。
- 依赖：`@laikaton/bwm-skin-mira`（皮肤资产包，随依赖自动安装）；语音 ASR/TTS 走小米 MiMo（`XIAOMI_MIMO_API_KEY` 可选，未配置时显式降级为文字）；陪伴聊天复用宿主 `~/.dsh/.credentials.yaml`，无需额外配置 key。
- 已知限制：语音依赖浏览器麦克风权限与云端 API（断网退化为文字壳）；记忆为规则启发式抽取（v1，作者如实标注）；悬浮按钮拖动未实现（README Known Limitations 明示）。

- [x] 已按 [docs/plugins.md](../docs/plugins.md) 的登记说明在 `packages/dsh-community-plugins/community.json` 追加条目，并运行 `node scripts/community-index` 重新生成注册表（`node scripts/community-index --check` → OK 59 entries；`market/dist/manifest/plugins.json` 已重新生成随附提交）。
- [x] 已确认插件与 dsh-web 插件体系兼容：遵循官方 cordis bundle 独立标准（package.json 声明 `dsh.bundle.patch` 指向 `cordis.patch.yml`、`dsh.client`（platform: web, immediately: true）），类型仅基于官方 `@deepseek-ai/*` NPM SDK，未修改 DSH 源码；已在真实 DSH 全新实例（隔离 HOME/DSH_HOME 全新装载）验证 `dsh web` 挂载并正常运行——health/work/companion 三端点断言、页面级注入断言共 15 项检查全过，DSH 根路径不受影响。
- [x] 承诺负责后续更新跟进：插件与 DSH / dsh-web 生态保持同步，生态升级导致不兼容时主动跟进修复；条目信息（description / npm 等）变动或插件停更时，及时更新索引登记或提交移除。

## 本地验证（Local Validation）

执行的命令：

```bash
node scripts/community-index --check
npm view dsh-plugin-bwm-friend@0.6.0 dist-shasum
npm i dsh-plugin-bwm-friend@0.6.0 --registry=https://registry.npmjs.org
# 插件仓库内发布门槛（登记前已全绿）：core 36 / host 38 / e2e 12 / 状态同步 17 项 / 干净机安装冒烟 8 检查 / 全新 DSH 装载 15 检查
```

结果摘要：

- `community-index: OK (59 entries)`；两文件均为纯尾部追加（community.json +11 行，plugins.json +12 行），JSON 语法校验通过
- npm 0.6.0 官方源与 npmmirror 均安装成功（版本号与 shasum 一致）
- 插件发布门槛全绿（见上），登记使用的 npm 版本即通过全部门禁的版本

## 用户可见变更证据（Local Feature Evidence）

市场条目为数据登记，dsh-web 本身无用户可见变更（N/A）。插件自身运行效果：截图见插件镜像仓库 `docs/screenshots/`（companion-page 1600x1000 基线），市场提交材料含 work/companion 双页截图。
