### PR TITLE
community: register dsh-whale-girl (Whale Girl Widget)

### DIFF
--- a/packages/dsh-community-plugins/community.json
+++ b/packages/dsh-community-plugins/community.json
@@ -679,5 +679,16 @@
     "npm": "dsh-taskfold",
     "category": "tools",
     "subcategory": "context"
+  },
+  {
+    "id": "dsh-whale-girl",
+    "name": "鲸鱼娘·灵动挂件",
+    "nameEn": "Whale Girl Widget",
+    "author": "nickkkkkk123123",
+    "description": "会卖萌、会记账的 DSH 桌面挂件：实时余额与用量、上下文进度条、CPU/内存信息面板（独立窗口+物理跟随）、拖拽甩抛与碰撞反弹、子代理状态徽章、右键菜单与彩蛋。",
+    "descriptionEn": "A lively DSH desktop widget: realtime balance & usage, context progress bar, CPU/RAM info panel (independent window with physics follow), drag-fling with collision bounce, subagent badges, context menu and easter eggs.",
+    "repo": "https://github.com/nickkkkkk123123/dsh-whale-girl",
+    "category": "ui",
+    "subcategory": "panel"
   }
 ]


### PR DESCRIPTION
### 摘要（Summary）
在社区插件索引（community.json）登记社区插件 **dsh-whale-girl（鲸鱼娘·灵动挂件 / Whale Girl Widget）**，仅改动 `packages/dsh-community-plugins/community.json` 一个文件（58 → 59 条）。

### 涉及区块（Affected Packages）
仅脚本改动（community-index 数据文件），上述 packages 均不涉及。

### PR 类别（PR Category）
- [ ] 壁纸 / 渲染器（Wallpaper Engine / WebGL / 背景场景）
- [ ] 皮肤 / 皮肤中心（新皮肤收录、皮肤样式）
- [ ] 插件功能（任务看板 / Git 图谱 / 右侧面板 / 远程 Web UI / SSH / 宠物 / 预设中心 / 设置 / 聚合包）
- [x] 社区插件索引
- [ ] 维护 / 其他

### PR 类型（PR Type）
- [x] 面向用户的功能或行为变更
- [ ] Bug 修复
- [ ] 视觉修复（UI / 视觉类问题的修复）
- [ ] 增强 / 优化（现有功能的改进、性能 / 体验优化）
- [ ] 新皮肤收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新宠物收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 新预设收录（内容贡献，欢迎直接提交，无需先提 issue）
- [ ] 维护 / 重构

### 最新代码确认（Latest Codebase Confirmation）
- [x] 我已基于最新 `dev` 分支开发，或在提交前已 rebase / 合并最新 `dev`。
同步命令：`git fetch origin && git rebase origin/dev`（本 PR 分支 add-whale-girl 已基于 dev@d56328c 重建）。

### 测试证据与上游同步（Test Evidence & Upstream Sync）
- [x] 我提供了自己本地测试的证据（执行的命令 / 测试结果 / 运行截图）。
- [x] 我已同步上游最新 `dev` 分支（`git fetch origin && git rebase origin/dev`），并附上同步后重新测试通过的证据（视觉 / 用户可见变更附截图）。

本地验证：
1. `community.json` 修改后经 JSON 解析校验通过（58 → 59 条，新增条目字段与既有条目结构一致：id/name/nameEn/author/description/descriptionEn/repo/category/subcategory）；
2. 插件实机可用：`dsh plugin add nickkkkkk123123/dsh-whale-girl`（lib/ 已提交、无需构建），已在 DSH Desktop 2.0.5 + dsh-web-all 0.3.21 环境运行验证（挂件显示、余额/上下文/信息面板正常）；
3. 分类按索引既有值取 `ui/panel`。

### 插件信息
- repo: https://github.com/nickkkkkk123123/dsh-whale-girl
- 安装：`dsh plugin add nickkkkkk123123/dsh-whale-girl`
- author: @nickkkkkk123123