### PR TITLE
fix(dsh-pet): 高 DPR 桌面下宠物被视口裁剪（尺寸封顶 + 位置钳制）

### DIFF
--- a/packages/dsh-pet/src/client/PetSprite.tsx
+++ b/packages/dsh-pet/src/client/PetSprite.tsx
@@ -329,7 +329,14 @@ export function PetSprite(props: PetSpriteProps): ReactPortal {
   // the loop reads every tick. Under prefers-reduced-motion the sprite holds
   // its track's first frame instead of animating (presentation-only; the
   // animation state machine is untouched).
-  const spriteScale = display.size / cell.height
+  // Viewport guard: on high-devicePixelRatio desktops (e.g. DSH Desktop at
+  // 250% display scaling) the CSS viewport shrinks until the configured
+  // size/offset pushes the sprite past the visible area and only a slice of
+  // the pet renders. Cap the effective size so the whole sprite always fits.
+  const viewportW = typeof window !== 'undefined' ? window.innerWidth : 1280
+  const viewportH = typeof window !== 'undefined' ? window.innerHeight : 720
+  const effectiveSize = Math.max(48, Math.min(display.size, viewportH * 0.6, viewportW * 0.6))
+  const spriteScale = effectiveSize / cell.height
   const phase = snapshot?.phase ?? 'idle'
   const animation = snapshot?.animation ?? 'idle'
   const scaleRef = useRef(spriteScale)
@@ -481,7 +488,19 @@ export function PetSprite(props: PetSpriteProps): ReactPortal {
     if (dragPos !== null) props.onDragEnd(dragPos.right, dragPos.bottom)
   }
 
-  const pos = dragPos ?? { right: display.right, bottom: display.bottom }
+  // Clamp the persisted/dragged offsets into the viewport as well: without
+  // this the saved position from a larger window (or a high-DPR desktop)
+  // parks the sprite partially off-screen and it stays clipped until the
+  // user drags it back.
+  const pos = ((): { right: number; bottom: number } => {
+    const raw = dragPos ?? { right: display.right, bottom: display.bottom }
+    const w = Math.round(cell.width * spriteScale)
+    const h = Math.round(cell.height * spriteScale)
+    return {
+      right: clampOffset(raw.right, Math.max(0, viewportW - w - 8)),
+      bottom: clampOffset(raw.bottom, Math.max(0, viewportH - h - 8)),
+    }
+  })()
   const spriteWidth = Math.round(cell.width * spriteScale)
   const spriteHeight = Math.round(cell.height * spriteScale)
 


### PR DESCRIPTION
## 问题

在高 DPI 桌面环境（例如 DSH Desktop 以 250% 显示缩放运行，`devicePixelRatio=2.5`）下，CSS 视口远小于物理窗口。宠物的持久化显示配置（`size` / `right` / `bottom`）在启动时被原样应用——只有拖拽路径会调用 `clampOffset` 钳制，初始渲染路径没有。当 `bottom` + `size` 超过视口高度时，精灵顶部被推出可视区，宠物只显示一截（"显示不全"），直到用户手动拖回。

## 修复

- 有效尺寸封顶为视口的 60%（`effectiveSize`），视口不可用时回退 1280×720；
- 每次渲染时将持久化的 `right`/`bottom` 钳制进视口（复用现有 `clampOffset`）。

拖拽行为、气泡、面板、动画帧循环均不受影响（`scaleRef` 照常读取缩放值，帧定位沿用既有 scaled-coordinate 逻辑）。

## 验证

DSH Desktop 0.5.10（Electron，DPR 2.5，视口 512×328 CSS px）实测：

- 修复前：宠物 rect `y=-85`（顶部 85px 被裁掉）；
- 修复后：rect `{x:283, y:8, w:182, h:197}` 完整落在视口内，鲸鱼娘整只可见。

Verified with the sprite2d renderer (`whale-girl-refined`, 1536×1872 webp atlas).